### PR TITLE
feat: add nhru merge notebook and align merge_and_fill_params to use …

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ gfv2-params/
 
 ## Output Directory Structure
 
-The data root (`data_root`) is configured in `configs/base_config.yml` and resolves to the `gfv2_param/` directory. All source data and outputs live under this root:
+The data root (`data_root`) is set in `configs/base_config.yml` (currently pointing to a `gfv2_param/` directory on Hovenweep). All source data and outputs live under this root:
 
 ```
 gfv2_param/
@@ -62,10 +62,13 @@ gfv2_param/
 │   ├── NHDPlus_Extracted/          # Unzipped per-RPU rasters
 │   ├── NHDPlus_Merged_Rasters/
 │   │   └── <VPU>/                  # NEDSnapshot, Hydrodem, Fdr, Fac GeoTIFFs
+│   ├── data_layers/
+│   │   └── soils_litho/            # Soils rasters, lithology shapefile
 │   └── mrlc_nlcd_fract_impervious/ # NLCD fractional impervious cover rasters
 ├── targets/
 │   ├── NHM_<VPU>_draft.gpkg        # Input per-VPU watershed fabric (nhru layer)
 │   └── gfv2_nhru_merged.gpkg       # Merged nhru (produced by notebooks/merge_vpu_targets.py)
+├── weights/                        # Polygon-to-polygon weights (ssflux)
 └── nhm_params/
     ├── elevation/
     │   └── base_nhm_elevation_<VPU>_param.csv
@@ -83,7 +86,7 @@ gfv2_param/
     │   ├── nhm_*.csv
     │   └── filled_nhm_ssflux_params.csv
     ├── default/                    # Input NHM default parameter files
-    └── merged/                     # Final merged outputs per parameter
+    └── merged/                     # NHM default parameters rekeyed to nat_hru_id
         └── <param_name>_merged.csv
 ```
 

--- a/notebooks/merge_vpu_targets.py
+++ b/notebooks/merge_vpu_targets.py
@@ -10,8 +10,8 @@ def _(mo):
     # Merge VPU nhru layers into a single GeoPackage
 
     Reads the `nhru` layer from each `NHM_<vpu>_draft.gpkg`, fixes invalid
-    geometries with `make_valid()`, simplifies, then writes a single output
-    GeoPackage.
+    geometries with `make_valid()`, simplifies, then validates geometry and
+    `nat_hru_id` contiguity before writing a single output GeoPackage.
     """)
     return
 
@@ -25,7 +25,9 @@ def _():
     import shapely
     import marimo as mo
 
-    return Path, gpd, mo, pd, shapely
+    from gfv2_params.config import VPUS_DETAILED, load_base_config
+
+    return Path, VPUS_DETAILED, gpd, load_base_config, mo, pd, shapely
 
 
 @app.cell
@@ -37,20 +39,16 @@ def _(mo):
 
 
 @app.cell
-def _(Path):
-    TARGETS_DIR = Path(
-        "/caldera/hovenweep/projects/usgs/water/impd/nhgf/gfv2_param/targets"
-    )
+def _(Path, VPUS_DETAILED, load_base_config):
+    _base = load_base_config()
+    TARGETS_DIR = Path(_base["data_root"]) / "targets"
     OUTPUT_PATH = TARGETS_DIR / "gfv2_nhru_merged.gpkg"
 
-    VPUS = [
-        "01", "02", "03N", "03S", "03W",
-        "04", "05", "06", "07", "08", "09",
-        "10L", "10U",
-        "11", "12", "13", "14", "15", "16", "17", "18",
-    ]
+    VPUS = VPUS_DETAILED
 
     # Simplification tolerance in map units (EPSG:5070 → metres).
+    # 10 m preserves more detail than the legacy 100 m used by
+    # merge_and_fill_params.py --force_rebuild.
     # Set to 0 or None to skip simplification.
     SIMPLIFY_TOLERANCE = 10.0
     PRESERVE_TOPOLOGY  = True
@@ -81,10 +79,23 @@ def _(
     pd,
     shapely,
 ):
+    if not TARGETS_DIR.exists():
+        raise FileNotFoundError(
+            f"Targets directory not found: {TARGETS_DIR}\n"
+            "Verify that data_root in configs/base_config.yml is correct "
+            "and the filesystem is mounted."
+        )
+
     _gdfs = []
+    _skipped = []
 
     for _vpu in VPUS:
         _path = TARGETS_DIR / f"NHM_{_vpu}_draft.gpkg"
+        if not _path.exists():
+            print(f"VPU {_vpu:4s}: MISSING — {_path}")
+            _skipped.append(_vpu)
+            continue
+
         _gdf = gpd.read_file(_path, layer="nhru")
         _gdf["source_vpu"] = _path.stem
 
@@ -94,6 +105,13 @@ def _(
             _gdf.loc[_invalid, "geometry"] = shapely.make_valid(
                 _gdf.loc[_invalid, "geometry"].values
             )
+            # make_valid can produce GeometryCollections; extract polygons only
+            _non_poly = ~_gdf.geometry.geom_type.isin(["Polygon", "MultiPolygon"])
+            if _non_poly.any():
+                print(f"  VPU {_vpu}: {_non_poly.sum()} non-polygon geometries after make_valid, extracting polygons")
+                _gdf.loc[_non_poly, "geometry"] = _gdf.loc[_non_poly, "geometry"].apply(
+                    lambda g: shapely.ops.unary_union([p for p in getattr(g, "geoms", [g]) if p.geom_type in ("Polygon", "MultiPolygon")]) if hasattr(g, "geoms") else g
+                )
 
         # Simplify
         if SIMPLIFY_TOLERANCE:
@@ -104,6 +122,12 @@ def _(
 
         _gdfs.append(_gdf)
         print(f"VPU {_vpu:4s}: {len(_gdf):>6,} HRUs")
+
+    if not _gdfs:
+        raise RuntimeError(f"No VPU GeoPackages were successfully loaded from {TARGETS_DIR}")
+
+    if _skipped:
+        print(f"\nWARNING: {len(_skipped)} VPU(s) skipped (missing): {_skipped}")
 
     nhru = gpd.GeoDataFrame(pd.concat(_gdfs, ignore_index=True), crs=_gdfs[0].crs)
     print(f"\nTotal: {len(nhru):,} HRUs  |  CRS: {nhru.crs}")
@@ -126,6 +150,11 @@ def _(nhru):
     print(f"valid  : {n_valid:,}")
     print(f"invalid: {n_invalid:,}")
     print(f"empty  : {n_empty:,}")
+
+    if n_invalid > 0:
+        raise ValueError(f"{n_invalid} invalid geometries remain after make_valid — inspect before writing output")
+    if n_empty > 0:
+        print(f"WARNING: {n_empty} empty geometries detected — these HRUs will have no spatial extent")
     return
 
 
@@ -179,11 +208,14 @@ def _(mo):
 @app.cell
 def _(OUTPUT_PATH, nhru):
     OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+    # Write to a temp file first to avoid losing existing data if the write fails
+    _tmp = OUTPUT_PATH.with_suffix(".gpkg.tmp")
+    nhru.to_file(_tmp, layer="nhru", driver="GPKG")
+
     if OUTPUT_PATH.exists():
         OUTPUT_PATH.unlink()
-        print(f"Removed existing: {OUTPUT_PATH}")
-
-    nhru.to_file(OUTPUT_PATH, layer="nhru", driver="GPKG")
+    _tmp.rename(OUTPUT_PATH)
     print(f"Written {len(nhru):,} features → {OUTPUT_PATH}")
     return
 

--- a/scripts/merge_and_fill_params.py
+++ b/scripts/merge_and_fill_params.py
@@ -19,13 +19,15 @@ from gfv2_params.log import configure_logging
 
 
 def merge_vpu_geopackages(targets_dir, vpus, output_file, simplify_tolerance, logger):
-    logger.info("Merging VPU geopackages...")
+    logger.info("Merging VPU geopackages (legacy fallback — does not run make_valid)...")
     merged_gdfs = []
+    skipped = []
 
     for vpu in tqdm(vpus, desc="Merging VPU geopackages"):
         gpkg_file = targets_dir / f"NHM_{vpu}_draft.gpkg"
         if not gpkg_file.exists():
             logger.warning("%s not found, skipping...", gpkg_file)
+            skipped.append(vpu)
             continue
 
         gdf = gpd.read_file(gpkg_file, layer="nhru")
@@ -43,6 +45,12 @@ def merge_vpu_geopackages(targets_dir, vpus, output_file, simplify_tolerance, lo
 
     if not merged_gdfs:
         raise FileNotFoundError(f"No VPU geopackages found in {targets_dir}")
+
+    if skipped:
+        logger.warning(
+            "Only %d of %d VPU files found. Missing VPUs: %s. Output may be incomplete.",
+            len(merged_gdfs), len(vpus), skipped,
+        )
 
     merged_gdf = pd.concat(merged_gdfs, ignore_index=True)
     merged_gdf = merged_gdf.sort_values("nat_hru_id").reset_index(drop=True)
@@ -112,11 +120,13 @@ def main():
     parser.add_argument("--param_file", default=None)
     parser.add_argument("--output_dir", default=None)
     parser.add_argument("--simplify_tolerance", type=float, default=100,
-                        help="Only used with --force_rebuild (legacy VPU merge fallback).")
+                        help="Only used with --force_rebuild (legacy VPU merge fallback). "
+                             "Default 100 m; the notebook uses 10 m for higher detail.")
     parser.add_argument("--k_neighbors", type=int, default=1)
     parser.add_argument("--force_rebuild", action="store_true",
                         help="Rebuild the merged geopackage from individual VPU files "
-                             "instead of using the pre-built notebook output.")
+                             "instead of using the pre-built notebook output. "
+                             "Note: does not run make_valid on geometries (the notebook does).")
     args = parser.parse_args()
 
     logger = configure_logging("merge_and_fill_params")
@@ -151,7 +161,14 @@ def main():
         merged_gdf = merge_vpu_geopackages(targets_dir, VPUS_DETAILED, merged_gpkg, args.simplify_tolerance, logger)
     elif merged_gpkg.exists():
         logger.info("Loading pre-built merged geopackage: %s", merged_gpkg)
-        merged_gdf = gpd.read_file(merged_gpkg, layer="nhru")
+        try:
+            merged_gdf = gpd.read_file(merged_gpkg, layer="nhru")
+        except Exception as exc:
+            raise RuntimeError(
+                f"Failed to read merged geopackage: {merged_gpkg}\n"
+                "The file may be corrupt. Re-run notebooks/merge_vpu_targets.py "
+                "or pass --force_rebuild."
+            ) from exc
         logger.info("Loaded %d features", len(merged_gdf))
     else:
         raise FileNotFoundError(

--- a/tests/test_merge_and_fill_params.py
+++ b/tests/test_merge_and_fill_params.py
@@ -1,0 +1,271 @@
+"""Tests for scripts/merge_and_fill_params.py"""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import geopandas as gpd
+import numpy as np
+import pandas as pd
+import pytest
+from shapely.geometry import Point, box
+
+# We need to import the functions from the script.
+# Since scripts/ is not a package, import via importlib.
+import importlib.util
+
+_spec = importlib.util.spec_from_file_location(
+    "merge_and_fill_params",
+    Path(__file__).resolve().parent.parent / "scripts" / "merge_and_fill_params.py",
+)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+merge_vpu_geopackages = _mod.merge_vpu_geopackages
+find_missing_ids = _mod.find_missing_ids
+fill_missing_values_knn = _mod.fill_missing_values_knn
+
+
+# ---------------------------------------------------------------------------
+# find_missing_ids
+# ---------------------------------------------------------------------------
+
+class TestFindMissingIds:
+    def test_finds_missing_ids(self, tmp_path):
+        import logging
+        logger = logging.getLogger("test")
+        csv = tmp_path / "params.csv"
+        df = pd.DataFrame({"nat_hru_id": [1, 2, 4, 5], "val": [10, 20, 40, 50]})
+        df.to_csv(csv, index=False)
+
+        param_df, missing = find_missing_ids(csv, 5, logger)
+        assert missing == [3]
+        assert len(param_df) == 4
+
+    def test_no_missing_ids(self, tmp_path):
+        import logging
+        logger = logging.getLogger("test")
+        csv = tmp_path / "params.csv"
+        df = pd.DataFrame({"nat_hru_id": [1, 2, 3], "val": [10, 20, 30]})
+        df.to_csv(csv, index=False)
+
+        _, missing = find_missing_ids(csv, 3, logger)
+        assert missing == []
+
+    def test_all_missing(self, tmp_path):
+        import logging
+        logger = logging.getLogger("test")
+        csv = tmp_path / "params.csv"
+        # Empty dataframe with the right columns
+        df = pd.DataFrame({"nat_hru_id": pd.Series(dtype=int), "val": pd.Series(dtype=float)})
+        df.to_csv(csv, index=False)
+
+        _, missing = find_missing_ids(csv, 3, logger)
+        assert missing == [1, 2, 3]
+
+
+# ---------------------------------------------------------------------------
+# Merged gpkg path resolution (main function logic)
+# ---------------------------------------------------------------------------
+
+class TestMergedGpkgPathResolution:
+    def test_default_path_uses_new_filename(self, tmp_path):
+        """Default merged gpkg should be gfv2_nhru_merged.gpkg, not the old name."""
+        targets_dir = tmp_path / "targets"
+        targets_dir.mkdir()
+        # The default path should use the new name
+        expected = targets_dir / "gfv2_nhru_merged.gpkg"
+        # Verify old name is NOT used
+        old_name = targets_dir / "gfv2_merged_simplified.gpkg"
+        assert expected.name == "gfv2_nhru_merged.gpkg"
+        assert expected.name != old_name.name
+
+    def test_merged_gpkg_override(self, tmp_path):
+        """--merged_gpkg should be used directly when provided."""
+        custom_path = tmp_path / "my_custom_merged.gpkg"
+        merged_gpkg = Path(custom_path)
+        assert merged_gpkg == custom_path
+
+
+# ---------------------------------------------------------------------------
+# FileNotFoundError when merged gpkg missing
+# ---------------------------------------------------------------------------
+
+class TestFileNotFoundBehavior:
+    def test_raises_when_gpkg_missing_and_no_force_rebuild(self, tmp_path):
+        """When merged gpkg doesn't exist and force_rebuild is False, should raise."""
+        merged_gpkg = tmp_path / "nonexistent.gpkg"
+        assert not merged_gpkg.exists()
+
+        # Simulate the branch logic from main()
+        force_rebuild = False
+        with pytest.raises(FileNotFoundError, match="notebooks/merge_vpu_targets.py"):
+            if force_rebuild:
+                pass  # would rebuild
+            elif merged_gpkg.exists():
+                pass  # would load
+            else:
+                raise FileNotFoundError(
+                    f"Merged geopackage not found: {merged_gpkg}\n"
+                    "Run the notebooks/merge_vpu_targets.py notebook to produce it, "
+                    "or pass --force_rebuild to build from individual VPU files."
+                )
+
+    def test_error_message_mentions_force_rebuild(self, tmp_path):
+        merged_gpkg = tmp_path / "nonexistent.gpkg"
+        with pytest.raises(FileNotFoundError, match="--force_rebuild"):
+            if not merged_gpkg.exists():
+                raise FileNotFoundError(
+                    f"Merged geopackage not found: {merged_gpkg}\n"
+                    "Run the notebooks/merge_vpu_targets.py notebook to produce it, "
+                    "or pass --force_rebuild to build from individual VPU files."
+                )
+
+
+# ---------------------------------------------------------------------------
+# Three-way branch logic
+# ---------------------------------------------------------------------------
+
+class TestThreeWayBranch:
+    def test_force_rebuild_takes_priority_over_existing_file(self, tmp_path):
+        """force_rebuild should trigger rebuild even when file exists."""
+        merged_gpkg = tmp_path / "merged.gpkg"
+        merged_gpkg.touch()  # file exists
+
+        path_taken = None
+        force_rebuild = True
+
+        if force_rebuild:
+            path_taken = "rebuild"
+        elif merged_gpkg.exists():
+            path_taken = "load"
+        else:
+            path_taken = "error"
+
+        assert path_taken == "rebuild"
+
+    def test_loads_existing_when_no_force_rebuild(self, tmp_path):
+        merged_gpkg = tmp_path / "merged.gpkg"
+        merged_gpkg.touch()
+
+        path_taken = None
+        force_rebuild = False
+
+        if force_rebuild:
+            path_taken = "rebuild"
+        elif merged_gpkg.exists():
+            path_taken = "load"
+        else:
+            path_taken = "error"
+
+        assert path_taken == "load"
+
+    def test_errors_when_missing_and_no_force_rebuild(self, tmp_path):
+        merged_gpkg = tmp_path / "nonexistent.gpkg"
+
+        path_taken = None
+        force_rebuild = False
+
+        if force_rebuild:
+            path_taken = "rebuild"
+        elif merged_gpkg.exists():
+            path_taken = "load"
+        else:
+            path_taken = "error"
+
+        assert path_taken == "error"
+
+
+# ---------------------------------------------------------------------------
+# merge_vpu_geopackages
+# ---------------------------------------------------------------------------
+
+class TestMergeVpuGeopackages:
+    def _make_vpu_gpkg(self, path, n_features=5, start_id=1):
+        gdf = gpd.GeoDataFrame(
+            {"nat_hru_id": range(start_id, start_id + n_features)},
+            geometry=[box(i, i, i + 1, i + 1) for i in range(n_features)],
+            crs="EPSG:5070",
+        )
+        gdf.to_file(path, layer="nhru", driver="GPKG")
+
+    def test_merges_multiple_vpus(self, tmp_path):
+        import logging
+        logger = logging.getLogger("test")
+
+        self._make_vpu_gpkg(tmp_path / "NHM_01_draft.gpkg", 3, 1)
+        self._make_vpu_gpkg(tmp_path / "NHM_02_draft.gpkg", 2, 4)
+
+        out = tmp_path / "merged.gpkg"
+        result = merge_vpu_geopackages(tmp_path, ["01", "02"], out, 0, logger)
+        assert len(result) == 5
+        assert out.exists()
+
+    def test_raises_when_no_vpus_found(self, tmp_path):
+        import logging
+        logger = logging.getLogger("test")
+
+        with pytest.raises(FileNotFoundError, match="No VPU geopackages"):
+            merge_vpu_geopackages(tmp_path, ["99"], tmp_path / "out.gpkg", 0, logger)
+
+    def test_warns_on_partial_vpus(self, tmp_path):
+        import logging
+        logger = logging.getLogger("test")
+
+        self._make_vpu_gpkg(tmp_path / "NHM_01_draft.gpkg", 3, 1)
+        # VPU 02 is missing
+
+        out = tmp_path / "merged.gpkg"
+        result = merge_vpu_geopackages(tmp_path, ["01", "02"], out, 0, logger)
+        # Should succeed but only have VPU 01 data
+        assert len(result) == 3
+
+
+# ---------------------------------------------------------------------------
+# fill_missing_values_knn
+# ---------------------------------------------------------------------------
+
+class TestFillMissingValuesKnn:
+    def test_knn_fills_with_nearest_value(self):
+        import logging
+        logger = logging.getLogger("test")
+
+        # Create a merged GeoDataFrame with known positions
+        merged_gdf = gpd.GeoDataFrame(
+            {
+                "nat_hru_id": [1, 2, 3],
+                "vpu": ["01", "01", "01"],
+            },
+            geometry=[Point(0, 0), Point(10, 0), Point(5, 0)],
+            crs="EPSG:5070",
+        )
+
+        # Param file has IDs 1 and 2 but not 3
+        param_df = pd.DataFrame({
+            "nat_hru_id": [1, 2],
+            "hru_id": [1, 2],
+            "my_param": [100.0, 200.0],
+        })
+
+        result = fill_missing_values_knn(param_df, [3], merged_gdf, "my_param", 1, logger)
+        assert len(result) == 3
+        assert 3 in result["nat_hru_id"].values
+
+        # ID 3 is at (5,0), equidistant from 1 and 2 but k=1 picks one
+        filled_val = result.loc[result["nat_hru_id"] == 3, "my_param"].iloc[0]
+        assert filled_val in [100.0, 200.0]
+
+    def test_knn_no_missing_returns_original(self):
+        import logging
+        logger = logging.getLogger("test")
+
+        merged_gdf = gpd.GeoDataFrame(
+            {"nat_hru_id": [1], "vpu": ["01"]},
+            geometry=[Point(0, 0)],
+            crs="EPSG:5070",
+        )
+        param_df = pd.DataFrame({"nat_hru_id": [1], "my_param": [42.0]})
+
+        result = fill_missing_values_knn(param_df, [], merged_gdf, "my_param", 1, logger)
+        assert len(result) == 1
+        assert result["my_param"].iloc[0] == 42.0


### PR DESCRIPTION
Closes #20 

## Summary

Introduces a marimo notebook to produce a single canonical merged nhru geopackage, and aligns the downstream KNN gap-filling script to consume it rather than rebuilding the geometry on every run.

## Changes

### `notebooks/merge_vpu_targets.py` (new)
- Merges all 21 VPU `nhru` layers into `targets/gfv2_nhru_merged.gpkg`
- Applies `shapely.make_valid` before simplification (10 m tolerance, EPSG:5070)
- Validates `nat_hru_id` contiguity — confirmed 1–361,471, no gaps or duplicates

### `scripts/merge_and_fill_params.py`
- Default merged gpkg changed from `gfv2_merged_simplified.gpkg` → `gfv2_nhru_merged.gpkg`
- Add `--merged_gpkg` CLI argument to override the path
- Add `--force_rebuild` flag to fall back to legacy per-VPU inline merge
- Raise `FileNotFoundError` with a helpful message pointing to the notebook when the file is missing and `--force_rebuild` is not set
- Improve module docstring

### `README.md`
- Add *Output Directory Structure* section documenting the full `gfv2_param/` data tree and the role of `gfv2_nhru_merged.gpkg`

## Testing

Run the notebook once to produce `targets/gfv2_nhru_merged.gpkg`, then verify `merge_and_fill_params.py` picks it up without `--force_rebuild`.