### PR TITLE
fix: correct nodata declaration in merge_rpu_by_vpu.py

### DIFF
--- a/scripts/merge_rpu_by_vpu.py
+++ b/scripts/merge_rpu_by_vpu.py
@@ -74,15 +74,20 @@ def main():
                 merged = merged.astype("float32")
                 merged = merged.where(~merged.isnull(), nodata_val)
                 merged = merged / 100.0
+                # After ÷100 the fill pixels are -99.99, not -9999.
+                # Declare the actual fill value so downstream consumers
+                # (build_vrt.py, compute_slope_aspect.py) can trust the metadata.
+                nodata_val = nodata_val / 100.0  # -99.99
                 merged.rio.write_nodata(nodata_val, inplace=True)
-                logger.info("Converted NEDSnapshot from centimeters to meters.")
+                logger.info("Converted NEDSnapshot from centimeters to meters (nodata=%.2f).", nodata_val)
 
             case "Hydrodem":
                 nodata_val = -9999
                 merged = merged.astype("float32")
                 merged = merged.where(~merged.isnull(), nodata_val)
                 merged = merged / 100.0
-                logger.info("Converted Hydrodem from centimeters to meters.")
+                nodata_val = nodata_val / 100.0  # -99.99
+                logger.info("Converted Hydrodem from centimeters to meters (nodata=%.2f).", nodata_val)
 
             case "FdrFac_Fdr":
                 nodata_val = 255


### PR DESCRIPTION
Closes #28

## Summary

`merge_rpu_by_vpu.py` now declares `nodata=-99.99` after dividing DEM values by 100 (cm → m), matching the actual fill pixel values. Previously the metadata declared `-9999` while pixels held `-99.99`, causing any downstream consumer trusting GDAL metadata to silently treat the VPU padding region as valid data.

Applied to both NEDSnapshot and Hydrodem cases. FdrFac datasets are unaffected (no division).

## What changed

Single file: `scripts/merge_rpu_by_vpu.py` (+7/-2 lines)

After `merged = merged / 100.0`, update `nodata_val = nodata_val / 100.0` so that `write_nodata` declares the actual fill value. Downstream consumers (`build_vrt.py`, `compute_slope_aspect.py`) already use `-99.99` via PR #27.

## Impact

- Requires re-running `merge_rpu_by_vpu.py --force` for all VPUs to regenerate tiles with correct metadata
- No downstream code changes needed (PR #27 already handles `-99.99`)

## Test plan

- [x] `pytest tests/` — 82 tests pass
- [ ] Re-run `merge_rpu_by_vpu.py --force` on a test VPU, verify `gdalinfo` shows `NoData Value=-99.99`

🤖 Generated with [Claude Code](https://claude.com/claude-code)