### PR TITLE
feat: Copernicus GLO-30 border DEM fill for Canada/Mexico HRUs

### DIFF
--- a/scripts/build_border_dem.py
+++ b/scripts/build_border_dem.py
@@ -25,11 +25,11 @@ BORDER_ZONES = {
     "mexico": (25.0, 33.0, -118.0, -96.0),
 }
 
-# Copernicus GLO-30 nodata: the COG tiles declare nodata=0 in their metadata.
-# Sea-level pixels along coastlines could legitimately be 0, but the border
-# zones (Great Lakes, Rio Grande) are inland so this is not a practical concern.
-# Where NHDPlus has valid data it takes priority via VRT source ordering anyway.
-COPERNICUS_NODATA = 0
+# Copernicus GLO-30 nodata: the COG tiles declare NO nodata value (None).
+# We do not set srcNodata in gdal.Warp — all Copernicus pixel values
+# (including legitimate 0m sea-level elevations) pass through as-is.
+# The VRT source ordering ensures NHDPlus takes priority wherever it has
+# valid data; Copernicus only contributes in the border gaps.
 
 # Output nodata must match the pipeline convention (build_vrt.py srcNodata).
 OUTPUT_NODATA = -9999
@@ -108,7 +108,6 @@ def main():
             xRes=30,
             yRes=30,
             resampleAlg="bilinear",
-            srcNodata=COPERNICUS_NODATA,
             dstNodata=OUTPUT_NODATA,
             outputType=gdal.GDT_Float32,
             creationOptions=[

--- a/scripts/build_border_dem.py
+++ b/scripts/build_border_dem.py
@@ -25,9 +25,10 @@ BORDER_ZONES = {
     "mexico": (25.0, 33.0, -118.0, -96.0),
 }
 
-# Copernicus GLO-30 nodata: the COG tiles typically have no declared nodata,
-# but ocean/void pixels are 0.  Since border zones are inland (Great Lakes,
-# Rio Grande), legitimate 0-elevation pixels are unlikely.
+# Copernicus GLO-30 nodata: the COG tiles declare nodata=0 in their metadata.
+# Sea-level pixels along coastlines could legitimately be 0, but the border
+# zones (Great Lakes, Rio Grande) are inland so this is not a practical concern.
+# Where NHDPlus has valid data it takes priority via VRT source ordering anyway.
 COPERNICUS_NODATA = 0
 
 # Output nodata must match the pipeline convention (build_vrt.py srcNodata).
@@ -63,7 +64,7 @@ def main():
     aspect_out = fill_dir / "NEDSnapshot_merged_aspect_copernicus.tif"
 
     # --- Step 1: Compute tile list and download ---
-    logger.info("=== Step 1/4: Download Copernicus GLO-30 tiles ===")
+    logger.info("=== Step 1/3: Download Copernicus GLO-30 tiles ===")
     all_labels = []
     for zone_name, (south, north, west, east) in BORDER_ZONES.items():
         labels = tiles_for_bbox(south, north, west, east)
@@ -83,8 +84,8 @@ def main():
         logger.error("No tiles downloaded — cannot build border DEM")
         return
 
-    # --- Step 2: Mosaic raw tiles into a temporary VRT ---
-    logger.info("=== Step 2/4: Mosaic → reproject to EPSG:5070 ===")
+    # --- Step 2: Mosaic raw tiles and reproject ---
+    logger.info("=== Step 2/3: Mosaic → reproject to EPSG:5070 ===")
     raw_vrt = fill_dir / "copernicus_raw.vrt"
     vrt_ds = gdal.BuildVRT(
         str(raw_vrt),
@@ -96,7 +97,7 @@ def main():
     del vrt_ds
     logger.info("  Raw VRT: %s (%d sources)", raw_vrt, len(tile_paths))
 
-    # --- Step 3: Warp to EPSG:5070, 30m, nodata=-9999 ---
+    # Warp to EPSG:5070, 30m, nodata=-9999
     if not elev_out.exists() or args.force:
         logger.info("  Warping to EPSG:5070 at 30m (bilinear)...")
         t2 = time.time()
@@ -127,9 +128,9 @@ def main():
     else:
         logger.info("  Elevation fill already exists: %s", elev_out)
 
-    # --- Step 4: Compute slope and aspect via RichDEM ---
+    # --- Step 3: Compute slope and aspect via RichDEM ---
     if not slope_out.exists() or not aspect_out.exists() or args.force:
-        logger.info("=== Step 3/4: Compute slope/aspect via RichDEM ===")
+        logger.info("=== Step 3/3: Compute slope/aspect via RichDEM ===")
         logger.info("  Loading DEM: %s", elev_out)
         t3 = time.time()
         dem = rd.LoadGDAL(str(elev_out), no_data=OUTPUT_NODATA)
@@ -147,8 +148,10 @@ def main():
     else:
         logger.info("  Slope/aspect outputs already exist — skipping")
 
-    # Clean up raw VRT (intermediate)
-    raw_vrt.unlink(missing_ok=True)
+    # Clean up raw VRT (intermediate, only if we created it this run)
+    if raw_vrt.exists():
+        raw_vrt.unlink()
+        logger.info("  Cleaned up intermediate VRT: %s", raw_vrt)
 
     logger.info("=== build_border_dem complete in %s ===", _elapsed(t_start))
     logger.info("  Outputs in: %s", fill_dir)

--- a/scripts/build_border_dem.py
+++ b/scripts/build_border_dem.py
@@ -1,0 +1,159 @@
+"""Build Copernicus GLO-30 elevation fill for border HRUs (Canada/Mexico).
+
+Downloads Copernicus 30m tiles covering border zones, mosaics them,
+reprojects to EPSG:5070 at 30m, and computes slope/aspect via RichDEM.
+The output tiles are placed in work/nhd_merged/copernicus_fill/ where
+build_vrt.py picks them up as lower-priority fill behind NHDPlus tiles.
+"""
+
+import argparse
+import time
+from pathlib import Path
+
+import richdem as rd
+from osgeo import gdal
+
+from gfv2_params.config import load_base_config
+from gfv2_params.download.copernicus_dem import download_tiles, tiles_for_bbox
+from gfv2_params.log import configure_logging
+
+# Border bounding boxes in EPSG:4326 (south, north, west, east).
+# Deliberately generous — extra ocean tiles are skipped (404) and
+# NHDPlus takes priority in overlapping areas via VRT source ordering.
+BORDER_ZONES = {
+    "canada": (41.0, 55.0, -141.0, -52.0),
+    "mexico": (25.0, 33.0, -118.0, -96.0),
+}
+
+# Copernicus GLO-30 nodata: the COG tiles typically have no declared nodata,
+# but ocean/void pixels are 0.  Since border zones are inland (Great Lakes,
+# Rio Grande), legitimate 0-elevation pixels are unlikely.
+COPERNICUS_NODATA = 0
+
+# Output nodata must match the pipeline convention (build_vrt.py srcNodata).
+OUTPUT_NODATA = -9999
+
+
+def _elapsed(t0: float) -> str:
+    secs = time.time() - t0
+    m, s = divmod(int(secs), 60)
+    return f"{m}m {s:02d}s" if m else f"{s}s"
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Build Copernicus DEM fill for border HRUs (Canada/Mexico).",
+    )
+    parser.add_argument("--base_config", default=None, help="Path to base_config.yml")
+    parser.add_argument("--force", action="store_true", help="Overwrite existing outputs")
+    args = parser.parse_args()
+
+    logger = configure_logging("build_border_dem")
+    t_start = time.time()
+
+    base = load_base_config(Path(args.base_config) if args.base_config else None)
+    data_root = Path(base["data_root"])
+
+    raw_dir = data_root / "input" / "copernicus_dem" / "raw"
+    fill_dir = data_root / "work" / "nhd_merged" / "copernicus_fill"
+    fill_dir.mkdir(parents=True, exist_ok=True)
+
+    elev_out = fill_dir / "NEDSnapshot_merged_fixed_copernicus.tif"
+    slope_out = fill_dir / "NEDSnapshot_merged_slope_copernicus.tif"
+    aspect_out = fill_dir / "NEDSnapshot_merged_aspect_copernicus.tif"
+
+    # --- Step 1: Compute tile list and download ---
+    logger.info("=== Step 1/4: Download Copernicus GLO-30 tiles ===")
+    all_labels = []
+    for zone_name, (south, north, west, east) in BORDER_ZONES.items():
+        labels = tiles_for_bbox(south, north, west, east)
+        logger.info("  %s zone: %d tiles (%.0f°N–%.0f°N, %.0f°W–%.0f°W)",
+                     zone_name, len(labels), south, north, abs(west), abs(east))
+        all_labels.extend(labels)
+
+    # Deduplicate (zones may overlap slightly)
+    all_labels = sorted(set(all_labels))
+    logger.info("  Total unique tiles: %d", len(all_labels))
+
+    t1 = time.time()
+    tile_paths = download_tiles(all_labels, raw_dir)
+    logger.info("  Download complete in %s: %d tiles available", _elapsed(t1), len(tile_paths))
+
+    if not tile_paths:
+        logger.error("No tiles downloaded — cannot build border DEM")
+        return
+
+    # --- Step 2: Mosaic raw tiles into a temporary VRT ---
+    logger.info("=== Step 2/4: Mosaic → reproject to EPSG:5070 ===")
+    raw_vrt = fill_dir / "copernicus_raw.vrt"
+    vrt_ds = gdal.BuildVRT(
+        str(raw_vrt),
+        [str(p) for p in tile_paths],
+    )
+    if vrt_ds is None:
+        raise RuntimeError("gdal.BuildVRT failed for Copernicus raw tiles")
+    vrt_ds.FlushCache()
+    del vrt_ds
+    logger.info("  Raw VRT: %s (%d sources)", raw_vrt, len(tile_paths))
+
+    # --- Step 3: Warp to EPSG:5070, 30m, nodata=-9999 ---
+    if not elev_out.exists() or args.force:
+        logger.info("  Warping to EPSG:5070 at 30m (bilinear)...")
+        t2 = time.time()
+        warp_ds = gdal.Warp(
+            str(elev_out),
+            str(raw_vrt),
+            dstSRS="EPSG:5070",
+            xRes=30,
+            yRes=30,
+            resampleAlg="bilinear",
+            srcNodata=COPERNICUS_NODATA,
+            dstNodata=OUTPUT_NODATA,
+            outputType=gdal.GDT_Float32,
+            creationOptions=[
+                "COMPRESS=LZW",
+                "PREDICTOR=2",
+                "TILED=YES",
+                "BLOCKXSIZE=512",
+                "BLOCKYSIZE=512",
+                "BIGTIFF=YES",
+            ],
+        )
+        if warp_ds is None:
+            raise RuntimeError("gdal.Warp failed")
+        warp_ds.FlushCache()
+        del warp_ds
+        logger.info("  Warp complete in %s: %s", _elapsed(t2), elev_out)
+    else:
+        logger.info("  Elevation fill already exists: %s", elev_out)
+
+    # --- Step 4: Compute slope and aspect via RichDEM ---
+    if not slope_out.exists() or not aspect_out.exists() or args.force:
+        logger.info("=== Step 3/4: Compute slope/aspect via RichDEM ===")
+        logger.info("  Loading DEM: %s", elev_out)
+        t3 = time.time()
+        dem = rd.LoadGDAL(str(elev_out), no_data=OUTPUT_NODATA)
+
+        logger.info("  Computing slope (degrees)...")
+        slope = rd.TerrainAttribute(dem, attrib="slope_degrees")
+        rd.SaveGDAL(str(slope_out), slope)
+        logger.info("  Slope saved: %s", slope_out)
+
+        logger.info("  Computing aspect...")
+        aspect = rd.TerrainAttribute(dem, attrib="aspect")
+        rd.SaveGDAL(str(aspect_out), aspect)
+        logger.info("  Aspect saved: %s", aspect_out)
+        logger.info("  Slope/aspect complete in %s", _elapsed(t3))
+    else:
+        logger.info("  Slope/aspect outputs already exist — skipping")
+
+    # Clean up raw VRT (intermediate)
+    raw_vrt.unlink(missing_ok=True)
+
+    logger.info("=== build_border_dem complete in %s ===", _elapsed(t_start))
+    logger.info("  Outputs in: %s", fill_dir)
+    logger.info("  Run build_vrt.py to rebuild VRTs with the fill layer.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/build_vrt.py
+++ b/scripts/build_vrt.py
@@ -1,8 +1,10 @@
-"""Build CONUS-wide VRT files from per-VPU merged GeoTIFFs.
+"""Build VRT files from per-VPU merged GeoTIFFs and optional fill layers.
 
 Creates GDAL virtual rasters that reference per-VPU source files,
-allowing them to be read as a single CONUS-wide raster without
-duplicating data on disk.
+allowing them to be read as a single raster without duplicating data
+on disk.  If a ``copernicus_fill`` subdirectory exists under
+``nhd_merged/``, its tiles are appended as lower-priority fill sources
+(NHDPlus VPU tiles take priority in overlapping regions).
 """
 
 import argparse
@@ -41,15 +43,34 @@ def main():
     if not nhd_merged_dir.exists():
         raise FileNotFoundError(f"NHD merged directory not found: {nhd_merged_dir}")
 
+    # Fill subdirectories whose tiles should be appended AFTER the primary
+    # NHDPlus VPU tiles.  GDAL VRT uses first-source-wins for overlapping
+    # pixels, so listing NHDPlus first ensures it takes priority and fill
+    # sources only contribute where NHDPlus has nodata.
+    FILL_DIRS = {"copernicus_fill"}
+
     built_count = 0
     for vrt_name, pattern in RASTER_TYPES.items():
-        source_files = sorted(nhd_merged_dir.glob(f"*/{pattern}"))
+        # Primary NHDPlus VPU tiles (high priority)
+        primary_files = sorted(
+            f for f in nhd_merged_dir.glob(f"*/{pattern}")
+            if f.parent.name not in FILL_DIRS
+        )
+        # Fill tiles (low priority — appended after primary)
+        fill_files = []
+        for fill_dir_name in sorted(FILL_DIRS):
+            fill_files.extend(sorted(nhd_merged_dir.glob(f"{fill_dir_name}/{pattern}")))
+
+        source_files = primary_files + fill_files
         if not source_files:
             logger.warning("No source files found for %s (pattern: */%s)", vrt_name, pattern)
             continue
 
         vrt_path = nhd_merged_dir / f"{vrt_name}.vrt"
-        logger.info("Building %s from %d source files", vrt_path, len(source_files))
+        n_fill = len(fill_files)
+        fill_msg = f" + {n_fill} fill" if n_fill else ""
+        logger.info("Building %s from %d source files (%d primary%s)",
+                     vrt_path, len(source_files), len(primary_files), fill_msg)
 
         # srcNodata tells GDAL to treat that pixel value as transparent when
         # compositing overlapping VPU source tiles.  All three types use -9999:

--- a/scripts/init_data_root.py
+++ b/scripts/init_data_root.py
@@ -62,6 +62,8 @@ _TREE = [
     ("input/lulc/nalcms_2020", None),
     ("input/nhm_default", None),
     ("input/nhd_downloads", None),
+    ("input/copernicus_dem", None),
+    ("input/copernicus_dem/raw", None),
     # ---- work (intermediates) ----------------------------------------------
     (
         "work",

--- a/slurm_batch/RUNME.md
+++ b/slurm_batch/RUNME.md
@@ -104,9 +104,23 @@ sbatch slurm_batch/merge_rpu_by_vpu.batch
 sbatch slurm_batch/compute_slope_aspect.batch
 ```
 
+### Stage 1b: Build border DEM fill (one-time)
+
+Download Copernicus GLO-30 tiles and build elevation/slope/aspect fill rasters
+for HRUs that extend into Canada or Mexico beyond NHDPlus coverage:
+
+```bash
+sbatch slurm_batch/build_border_dem.batch
+```
+
+This creates fill rasters in `work/nhd_merged/copernicus_fill/`. The subsequent
+`build_vrt.py` step composites these behind the NHDPlus tiles, so NHDPlus takes
+priority where it has valid data and Copernicus fills the border gaps. Can run
+in parallel with Stage 1.
+
 ### Stage 2a: Build VRTs (one-time)
 
-Combine per-VPU rasters into CONUS-wide virtual rasters:
+Combine per-VPU rasters and optional Copernicus fill into virtual rasters:
 
 ```bash
 python scripts/build_vrt.py --base_config configs/base_config.yml
@@ -282,6 +296,7 @@ sacct -j <JOBID> -o JobID,State,Elapsed,MaxRSS
 |---|---|---|
 | merge_rpu_by_vpu.batch | merge_rpu_by_vpu.yml | merge_rpu_by_vpu.py |
 | compute_slope_aspect.batch | slope_aspect.yml | compute_slope_aspect.py |
+| build_border_dem.batch | base_config.yml | build_border_dem.py |
 | build_derived_rasters.batch | base_config.yml | build_derived_rasters.py |
 | build_lulc_rasters.batch | lulc_nhm_v11_param.yml | build_lulc_rasters.py |
 | create_zonal_elev_params.batch | elev_param.yml | create_zonal_params.py |

--- a/slurm_batch/build_border_dem.batch
+++ b/slurm_batch/build_border_dem.batch
@@ -1,0 +1,18 @@
+#!/bin/bash
+#SBATCH -p cpu
+#SBATCH -A impd
+#SBATCH --job-name=border_dem
+#SBATCH --output=logs/job_%j.out
+#SBATCH --error=logs/job_%j.err
+#SBATCH --time=04:00:00
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=128G
+
+module load miniforge/latest
+conda activate geoenv
+
+cd "$SLURM_SUBMIT_DIR"
+BASE_CONFIG=${BASE_CONFIG:-configs/base_config.yml}
+
+python scripts/build_border_dem.py --base_config "$BASE_CONFIG"

--- a/src/gfv2_params/download/copernicus_dem.py
+++ b/src/gfv2_params/download/copernicus_dem.py
@@ -1,0 +1,109 @@
+"""Download Copernicus GLO-30 DEM tiles from AWS S3 for border gap fill.
+
+Copernicus GLO-30 provides near-global 30m elevation data as 1-degree
+Cloud-Optimized GeoTIFFs on a public S3 bucket (no credentials needed).
+
+Tile naming convention:
+    Copernicus_DSM_COG_10_{lat_label}_00_{lon_label}_00_DEM.tif
+    - lat_label: N{dd} or S{dd}  (south edge of tile, zero-padded 2 digits)
+    - lon_label: W{ddd} or E{ddd} (west edge of tile, zero-padded 3 digits)
+"""
+
+import logging
+import math
+from pathlib import Path
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+S3_BASE_URL = "https://copernicus-dem-30m.s3.eu-central-1.amazonaws.com"
+
+
+def tile_label(lat: int, lon: int) -> str:
+    """Return the Copernicus tile label for the cell whose SW corner is (lat, lon).
+
+    Parameters
+    ----------
+    lat : int
+        South edge latitude (e.g. 48 for the 48N-49N band).
+    lon : int
+        West edge longitude (e.g. -123 for the 123W-122W band).
+    """
+    lat_part = f"N{abs(lat):02d}" if lat >= 0 else f"S{abs(lat):02d}"
+    lon_part = f"E{abs(lon):03d}" if lon >= 0 else f"W{abs(lon):03d}"
+    return f"Copernicus_DSM_COG_10_{lat_part}_00_{lon_part}_00_DEM"
+
+
+def tiles_for_bbox(
+    south: float, north: float, west: float, east: float,
+) -> list[str]:
+    """Return Copernicus tile labels covering a WGS84 bounding box.
+
+    Each tile covers 1x1 degrees.  The label encodes the SW corner.
+    """
+    lat_min = math.floor(south)
+    lat_max = math.floor(north)
+    lon_min = math.floor(west)
+    lon_max = math.floor(east)
+    labels = []
+    for lat in range(lat_min, lat_max + 1):
+        for lon in range(lon_min, lon_max + 1):
+            labels.append(tile_label(lat, lon))
+    return labels
+
+
+def download_tiles(
+    tile_labels: list[str],
+    out_dir: Path,
+    timeout: int = 120,
+) -> list[Path]:
+    """Download Copernicus GLO-30 tiles to *out_dir*.
+
+    Idempotent: skips files that already exist.  Tiles that return 404
+    (ocean, polar) are logged as warnings and skipped.
+
+    Returns list of paths to successfully downloaded .tif files.
+    """
+    out_dir.mkdir(parents=True, exist_ok=True)
+    paths = []
+    skipped = 0
+
+    for i, label in enumerate(tile_labels, start=1):
+        tif_name = f"{label}.tif"
+        local_path = out_dir / tif_name
+
+        if local_path.exists():
+            paths.append(local_path)
+            skipped += 1
+            continue
+
+        url = f"{S3_BASE_URL}/{label}/{tif_name}"
+        partial = local_path.with_suffix(".tif.partial")
+
+        try:
+            with requests.get(url, stream=True, timeout=timeout) as r:
+                if r.status_code == 404:
+                    logger.debug("Tile not available (ocean/polar): %s", label)
+                    continue
+                r.raise_for_status()
+                with open(partial, "wb") as f:
+                    for chunk in r.iter_content(chunk_size=65536):
+                        f.write(chunk)
+            partial.rename(local_path)
+            paths.append(local_path)
+
+            if i % 50 == 0 or i == len(tile_labels):
+                logger.info(
+                    "Downloaded %d/%d tiles (%d skipped existing)",
+                    i, len(tile_labels), skipped,
+                )
+        except requests.RequestException as e:
+            partial.unlink(missing_ok=True)
+            logger.warning("Failed to download %s: %s", label, e)
+
+    logger.info(
+        "Download complete: %d tiles available, %d skipped (existing), %d total requested",
+        len(paths), skipped, len(tile_labels),
+    )
+    return paths

--- a/tests/test_copernicus_dem.py
+++ b/tests/test_copernicus_dem.py
@@ -1,0 +1,63 @@
+import pytest
+
+from gfv2_params.download.copernicus_dem import tile_label, tiles_for_bbox
+
+
+class TestTileLabel:
+    def test_north_west(self):
+        assert tile_label(48, -123) == "Copernicus_DSM_COG_10_N48_00_W123_00_DEM"
+
+    def test_north_east(self):
+        assert tile_label(48, 10) == "Copernicus_DSM_COG_10_N48_00_E010_00_DEM"
+
+    def test_south_west(self):
+        assert tile_label(-5, -70) == "Copernicus_DSM_COG_10_S05_00_W070_00_DEM"
+
+    def test_zero_zero(self):
+        assert tile_label(0, 0) == "Copernicus_DSM_COG_10_N00_00_E000_00_DEM"
+
+    def test_negative_lat_negative_lon(self):
+        assert tile_label(-33, -71) == "Copernicus_DSM_COG_10_S33_00_W071_00_DEM"
+
+    def test_padding(self):
+        # Single-digit lat gets zero-padded to 2 digits, lon to 3
+        label = tile_label(5, -8)
+        assert "N05" in label
+        assert "W008" in label
+
+
+class TestTilesForBbox:
+    def test_single_tile(self):
+        labels = tiles_for_bbox(48.0, 48.5, -123.0, -122.5)
+        assert len(labels) == 1
+        assert labels[0] == tile_label(48, -123)
+
+    def test_four_tiles(self):
+        # 2x2 grid: 48-50N, 123-121W
+        labels = tiles_for_bbox(48.0, 49.5, -123.0, -121.5)
+        assert len(labels) == 4
+
+    def test_exact_degree_boundary(self):
+        # Bbox from exactly 48.0 to 49.0 should cover tiles at lat 48 and 49
+        labels = tiles_for_bbox(48.0, 49.0, -123.0, -122.0)
+        lats = {48, 49}
+        lons = {-123, -122}
+        assert len(labels) == len(lats) * len(lons)
+
+    def test_no_duplicates(self):
+        labels = tiles_for_bbox(41.0, 55.0, -141.0, -52.0)
+        assert len(labels) == len(set(labels))
+
+    def test_canada_zone_count(self):
+        # Canada border zone: 41-55N, 141-52W
+        labels = tiles_for_bbox(41.0, 55.0, -141.0, -52.0)
+        expected_lats = 55 - 41 + 1  # 15
+        expected_lons = -52 - (-141) + 1  # 90
+        assert len(labels) == expected_lats * expected_lons
+
+    def test_mexico_zone_count(self):
+        # Mexico border zone: 25-33N, 118-96W
+        labels = tiles_for_bbox(25.0, 33.0, -118.0, -96.0)
+        expected_lats = 33 - 25 + 1  # 9
+        expected_lons = -96 - (-118) + 1  # 23
+        assert len(labels) == expected_lats * expected_lons


### PR DESCRIPTION
## Summary

The gfv2 fabric has HRUs extending into Canada and Mexico, but NHDPlus DEMs only cover US territory. These border HRUs previously had no elevation data and received incorrect KNN-interpolated values. This adds a Copernicus GLO-30 fill layer that composites behind NHDPlus tiles in the VRT.

## How it works

1. **Download**: `copernicus_dem.py` downloads 30m GLO-30 tiles from public AWS S3 for Canada/Mexico border zones (~700 tiles, idempotent, handles 404 ocean tiles)
2. **Mosaic + Reproject**: `build_border_dem.py` builds a VRT from raw tiles, then `gdal.Warp` reprojects to EPSG:5070 at 30m with `nodata=-9999`
3. **Slope/Aspect**: RichDEM computes slope and aspect from the reprojected DEM
4. **VRT Priority**: `build_vrt.py` lists NHDPlus VPU tiles first, Copernicus fill tiles last — GDAL first-source-wins ensures NHDPlus takes priority and Copernicus fills only the border gaps

## New files

- `src/gfv2_params/download/copernicus_dem.py` — tile naming, bounding box → tile list, HTTPS download
- `scripts/build_border_dem.py` — orchestration: download → mosaic → warp → RichDEM
- `slurm_batch/build_border_dem.batch` — SLURM wrapper (Stage 1b, can run in parallel with Stage 1)

## Modified files

- `scripts/build_vrt.py` — source ordering: primary VPU tiles first, `copernicus_fill` last
- `scripts/init_data_root.py` — scaffold `input/copernicus_dem/raw/`
- `slurm_batch/RUNME.md` — Stage 1b docs + mapping table

## Notes

- Copernicus uses EGM2008 geoid heights vs NHDPlus NAVD88 — ~1-2m offset at borders. Irrelevant for slope/aspect; acceptable for elevation given the alternative (KNN interpolation)
- Border bounding boxes are deliberately generous; ocean tiles return 404 and are skipped
- Memory: RichDEM loads full raster into RAM. If the border mosaic exceeds 128G, can split into Canada/Mexico as separate rasters (VRT glob picks up both)

## Test plan

- [x] `pytest tests/` — 82 tests pass
- [x] `copernicus_dem.py` import and basic functions verified
- [ ] HPC: run `build_border_dem.py` and verify output in `work/nhd_merged/copernicus_fill/`
- [ ] Rebuild VRTs and verify border HRUs get elevation values

🤖 Generated with [Claude Code](https://claude.com/claude-code)