### PR TITLE
feat: port depression-storage workflow + operational follow-ups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,6 +180,7 @@ cython_debug/
 output/
 logs/
 
-# stray working copies at repo root (canonical homes are scripts/ and src/)
-/create_lulc_params.py
-/gfv2_params/
+# abock's stray working copies, renamed out of the way so they don't shadow
+# imports from the repo root (canonical homes are scripts/ and src/)
+/_gfv2_params_legacy/
+/_create_lulc_params_legacy.py

--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,7 @@ cython_debug/
 # repo specific
 output/
 logs/
+
+# stray working copies at repo root (canonical homes are scripts/ and src/)
+/create_lulc_params.py
+/gfv2_params/

--- a/configs/depstor_dprst_raster.yml
+++ b/configs/depstor_dprst_raster.yml
@@ -1,0 +1,12 @@
+# Combine the three depstor binary inputs into the dprst (depression-storage)
+# and on-stream-storage rasters. Region-level masking: a wbody region must NOT
+# touch the stream buffer or impervious mask in any cell to qualify as
+# depression storage.
+
+template_raster: "{data_root}/work/nhd_merged/elevation.vrt"
+wbody_binary_raster: "{data_root}/{fabric}/depstor_rasters/wbody_binary.tif"
+wbody_regions_raster: "{data_root}/{fabric}/depstor_rasters/wbody_regions.tif"
+stream_buffer_raster: "{data_root}/{fabric}/depstor_rasters/stream_buffer.tif"
+imperv_raster: "{data_root}/{fabric}/depstor_rasters/imperv_binary.tif"
+dprst_raster: "{data_root}/{fabric}/depstor_rasters/dprst_binary.tif"
+onstream_raster: "{data_root}/{fabric}/depstor_rasters/onstream_binary.tif"

--- a/configs/depstor_imperv_raster.yml
+++ b/configs/depstor_imperv_raster.yml
@@ -1,0 +1,11 @@
+# Build the depression-storage imperviousness binary raster.
+#
+# Threshold the staged Imperv.tif and snap to the elevation-VRT grid.
+# Cells with imperv >= imperv_threshold (percent) are marked 1; otherwise 255 (nodata).
+# Output is a fabric-scoped uint8 binary GeoTIFF used downstream by
+# build_depstor_dprst.py and aggregated per HRU via create_zonal_params.py.
+
+template_raster: "{data_root}/work/nhd_merged/elevation.vrt"
+imperv_raster: "{data_root}/input/lulc_veg/Imperv.tif"
+output_raster: "{data_root}/{fabric}/depstor_rasters/imperv_binary.tif"
+imperv_threshold: 50

--- a/configs/depstor_routing_raster.yml
+++ b/configs/depstor_routing_raster.yml
@@ -1,0 +1,13 @@
+# Build the drains-to-depression binary raster via WhiteboxTools Watershed.
+#
+# Requires a per-fabric staged FDR raster (D8 flow direction, Esri pointer
+# encoding) at `input/depstor/{fabric}_fdr.tif`. The FDR is reprojected onto
+# the dprst grid (rioxarray.reproject_match), then WhiteboxTools delineates
+# which depression each cell drains into. The resulting per-depression labels
+# are collapsed to uint8 binary (1 = drains to any depression, 255 = no/nodata).
+
+template_raster: "{data_root}/work/nhd_merged/elevation.vrt"
+fdr_raster: "{data_root}/input/depstor/{fabric}_fdr.tif"
+dprst_raster: "{data_root}/{fabric}/depstor_rasters/dprst_binary.tif"
+output_raster: "{data_root}/{fabric}/depstor_rasters/drains_to_dprst.tif"
+keep_intermediates: false

--- a/configs/depstor_streambuffer_raster.yml
+++ b/configs/depstor_streambuffer_raster.yml
@@ -1,0 +1,11 @@
+# Build the depression-storage stream-buffer binary raster.
+#
+# Reads the staged fabric-specific segments+wbodies gpkg and rasterizes a
+# `buffer_distance`-metre buffer around each stream segment onto the
+# elevation-VRT template grid.
+
+template_raster: "{data_root}/work/nhd_merged/elevation.vrt"
+segments_gpkg: "{data_root}/input/depstor/{fabric}_segments_wbodies.gpkg"
+segments_layer: nsegment
+output_raster: "{data_root}/{fabric}/depstor_rasters/stream_buffer.tif"
+buffer_distance: 60

--- a/configs/depstor_waterbody_raster.yml
+++ b/configs/depstor_waterbody_raster.yml
@@ -1,0 +1,15 @@
+# Build the depression-storage water-body binary raster + connected-component
+# region labels.
+#
+# Reads the staged fabric-specific segments+wbodies gpkg, filters wbodies by
+# minimum area, and burns them onto the elevation-VRT template grid. A
+# scipy.ndimage.label pass (8-connectivity) gives each connected wbody a unique
+# region ID — used downstream by build_depstor_dprst.py to apply region-level
+# masks (a region is excluded entirely if any cell touches a stream/imperv).
+
+template_raster: "{data_root}/work/nhd_merged/elevation.vrt"
+waterbody_gpkg: "{data_root}/input/depstor/{fabric}_segments_wbodies.gpkg"
+waterbody_layer: v2_wb
+wbody_binary_raster: "{data_root}/{fabric}/depstor_rasters/wbody_binary.tif"
+wbody_regions_raster: "{data_root}/{fabric}/depstor_rasters/wbody_regions.tif"
+min_area_threshold: 900.0

--- a/configs/dprst_frac_param.yml
+++ b/configs/dprst_frac_param.yml
@@ -1,0 +1,13 @@
+# Per-HRU depression-storage fraction.
+# Aggregates dprst_binary.tif (uint8 0/1) per HRU via gdptools exactextract.
+# With categorical=false on a binary uint8 raster, the per-HRU mean is the
+# fraction of the HRU covered by depression storage cells.
+
+source_type: dprst_frac
+source_raster: "{data_root}/{fabric}/depstor_rasters/dprst_binary.tif"
+batch_dir: "{data_root}/{fabric}/batches"
+target_layer: nhru
+id_feature: nat_hru_id
+output_dir: "{data_root}/{fabric}/params"
+merged_file: nhm_dprst_frac_params.csv
+categorical: false

--- a/configs/drains_to_dprst_frac_param.yml
+++ b/configs/drains_to_dprst_frac_param.yml
@@ -1,0 +1,13 @@
+# Per-HRU drains-to-depression fraction.
+# Aggregates drains_to_dprst.tif (uint8 0/1) produced by the WhiteboxTools
+# Watershed step. Per-HRU mean = fraction of HRU cells whose D8 flow path
+# terminates in a depression-storage cell.
+
+source_type: drains_to_dprst_frac
+source_raster: "{data_root}/{fabric}/depstor_rasters/drains_to_dprst.tif"
+batch_dir: "{data_root}/{fabric}/batches"
+target_layer: nhru
+id_feature: nat_hru_id
+output_dir: "{data_root}/{fabric}/params"
+merged_file: nhm_drains_to_dprst_frac_params.csv
+categorical: false

--- a/configs/imperv_frac_param.yml
+++ b/configs/imperv_frac_param.yml
@@ -1,0 +1,12 @@
+# Per-HRU impervious fraction (analogous to PRMS hru_percent_imperv).
+# Aggregates imperv_binary.tif (uint8 0/1, threshold = 50% by default).
+# Per-HRU mean = fraction of HRU at or above the impervious threshold.
+
+source_type: imperv_frac
+source_raster: "{data_root}/{fabric}/depstor_rasters/imperv_binary.tif"
+batch_dir: "{data_root}/{fabric}/batches"
+target_layer: nhru
+id_feature: nat_hru_id
+output_dir: "{data_root}/{fabric}/params"
+merged_file: nhm_imperv_frac_params.csv
+categorical: false

--- a/configs/lulc_nalcms_param.yml
+++ b/configs/lulc_nalcms_param.yml
@@ -3,8 +3,8 @@ lulc_source: nalcms
 scenario: observed
 year: 2020
 
-source_raster: "{data_root}/input/lulc_veg/{lulc_source}/nalcms_{year}_land_cover.tif"
-canopy_raster: "{data_root}/input/lulc_veg/{lulc_source}/nalcms_{year}_tree_canopy.tif"
+source_raster: "{data_root}/input/lulc/{lulc_source}_{year}/NA_NALCMS_landcover_2020v2_30m.tif"
+canopy_raster: "{data_root}/input/lulc_veg/CNPY.tif"
 # No keep raster for NALCMS; evergreen retention derived from crosswalk
 crosswalk_file: "crosswalks/nalcms_nhm.csv"
 

--- a/configs/onstream_storage_frac_param.yml
+++ b/configs/onstream_storage_frac_param.yml
@@ -1,0 +1,13 @@
+# Per-HRU on-stream-storage fraction.
+# Aggregates onstream_binary.tif (uint8 0/1) — water-body cells whose region
+# touches a stream buffer or impervious mask, hence excluded from dprst.
+# Per-HRU mean = fraction of HRU covered by on-stream water-body storage.
+
+source_type: onstream_storage_frac
+source_raster: "{data_root}/{fabric}/depstor_rasters/onstream_binary.tif"
+batch_dir: "{data_root}/{fabric}/batches"
+target_layer: nhru
+id_feature: nat_hru_id
+output_dir: "{data_root}/{fabric}/params"
+merged_file: nhm_onstream_storage_frac_params.csv
+categorical: false

--- a/environment.yml
+++ b/environment.yml
@@ -11,4 +11,5 @@ dependencies:
   - llvmlite
   - richdem
   - exactextract
+  - scipy
   - pip

--- a/environment.yml
+++ b/environment.yml
@@ -13,3 +13,5 @@ dependencies:
   - exactextract
   - scipy
   - pip
+  - pip:
+    - -e .

--- a/notebooks/check_border_dem.py
+++ b/notebooks/check_border_dem.py
@@ -181,6 +181,7 @@ def _(
     _cmaps = {"elevation": "terrain", "slope": "YlOrRd", "aspect": "hsv"}
     _units = {"elevation": "m", "slope": "degrees", "aspect": "degrees"}
 
+    _out = None
     if _vrt_path.exists():
         _data, _, _meta = windowed_decimated_read(_vrt_path, _bounds)
         _stretched, _vmin, _vmax = percentile_stretch(_data)
@@ -209,7 +210,7 @@ def _(
         _ax_hist.set_ylabel("density")
 
         _h, _w = _meta["shape"]
-        _info = (
+        _text = (
             f"Full grid : {_h:,} x {_w:,} px\n"
             f"Pixel size: {_meta['res_m']:.1f} m\n"
             f"NoData    : {_meta['nodata']}\n"
@@ -219,14 +220,15 @@ def _(
             f"Max       : {_valid.max():.4g}"
         )
         _ax_img.text(
-            1.01, 0.5, _info, transform=_ax_img.transAxes, fontsize=8,
+            1.01, 0.5, _text, transform=_ax_img.transAxes, fontsize=8,
             verticalalignment="center", family="monospace",
             bbox=dict(boxstyle="round", facecolor="lightyellow", alpha=0.8),
         )
         plt.tight_layout()
-        _fig
+        _out = _fig
     else:
         print(f"VRT not found: {_vrt_path}")
+    _out
 
 
 @app.cell
@@ -251,6 +253,7 @@ def _(
         for name, cmap, units in _layers
         if (NHD_MERGED / f"{name}.vrt").exists()
     ]
+    _out = None
     if _available:
         _fig, _axes = plt.subplots(
             1, len(_available), figsize=(8 * len(_available), 6),
@@ -271,9 +274,10 @@ def _(
             plt.colorbar(_im, ax=_ax, fraction=0.03, pad=0.02, label=_units)
         plt.suptitle("Slope/Aspect — check for seam artifacts", fontsize=13)
         plt.tight_layout()
-        _fig
+        _out = _fig
     else:
         print("No slope/aspect VRTs found yet.")
+    _out
 
 
 @app.cell
@@ -292,6 +296,7 @@ def _(mo):
 @app.cell
 def _(FABRIC_DIR, gpd, mo, np, plt):
     _merged_gpkg = FABRIC_DIR / "gfv2_nhru_merged.gpkg"
+    _out = None
     if _merged_gpkg.exists():
         _gdf = gpd.read_file(_merged_gpkg, layer="nhru")
         _gdf["centroid_y"] = _gdf.geometry.centroid.y
@@ -306,7 +311,7 @@ def _(FABRIC_DIR, gpd, mo, np, plt):
         _n_mexico = _mexico_mask.sum()
         _n_total = len(_gdf)
 
-        mo.md(
+        _info = mo.md(
             f"**Fabric:** {_n_total:,} total HRUs | "
             f"**Canada border:** {_n_canada:,} | "
             f"**Mexico border:** {_n_mexico:,}"
@@ -329,9 +334,12 @@ def _(FABRIC_DIR, gpd, mo, np, plt):
             _ax.set_title("Border HRUs identified by centroid latitude")
             _ax.axis("off")
             plt.tight_layout()
-            _fig
+            _out = mo.vstack([_info, _fig])
+        else:
+            _out = _info
     else:
         print(f"Merged fabric not found: {_merged_gpkg}")
+    _out
 
 
 @app.cell
@@ -368,6 +376,7 @@ def _(
             mask=~_both_valid,
         )
 
+        _out = None
         if _diff.count() > 0:
             _valid = _diff.compressed()
             _vmax = max(abs(np.percentile(_valid, 2)), abs(np.percentile(_valid, 98)))
@@ -394,21 +403,22 @@ def _(
             _ax_hist.set_xlabel("m (NHDPlus - Copernicus)")
             _ax_hist.set_ylabel("density")
 
-            _info = (
+            _text = (
                 f"Overlap px: {_valid.size:,}\n"
                 f"Mean diff : {_valid.mean():.3f} m\n"
                 f"Std diff  : {_valid.std():.3f} m\n"
                 f"Max |diff|: {np.abs(_valid).max():.3f} m"
             )
             _ax_img.text(
-                1.01, 0.5, _info, transform=_ax_img.transAxes, fontsize=9,
+                1.01, 0.5, _text, transform=_ax_img.transAxes, fontsize=9,
                 verticalalignment="center", family="monospace",
                 bbox=dict(boxstyle="round", facecolor="lightyellow", alpha=0.8),
             )
             plt.tight_layout()
-            _fig
+            _out = _fig
         else:
             print("No overlapping valid pixels found in this region.")
+        _out
     else:
         _missing = []
         if not _elev_vrt.exists():

--- a/notebooks/check_vrts.py
+++ b/notebooks/check_vrts.py
@@ -33,9 +33,9 @@ def _():
     import rasterio
     from rasterio.enums import Resampling
 
-    NHD_MERGED = Path(
-        "/caldera/hovenweep/projects/usgs/water/impd/nhgf/gfv2_param_v2/work/nhd_merged"
-    )
+    from gfv2_params.config import load_base_config
+
+    NHD_MERGED = Path(load_base_config()["data_root"]) / "work" / "nhd_merged"
     TARGET_PX = 500
 
     LAYERS = [

--- a/notebooks/check_vrts.py
+++ b/notebooks/check_vrts.py
@@ -1,0 +1,108 @@
+import marimo
+
+__generated_with = "0.13.11"
+app = marimo.App(width="full")
+
+
+@app.cell
+def _():
+    import marimo as mo
+    return (mo,)
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        r"""
+        # VRT Quick-Look: elevation · slope · aspect
+
+        Decimated overview read of the three CONUS VRTs produced by `build_vrt.py`.
+        Uses rasterio's `out_shape` to read a thumbnail (~2000 px on the longest axis)
+        so the full raster is never loaded into memory.
+        """
+    )
+    return
+
+
+@app.cell
+def _():
+    from pathlib import Path
+
+    import matplotlib.pyplot as plt
+    import numpy as np
+    import rasterio
+    from rasterio.enums import Resampling
+
+    NHD_MERGED = Path(
+        "/caldera/hovenweep/projects/usgs/water/impd/nhgf/gfv2_param_v2/work/nhd_merged"
+    )
+    TARGET_PX = 500
+
+    LAYERS = [
+        ("elevation", "terrain",  "m",       2, 98),
+        ("slope",     "YlOrRd",   "degrees", 2, 98),
+        ("aspect",    "hsv",      "degrees", 0, 100),
+    ]
+
+    return NHD_MERGED, LAYERS, TARGET_PX, Path, plt, np, rasterio, Resampling
+
+
+@app.cell
+def _(NHD_MERGED, LAYERS, TARGET_PX, plt, np, rasterio, Resampling, mo):
+    def _read_overview(path, target_px=TARGET_PX):
+        """Return a masked 2-D float32 thumbnail of *path*."""
+        with rasterio.open(path) as src:
+            factor = max(1, max(src.width, src.height) // target_px)
+            out_h = max(1, src.height // factor)
+            out_w = max(1, src.width  // factor)
+            data = src.read(
+                1,
+                out_shape=(out_h, out_w),
+                resampling=Resampling.nearest,
+            ).astype(np.float32)
+            nd = src.nodata
+        mask = ~np.isfinite(data)
+        if nd is not None:
+            mask |= data == nd
+        return np.ma.array(data, mask=mask)
+
+    missing = [
+        name for name, *_ in LAYERS
+        if not (NHD_MERGED / f"{name}.vrt").exists()
+    ]
+    if missing:
+        _out = mo.callout(
+            mo.md(f"**Missing VRTs:** {', '.join(missing)}\n\nRun `build_vrt.py` first."),
+            kind="warn",
+        )
+    else:
+        fig, axes = plt.subplots(1, 3, figsize=(22, 7))
+        for ax, (name, cmap, unit, lo, hi) in zip(axes, LAYERS):
+            arr = _read_overview(NHD_MERGED / f"{name}.vrt")
+            valid = arr.compressed()
+            vmin, vmax = np.percentile(valid, [lo, hi])
+            im = ax.imshow(
+                np.clip(arr, vmin, vmax),
+                cmap=cmap,
+                vmin=vmin,
+                vmax=vmax,
+                interpolation="nearest",
+                rasterized=True,
+            )
+            ax.set_title(
+                f"{name.title()}\n"
+                f"min={valid.min():.3g}  mean={valid.mean():.3g}  max={valid.max():.3g}  ({unit})",
+                fontsize=10,
+            )
+            ax.axis("off")
+            fig.colorbar(im, ax=ax, fraction=0.03, pad=0.02, label=unit)
+
+        fig.suptitle(
+            f"CONUS VRTs — {NHD_MERGED}",
+            fontsize=11,
+            y=1.01,
+        )
+        plt.tight_layout()
+        _out = fig
+
+    _out

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,10 @@ dependencies = [
     "pooch",
     "py7zr",
     "scikit-learn",
+    "scipy",
     "pyyaml",
     "tqdm",
+    "whitebox",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,9 @@ dev = [
     "ruff",
 ]
 
+[tool.hatch.build.targets.wheel]
+packages = ["src/gfv2_params"]
+
 [tool.isort]
 profile = "black"
 line_length = 120

--- a/scripts/build_depstor_dprst.py
+++ b/scripts/build_depstor_dprst.py
@@ -1,0 +1,135 @@
+"""Combine wbody + stream-buffer + imperv to produce dprst and on-stream rasters.
+
+Region-level mask: a water-body region is "true depression storage" only if NO
+cell in that region intersects either the stream-buffer mask or the imperv mask.
+Regions that touch any stream/imperv cell are excluded entirely (preserves
+depstor's `remove_all_overlap=True` semantics — DepStor.py:382-407, 689-696).
+
+Inputs (all on the same template grid):
+- wbody_regions.tif (int32, 0 = nodata)  [from build_depstor_waterbody.py]
+- wbody_binary.tif  (uint8 1/255)         [from build_depstor_waterbody.py]
+- stream_buffer.tif (uint8 1/255)         [from build_depstor_streambuffer.py]
+- imperv_binary.tif (uint8 1/255)         [from build_depstor_imperv.py]
+
+Outputs:
+- dprst_binary.tif    : wbody cells whose region touches NO stream and NO imperv.
+- onstream_binary.tif : wbody cells that are NOT depression storage
+                        (i.e. wbody_binary AND NOT dprst_binary).
+
+Logic source: depstor/scripts/DepStor.py:666-701 (getDprst) and 768-791
+(onStreamStor non-imperv-wbody construction).
+"""
+
+import argparse
+import time
+from pathlib import Path
+
+import numpy as np
+import rasterio
+
+from gfv2_params.config import load_config
+from gfv2_params.depstor import (
+    RasterInfo,
+    read_aligned_uint8,
+    regions_to_binary,
+    regions_touching_mask,
+    write_uint8_binary,
+)
+from gfv2_params.log import configure_logging
+
+
+def _elapsed(t0: float) -> str:
+    secs = time.time() - t0
+    m, s = divmod(int(secs), 60)
+    return f"{m}m {s:02d}s" if m else f"{s}s"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Build depstor dprst_binary.tif and onstream_binary.tif.")
+    parser.add_argument("--config", required=True, help="Path to depstor_dprst_raster.yml")
+    parser.add_argument("--base_config", default=None, help="Path to base_config.yml")
+    parser.add_argument("--force", action="store_true", help="Overwrite existing outputs")
+    args = parser.parse_args()
+
+    logger = configure_logging("build_depstor_dprst")
+    t_start = time.time()
+
+    config = load_config(
+        Path(args.config),
+        base_config_path=Path(args.base_config) if args.base_config else None,
+    )
+
+    template_path = Path(config["template_raster"])
+    wbody_binary_path = Path(config["wbody_binary_raster"])
+    wbody_regions_path = Path(config["wbody_regions_raster"])
+    stream_buffer_path = Path(config["stream_buffer_raster"])
+    imperv_path = Path(config["imperv_raster"])
+    dprst_path = Path(config["dprst_raster"])
+    onstream_path = Path(config["onstream_raster"])
+
+    for p in (template_path, wbody_binary_path, wbody_regions_path, stream_buffer_path, imperv_path):
+        if not p.exists():
+            raise FileNotFoundError(f"Required input not found: {p}")
+
+    logger.info("=== build_depstor_dprst ===")
+    logger.info("Template      : %s", template_path)
+    logger.info("Wbody binary  : %s", wbody_binary_path)
+    logger.info("Wbody regions : %s", wbody_regions_path)
+    logger.info("Stream buffer : %s", stream_buffer_path)
+    logger.info("Imperv binary : %s", imperv_path)
+    logger.info("Dprst out     : %s", dprst_path)
+    logger.info("On-stream out : %s", onstream_path)
+
+    if dprst_path.exists() and onstream_path.exists() and not args.force:
+        logger.info("Both outputs exist — skipping (pass --force to rebuild)")
+        return
+
+    info = RasterInfo.from_path(template_path)
+
+    logger.info("--- Step 1/4: Read aligned inputs ---")
+    t1 = time.time()
+    wbody_binary = read_aligned_uint8(wbody_binary_path, info)
+    stream_binary = read_aligned_uint8(stream_buffer_path, info)
+    imperv_binary = read_aligned_uint8(imperv_path, info)
+    with rasterio.open(wbody_regions_path) as src:
+        regions = src.read(1)
+    logger.info("  Inputs read in %s", _elapsed(t1))
+
+    logger.info("--- Step 2/4: Identify regions touching stream or imperv ---")
+    t2 = time.time()
+    stream_regions = regions_touching_mask(regions, stream_binary)
+    imperv_regions = regions_touching_mask(regions, imperv_binary)
+    excluded = stream_regions | imperv_regions
+    n_total = int(regions.max())
+    logger.info(
+        "  %d total wbody regions; %d touch stream, %d touch imperv, %d excluded (%s)",
+        n_total, len(stream_regions), len(imperv_regions), len(excluded), _elapsed(t2),
+    )
+
+    logger.info("--- Step 3/4: Build dprst_binary (kept regions only) ---")
+    t3 = time.time()
+    all_ids = set(int(v) for v in np.unique(regions) if v != 0)
+    kept_ids = all_ids - excluded
+    dprst_binary = regions_to_binary(regions, kept_ids)
+    write_uint8_binary(dprst_binary, info, dprst_path)
+    n_dprst = int((dprst_binary == 1).sum())
+    logger.info(
+        "  %d regions kept; %d cells in dprst (%.4f%% of grid). Written in %s",
+        len(kept_ids), n_dprst, 100 * n_dprst / dprst_binary.size, _elapsed(t3),
+    )
+
+    logger.info("--- Step 4/4: Build onstream_binary (wbody AND NOT dprst) ---")
+    t4 = time.time()
+    onstream = np.where((wbody_binary == 1) & (dprst_binary != 1), np.uint8(1), np.uint8(255))
+    write_uint8_binary(onstream, info, onstream_path)
+    n_on = int((onstream == 1).sum())
+    logger.info(
+        "  %d cells in on-stream storage (%.4f%% of grid). Written in %s",
+        n_on, 100 * n_on / onstream.size, _elapsed(t4),
+    )
+
+    logger.info("=== build_depstor_dprst complete in %s ===", _elapsed(t_start))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/build_depstor_imperv.py
+++ b/scripts/build_depstor_imperv.py
@@ -1,0 +1,125 @@
+"""Build the imperviousness binary raster used by the depression-storage pipeline.
+
+Threshold the staged Imperv.tif at imperv_threshold (default 50%), warp/snap to the
+elevation-VRT template grid, and write a uint8 binary raster (1 = impervious,
+255 = nodata) to {fabric}/depstor_rasters/imperv_binary.tif.
+
+Logic ported from depstor/scripts/DepStor.py:452-518 — minus the HRU-tagging step.
+"""
+
+import argparse
+import time
+from pathlib import Path
+
+import rasterio
+from osgeo import gdal, gdalconst
+
+from gfv2_params.config import load_config
+from gfv2_params.depstor import RasterInfo, threshold_above, write_uint8_binary
+from gfv2_params.log import configure_logging
+
+
+def _elapsed(t0: float) -> str:
+    secs = time.time() - t0
+    m, s = divmod(int(secs), 60)
+    return f"{m}m {s:02d}s" if m else f"{s}s"
+
+
+def _warp_to_template(src_path: Path, info: RasterInfo, out_path: Path) -> None:
+    """Warp src_path to the template grid (EPSG:5070, 30m, exact bounds).
+
+    Uses bilinear resampling (Imperv is a continuous percentage 0-100).
+    """
+    output_bounds = (info.bounds.left, info.bounds.bottom, info.bounds.right, info.bounds.top)
+    warp_ds = gdal.Warp(
+        str(out_path),
+        str(src_path),
+        format="GTiff",
+        outputBounds=output_bounds,
+        width=info.width,
+        height=info.height,
+        dstSRS=info.crs.to_string(),
+        resampleAlg=gdalconst.GRA_Bilinear,
+        outputType=gdal.GDT_Float32,
+        creationOptions=[
+            "COMPRESS=LZW", "TILED=YES",
+            "BLOCKXSIZE=512", "BLOCKYSIZE=512", "BIGTIFF=YES",
+        ],
+    )
+    if warp_ds is None:
+        raise RuntimeError(
+            f"gdal.Warp failed: {src_path} -> {out_path} ({gdal.GetLastErrorMsg()})"
+        )
+    warp_ds.FlushCache()
+    del warp_ds
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Build depstor imperv_binary.tif.")
+    parser.add_argument("--config", required=True, help="Path to depstor_imperv_raster.yml")
+    parser.add_argument("--base_config", default=None, help="Path to base_config.yml")
+    parser.add_argument("--force", action="store_true", help="Overwrite existing output")
+    args = parser.parse_args()
+
+    logger = configure_logging("build_depstor_imperv")
+    t_start = time.time()
+
+    config = load_config(
+        Path(args.config),
+        base_config_path=Path(args.base_config) if args.base_config else None,
+    )
+
+    template_path = Path(config["template_raster"])
+    imperv_path = Path(config["imperv_raster"])
+    output_path = Path(config["output_raster"])
+    threshold = float(config.get("imperv_threshold", 50))
+
+    if not template_path.exists():
+        raise FileNotFoundError(f"Template raster not found: {template_path}")
+    if not imperv_path.exists():
+        raise FileNotFoundError(f"Imperv raster not found: {imperv_path}")
+
+    logger.info("=== build_depstor_imperv ===")
+    logger.info("Template : %s", template_path)
+    logger.info("Imperv   : %s", imperv_path)
+    logger.info("Output   : %s", output_path)
+    logger.info("Threshold: %s%% (cells >= threshold marked impervious)", threshold)
+
+    if output_path.exists() and not args.force:
+        logger.info("Output already exists — skipping (pass --force to rebuild)")
+        return
+
+    info = RasterInfo.from_path(template_path)
+    logger.info("Template grid: %dx%d, CRS=%s", info.width, info.height, info.crs)
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    warped_path = output_path.with_suffix(".warped.tif")
+    try:
+        logger.info("--- Step 1/2: Warp imperv to template grid ---")
+        t1 = time.time()
+        _warp_to_template(imperv_path, info, warped_path)
+        logger.info("  Warp done in %s: %s", _elapsed(t1), warped_path)
+
+        logger.info("--- Step 2/2: Threshold and write uint8 binary ---")
+        t2 = time.time()
+        with rasterio.open(warped_path) as src:
+            data = src.read(1)
+            src_nodata = src.nodata
+        binary = threshold_above(data, threshold, src_nodata)
+        write_uint8_binary(binary, info, output_path)
+        n_impervious = int((binary == 1).sum())
+        n_total = binary.size
+        logger.info(
+            "  Threshold + write done in %s | %d / %d cells impervious (%.2f%%)",
+            _elapsed(t2), n_impervious, n_total, 100 * n_impervious / n_total,
+        )
+    finally:
+        if warped_path.exists():
+            warped_path.unlink()
+            logger.debug("  Cleaned up intermediate: %s", warped_path)
+
+    logger.info("=== build_depstor_imperv complete in %s ===", _elapsed(t_start))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/build_depstor_routing.py
+++ b/scripts/build_depstor_routing.py
@@ -1,0 +1,195 @@
+"""Build the drains-to-depression binary raster via WhiteboxTools Watershed.
+
+Uses the staged D8 flow-direction raster (Esri pointer encoding) and the
+dprst_binary.tif as pour points to delineate, for every cell, which depression
+(if any) it drains into. The resulting per-depression labels are then collapsed
+to a uint8 binary raster where 1 = drains to ANY depression, 255 = does not /
+nodata.
+
+Outputs:
+- {fabric}/depstor_rasters/drains_to_dprst.tif (uint8 binary)
+
+Logic source: depstor/scripts/DepStor.py:413-449 (whitebox_run) and 704-739
+(getHruSro_to_dprst).
+"""
+
+import argparse
+import os
+import subprocess
+import time
+from pathlib import Path
+
+import numpy as np
+import rasterio
+import rioxarray  # noqa: F401  (registers .rio accessor)
+import xarray as xr
+
+from gfv2_params.config import load_config
+from gfv2_params.depstor import RasterInfo, write_uint8_binary
+from gfv2_params.log import configure_logging
+
+
+def _elapsed(t0: float) -> str:
+    secs = time.time() - t0
+    m, s = divmod(int(secs), 60)
+    return f"{m}m {s:02d}s" if m else f"{s}s"
+
+
+def _find_whitebox_tools_binary() -> str:
+    """Locate the WhiteboxTools executable inside the bundled `whitebox` package."""
+    import whitebox  # local import — keep optional unless this step runs
+
+    pkg_dir = os.path.dirname(whitebox.__file__)
+    candidates = [
+        os.path.join(pkg_dir, "whitebox_tools.exe"),
+        os.path.join(pkg_dir, "whitebox_tools"),
+        os.path.join(pkg_dir, "bin", "whitebox_tools.exe"),
+        os.path.join(pkg_dir, "bin", "whitebox_tools"),
+    ]
+    runner = next((c for c in candidates if os.path.isfile(c)), None)
+    if runner is None:
+        raise FileNotFoundError(
+            "WhiteboxTools binary not found inside `whitebox` package. "
+            "Reinstall the `whitebox` pip package."
+        )
+    return runner
+
+
+def _reproject_fdr_with_rioxarray(fdr_path: Path, dprst_path: Path, out_path: Path, logger) -> None:
+    """Reproject FDR onto the dprst grid using rioxarray.reproject_match."""
+    logger.info("  Reprojecting FDR to match dprst grid (rioxarray.reproject_match)...")
+    fdr_da = xr.open_dataarray(fdr_path, engine="rasterio").squeeze("band", drop=True)
+    dprst_da = xr.open_dataarray(dprst_path, engine="rasterio").squeeze("band", drop=True)
+    fdr_aligned = fdr_da.rio.reproject_match(dprst_da)
+    fdr_aligned = fdr_aligned.rio.write_nodata(np.uint8(255))
+    fdr_aligned.rio.to_raster(
+        out_path,
+        driver="GTiff",
+        compress="LZW",
+        tiled=True,
+        blockxsize=256,
+        blockysize=256,
+        dtype="uint8",
+        nodata=np.uint8(255),
+        BIGTIFF="YES",
+    )
+
+
+def _run_whitebox_watershed(fdr_path: Path, pour_pts_path: Path, output_path: Path, logger) -> None:
+    runner = _find_whitebox_tools_binary()
+    logger.info("  WhiteboxTools binary: %s", runner)
+    cmd = [
+        runner,
+        f"--wd={os.getcwd()}",
+        "--max_procs=-1",
+        "-r=Watershed",
+        f"--d8_pntr={fdr_path}",
+        f"--pour_pts={pour_pts_path}",
+        f"--output={output_path}",
+        "--esri_pntr",
+        "-v",
+    ]
+    logger.info("  Running: %s", " ".join(cmd))
+    proc = subprocess.run(cmd, text=True, capture_output=True)
+    if proc.stdout:
+        logger.debug("WBT stdout:\n%s", proc.stdout)
+    if proc.returncode != 0:
+        logger.error("WBT stderr:\n%s", proc.stderr)
+        raise RuntimeError(
+            f"WhiteboxTools Watershed failed (exit code {proc.returncode}). See stderr above."
+        )
+
+
+def _watershed_to_binary(watershed_path: Path, info: RasterInfo, out_path: Path, logger) -> None:
+    """Collapse the per-depression watershed labels into a uint8 binary mask.
+
+    Rule: any cell with a value not equal to the source nodata is "drains to a
+    depression" (1); all others become 255 (nodata).
+    """
+    with rasterio.open(watershed_path) as src:
+        data = src.read(1)
+        src_nodata = src.nodata
+    if src_nodata is None:
+        # WhiteboxTools typically writes a recognised nodata; if missing,
+        # treat <= 0 as nodata.
+        valid = data > 0
+    elif isinstance(src_nodata, float) and np.isnan(src_nodata):
+        valid = ~np.isnan(data)
+    else:
+        valid = data != src_nodata
+    binary = np.where(valid, np.uint8(1), np.uint8(255))
+    n_in = int((binary == 1).sum())
+    write_uint8_binary(binary, info, out_path)
+    logger.info(
+        "  Drains-to-dprst mask written: %s (%d cells, %.4f%% of grid)",
+        out_path, n_in, 100 * n_in / binary.size,
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Build depstor drains_to_dprst.tif via WhiteboxTools Watershed.")
+    parser.add_argument("--config", required=True, help="Path to depstor_routing_raster.yml")
+    parser.add_argument("--base_config", default=None, help="Path to base_config.yml")
+    parser.add_argument("--force", action="store_true", help="Overwrite existing output")
+    args = parser.parse_args()
+
+    logger = configure_logging("build_depstor_routing")
+    t_start = time.time()
+
+    config = load_config(
+        Path(args.config),
+        base_config_path=Path(args.base_config) if args.base_config else None,
+    )
+
+    template_path = Path(config["template_raster"])
+    fdr_path = Path(config["fdr_raster"])
+    dprst_path = Path(config["dprst_raster"])
+    output_path = Path(config["output_raster"])
+    keep_intermediates = bool(config.get("keep_intermediates", False))
+
+    for p in (template_path, fdr_path, dprst_path):
+        if not p.exists():
+            raise FileNotFoundError(f"Required input not found: {p}")
+
+    logger.info("=== build_depstor_routing ===")
+    logger.info("Template : %s", template_path)
+    logger.info("FDR      : %s", fdr_path)
+    logger.info("Dprst    : %s", dprst_path)
+    logger.info("Output   : %s", output_path)
+
+    if output_path.exists() and not args.force:
+        logger.info("Output exists — skipping (pass --force to rebuild)")
+        return
+
+    info = RasterInfo.from_path(template_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fdr_aligned = output_path.parent / "fdr_aligned.tif"
+    watershed_raw = output_path.parent / "hru_to_dprst_labels.tif"
+
+    try:
+        logger.info("--- Step 1/3: Align FDR to template grid ---")
+        t1 = time.time()
+        _reproject_fdr_with_rioxarray(fdr_path, dprst_path, fdr_aligned, logger)
+        logger.info("  FDR aligned in %s: %s", _elapsed(t1), fdr_aligned)
+
+        logger.info("--- Step 2/3: Run WhiteboxTools Watershed ---")
+        t2 = time.time()
+        _run_whitebox_watershed(fdr_aligned, dprst_path, watershed_raw, logger)
+        logger.info("  Watershed done in %s: %s", _elapsed(t2), watershed_raw)
+
+        logger.info("--- Step 3/3: Collapse labels to uint8 binary ---")
+        t3 = time.time()
+        _watershed_to_binary(watershed_raw, info, output_path, logger)
+        logger.info("  Binary mask written in %s", _elapsed(t3))
+    finally:
+        if not keep_intermediates:
+            for p in (fdr_aligned, watershed_raw):
+                if p.exists():
+                    p.unlink()
+                    logger.debug("  Cleaned up: %s", p)
+
+    logger.info("=== build_depstor_routing complete in %s ===", _elapsed(t_start))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/build_depstor_streambuffer.py
+++ b/scripts/build_depstor_streambuffer.py
@@ -1,0 +1,107 @@
+"""Build the stream-segment buffer binary raster.
+
+Reads the staged stream-segment vector layer, buffers each line by
+buffer_distance metres (default 60 m — 2 cell widths at 30 m), and burns the
+buffered polygons onto the elevation-VRT template grid as a uint8 binary mask
+(1 = inside any stream buffer, 255 = nodata).
+
+Output: {fabric}/depstor_rasters/stream_buffer.tif
+Logic source: depstor/scripts/DepStor.py:521-577 — minus the HRU-tagging step.
+"""
+
+import argparse
+import time
+from pathlib import Path
+
+import geopandas as gpd
+
+from gfv2_params.config import load_config
+from gfv2_params.depstor import RasterInfo, rasterize_binary, write_uint8_binary
+from gfv2_params.log import configure_logging
+
+
+def _elapsed(t0: float) -> str:
+    secs = time.time() - t0
+    m, s = divmod(int(secs), 60)
+    return f"{m}m {s:02d}s" if m else f"{s}s"
+
+
+def _load_segments(path: Path, layer: str | None, logger):
+    try:
+        return gpd.read_file(path, layer=layer, use_arrow=True)
+    except Exception:
+        logger.warning(
+            "PyArrow unavailable for vector load; falling back to fiona. "
+            "Install pyarrow for faster reads."
+        )
+        return gpd.read_file(path, layer=layer)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Build depstor stream_buffer.tif.")
+    parser.add_argument("--config", required=True, help="Path to depstor_streambuffer_raster.yml")
+    parser.add_argument("--base_config", default=None, help="Path to base_config.yml")
+    parser.add_argument("--force", action="store_true", help="Overwrite existing output")
+    args = parser.parse_args()
+
+    logger = configure_logging("build_depstor_streambuffer")
+    t_start = time.time()
+
+    config = load_config(
+        Path(args.config),
+        base_config_path=Path(args.base_config) if args.base_config else None,
+    )
+
+    template_path = Path(config["template_raster"])
+    segments_gpkg = Path(config["segments_gpkg"])
+    segments_layer = config.get("segments_layer", "nsegment")
+    output_path = Path(config["output_raster"])
+    buffer_distance = float(config.get("buffer_distance", 60))
+
+    if not template_path.exists():
+        raise FileNotFoundError(f"Template raster not found: {template_path}")
+    if not segments_gpkg.exists():
+        raise FileNotFoundError(f"Segments gpkg not found: {segments_gpkg}")
+
+    logger.info("=== build_depstor_streambuffer ===")
+    logger.info("Template     : %s", template_path)
+    logger.info("Segments gpkg: %s (layer=%s)", segments_gpkg, segments_layer)
+    logger.info("Output       : %s", output_path)
+    logger.info("Buffer       : %s metres", buffer_distance)
+
+    if output_path.exists() and not args.force:
+        logger.info("Output already exists — skipping (pass --force to rebuild)")
+        return
+
+    info = RasterInfo.from_path(template_path)
+    logger.info("Template grid: %dx%d, CRS=%s", info.width, info.height, info.crs)
+
+    logger.info("--- Step 1/3: Load and validate segments ---")
+    t1 = time.time()
+    seg_gdf = _load_segments(segments_gpkg, segments_layer, logger)
+    seg_gdf = seg_gdf[seg_gdf.geometry.notna() & ~seg_gdf.geometry.is_empty].copy()
+    logger.info("  Loaded %d valid segments in %s", len(seg_gdf), _elapsed(t1))
+
+    logger.info("--- Step 2/3: Reproject (if needed) and buffer ---")
+    t2 = time.time()
+    if seg_gdf.crs != info.crs:
+        logger.info("  Reprojecting segments from %s to %s", seg_gdf.crs, info.crs)
+        seg_gdf = seg_gdf.to_crs(info.crs)
+    seg_gdf["geometry"] = seg_gdf.geometry.buffer(buffer_distance)
+    logger.info("  Buffered in %s", _elapsed(t2))
+
+    logger.info("--- Step 3/3: Rasterize buffer onto template grid ---")
+    t3 = time.time()
+    binary = rasterize_binary(seg_gdf, info, all_touched=True)
+    write_uint8_binary(binary, info, output_path)
+    n_in = int((binary == 1).sum())
+    logger.info(
+        "  Rasterize + write done in %s | %d cells inside stream buffer (%.4f%%)",
+        _elapsed(t3), n_in, 100 * n_in / binary.size,
+    )
+
+    logger.info("=== build_depstor_streambuffer complete in %s ===", _elapsed(t_start))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/build_depstor_waterbody.py
+++ b/scripts/build_depstor_waterbody.py
@@ -1,0 +1,126 @@
+"""Build the water-body binary raster and its connected-component region labels.
+
+Reads the staged water-body polygon layer, filters by minimum area, rasterizes
+to the elevation-VRT template grid, then runs a connected-component label step
+(8-connectivity) to give each contiguous water body a unique region ID.
+
+Outputs:
+- {fabric}/depstor_rasters/wbody_binary.tif  (uint8 0/1, 255 nodata)
+- {fabric}/depstor_rasters/wbody_regions.tif (int32 region IDs, 0 nodata)
+
+Logic source: depstor/scripts/DepStor.py:580-663 — `wbe.clump(diag=True)`
+replaced by `scipy.ndimage.label` with 3x3 structure.
+"""
+
+import argparse
+import time
+from pathlib import Path
+
+import geopandas as gpd
+
+from gfv2_params.config import load_config
+from gfv2_params.depstor import (
+    RasterInfo,
+    clump_regions,
+    rasterize_binary,
+    write_int32_regions,
+    write_uint8_binary,
+)
+from gfv2_params.log import configure_logging
+
+
+def _elapsed(t0: float) -> str:
+    secs = time.time() - t0
+    m, s = divmod(int(secs), 60)
+    return f"{m}m {s:02d}s" if m else f"{s}s"
+
+
+def _load_waterbodies(path: Path, layer: str | None, logger):
+    try:
+        return gpd.read_file(path, layer=layer, use_arrow=True)
+    except Exception:
+        logger.warning(
+            "PyArrow unavailable for vector load; falling back to fiona."
+        )
+        return gpd.read_file(path, layer=layer)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Build depstor wbody_binary.tif and wbody_regions.tif.")
+    parser.add_argument("--config", required=True, help="Path to depstor_waterbody_raster.yml")
+    parser.add_argument("--base_config", default=None, help="Path to base_config.yml")
+    parser.add_argument("--force", action="store_true", help="Overwrite existing outputs")
+    args = parser.parse_args()
+
+    logger = configure_logging("build_depstor_waterbody")
+    t_start = time.time()
+
+    config = load_config(
+        Path(args.config),
+        base_config_path=Path(args.base_config) if args.base_config else None,
+    )
+
+    template_path = Path(config["template_raster"])
+    waterbody_gpkg = Path(config["waterbody_gpkg"])
+    waterbody_layer = config.get("waterbody_layer", "v2_wb")
+    binary_path = Path(config["wbody_binary_raster"])
+    regions_path = Path(config["wbody_regions_raster"])
+    min_area = float(config.get("min_area_threshold", 900.0))
+
+    if not template_path.exists():
+        raise FileNotFoundError(f"Template raster not found: {template_path}")
+    if not waterbody_gpkg.exists():
+        raise FileNotFoundError(f"Waterbody gpkg not found: {waterbody_gpkg}")
+
+    logger.info("=== build_depstor_waterbody ===")
+    logger.info("Template     : %s", template_path)
+    logger.info("Waterbody gpkg: %s (layer=%s)", waterbody_gpkg, waterbody_layer)
+    logger.info("Binary out   : %s", binary_path)
+    logger.info("Regions out  : %s", regions_path)
+    logger.info("Min area     : %.1f m^2", min_area)
+
+    if binary_path.exists() and regions_path.exists() and not args.force:
+        logger.info("Both outputs already exist — skipping (pass --force to rebuild)")
+        return
+
+    info = RasterInfo.from_path(template_path)
+    logger.info("Template grid: %dx%d, CRS=%s", info.width, info.height, info.crs)
+
+    logger.info("--- Step 1/4: Load and filter water bodies ---")
+    t1 = time.time()
+    wb_gdf = _load_waterbodies(waterbody_gpkg, waterbody_layer, logger)
+    if wb_gdf.crs != info.crs:
+        logger.info("  Reprojecting wbodies from %s to %s", wb_gdf.crs, info.crs)
+        wb_gdf = wb_gdf.to_crs(info.crs)
+    wb_gdf = wb_gdf[wb_gdf.geometry.notna() & ~wb_gdf.geometry.is_empty]
+    n_before = len(wb_gdf)
+    wb_gdf = wb_gdf[wb_gdf.geometry.area >= min_area].copy()
+    logger.info(
+        "  Loaded %d wbodies, kept %d after >= %.1f m^2 filter, in %s",
+        n_before, len(wb_gdf), min_area, _elapsed(t1),
+    )
+
+    logger.info("--- Step 2/4: Rasterize wbody polygons (binary) ---")
+    t2 = time.time()
+    binary = rasterize_binary(wb_gdf, info, all_touched=False)
+    n_in = int((binary == 1).sum())
+    logger.info("  Rasterized in %s | %d wbody cells", _elapsed(t2), n_in)
+
+    logger.info("--- Step 3/4: Write binary raster ---")
+    t3 = time.time()
+    write_uint8_binary(binary, info, binary_path)
+    logger.info("  Binary written in %s: %s", _elapsed(t3), binary_path)
+
+    logger.info("--- Step 4/4: Connected-component label (scipy.ndimage.label, 8-connectivity) ---")
+    t4 = time.time()
+    regions = clump_regions(binary)
+    n_regions = int(regions.max())
+    logger.info("  Labeled %d connected components in %s", n_regions, _elapsed(t4))
+    write_int32_regions(regions, info, regions_path)
+    logger.info("  Regions written: %s", regions_path)
+
+    logger.info("=== build_depstor_waterbody complete in %s ===", _elapsed(t_start))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/build_vrt.py
+++ b/scripts/build_vrt.py
@@ -17,18 +17,18 @@ from osgeo import gdal
 from gfv2_params.config import load_base_config
 from gfv2_params.log import configure_logging
 
+# Maps VRT name -> (glob pattern, srcNodata for BuildVRT).
+# srcNodata rationale:
+#   elevation: _fixed_ tiles are written by compute_slope_aspect.py with
+#              fillna(-9999) and write_nodata(-9999).
+#   slope/aspect: RichDEM SaveGDAL always writes -9999.
+#   fdr: NHDPlus FDR tiles are Byte rasters with nodata=255 (D8 codes are 1-128).
 RASTER_TYPES = {
-    "elevation": "NEDSnapshot_merged_fixed_*.tif",
-    "slope": "NEDSnapshot_merged_slope_*.tif",
-    "aspect": "NEDSnapshot_merged_aspect_*.tif",
+    "elevation": ("NEDSnapshot_merged_fixed_*.tif", "-9999"),
+    "slope": ("NEDSnapshot_merged_slope_*.tif", "-9999"),
+    "aspect": ("NEDSnapshot_merged_aspect_*.tif", "-9999"),
+    "fdr": ("Fdr_merged_*.tif", "255"),
 }
-
-# All three VRT types use srcNodata="-9999" because:
-#   elevation: _fixed_ tiles are written by compute_slope_aspect.py with fillna(-9999)
-#              and write_nodata(-9999), so -9999 is the fill value GDAL must treat as
-#              transparent when compositing VPU tiles in the VRT.
-#   slope/aspect: RichDEM SaveGDAL always writes -9999 as its nodata value.
-VRT_SRCNODATA = "-9999"
 
 
 def main():
@@ -52,7 +52,7 @@ def main():
     FILL_DIRS = {"copernicus_fill"}
 
     built_count = 0
-    for vrt_name, pattern in RASTER_TYPES.items():
+    for vrt_name, (pattern, src_nodata) in RASTER_TYPES.items():
         # Primary NHDPlus VPU tiles (listed last = highest priority)
         primary_files = sorted(
             f for f in nhd_merged_dir.glob(f"*/{pattern}")
@@ -74,8 +74,8 @@ def main():
         logger.info("Building %s from %d source files (%d primary%s)",
                      vrt_path, len(source_files), len(primary_files), fill_msg)
 
-        # srcNodata: see VRT_SRCNODATA constant above for rationale.
-        vrt_options = gdal.BuildVRTOptions(resolution="highest", srcNodata=VRT_SRCNODATA)
+        # srcNodata: see RASTER_TYPES table above for per-type rationale.
+        vrt_options = gdal.BuildVRTOptions(resolution="highest", srcNodata=src_nodata)
         vrt_ds = gdal.BuildVRT(str(vrt_path), [str(f) for f in source_files], options=vrt_options)
         if vrt_ds is None:
             raise RuntimeError(f"gdal.BuildVRT failed for {vrt_name}")

--- a/scripts/init_data_root.py
+++ b/scripts/init_data_root.py
@@ -89,7 +89,7 @@ _TREE = [
                                NEDSnapshot_merged_aspect_*.tif)
           nhd_merged/*.vrt    CONUS-wide GDAL virtual rasters built by
                               build_vrt.py (elevation.vrt, slope.vrt,
-                              aspect.vrt)
+                              aspect.vrt, fdr.vrt)
           derived_rasters/    Derived rasters written during parameter
                               computation (e.g. soil_moist_max.tif)
           weights/            Polygon-to-polygon weight tables built by

--- a/scripts/init_data_root.py
+++ b/scripts/init_data_root.py
@@ -52,6 +52,9 @@ _TREE = [
           nhm_default/      NHM default parameter files (input to final merge)
           nhd_downloads/    Raw NHDPlus zip archives
                             (downloadable via download/rpu_rasters.py)
+          depstor/          Per-fabric depression-storage inputs:
+                            <fabric>_segments_wbodies.gpkg (layers nsegment, v2_wb)
+                            <fabric>_fdr.tif (D8 flow direction, Esri pointer)
         """,
     ),
     ("input/fabric", None),
@@ -64,6 +67,7 @@ _TREE = [
     ("input/nhd_downloads", None),
     ("input/copernicus_dem", None),
     ("input/copernicus_dem/raw", None),
+    ("input/depstor", None),
     # ---- work (intermediates) ----------------------------------------------
     (
         "work",
@@ -115,6 +119,13 @@ def _fabric_tree(fabric: str) -> list:
                           ({fabric}_nhru_merged.gpkg)
               batches/    Spatially-partitioned batch GeoPackages produced by
                           prepare_fabric.py (used by zonal stats scripts)
+              depstor_rasters/
+                          Per-fabric depression-storage intermediate rasters
+                          produced by build_depstor_*.py
+                          (imperv_binary.tif, stream_buffer.tif,
+                           wbody_binary.tif, wbody_regions.tif,
+                           dprst_binary.tif, onstream_binary.tif,
+                           drains_to_dprst.tif)
               params/     Per-VPU and merged parameter CSVs produced by
                           create_zonal_params.py, create_soils_params.py,
                           create_ssflux_params.py, merge_params.py, and
@@ -126,6 +137,7 @@ def _fabric_tree(fabric: str) -> list:
         ),
         (f"{fabric}/fabric", None),
         (f"{fabric}/batches", None),
+        (f"{fabric}/depstor_rasters", None),
         (f"{fabric}/params", None),
         (f"{fabric}/params/merged", None),
     ]
@@ -170,6 +182,8 @@ def validate_inputs(data_root: Path, fabric: str, logger) -> None:
         data_root / "input" / "soils_litho" / "AWC.tif",
         data_root / "input" / "soils_litho" / "Lithology_exp_Konly_Project.shp",
         data_root / "input" / "lulc_veg" / "RootDepth.tif",
+        data_root / "input" / "depstor" / f"{fabric}_segments_wbodies.gpkg",
+        data_root / "input" / "depstor" / f"{fabric}_fdr.tif",
     ]
     missing = [p for p in required if not p.exists()]
     if missing:

--- a/slurm_batch/RUNME.md
+++ b/slurm_batch/RUNME.md
@@ -68,6 +68,7 @@ The following externally-provided files must be placed in the scaffolded directo
 | `input/soils_litho/` | `TEXT_PRMS.tif`, `AWC.tif`, `Lithology_exp_Konly_Project.shp` (+ sidecar files: `.dbf`, `.prj`, `.shx`) |
 | `input/lulc_veg/` | `RootDepth.tif`, `CNPY.tif`, `Imperv.tif` |
 | `input/nhm_default/` | NHM default parameter files (input to final merge step) |
+| `input/depstor/` | Per-fabric: `<fabric>_segments_wbodies.gpkg` (layers `nsegment`, `v2_wb`); `<fabric>_fdr.tif` (D8 flow direction, Esri pointer encoding) |
 
 The NALCMS 2020 land cover raster can be downloaded automatically (see below).
 
@@ -157,6 +158,36 @@ To use a different LULC source, override `LULC_CONFIG`:
 LULC_CONFIG=configs/lulc_nalcms_param.yml sbatch slurm_batch/build_lulc_rasters.batch
 ```
 
+### Stage 2d: Build depstor rasters (per fabric)
+
+Build the depression-storage intermediate rasters on the elevation-VRT template
+grid. Outputs go to `{fabric}/depstor_rasters/` and feed the new Stage 4
+zonal-stats jobs (`dprst_frac`, `imperv_frac`, `onstream_storage_frac`,
+`drains_to_dprst_frac`).
+
+Inputs (manually staged per fabric):
+- `input/depstor/<fabric>_segments_wbodies.gpkg` (layers `nsegment`, `v2_wb`)
+- `input/depstor/<fabric>_fdr.tif` (D8 flow direction, Esri pointer)
+- Reuses existing `input/lulc_veg/Imperv.tif` and `work/nhd_merged/elevation.vrt`.
+
+Run in order — each step writes intermediates the next consumes:
+
+```bash
+sbatch slurm_batch/build_depstor_imperv.batch
+sbatch slurm_batch/build_depstor_streambuffer.batch
+sbatch slurm_batch/build_depstor_waterbody.batch
+sbatch slurm_batch/build_depstor_dprst.batch        # depends on the three above
+sbatch slurm_batch/build_depstor_routing.batch       # depends on dprst + staged FDR
+```
+
+Steps 1-3 are independent of each other and can run concurrently. Step 4
+combines them and must wait. Step 5 runs WhiteboxTools `Watershed` against the
+staged FDR + the dprst output and is the most memory- and time-intensive.
+
+Note: Stage 2d depends on Stage 2a (the elevation VRT exists) but is otherwise
+fabric-independent of the rest of Part 1. It can run in parallel with Part 2's
+fabric prep.
+
 ---
 
 ## Part 2: Fabric-Dependent Tasks
@@ -206,6 +237,19 @@ slurm_batch/submit_jobs.sh $BATCHES slurm_batch/create_lulc_nalcms_params.batch
 The `create_lulc_params.batch` job produces per-HRU fractional land cover percentages for each
 NALCMS 2020 class (19 classes). Output: `{fabric}/params/nalcms_2020/` per batch, merged to
 `{fabric}/params/merged/nhm_nalcms_2020_lulc_params.csv`.
+
+Depression-storage zonal stats (require Stage 2d outputs):
+
+```bash
+slurm_batch/submit_jobs.sh $BATCHES slurm_batch/create_dprst_frac_params.batch
+slurm_batch/submit_jobs.sh $BATCHES slurm_batch/create_imperv_frac_params.batch
+slurm_batch/submit_jobs.sh $BATCHES slurm_batch/create_onstream_storage_frac_params.batch
+slurm_batch/submit_jobs.sh $BATCHES slurm_batch/create_drains_to_dprst_frac_params.batch
+```
+
+Each produces a per-HRU fraction in [0, 1]. With `categorical: false` on a uint8
+binary raster, the gdptools exactextract mean equals the fraction of HRU area
+covered by 1-valued cells.
 
 ### Stage 5: Merge and validate
 
@@ -318,3 +362,12 @@ sacct -j <JOBID> -o JobID,State,Elapsed,MaxRSS
 | download_rpu_rasters.batch | base_config.yml | gfv2_params.download.rpu_rasters |
 | download_nalcms.batch | base_config.yml | gfv2_params.download.nalcms_lulc |
 | download_nhm_v11.batch | base_config.yml | gfv2_params.download.nhm_v11_lulc |
+| build_depstor_imperv.batch | depstor_imperv_raster.yml | build_depstor_imperv.py |
+| build_depstor_streambuffer.batch | depstor_streambuffer_raster.yml | build_depstor_streambuffer.py |
+| build_depstor_waterbody.batch | depstor_waterbody_raster.yml | build_depstor_waterbody.py |
+| build_depstor_dprst.batch | depstor_dprst_raster.yml | build_depstor_dprst.py |
+| build_depstor_routing.batch | depstor_routing_raster.yml | build_depstor_routing.py |
+| create_dprst_frac_params.batch | dprst_frac_param.yml | create_zonal_params.py |
+| create_imperv_frac_params.batch | imperv_frac_param.yml | create_zonal_params.py |
+| create_onstream_storage_frac_params.batch | onstream_storage_frac_param.yml | create_zonal_params.py |
+| create_drains_to_dprst_frac_params.batch | drains_to_dprst_frac_param.yml | create_zonal_params.py |

--- a/slurm_batch/RUNME.md
+++ b/slurm_batch/RUNME.md
@@ -267,13 +267,17 @@ python scripts/merge_params.py --config configs/elev_param.yml --base_config con
 
 ### Stage 6: SSFlux (depends on merged slope)
 
-Pre-compute weights, then run batch jobs:
+A single batch job handles the full ssflux workflow: pre-compute weights, submit the
+ssflux array job, and automatically chain a merge job via `afterok` dependency:
 
 ```bash
-python scripts/build_weights.py --config configs/ssflux_param.yml --base_config configs/base_config.yml
-slurm_batch/submit_jobs.sh $BATCHES slurm_batch/create_ssflux_params.batch
-python scripts/merge_params.py --config configs/ssflux_param.yml --base_config configs/base_config.yml
+BATCHES={data_root}/gfv2/batches \
+  sbatch slurm_batch/build_weights.batch
 ```
+
+The job sequence is:
+1. `build_weights.py` — computes CONUS-wide P2P lithology weights
+2. `submit_jobs.sh` — submits the ssflux array; merge job is chained automatically
 
 ### Stage 7: KNN gap-fill
 
@@ -355,6 +359,7 @@ sacct -j <JOBID> -o JobID,State,Elapsed,MaxRSS
 | create_lulc_params.batch | lulc_foresce_param.yml | create_lulc_params.py |
 | create_lulc_nlcd_params.batch | lulc_nlcd_param.yml | create_lulc_params.py |
 | create_lulc_nalcms_params.batch | lulc_nalcms_param.yml | create_lulc_params.py |
+| build_weights.batch | ssflux_param.yml | build_weights.py → create_ssflux_params.py → merge_params.py |
 | create_ssflux_params.batch | ssflux_param.yml | create_ssflux_params.py |
 | merge_output_params.batch | all param configs | merge_params.py |
 | merge_params.batch | (via MERGE_CONFIG env) | merge_params.py |

--- a/slurm_batch/build_depstor_dprst.batch
+++ b/slurm_batch/build_depstor_dprst.batch
@@ -1,0 +1,20 @@
+#!/bin/bash
+#SBATCH -p cpu
+#SBATCH -A impd
+#SBATCH --job-name=build_depstor_dprst
+#SBATCH --output=logs/job_%j.out
+#SBATCH --error=logs/job_%j.err
+#SBATCH --time=04:00:00
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=128G
+
+module load miniforge/latest
+conda activate geoenv
+
+cd "$SLURM_SUBMIT_DIR"
+BASE_CONFIG=${BASE_CONFIG:-configs/base_config.yml}
+
+python scripts/build_depstor_dprst.py \
+    --config configs/depstor_dprst_raster.yml \
+    --base_config "$BASE_CONFIG"

--- a/slurm_batch/build_depstor_imperv.batch
+++ b/slurm_batch/build_depstor_imperv.batch
@@ -1,0 +1,20 @@
+#!/bin/bash
+#SBATCH -p cpu
+#SBATCH -A impd
+#SBATCH --job-name=build_depstor_imperv
+#SBATCH --output=logs/job_%j.out
+#SBATCH --error=logs/job_%j.err
+#SBATCH --time=04:00:00
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=64G
+
+module load miniforge/latest
+conda activate geoenv
+
+cd "$SLURM_SUBMIT_DIR"
+BASE_CONFIG=${BASE_CONFIG:-configs/base_config.yml}
+
+python scripts/build_depstor_imperv.py \
+    --config configs/depstor_imperv_raster.yml \
+    --base_config "$BASE_CONFIG"

--- a/slurm_batch/build_depstor_routing.batch
+++ b/slurm_batch/build_depstor_routing.batch
@@ -1,0 +1,20 @@
+#!/bin/bash
+#SBATCH -p cpu
+#SBATCH -A impd
+#SBATCH --job-name=build_depstor_routing
+#SBATCH --output=logs/job_%j.out
+#SBATCH --error=logs/job_%j.err
+#SBATCH --time=12:00:00
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=192G
+
+module load miniforge/latest
+conda activate geoenv
+
+cd "$SLURM_SUBMIT_DIR"
+BASE_CONFIG=${BASE_CONFIG:-configs/base_config.yml}
+
+python scripts/build_depstor_routing.py \
+    --config configs/depstor_routing_raster.yml \
+    --base_config "$BASE_CONFIG"

--- a/slurm_batch/build_depstor_streambuffer.batch
+++ b/slurm_batch/build_depstor_streambuffer.batch
@@ -1,0 +1,20 @@
+#!/bin/bash
+#SBATCH -p cpu
+#SBATCH -A impd
+#SBATCH --job-name=build_depstor_streambuffer
+#SBATCH --output=logs/job_%j.out
+#SBATCH --error=logs/job_%j.err
+#SBATCH --time=04:00:00
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=64G
+
+module load miniforge/latest
+conda activate geoenv
+
+cd "$SLURM_SUBMIT_DIR"
+BASE_CONFIG=${BASE_CONFIG:-configs/base_config.yml}
+
+python scripts/build_depstor_streambuffer.py \
+    --config configs/depstor_streambuffer_raster.yml \
+    --base_config "$BASE_CONFIG"

--- a/slurm_batch/build_depstor_waterbody.batch
+++ b/slurm_batch/build_depstor_waterbody.batch
@@ -1,0 +1,20 @@
+#!/bin/bash
+#SBATCH -p cpu
+#SBATCH -A impd
+#SBATCH --job-name=build_depstor_waterbody
+#SBATCH --output=logs/job_%j.out
+#SBATCH --error=logs/job_%j.err
+#SBATCH --time=08:00:00
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=128G
+
+module load miniforge/latest
+conda activate geoenv
+
+cd "$SLURM_SUBMIT_DIR"
+BASE_CONFIG=${BASE_CONFIG:-configs/base_config.yml}
+
+python scripts/build_depstor_waterbody.py \
+    --config configs/depstor_waterbody_raster.yml \
+    --base_config "$BASE_CONFIG"

--- a/slurm_batch/build_weights.batch
+++ b/slurm_batch/build_weights.batch
@@ -1,0 +1,31 @@
+#!/bin/bash
+#SBATCH -p cpu
+#SBATCH -A impd
+#SBATCH --job-name=build_weights
+#SBATCH --output=logs/job_%j.out
+#SBATCH --error=logs/job_%j.err
+#SBATCH --time=08:00:00
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=2
+#SBATCH --mem=96G
+
+module load miniforge/latest
+conda activate geoenv
+
+cd "$SLURM_SUBMIT_DIR"
+BASE_CONFIG=${BASE_CONFIG:-configs/base_config.yml}
+
+if [ -z "${BATCHES:-}" ]; then
+    echo "Error: BATCHES env var must be set to the fabric batches directory" >&2
+    echo "  e.g. BATCHES=/path/to/gfv2/batches sbatch slurm_batch/build_weights.batch" >&2
+    exit 1
+fi
+
+# Step 1: pre-compute P2P weights
+python scripts/build_weights.py \
+    --config configs/ssflux_param.yml \
+    --base_config "$BASE_CONFIG"
+
+# Step 2: submit ssflux array job; merge job is chained automatically via afterok
+slurm_batch/submit_jobs.sh "$BATCHES" slurm_batch/create_ssflux_params.batch \
+    "$BASE_CONFIG" configs/ssflux_param.yml

--- a/slurm_batch/create_dprst_frac_params.batch
+++ b/slurm_batch/create_dprst_frac_params.batch
@@ -1,0 +1,21 @@
+#!/bin/bash
+#SBATCH -p cpu
+#SBATCH -A impd
+#SBATCH --job-name=dprst_zonal
+#SBATCH --output=logs/job_%A_%a.out
+#SBATCH --error=logs/job_%A_%a.err
+#SBATCH --time=02:00:00
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=2
+#SBATCH --mem=32G
+
+module load miniforge/latest
+conda activate geoenv
+
+cd "$SLURM_SUBMIT_DIR"
+BASE_CONFIG=${BASE_CONFIG:-configs/base_config.yml}
+
+python scripts/create_zonal_params.py \
+    --config configs/dprst_frac_param.yml \
+    --base_config "$BASE_CONFIG" \
+    --batch_id $SLURM_ARRAY_TASK_ID

--- a/slurm_batch/create_drains_to_dprst_frac_params.batch
+++ b/slurm_batch/create_drains_to_dprst_frac_params.batch
@@ -1,0 +1,21 @@
+#!/bin/bash
+#SBATCH -p cpu
+#SBATCH -A impd
+#SBATCH --job-name=drains_dprst_zonal
+#SBATCH --output=logs/job_%A_%a.out
+#SBATCH --error=logs/job_%A_%a.err
+#SBATCH --time=02:00:00
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=2
+#SBATCH --mem=32G
+
+module load miniforge/latest
+conda activate geoenv
+
+cd "$SLURM_SUBMIT_DIR"
+BASE_CONFIG=${BASE_CONFIG:-configs/base_config.yml}
+
+python scripts/create_zonal_params.py \
+    --config configs/drains_to_dprst_frac_param.yml \
+    --base_config "$BASE_CONFIG" \
+    --batch_id $SLURM_ARRAY_TASK_ID

--- a/slurm_batch/create_imperv_frac_params.batch
+++ b/slurm_batch/create_imperv_frac_params.batch
@@ -1,0 +1,21 @@
+#!/bin/bash
+#SBATCH -p cpu
+#SBATCH -A impd
+#SBATCH --job-name=imperv_zonal
+#SBATCH --output=logs/job_%A_%a.out
+#SBATCH --error=logs/job_%A_%a.err
+#SBATCH --time=02:00:00
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=2
+#SBATCH --mem=32G
+
+module load miniforge/latest
+conda activate geoenv
+
+cd "$SLURM_SUBMIT_DIR"
+BASE_CONFIG=${BASE_CONFIG:-configs/base_config.yml}
+
+python scripts/create_zonal_params.py \
+    --config configs/imperv_frac_param.yml \
+    --base_config "$BASE_CONFIG" \
+    --batch_id $SLURM_ARRAY_TASK_ID

--- a/slurm_batch/create_lulc_nalcms_params.batch
+++ b/slurm_batch/create_lulc_nalcms_params.batch
@@ -4,9 +4,10 @@
 #SBATCH --job-name=lulc_nalcms
 #SBATCH --output=logs/job_%A_%a.out
 #SBATCH --error=logs/job_%A_%a.err
+#SBATCH --array=0-63                   # Array index range (0 to len(vpus)-1)
 #SBATCH --time=02:00:00
 #SBATCH --ntasks=1
-#SBATCH --cpus-per-task=2
+#SBATCH --cpus-per-task=1
 #SBATCH --mem=32G
 
 module load miniforge/latest

--- a/slurm_batch/create_onstream_storage_frac_params.batch
+++ b/slurm_batch/create_onstream_storage_frac_params.batch
@@ -1,0 +1,21 @@
+#!/bin/bash
+#SBATCH -p cpu
+#SBATCH -A impd
+#SBATCH --job-name=onstream_zonal
+#SBATCH --output=logs/job_%A_%a.out
+#SBATCH --error=logs/job_%A_%a.err
+#SBATCH --time=02:00:00
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=2
+#SBATCH --mem=32G
+
+module load miniforge/latest
+conda activate geoenv
+
+cd "$SLURM_SUBMIT_DIR"
+BASE_CONFIG=${BASE_CONFIG:-configs/base_config.yml}
+
+python scripts/create_zonal_params.py \
+    --config configs/onstream_storage_frac_param.yml \
+    --base_config "$BASE_CONFIG" \
+    --batch_id $SLURM_ARRAY_TASK_ID

--- a/slurm_batch/diagnose_slope_aspect.batch
+++ b/slurm_batch/diagnose_slope_aspect.batch
@@ -1,0 +1,81 @@
+#!/bin/bash
+#SBATCH -p cpu
+#SBATCH -A impd
+#SBATCH --job-name=diagnose_topo
+#SBATCH --output=logs/job_%j.out
+#SBATCH --error=logs/job_%j.err
+#SBATCH --time=00:30:00
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=2
+#SBATCH --mem=16G
+
+module load miniforge/latest
+conda activate geoenv
+
+cd "$SLURM_SUBMIT_DIR"
+
+python - <<'PYEOF'
+import rasterio
+import numpy as np
+from pathlib import Path
+
+NHD = Path("/caldera/hovenweep/projects/usgs/water/impd/nhgf/gfv2_param_v2/work/nhd_merged")
+VPUS = ["01","02","03","04","05","06","07","08","09","10","11","12","13","14","15","16","17","18"]
+
+print("=" * 80)
+print("DIAGNOSTIC: slope/aspect/fixed tile nodata fill values")
+print("=" * 80)
+
+for vpu in VPUS:
+    for suffix in ["fixed", "slope", "aspect"]:
+        f = NHD / vpu / f"NEDSnapshot_merged_{suffix}_{vpu}.tif"
+        if not f.exists():
+            print(f"VPU {vpu} {suffix:7s}: MISSING")
+            continue
+        with rasterio.open(f) as src:
+            nodata_decl = src.nodata
+            arr = src.read(1)
+            total = arr.size
+            # Count values by range
+            n_neg99 = int(np.isclose(arr, -99.99, atol=0.01).sum())
+            n_neg9999 = int(np.isclose(arr, -9999.0, atol=0.5).sum())
+            n_zero = int((arr == 0.0).sum())
+            n_nan = int(np.isnan(arr).sum())
+            # Any other nodata-like negative values?
+            neg_other = arr[(arr < -50) & ~np.isclose(arr, -99.99, atol=0.01) & ~np.isclose(arr, -9999.0, atol=0.5)]
+            uniq_other = np.unique(neg_other)[:3] if len(neg_other) else []
+            print(
+                f"VPU {vpu} {suffix:7s}: declared_nodata={nodata_decl:10}, "
+                f"~-99.99={n_neg99:>12,}, ~-9999={n_neg9999:>10,}, "
+                f"=0={n_zero:>10,}, nan={n_nan:>7,}, other_neg={uniq_other}"
+            )
+
+print()
+print("=" * 80)
+print("VRT srcNodata check (what the VRT will mask):")
+for vrt_name in ["elevation", "slope", "aspect"]:
+    p = NHD / f"{vrt_name}.vrt"
+    if p.exists():
+        content = p.read_text()
+        # Extract SourceFilename and srcNoData from VRT XML
+        import re
+        src_nodata = re.findall(r'<NODATA>(.*?)</NODATA>', content)
+        print(f"  {vrt_name}.vrt: NODATA tags = {set(src_nodata)}")
+    else:
+        print(f"  {vrt_name}.vrt: MISSING")
+
+print()
+print("=" * 80)
+print("Merged params bad-value count:")
+import pandas as pd
+MERGED = Path("/caldera/hovenweep/projects/usgs/water/impd/nhgf/gfv2_param_v2/gfv2/params/merged")
+for name in ["nhm_elevation_params", "nhm_slope_params", "nhm_aspect_params"]:
+    p = MERGED / f"{name}.csv"
+    if p.exists():
+        df = pd.read_csv(p)
+        bad = (df["mean"] < -100).sum()
+        zeros = (df["mean"] == 0.0).sum()
+        print(f"  {name}: bad(<-100)={bad:,}, zeros={zeros:,}, mean={df['mean'].mean():.3f}")
+    else:
+        print(f"  {name}: MISSING")
+PYEOF

--- a/src/gfv2_params/depstor.py
+++ b/src/gfv2_params/depstor.py
@@ -1,0 +1,193 @@
+"""Raster-creation utilities for the depression-storage pipeline.
+
+Ported from depstor's RasterPipeline (depstor/scripts/DepStor.py:42-410), but
+operating on numpy arrays + a shared raster template. The depstor "rasterize
+HRU polygons and tag cells with HRU IDs" pattern is intentionally NOT carried
+over — gdptools handles HRU overlay directly during zonal aggregation.
+
+All raster outputs use the conventions:
+- uint8 binary masks: value 1 = present, value 255 = nodata
+- int32 region labels: value 0 = nodata
+- ZSTD-compressed, tiled 256x256
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+import rasterio
+from rasterio.crs import CRS
+from rasterio.coords import BoundingBox
+from rasterio.features import rasterize as rio_rasterize
+from rasterio.transform import Affine
+from scipy import ndimage
+
+
+@dataclass
+class RasterInfo:
+    """Spatial metadata for the template raster."""
+    crs: CRS
+    width: int
+    height: int
+    transform: Affine
+    nodata: Optional[float]
+    bounds: BoundingBox
+
+    @classmethod
+    def from_path(cls, path: Path) -> "RasterInfo":
+        with rasterio.open(path) as src:
+            return cls(
+                crs=src.crs,
+                width=src.width,
+                height=src.height,
+                transform=src.transform,
+                nodata=src.nodata,
+                bounds=src.bounds,
+            )
+
+
+def rasterize_binary(gdf, info: RasterInfo, all_touched: bool = False) -> np.ndarray:
+    """Burn polygons in `gdf` to a uint8 binary raster aligned to `info`.
+
+    Returns an array shaped (info.height, info.width) where 1 = covered by any
+    geometry and 255 = uncovered (nodata convention).
+    Geometries are reprojected to `info.crs` first if needed.
+    """
+    if gdf.crs is None:
+        raise ValueError("Input GeoDataFrame has no CRS")
+    if info.crs is None:
+        raise ValueError("RasterInfo has no CRS")
+    if gdf.crs != info.crs:
+        gdf = gdf.to_crs(info.crs)
+
+    valid = gdf[gdf.geometry.notna() & ~gdf.geometry.is_empty]
+    if valid.empty:
+        return np.full((info.height, info.width), 255, dtype=np.uint8)
+
+    shapes = ((geom, 1) for geom in valid.geometry)
+    out = rio_rasterize(
+        shapes=shapes,
+        out_shape=(info.height, info.width),
+        transform=info.transform,
+        fill=255,
+        dtype=np.uint8,
+        all_touched=all_touched,
+    )
+    return out
+
+
+def threshold_above(values: np.ndarray, threshold: float, src_nodata) -> np.ndarray:
+    """Return uint8 binary mask: 1 where values >= threshold, else 255 (nodata).
+
+    Nodata pixels in the source map to 255 in the output.
+    """
+    if src_nodata is not None and isinstance(src_nodata, float) and np.isnan(src_nodata):
+        valid = ~np.isnan(values)
+    elif src_nodata is not None:
+        valid = values != src_nodata
+    else:
+        valid = np.ones_like(values, dtype=bool)
+
+    above = valid & (values >= threshold)
+    return np.where(above, np.uint8(1), np.uint8(255))
+
+
+def clump_regions(binary_arr: np.ndarray) -> np.ndarray:
+    """Label connected components in a binary raster (8-connectivity).
+
+    Replaces depstor's broken `wbe.clump(diag=True)` (DepStor.py:657-661).
+    Treats any cell != 255 (nodata) as foreground if its value is 1.
+    Returns int32 labels with 0 = background/nodata.
+    """
+    foreground = (binary_arr == 1)
+    structure = np.ones((3, 3), dtype=bool)  # 8-connectivity
+    labels, _ = ndimage.label(foreground, structure=structure)
+    return labels.astype(np.int32)
+
+
+def regions_touching_mask(regions: np.ndarray, mask: np.ndarray) -> set[int]:
+    """Return the set of region IDs that share at least one cell with `mask`.
+
+    `regions`: int32 label array (0 = background).
+    `mask`: uint8 binary (1 = present, 255 = nodata).
+    """
+    touched = regions[mask == 1]
+    ids = set(int(v) for v in np.unique(touched) if v != 0)
+    return ids
+
+
+def regions_to_binary(regions: np.ndarray, keep_ids: set[int]) -> np.ndarray:
+    """Convert a region-label raster back to a uint8 binary mask.
+
+    Cells whose region ID is in `keep_ids` become 1; all others become 255.
+    """
+    if not keep_ids:
+        return np.full(regions.shape, 255, dtype=np.uint8)
+    keep = np.isin(regions, list(keep_ids))
+    return np.where(keep, np.uint8(1), np.uint8(255))
+
+
+def write_uint8_binary(arr: np.ndarray, info: RasterInfo, out_path: Path) -> None:
+    """Write a uint8 binary mask using the template spatial metadata."""
+    out_path = Path(out_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    profile = {
+        "driver": "GTiff",
+        "height": info.height,
+        "width": info.width,
+        "count": 1,
+        "dtype": "uint8",
+        "crs": info.crs,
+        "transform": info.transform,
+        "nodata": 255,
+        "compress": "ZSTD",
+        "tiled": True,
+        "blockxsize": 256,
+        "blockysize": 256,
+        "BIGTIFF": "YES",
+    }
+    with rasterio.open(out_path, "w", **profile) as dst:
+        dst.write(arr.astype(np.uint8), 1)
+
+
+def write_int32_regions(arr: np.ndarray, info: RasterInfo, out_path: Path) -> None:
+    """Write an int32 region-label raster using the template spatial metadata."""
+    out_path = Path(out_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    profile = {
+        "driver": "GTiff",
+        "height": info.height,
+        "width": info.width,
+        "count": 1,
+        "dtype": "int32",
+        "crs": info.crs,
+        "transform": info.transform,
+        "nodata": 0,
+        "compress": "ZSTD",
+        "tiled": True,
+        "blockxsize": 256,
+        "blockysize": 256,
+        "BIGTIFF": "YES",
+    }
+    with rasterio.open(out_path, "w", **profile) as dst:
+        dst.write(arr.astype(np.int32), 1)
+
+
+def read_aligned_uint8(path: Path, info: RasterInfo) -> np.ndarray:
+    """Read a uint8 raster, asserting it matches the template grid exactly.
+
+    Use this when consuming intermediates we wrote ourselves with
+    `write_uint8_binary`. Raises if the input does not align with `info`.
+    """
+    with rasterio.open(path) as src:
+        if (src.width, src.height) != (info.width, info.height):
+            raise ValueError(
+                f"Raster {path} has shape ({src.width}x{src.height}); "
+                f"expected ({info.width}x{info.height})"
+            )
+        if src.crs != info.crs:
+            raise ValueError(f"Raster {path} CRS {src.crs} != template CRS {info.crs}")
+        if src.transform != info.transform:
+            raise ValueError(f"Raster {path} transform mismatch with template")
+        return src.read(1)

--- a/src/gfv2_params/depstor.py
+++ b/src/gfv2_params/depstor.py
@@ -97,8 +97,9 @@ def clump_regions(binary_arr: np.ndarray) -> np.ndarray:
     """Label connected components in a binary raster (8-connectivity).
 
     Replaces depstor's broken `wbe.clump(diag=True)` (DepStor.py:657-661).
-    Treats any cell != 255 (nodata) as foreground if its value is 1.
-    Returns int32 labels with 0 = background/nodata.
+    Treats cells with value 1 as foreground; anything else (including the
+    255 nodata sentinel) is background. Returns int32 labels with 0 =
+    background/nodata.
     """
     foreground = (binary_arr == 1)
     structure = np.ones((3, 3), dtype=bool)  # 8-connectivity


### PR DESCRIPTION
## Summary

A hodgepodge of work that piled up on this branch after the depression-storage port. Future feature branches should be tighter scoped; merging this batch now and triaging follow-ups separately.

**Depression-storage port** (`84d935f`)
Ported from the standalone `depstor` repo: `src/gfv2_params/depstor.py`, five `scripts/build_depstor_*.py` raster builders (impervious, dprst, waterbody, streambuffer, routing), four `*_frac_param.yml` configs, six matching slurm batch files, plus `init_data_root.py`, `pyproject.toml`/`environment.yml` updates.

**FDR VRT** (`6664b38`)
Added `fdr` to `RASTER_TYPES` in `build_vrt.py` and refactored to per-layer `srcNodata` (NHDPlus FDR is Byte / nodata=255, doesn't fit the prior single -9999 constant). `work/nhd_merged/fdr.vrt` now composes the 18 per-VPU `Fdr_merged_<vpu>.tif` tiles. No Canada/Mexico fill yet.

**Editable-install fix** (`9c250e7`, `fbf2cf4`)
Hatchling auto-discovery had been picking up a stray `gfv2_params/` at the repo root (a colleague's working copy missing `depstor.py`), so editable installs registered the wrong directory and shipped without an import hook. Pin the wheel target to `src/gfv2_params`, add `pip install -e .` to `environment.yml`, and rename the root leftovers to `_gfv2_params_legacy/` / `_create_lulc_params_legacy.py` so they no longer shadow imports. After merge, existing geoenv users need `pip install -e . --force-reinstall` once.

**SSFlux build_weights wrapper** (`b39352e`)
Single sbatch entry point chaining `build_weights.py` → ssflux array → merge via `afterok`. RUNME Stage 6 docs updated.

**NALCMS LULC** (`9ee2122`)
Point at canonical `NA_NALCMS_landcover_2020v2_30m.tif` and shared `CNPY.tif`; add `--array=0-63` to the slurm script.

**Notebook & diagnostic tooling**
- `b38783e` — fix Marimo cell output (`_out` pattern) so conditional branches in `check_border_dem.py` return their figure/message
- `9311253` — new `notebooks/check_vrts.py` for decimated-overview thumbnails of CONUS VRTs
- `c950db0` — new `slurm_batch/diagnose_slope_aspect.batch` audit of nodata/fill values across per-VPU tiles, VRTs, and merged params

## Test plan

- [x] `python scripts/build_vrt.py` produces `work/nhd_merged/fdr.vrt` and rebuilds elevation/slope/aspect byte-identical
- [x] After `pip install -e . --force-reinstall`, `import gfv2_params.depstor` resolves to `src/gfv2_params/depstor.py` from any CWD
- [x] `python scripts/build_vrt.py` runs without `PYTHONPATH=src`
- [ ] Submit one depstor batch (e.g. `build_depstor_dprst.batch`) on a small VPU end-to-end
- [ ] Submit `BATCHES=... sbatch slurm_batch/build_weights.batch` and confirm array + merge dependency chain
- [ ] Submit `create_lulc_nalcms_params.batch` array and confirm all 64 batches dispatch
- [ ] Open `notebooks/check_border_dem.py` in Marimo and confirm previously-empty conditional cells render
- [ ] Open `notebooks/check_vrts.py` in Marimo and confirm thumbnails render

## Post-merge follow-ups (will file as issues)

- Continue depression-storage validation
- Migrate env management from conda + `pip install -e .` to pixi
- Other follow-ups identified in PR discussion

🤖 Generated with [Claude Code](https://claude.com/claude-code)