### PR TITLE
feat(depstor): VPU01 validation overlay + three routing-bug fixes (issue #38)

### DIFF
--- a/configs/base_config_vpu01.yml
+++ b/configs/base_config_vpu01.yml
@@ -1,0 +1,4 @@
+data_root: /caldera/hovenweep/projects/usgs/water/impd/nhgf/gfv2_param_v2
+fabric: gfv2_vpu01
+expected_max_hru_id: 11278
+batch_size: 2000

--- a/configs/depstor_dprst_raster_vpu01.yml
+++ b/configs/depstor_dprst_raster_vpu01.yml
@@ -1,0 +1,11 @@
+# VPU01 validation overlay for depstor dprst/onstream raster (issue #38).
+# Combines the three VPU01 binary inputs to produce dprst_binary.tif and
+# onstream_binary.tif scoped to the VPU01 hydrodem grid.
+
+template_raster: "{data_root}/work/nhd_merged/01/Hydrodem_merged_01.tif"
+wbody_binary_raster: "{data_root}/{fabric}/depstor_rasters/wbody_binary.tif"
+wbody_regions_raster: "{data_root}/{fabric}/depstor_rasters/wbody_regions.tif"
+stream_buffer_raster: "{data_root}/{fabric}/depstor_rasters/stream_buffer.tif"
+imperv_raster: "{data_root}/{fabric}/depstor_rasters/imperv_binary.tif"
+dprst_raster: "{data_root}/{fabric}/depstor_rasters/dprst_binary.tif"
+onstream_raster: "{data_root}/{fabric}/depstor_rasters/onstream_binary.tif"

--- a/configs/depstor_imperv_raster_vpu01.yml
+++ b/configs/depstor_imperv_raster_vpu01.yml
@@ -1,0 +1,8 @@
+# VPU01 validation overlay for depstor imperviousness raster (issue #38).
+# Same logic as depstor_imperv_raster.yml but snaps to the VPU01 hydrodem grid
+# (25,845 x 31,405) instead of the CONUS elevation.vrt.
+
+template_raster: "{data_root}/work/nhd_merged/01/Hydrodem_merged_01.tif"
+imperv_raster: "{data_root}/input/lulc_veg/Imperv.tif"
+output_raster: "{data_root}/{fabric}/depstor_rasters/imperv_binary.tif"
+imperv_threshold: 50

--- a/configs/depstor_routing_raster_vpu01.yml
+++ b/configs/depstor_routing_raster_vpu01.yml
@@ -1,0 +1,10 @@
+# VPU01 validation overlay for depstor routing (drains-to-dprst) raster (issue #38).
+# Uses the per-VPU Fdr_merged_01.tif (51 MB) directly instead of the CONUS
+# work/nhd_merged/fdr.vrt — sidesteps the chunked-reproject work tracked in
+# issue #41 entirely, since the VPU01 FDR fits comfortably in memory.
+
+template_raster: "{data_root}/work/nhd_merged/01/Hydrodem_merged_01.tif"
+fdr_raster: "{data_root}/work/nhd_merged/01/Fdr_merged_01.tif"
+dprst_raster: "{data_root}/{fabric}/depstor_rasters/dprst_binary.tif"
+output_raster: "{data_root}/{fabric}/depstor_rasters/drains_to_dprst.tif"
+keep_intermediates: false

--- a/configs/depstor_streambuffer_raster_vpu01.yml
+++ b/configs/depstor_streambuffer_raster_vpu01.yml
@@ -1,0 +1,9 @@
+# VPU01 validation overlay for depstor stream-buffer raster (issue #38).
+# Reads nsegment lines from the VPU01 draft fabric gpkg instead of the staged
+# {fabric}_segments_wbodies.gpkg used at CONUS scale.
+
+template_raster: "{data_root}/work/nhd_merged/01/Hydrodem_merged_01.tif"
+segments_gpkg: "{data_root}/input/fabric/NHM_01_draft.gpkg"
+segments_layer: nsegment
+output_raster: "{data_root}/{fabric}/depstor_rasters/stream_buffer.tif"
+buffer_distance: 60

--- a/configs/depstor_waterbody_raster_vpu01.yml
+++ b/configs/depstor_waterbody_raster_vpu01.yml
@@ -1,0 +1,10 @@
+# VPU01 validation overlay for depstor waterbody raster (issue #38).
+# NHM_01_draft.gpkg uses layer name `wbs` (NOT `v2_wb` as in the CONUS-scale
+# {fabric}_segments_wbodies.gpkg).
+
+template_raster: "{data_root}/work/nhd_merged/01/Hydrodem_merged_01.tif"
+waterbody_gpkg: "{data_root}/input/fabric/NHM_01_draft.gpkg"
+waterbody_layer: wbs
+wbody_binary_raster: "{data_root}/{fabric}/depstor_rasters/wbody_binary.tif"
+wbody_regions_raster: "{data_root}/{fabric}/depstor_rasters/wbody_regions.tif"
+min_area_threshold: 900.0

--- a/configs/dprst_frac_param_vpu01.yml
+++ b/configs/dprst_frac_param_vpu01.yml
@@ -1,0 +1,11 @@
+# VPU01 validation overlay for per-HRU dprst_frac zonal stat (issue #38).
+# Sources are auto-scoped to fabric=gfv2_vpu01 via {fabric} interpolation.
+
+source_type: dprst_frac
+source_raster: "{data_root}/{fabric}/depstor_rasters/dprst_binary.tif"
+batch_dir: "{data_root}/{fabric}/batches"
+target_layer: nhru
+id_feature: nat_hru_id
+output_dir: "{data_root}/{fabric}/params"
+merged_file: nhm_dprst_frac_params_vpu01.csv
+categorical: false

--- a/configs/drains_to_dprst_frac_param_vpu01.yml
+++ b/configs/drains_to_dprst_frac_param_vpu01.yml
@@ -1,0 +1,10 @@
+# VPU01 validation overlay for per-HRU drains_to_dprst_frac zonal stat (issue #38).
+
+source_type: drains_to_dprst_frac
+source_raster: "{data_root}/{fabric}/depstor_rasters/drains_to_dprst.tif"
+batch_dir: "{data_root}/{fabric}/batches"
+target_layer: nhru
+id_feature: nat_hru_id
+output_dir: "{data_root}/{fabric}/params"
+merged_file: nhm_drains_to_dprst_frac_params_vpu01.csv
+categorical: false

--- a/configs/imperv_frac_param_vpu01.yml
+++ b/configs/imperv_frac_param_vpu01.yml
@@ -1,0 +1,10 @@
+# VPU01 validation overlay for per-HRU imperv_frac zonal stat (issue #38).
+
+source_type: imperv_frac
+source_raster: "{data_root}/{fabric}/depstor_rasters/imperv_binary.tif"
+batch_dir: "{data_root}/{fabric}/batches"
+target_layer: nhru
+id_feature: nat_hru_id
+output_dir: "{data_root}/{fabric}/params"
+merged_file: nhm_imperv_frac_params_vpu01.csv
+categorical: false

--- a/configs/onstream_storage_frac_param_vpu01.yml
+++ b/configs/onstream_storage_frac_param_vpu01.yml
@@ -1,0 +1,10 @@
+# VPU01 validation overlay for per-HRU onstream_storage_frac zonal stat (issue #38).
+
+source_type: onstream_storage_frac
+source_raster: "{data_root}/{fabric}/depstor_rasters/onstream_binary.tif"
+batch_dir: "{data_root}/{fabric}/batches"
+target_layer: nhru
+id_feature: nat_hru_id
+output_dir: "{data_root}/{fabric}/params"
+merged_file: nhm_onstream_storage_frac_params_vpu01.csv
+categorical: false

--- a/docs/depstor_vpu01_validation_results.md
+++ b/docs/depstor_vpu01_validation_results.md
@@ -1,0 +1,65 @@
+# Depression-storage VPU 01 validation results (issue #38)
+
+Branch: `feat/depstor-validation-issue-38`
+Run window: _TBD — populate after submission_
+
+## Configuration
+
+- Fabric: `gfv2_vpu01`
+- Template grid: `work/nhd_merged/01/Hydrodem_merged_01.tif` (25,845 × 31,405, unnamed Albers ≈ EPSG:5070)
+- FDR: `work/nhd_merged/01/Fdr_merged_01.tif` (per-VPU; sidesteps the CONUS `fdr.vrt` memory issue tracked in issue #41)
+- Fabric polygons: `input/fabric/NHM_01_draft.gpkg` layers `nhru` (11,278 features, `nat_hru_id` 1..11,278), `nsegment`, `wbs` (note: NOT `v2_wb`)
+- Batch size: 2000 → expect ~6 batches in `gfv2_vpu01/batches/`
+
+## Job submission record
+
+| Step | Batch script | Job ID | Status | Elapsed |
+|---|---|---|---|---|
+| imperv | `build_depstor_imperv_vpu01.batch` | _TBD_ | _TBD_ | _TBD_ |
+| streambuffer | `build_depstor_streambuffer_vpu01.batch` | _TBD_ | _TBD_ | _TBD_ |
+| waterbody | `build_depstor_waterbody_vpu01.batch` | _TBD_ | _TBD_ | _TBD_ |
+| dprst | `build_depstor_dprst_vpu01.batch` | _TBD_ | _TBD_ | _TBD_ |
+| routing | `build_depstor_routing_vpu01.batch` | _TBD_ | _TBD_ | _TBD_ |
+| dprst_frac (array) | `create_dprst_frac_params_vpu01.batch` | _TBD_ | _TBD_ | _TBD_ |
+| imperv_frac (array) | `create_imperv_frac_params_vpu01.batch` | _TBD_ | _TBD_ | _TBD_ |
+| onstream_frac (array) | `create_onstream_storage_frac_params_vpu01.batch` | _TBD_ | _TBD_ | _TBD_ |
+| drains_to_dprst_frac (array) | `create_drains_to_dprst_frac_params_vpu01.batch` | _TBD_ | _TBD_ | _TBD_ |
+
+## Raster output summary
+
+_Populate from `notebooks/check_depstor_vpu01.ipynb` raster summary table._
+
+| Raster | Shape | Dtype | Valid % | % == 1 | Notes |
+|---|---|---|---|---|---|
+| `imperv_binary.tif` | | uint8 | | | |
+| `stream_buffer.tif` | | uint8 | | | |
+| `wbody_binary.tif` | | uint8 | | | |
+| `wbody_regions.tif` | | int32 | | N/A (n_regions=) | |
+| `dprst_binary.tif` | | uint8 | | | |
+| `onstream_binary.tif` | | uint8 | | | |
+| `drains_to_dprst.tif` | | uint8 | | | |
+
+## Zonal CSV summary
+
+_Populate from `notebooks/check_depstor_vpu01.ipynb` zonal table._
+
+| Source | Batch files | Rows | Unique HRUs | NaNs | min/max | mean | In [0,1]? | Count match (11,278)? |
+|---|---|---|---|---|---|---|---|---|
+| dprst_frac | | | | | | | | |
+| imperv_frac | | | | | | | | |
+| onstream_storage_frac | | | | | | | | |
+| drains_to_dprst_frac | | | | | | | | |
+
+## Observations
+
+_TBD — fill in after running. Document anything surprising vs. the expectations in the plan._
+
+## Known scope limits / follow-ups
+
+- **Issue #41 sidestepped.** Routing here uses the per-VPU `Fdr_merged_01.tif` directly. The CONUS run still needs the chunked rioxarray reproject (or `gdal.Warp` cutline) before it can consume `work/nhd_merged/fdr.vrt`.
+- **Layer naming inconsistency.** `NHM_01_draft.gpkg` uses `wbs`; the CONUS `{fabric}_segments_wbodies.gpkg` uses `v2_wb`. Worth standardizing during the CONUS fabric prep — file a follow-up if a convention is chosen.
+- **No parity comparison.** Per the issue, parity vs. the standalone `depstor` reference repo is deferred. Once the smoke test passes, schedule a parity comparison against the reference outputs.
+- **CONUS scale-up checklist** (separate work):
+  - Resolve issue #41 (chunked `fdr.vrt` reproject)
+  - Verify resource asks at CONUS scale (existing CONUS batches: routing 192G/12h, waterbody 128G/8h)
+  - Stage `{fabric}_segments_wbodies.gpkg` with the `v2_wb` layer naming OR update configs to read from a per-VPU pattern.

--- a/docs/depstor_vpu01_validation_results.md
+++ b/docs/depstor_vpu01_validation_results.md
@@ -1,10 +1,12 @@
 # Depression-storage VPU 01 validation results (issue #38)
 
 Branch: `feat/depstor-validation-issue-38`
-Run submitted: 2026-05-11 15:39 UTC
-Run completed: 2026-05-11 15:45 UTC (~3 min, end-to-end for the 8 jobs that ran to completion)
+Run 1: 2026-05-11 15:39–15:45 UTC (initial submission, 8/9 jobs COMPLETED — routing failed)
+Run 2: 2026-05-11 16:25 UTC (resubmit after `_FillValue` fix — routing surfaced WBT/ZSTD bug)
+Run 3: 2026-05-11 16:34 UTC (resubmit after ZSTD→LZW fix — routing surfaced WBT pour-points bug)
+Run 4: 2026-05-11 17:00 UTC (resubmit after pour-points fix — **all 9 jobs COMPLETED with sensible outputs**)
 
-**Outcome:** 8 of 9 jobs `COMPLETED`. Routing (`build_depstor_routing_vpu01.batch`, job 17021337) `FAILED` on an xarray/rioxarray `_FillValue` attribute conflict in `scripts/build_depstor_routing.py:65`. The dependent `drains_to_dprst_frac` array (17021341) was `CANCELLED` once routing failed. **6 of 7 expected rasters and 3 of 4 zonal-stat CSV groups were produced; sanity checks on all of these pass** (see Raster / Zonal sections below). The routing bug is a real source-code issue surfaced by validation — filing as a separate follow-up per the plan's "no script changes in this PR" guidance.
+**Final outcome:** all 9 depstor jobs COMPLETED, all 7 rasters and all 4 zonal-stat CSV groups produced and sanity-checked. Three independent script bugs were surfaced and fixed in commits on this branch (see "Bugs fixed during validation" below). Validation also surfaced one documentation/normalization improvement (zonal stat `mean` vs `count`) and confirmed the workflow design choices (layer naming, fabric overlay pattern, per-VPU FDR sidestepping issue #41).
 
 ## Configuration
 
@@ -18,17 +20,30 @@ Run completed: 2026-05-11 15:45 UTC (~3 min, end-to-end for the 8 jobs that ran 
 
 8 batches in `gfv2_vpu01/batches/` (KD-tree bisection from `batch_size: 2000` over 11,278 features → array range `0-7`).
 
+### Run 1 — initial validation
+
 | Step | Batch script | Job ID | Dependency | Status | Elapsed |
 |---|---|---|---|---|---|
 | imperv | `build_depstor_imperv_vpu01.batch` | 17021333 | — | COMPLETED | 1m10s |
 | streambuffer | `build_depstor_streambuffer_vpu01.batch` | 17021334 | — | COMPLETED | 0m59s |
 | waterbody | `build_depstor_waterbody_vpu01.batch` | 17021335 | — | COMPLETED | 1m07s |
 | dprst | `build_depstor_dprst_vpu01.batch` | 17021336 | afterok: 17021333, 17021334, 17021335 | COMPLETED | 0m22s |
-| routing | `build_depstor_routing_vpu01.batch` | 17021337 | afterok: 17021336 | **FAILED** (exit 1) | 0m56s |
+| routing | `build_depstor_routing_vpu01.batch` | 17021337 | afterok: 17021336 | **FAILED** (`_FillValue`) | 0m56s |
 | dprst_frac (array 0-7) | `create_dprst_frac_params_vpu01.batch` | 17021338 | afterok: 17021336 | COMPLETED (all 8) | 0:31–0:59 per task |
 | imperv_frac (array 0-7) | `create_imperv_frac_params_vpu01.batch` | 17021339 | afterok: 17021333 | COMPLETED (all 8) | 0:53–1:25 per task |
 | onstream_frac (array 0-7) | `create_onstream_storage_frac_params_vpu01.batch` | 17021340 | afterok: 17021336 | COMPLETED (all 8) | 0:57–0:59 per task |
 | drains_to_dprst_frac (array 0-7) | `create_drains_to_dprst_frac_params_vpu01.batch` | 17021341 | afterok: 17021337 | CANCELLED (dep never satisfied) | n/a |
+
+### Run 4 — final, after all three bug fixes
+
+| Step | Job ID | Status | Elapsed |
+|---|---|---|---|
+| imperv | 17026711 | COMPLETED | 0m49s |
+| streambuffer | 17026712 | COMPLETED | 0m19s |
+| waterbody | 17026713 | COMPLETED | 0m27s |
+| dprst | 17026714 | COMPLETED | 0m25s |
+| routing (re-run with intermediates + pour-points fix) | 17029832 → 17031363 prep | COMPLETED | ~3m |
+| drains_to_dprst_frac array (final) | 17031363 | COMPLETED (all 8) | 0:14–1:21 per task |
 
 ## Raster output summary
 
@@ -42,7 +57,7 @@ All rasters share shape `31,405 × 25,845` (snapped to `work/nhd_merged/01/Hydro
 | `wbody_regions.tif` | int32 | 0.63 | n/a (864 unique IDs, max 864) | n/a | scipy.ndimage 8-conn labels |
 | `dprst_binary.tif` | uint8 | 0.01 | 76,878 | 0.009 | Waterbody regions NOT touching streams or impervious |
 | `onstream_binary.tif` | uint8 | 0.62 | 5,037,175 | 0.621 | Complement of dprst within wbody universe |
-| `drains_to_dprst.tif` | — | — | — | — | **MISSING — routing job failed (job 17021337)** |
+| `drains_to_dprst.tif` | uint8 | 0.07 | 554,688 | 0.068 | Cells whose D8 flow path terminates at any dprst pour-point. Includes the 76,878 dprst cells themselves + ~478k upstream contributing cells. |
 
 **Plausibility check:** dprst (0.009%) << onstream (0.621%) is consistent with most New England waterbodies being on-stream (lakes connected to the river network). The wbody_binary ≈ dprst + onstream identity holds approximately (0.630 ≈ 0.009 + 0.621 + tiny boundary loss).
 
@@ -55,39 +70,58 @@ Each `*_frac` group has 8 batch CSV files (one per `gfv2_vpu01/batches/batch_NNN
 | `dprst_frac` | 8 | 11,278 | 11,278 | ✓ | 0 | 0.0 – 7,146.0 | 6.82 |
 | `imperv_frac` | 8 | 11,278 | 11,278 | ✓ | 0 | 0.0 – 24,921.67 | 130.73 |
 | `onstream_storage_frac` | 8 | 11,278 | 11,278 | ✓ | 0 | 0.0 – 65,182.21 | 446.67 |
-| `drains_to_dprst_frac` | — | — | — | — | — | — | **MISSING — array cancelled (routing dep never satisfied)** |
+| `drains_to_dprst_frac` | 8 | 11,278 | 11,278 | ✓ | 0 | 0.0 – 84,641.89 | 49.18 |
+
+**Cross-check on `drains_to_dprst_frac`:** 98.4% of HRUs have `count == 0` (no flow path reaches any depression), versus 99.5% for `dprst_frac` (HRUs that *are* the depression). The 1.6% non-zero HRUs include the dprst-containing HRUs themselves plus their immediate upstream-neighbour HRUs — physically reasonable for VPU01's mostly through-flowing river network where most HRUs drain to streams, not to depressions. The max-count `84,641` (~76 km² of contributing area) exceeds any individual dprst max (`7,146`, ~6.4 km²), as upstream contributing area is expected to be larger than the depression itself.
 
 **Important semantic note about the CSV format.** The binary source rasters use `1 / nodata=255` (NOT `1 / 0 / 255`). When gdptools+exactextract is invoked in `categorical: false` mode against this encoding, the resulting `mean` is `1.0` for every HRU with non-zero overlap (since every *valid* pixel is `1`), and `NaN` for HRUs with zero overlap. The actually-useful column is **`count`** — the (sub-pixel-weighted) number of `1`-valued cells per HRU. To convert this to a true fraction of HRU area, a downstream step must divide by the total HRU area in pixels (or use an HRU-area lookup). This appears to be intentional given the workflow's downstream consumers, but it contradicts the inline comment in `configs/dprst_frac_param.yml` lines 3-4 that claims "per-HRU mean is the fraction" — flagging as a documentation follow-up below.
 
+## Bugs fixed during validation
+
+Three latent bugs in the depstor port (introduced in PR #37) were exposed when running end-to-end against per-VPU NHDPlus inputs. The plan originally said "no script changes in this PR," but per user decision these were fixed on the branch to actually produce `drains_to_dprst.tif`. Each is a tightly scoped, principled fix:
+
+1. **xarray `_FillValue` conflict** — commit `77fd4dc`. `scripts/build_depstor_routing.py:65` raised `ValueError: Key '_FillValue' already exists in attrs, and will not be overwritten` inside `rioxarray.to_raster` → `xarray.conventions.encode_cf_variable`. xarray 2023+ refuses to encode when `_FillValue` is in both `attrs` and `encoding`. `reproject_match` preserves the source raster's `_FillValue` in attrs, and `write_nodata` adds it to encoding. Fix: `attrs.pop("_FillValue", None)` after `write_nodata`.
+
+2. **ZSTD compression incompatible with WhiteboxTools** — same commit. `src/gfv2_params/depstor.py` wrote all depstor rasters as ZSTD-compressed GeoTIFFs. WhiteboxTools' GeoTIFF decoder only accepts PACKBITS, LZW, and DEFLATE. The routing step feeds `dprst_binary.tif` to WBT as pour points, so the whole routing path failed at WBT load with `The WhiteboxTools GeoTIFF decoder currently only supports PACKBITS, LZW, and DEFLATE compression`. Fix: switched both `write_uint8_binary` (line 145) and `write_int32_regions` (line 168) to LZW. Negligible size impact for these sparse rasters (uint8 and int32 with mostly nodata).
+
+3. **WhiteboxTools Watershed pour-points nodata bug** — same commit. The most subtle issue. WBT's Watershed reads the pour-points raster's raw values and treats every non-zero value as a pour point — it **does not consult the GeoTIFF NoData tag** for the pour-points input. `dprst_binary.tif` uses `1=pour, nodata=255`, so WBT was treating the 811M nodata-255 cells as 811M additional pour points, each becoming its own single-cell watershed. The collapse-to-binary then marked every cell as "drains to somewhere," producing the all-black 100%-coverage `drains_to_dprst.tif` that initially looked correct (`COMPLETED, ExitCode=0`) but was useless. Fix: added `_prepare_pour_points` helper that rewrites `dprst_binary.tif` as uint8 0/1 with nodata=0 before passing to WBT. With this fix, `hru_to_dprst_labels.tif` now contains only two values (`1` for the 554,688 cells that drain to a depression, `-32768` for the 811M cells that don't), and `drains_to_dprst.tif` is a sparse, meaningful signal at 0.068% coverage.
+
+Separately, commit `ae3f8d3` migrated `scripts/create_zonal_params.py` to gdptools 0.3.13's new kwarg names (`source_ds`, `source_crs`, etc.) and enabled `gdal.UseExceptions()` / `osr.UseExceptions()` — silencing eight DeprecationWarnings / FutureWarnings per zonal-stats invocation.
+
 ## Observations
 
-1. **Wall-time was minutes, not hours.** The plan estimated 1–2h end-to-end at VPU01 scale; actual was ~3 minutes. The per-VPU scope is small enough that the default CONUS-scale resource asks (192G/12h on routing) are wildly conservative. The reduced asks in the `_vpu01.batch` files (16-48G mem, 1-2h time) were more than sufficient; routing's 48G/2h would still be roughly 4x the actual needs once the script bug is fixed.
+1. **Wall-time was minutes, not hours.** The plan estimated 1–2h end-to-end at VPU01 scale; actual single-pass was ~3 minutes. The per-VPU scope is small enough that the reduced `_vpu01.batch` resource asks (16-48G mem, 1-2h time) were more than sufficient — routing in particular peaked at <3 min and well under 8 GB RAM. The CONUS-scale routing batch (192G/12h) was sized for the failed-design unchunked CONUS `fdr.vrt` case; once issue #41 lands or a per-VPU pattern is adopted, those numbers can come down substantially.
 
-2. **Routing failure** — `scripts/build_depstor_routing.py:65` raises `ValueError: Key '_FillValue' already exists in attrs, and will not be overwritten` from inside `rioxarray.raster_array.to_raster` → `xarray.conventions.encode_cf_variable`. This is an xarray-2023+ stricter behavior triggered when the reprojected DataArray retains a `_FillValue` in `attrs` that conflicts with its encoding. The CONUS `input/depstor/{fabric}_fdr.tif` may have been pre-processed to avoid this (or the original test used a different xarray version). Workarounds:
-   - One-line fix: `del fdr_aligned.attrs['_FillValue']` (or `.attrs.pop('_FillValue', None)`) before `to_raster` at line 65.
-   - Cleaner fix: pass `nodata=...` to `to_raster` explicitly and drop the conflicting attr.
-   - Best fix (aligns with issue #41): replace the rioxarray reproject_match path entirely with a `gdal.Warp` cutline (matches the pattern in `build_depstor_imperv.py:_warp_to_template`).
+2. **Layer name `wbs` vs `v2_wb`.** Verified at Phase 0; the VPU01 config correctly uses `wbs`. No surprises.
 
-3. **Layer name `wbs` vs `v2_wb`.** Verified at Phase 0; the VPU01 config correctly uses `wbs`. No surprises.
+3. **CRS handling worked.** `Hydrodem_merged_01.tif` advertises itself as unnamed Albers (NAD83 + GRS80 + Albers Equal Area params); `NHM_01_draft.gpkg` is EPSG:5070 (NAD83/Conus Albers). The build scripts' `to_crs(info.crs)` handled this transparently — no projection warnings in logs.
 
-4. **CRS handling worked.** Hydrodem_merged_01.tif advertises itself as unnamed Albers (NAD83 + GRS80 + Albers Equal Area params); NHM_01_draft.gpkg is EPSG:5070 (NAD83/Conus Albers). The build scripts' `to_crs(info.crs)` handled this transparently — no projection warnings in logs.
+4. **Zonal CSV semantics gotcha.** See the note in the Zonal CSV summary above. `count` is the parameter to use, not `mean`. The CONUS-scale runs will hit the same surprise; a docstring clarification on `configs/*_frac_param.yml` would save someone an afternoon of debugging.
 
-5. **Zonal CSV semantics gotcha.** See the note in the Zonal CSV summary above. `count` is the parameter to use, not `mean`. The CONUS-scale runs will hit the same surprise; a docstring clarification on `configs/*_frac_param.yml` would save someone an afternoon of debugging.
+5. **The pour-points bug (#3 above) would have been invisible without `keep_intermediates: true`.** WBT exited with `ExitCode=0`, the script wrote a valid GeoTIFF, and per-HRU zonal stats produced non-zero counts. It was only when looking at the *value distribution* of the output raster (100% == 1) that it was clear something was wrong. Recommendation: add a `STATISTICS_VALID_PERCENT < some_threshold` sanity-check assertion at the end of `build_depstor_routing.py`, or a notebook smoke-test step. The notebook in this PR (`notebooks/check_depstor_vpu01.ipynb`) does include `pct_of_total` per raster, which would have caught this.
 
-## Follow-ups (file as separate issues)
+## Follow-ups
 
-1. **NEW — `_FillValue` conflict in `build_depstor_routing.py`.** Job 17021337 failed on this. See Observations #2 for the exact stack trace and three candidate fixes. Highest priority — this blocks both the VPU01 `drains_to_dprst_frac` and the eventual CONUS routing run. Issue title suggestion: *"Fix `_FillValue` conflict in `build_depstor_routing.py` rioxarray to_raster call"*.
+The three routing bugs are fixed in this branch (split across commits during the final review). Remaining follow-ups, ordered roughly by priority:
 
-2. **NEW — clarify zonal-stat output semantics.** The inline comment in `configs/dprst_frac_param.yml` (and the parallel three configs) claims "per-HRU mean is the fraction." That's only true when the source raster is `1/0` — these rasters are `1/nodata=255`, so `count` (not `mean`) is the actually-useful column. Either update the comments, or change `categorical: false` callsites to emit a normalized fraction (count / hru_pixel_area). Issue title suggestion: *"Document or normalize depstor zonal-stat outputs: `count` is the parameter, not `mean`"*.
+**Highest priority — surfaced during VPU01 visual review:**
+
+0. **The 50% imperv threshold under-counts roads.** Verified against `input/lulc_veg/Imperv.tif` over the VPU01 extent: of 10.96M cells with any impervious surface (1–100%), only **16.14% (1.77M cells) clear the 50% threshold**. The other 84% — most of which is roads at 30m resolution — is dropped. A 2-lane road (~7m) crossing a 30m pixel orthogonally covers ~23% (in the 20-30% band); only urban arterials with shoulders + medians + adjacent parking exceed 50%. This is faithful to the legacy `0b_TB_depr_stor.py:getImpervBin` ("VALUE > 50"), so the port did not introduce it — but it propagates to a systematically under-counted `hru_percent_imperv`. Options: (a) lower the threshold to ~20-25%, (b) compute `hru_percent_imperv` from the raw fractional `Imperv.tif` (0-100) via gdptools `mean / 100` and keep the 50% binary only for dprst exclusion, (c) write two separate rasters (binary for dprst, fractional for hru_percent_imperv). Option (b) or (c) is the architecturally correct fix.
+
+
+
+1. **Document or normalize depstor zonal-stat outputs.** The inline comment in `configs/dprst_frac_param.yml` (and the parallel three configs) claims "per-HRU mean is the fraction." That's only true when the source raster is `1/0` — the depstor port writes `1/nodata=255`, so `count` (not `mean`) is the actually-useful column. Either update the comments, or change `categorical: false` callsites to emit a normalized fraction (count / hru_pixel_area). Worth filing as a separate issue.
+
+2. **Add a sanity assertion to `build_depstor_routing.py`.** The all-black 100%-coverage bug shipped silently as `ExitCode=0`. A post-condition like "drains_to_dprst.tif coverage must be < 50% of the total grid" (it's typically < 1%) would have caught it. Same idea for the other depstor rasters (e.g., `imperv_binary.tif` should not exceed 5% in most fabrics).
 
 3. **Layer naming inconsistency.** `NHM_01_draft.gpkg` uses `wbs`; the CONUS `{fabric}_segments_wbodies.gpkg` uses `v2_wb`. Worth standardizing during the CONUS fabric prep.
 
-4. **Issue #41 sidestepped here.** Routing in this run used the per-VPU `Fdr_merged_01.tif` directly. The CONUS run still needs the chunked rioxarray reproject (or — even better, see Observations #2 — full replacement with a `gdal.Warp` cutline path, which would also fix the `_FillValue` bug from follow-up #1 in one shot).
+4. **Issue #41 sidestepped here.** Routing in this run used the per-VPU `Fdr_merged_01.tif` directly. The CONUS run still needs the chunked rioxarray reproject (or full replacement with a `gdal.Warp` cutline path).
 
-5. **No parity comparison.** Per the issue, parity vs. the standalone `depstor` reference repo is deferred. Worth doing once follow-ups #1 and #2 are resolved.
+5. **No parity comparison.** Per the issue, parity vs. the standalone `depstor` reference repo is deferred. Worth doing now that the routing pipeline produces meaningful outputs.
 
 6. **CONUS scale-up checklist** (separate work):
-  - Resolve follow-up #1 (and ideally #4 too).
-  - Right-size CONUS resource asks. Current values (routing 192G/12h, waterbody 128G/8h) were placeholders — VPU01 used 48G/2h and finished in <1min for routing's parent steps. CONUS is ~20× the area of VPU01; budgeting 8h on routing and 4h on waterbody is probably overkill but safe.
+  - Resolve follow-up #4.
+  - Right-size CONUS resource asks. Current values (routing 192G/12h, waterbody 128G/8h) were placeholders — VPU01 used 48G/2h and finished in <3min for the heaviest step. CONUS is ~20× the area of VPU01; budgeting 8h on routing and 4h on waterbody is probably overkill but safe.
   - Stage `{fabric}_segments_wbodies.gpkg` with the chosen layer naming convention (per follow-up #3).
-  - Decide whether `drains_to_dprst_frac` array depends on routing-COMPLETED or routing-COMPLETED-OR-SKIPPED, so a routing failure doesn't cascade-cancel the array.
+  - Add the sanity assertion from follow-up #2 before the CONUS run, since CONUS reruns are expensive.

--- a/docs/depstor_vpu01_validation_results.md
+++ b/docs/depstor_vpu01_validation_results.md
@@ -1,7 +1,10 @@
 # Depression-storage VPU 01 validation results (issue #38)
 
 Branch: `feat/depstor-validation-issue-38`
-Run window: _TBD — populate after submission_
+Run submitted: 2026-05-11 15:39 UTC
+Run completed: 2026-05-11 15:45 UTC (~3 min, end-to-end for the 8 jobs that ran to completion)
+
+**Outcome:** 8 of 9 jobs `COMPLETED`. Routing (`build_depstor_routing_vpu01.batch`, job 17021337) `FAILED` on an xarray/rioxarray `_FillValue` attribute conflict in `scripts/build_depstor_routing.py:65`. The dependent `drains_to_dprst_frac` array (17021341) was `CANCELLED` once routing failed. **6 of 7 expected rasters and 3 of 4 zonal-stat CSV groups were produced; sanity checks on all of these pass** (see Raster / Zonal sections below). The routing bug is a real source-code issue surfaced by validation — filing as a separate follow-up per the plan's "no script changes in this PR" guidance.
 
 ## Configuration
 
@@ -9,57 +12,82 @@ Run window: _TBD — populate after submission_
 - Template grid: `work/nhd_merged/01/Hydrodem_merged_01.tif` (25,845 × 31,405, unnamed Albers ≈ EPSG:5070)
 - FDR: `work/nhd_merged/01/Fdr_merged_01.tif` (per-VPU; sidesteps the CONUS `fdr.vrt` memory issue tracked in issue #41)
 - Fabric polygons: `input/fabric/NHM_01_draft.gpkg` layers `nhru` (11,278 features, `nat_hru_id` 1..11,278), `nsegment`, `wbs` (note: NOT `v2_wb`)
-- Batch size: 2000 → expect ~6 batches in `gfv2_vpu01/batches/`
+- Batch size: 2000 → KD-tree bisection produced **8** batches in `gfv2_vpu01/batches/`
 
 ## Job submission record
 
-| Step | Batch script | Job ID | Status | Elapsed |
-|---|---|---|---|---|
-| imperv | `build_depstor_imperv_vpu01.batch` | _TBD_ | _TBD_ | _TBD_ |
-| streambuffer | `build_depstor_streambuffer_vpu01.batch` | _TBD_ | _TBD_ | _TBD_ |
-| waterbody | `build_depstor_waterbody_vpu01.batch` | _TBD_ | _TBD_ | _TBD_ |
-| dprst | `build_depstor_dprst_vpu01.batch` | _TBD_ | _TBD_ | _TBD_ |
-| routing | `build_depstor_routing_vpu01.batch` | _TBD_ | _TBD_ | _TBD_ |
-| dprst_frac (array) | `create_dprst_frac_params_vpu01.batch` | _TBD_ | _TBD_ | _TBD_ |
-| imperv_frac (array) | `create_imperv_frac_params_vpu01.batch` | _TBD_ | _TBD_ | _TBD_ |
-| onstream_frac (array) | `create_onstream_storage_frac_params_vpu01.batch` | _TBD_ | _TBD_ | _TBD_ |
-| drains_to_dprst_frac (array) | `create_drains_to_dprst_frac_params_vpu01.batch` | _TBD_ | _TBD_ | _TBD_ |
+8 batches in `gfv2_vpu01/batches/` (KD-tree bisection from `batch_size: 2000` over 11,278 features → array range `0-7`).
+
+| Step | Batch script | Job ID | Dependency | Status | Elapsed |
+|---|---|---|---|---|---|
+| imperv | `build_depstor_imperv_vpu01.batch` | 17021333 | — | COMPLETED | 1m10s |
+| streambuffer | `build_depstor_streambuffer_vpu01.batch` | 17021334 | — | COMPLETED | 0m59s |
+| waterbody | `build_depstor_waterbody_vpu01.batch` | 17021335 | — | COMPLETED | 1m07s |
+| dprst | `build_depstor_dprst_vpu01.batch` | 17021336 | afterok: 17021333, 17021334, 17021335 | COMPLETED | 0m22s |
+| routing | `build_depstor_routing_vpu01.batch` | 17021337 | afterok: 17021336 | **FAILED** (exit 1) | 0m56s |
+| dprst_frac (array 0-7) | `create_dprst_frac_params_vpu01.batch` | 17021338 | afterok: 17021336 | COMPLETED (all 8) | 0:31–0:59 per task |
+| imperv_frac (array 0-7) | `create_imperv_frac_params_vpu01.batch` | 17021339 | afterok: 17021333 | COMPLETED (all 8) | 0:53–1:25 per task |
+| onstream_frac (array 0-7) | `create_onstream_storage_frac_params_vpu01.batch` | 17021340 | afterok: 17021336 | COMPLETED (all 8) | 0:57–0:59 per task |
+| drains_to_dprst_frac (array 0-7) | `create_drains_to_dprst_frac_params_vpu01.batch` | 17021341 | afterok: 17021337 | CANCELLED (dep never satisfied) | n/a |
 
 ## Raster output summary
 
-_Populate from `notebooks/check_depstor_vpu01.ipynb` raster summary table._
+All rasters share shape `31,405 × 25,845` (snapped to `work/nhd_merged/01/Hydrodem_merged_01.tif`) and `nodata = 255` (uint8) or `nodata = 0` (int32 regions). Coverage column = `(cells == 1) / (total cells)`.
 
-| Raster | Shape | Dtype | Valid % | % == 1 | Notes |
+| Raster | Dtype | Valid % (≠ nodata) | Cells == 1 | Coverage % | Notes |
 |---|---|---|---|---|---|
-| `imperv_binary.tif` | | uint8 | | | |
-| `stream_buffer.tif` | | uint8 | | | |
-| `wbody_binary.tif` | | uint8 | | | |
-| `wbody_regions.tif` | | int32 | | N/A (n_regions=) | |
-| `dprst_binary.tif` | | uint8 | | | |
-| `onstream_binary.tif` | | uint8 | | | |
-| `drains_to_dprst.tif` | | uint8 | | | |
+| `imperv_binary.tif` | uint8 | 0.27 | 2,187,698 | 0.270 | NE urban density |
+| `stream_buffer.tif` | uint8 | 0.83 | 6,742,060 | 0.831 | 60m buffer around 5,962 nsegment lines |
+| `wbody_binary.tif` | uint8 | 0.63 | 5,114,053 | 0.630 | All waterbodies (`wbs` layer, 835 polygons, min area 900 m²) |
+| `wbody_regions.tif` | int32 | 0.63 | n/a (864 unique IDs, max 864) | n/a | scipy.ndimage 8-conn labels |
+| `dprst_binary.tif` | uint8 | 0.01 | 76,878 | 0.009 | Waterbody regions NOT touching streams or impervious |
+| `onstream_binary.tif` | uint8 | 0.62 | 5,037,175 | 0.621 | Complement of dprst within wbody universe |
+| `drains_to_dprst.tif` | — | — | — | — | **MISSING — routing job failed (job 17021337)** |
+
+**Plausibility check:** dprst (0.009%) << onstream (0.621%) is consistent with most New England waterbodies being on-stream (lakes connected to the river network). The wbody_binary ≈ dprst + onstream identity holds approximately (0.630 ≈ 0.009 + 0.621 + tiny boundary loss).
 
 ## Zonal CSV summary
 
-_Populate from `notebooks/check_depstor_vpu01.ipynb` zonal table._
+Each `*_frac` group has 8 batch CSV files (one per `gfv2_vpu01/batches/batch_NNNN.gpkg`). CSV columns are the gdptools / exactextract defaults: `nat_hru_id, count, mean, std, min, 25%, 50%, 75%, max, sum`.
 
-| Source | Batch files | Rows | Unique HRUs | NaNs | min/max | mean | In [0,1]? | Count match (11,278)? |
-|---|---|---|---|---|---|---|---|---|
-| dprst_frac | | | | | | | | |
-| imperv_frac | | | | | | | | |
-| onstream_storage_frac | | | | | | | | |
-| drains_to_dprst_frac | | | | | | | | |
+| Source | Files | Rows | Unique HRUs | Count match (11,278)? | NaNs in `count` | `count` range | `count` mean |
+|---|---|---|---|---|---|---|---|
+| `dprst_frac` | 8 | 11,278 | 11,278 | ✓ | 0 | 0.0 – 7,146.0 | 6.82 |
+| `imperv_frac` | 8 | 11,278 | 11,278 | ✓ | 0 | 0.0 – 24,921.67 | 130.73 |
+| `onstream_storage_frac` | 8 | 11,278 | 11,278 | ✓ | 0 | 0.0 – 65,182.21 | 446.67 |
+| `drains_to_dprst_frac` | — | — | — | — | — | — | **MISSING — array cancelled (routing dep never satisfied)** |
+
+**Important semantic note about the CSV format.** The binary source rasters use `1 / nodata=255` (NOT `1 / 0 / 255`). When gdptools+exactextract is invoked in `categorical: false` mode against this encoding, the resulting `mean` is `1.0` for every HRU with non-zero overlap (since every *valid* pixel is `1`), and `NaN` for HRUs with zero overlap. The actually-useful column is **`count`** — the (sub-pixel-weighted) number of `1`-valued cells per HRU. To convert this to a true fraction of HRU area, a downstream step must divide by the total HRU area in pixels (or use an HRU-area lookup). This appears to be intentional given the workflow's downstream consumers, but it contradicts the inline comment in `configs/dprst_frac_param.yml` lines 3-4 that claims "per-HRU mean is the fraction" — flagging as a documentation follow-up below.
 
 ## Observations
 
-_TBD — fill in after running. Document anything surprising vs. the expectations in the plan._
+1. **Wall-time was minutes, not hours.** The plan estimated 1–2h end-to-end at VPU01 scale; actual was ~3 minutes. The per-VPU scope is small enough that the default CONUS-scale resource asks (192G/12h on routing) are wildly conservative. The reduced asks in the `_vpu01.batch` files (16-48G mem, 1-2h time) were more than sufficient; routing's 48G/2h would still be roughly 4x the actual needs once the script bug is fixed.
 
-## Known scope limits / follow-ups
+2. **Routing failure** — `scripts/build_depstor_routing.py:65` raises `ValueError: Key '_FillValue' already exists in attrs, and will not be overwritten` from inside `rioxarray.raster_array.to_raster` → `xarray.conventions.encode_cf_variable`. This is an xarray-2023+ stricter behavior triggered when the reprojected DataArray retains a `_FillValue` in `attrs` that conflicts with its encoding. The CONUS `input/depstor/{fabric}_fdr.tif` may have been pre-processed to avoid this (or the original test used a different xarray version). Workarounds:
+   - One-line fix: `del fdr_aligned.attrs['_FillValue']` (or `.attrs.pop('_FillValue', None)`) before `to_raster` at line 65.
+   - Cleaner fix: pass `nodata=...` to `to_raster` explicitly and drop the conflicting attr.
+   - Best fix (aligns with issue #41): replace the rioxarray reproject_match path entirely with a `gdal.Warp` cutline (matches the pattern in `build_depstor_imperv.py:_warp_to_template`).
 
-- **Issue #41 sidestepped.** Routing here uses the per-VPU `Fdr_merged_01.tif` directly. The CONUS run still needs the chunked rioxarray reproject (or `gdal.Warp` cutline) before it can consume `work/nhd_merged/fdr.vrt`.
-- **Layer naming inconsistency.** `NHM_01_draft.gpkg` uses `wbs`; the CONUS `{fabric}_segments_wbodies.gpkg` uses `v2_wb`. Worth standardizing during the CONUS fabric prep — file a follow-up if a convention is chosen.
-- **No parity comparison.** Per the issue, parity vs. the standalone `depstor` reference repo is deferred. Once the smoke test passes, schedule a parity comparison against the reference outputs.
-- **CONUS scale-up checklist** (separate work):
-  - Resolve issue #41 (chunked `fdr.vrt` reproject)
-  - Verify resource asks at CONUS scale (existing CONUS batches: routing 192G/12h, waterbody 128G/8h)
-  - Stage `{fabric}_segments_wbodies.gpkg` with the `v2_wb` layer naming OR update configs to read from a per-VPU pattern.
+3. **Layer name `wbs` vs `v2_wb`.** Verified at Phase 0; the VPU01 config correctly uses `wbs`. No surprises.
+
+4. **CRS handling worked.** Hydrodem_merged_01.tif advertises itself as unnamed Albers (NAD83 + GRS80 + Albers Equal Area params); NHM_01_draft.gpkg is EPSG:5070 (NAD83/Conus Albers). The build scripts' `to_crs(info.crs)` handled this transparently — no projection warnings in logs.
+
+5. **Zonal CSV semantics gotcha.** See the note in the Zonal CSV summary above. `count` is the parameter to use, not `mean`. The CONUS-scale runs will hit the same surprise; a docstring clarification on `configs/*_frac_param.yml` would save someone an afternoon of debugging.
+
+## Follow-ups (file as separate issues)
+
+1. **NEW — `_FillValue` conflict in `build_depstor_routing.py`.** Job 17021337 failed on this. See Observations #2 for the exact stack trace and three candidate fixes. Highest priority — this blocks both the VPU01 `drains_to_dprst_frac` and the eventual CONUS routing run. Issue title suggestion: *"Fix `_FillValue` conflict in `build_depstor_routing.py` rioxarray to_raster call"*.
+
+2. **NEW — clarify zonal-stat output semantics.** The inline comment in `configs/dprst_frac_param.yml` (and the parallel three configs) claims "per-HRU mean is the fraction." That's only true when the source raster is `1/0` — these rasters are `1/nodata=255`, so `count` (not `mean`) is the actually-useful column. Either update the comments, or change `categorical: false` callsites to emit a normalized fraction (count / hru_pixel_area). Issue title suggestion: *"Document or normalize depstor zonal-stat outputs: `count` is the parameter, not `mean`"*.
+
+3. **Layer naming inconsistency.** `NHM_01_draft.gpkg` uses `wbs`; the CONUS `{fabric}_segments_wbodies.gpkg` uses `v2_wb`. Worth standardizing during the CONUS fabric prep.
+
+4. **Issue #41 sidestepped here.** Routing in this run used the per-VPU `Fdr_merged_01.tif` directly. The CONUS run still needs the chunked rioxarray reproject (or — even better, see Observations #2 — full replacement with a `gdal.Warp` cutline path, which would also fix the `_FillValue` bug from follow-up #1 in one shot).
+
+5. **No parity comparison.** Per the issue, parity vs. the standalone `depstor` reference repo is deferred. Worth doing once follow-ups #1 and #2 are resolved.
+
+6. **CONUS scale-up checklist** (separate work):
+  - Resolve follow-up #1 (and ideally #4 too).
+  - Right-size CONUS resource asks. Current values (routing 192G/12h, waterbody 128G/8h) were placeholders — VPU01 used 48G/2h and finished in <1min for routing's parent steps. CONUS is ~20× the area of VPU01; budgeting 8h on routing and 4h on waterbody is probably overkill but safe.
+  - Stage `{fabric}_segments_wbodies.gpkg` with the chosen layer naming convention (per follow-up #3).
+  - Decide whether `drains_to_dprst_frac` array depends on routing-COMPLETED or routing-COMPLETED-OR-SKIPPED, so a routing failure doesn't cascade-cancel the array.

--- a/notebooks/check_depstor_vpu01.ipynb
+++ b/notebooks/check_depstor_vpu01.ipynb
@@ -1,0 +1,197 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# VPU01 depression-storage validation (issue #38)\n",
+    "\n",
+    "Sanity-check outputs from the `feat/depstor-validation-issue-38` cluster run.\n",
+    "Reads the 7 depstor rasters and 4 zonal-stat CSV groups under `gfv2_vpu01/` and confirms:\n",
+    "- Rasters are non-empty, correct dtypes, value distributions in the expected band.\n",
+    "- Zonal CSVs have one row per VPU01 HRU (~11,278), no NaNs, fractions in [0, 1]."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import glob\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import rasterio\n",
+    "from rasterio.enums import Resampling\n",
+    "\n",
+    "DATA_ROOT = Path('/caldera/hovenweep/projects/usgs/water/impd/nhgf/gfv2_param_v2')\n",
+    "FABRIC_DIR = DATA_ROOT / 'gfv2_vpu01'\n",
+    "RASTER_DIR = FABRIC_DIR / 'depstor_rasters'\n",
+    "PARAMS_DIR = FABRIC_DIR / 'params'\n",
+    "EXPECTED_HRU_COUNT = 11278"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Raster summaries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "RASTERS = [\n",
+    "    ('imperv_binary.tif', 'imperv >= 50%'),\n",
+    "    ('stream_buffer.tif', '60m stream buffer'),\n",
+    "    ('wbody_binary.tif', 'waterbodies'),\n",
+    "    ('wbody_regions.tif', 'connected-component IDs'),\n",
+    "    ('dprst_binary.tif', 'true depression storage'),\n",
+    "    ('onstream_binary.tif', 'on-stream water bodies'),\n",
+    "    ('drains_to_dprst.tif', 'cells draining to dprst'),\n",
+    "]\n",
+    "\n",
+    "rows = []\n",
+    "for fname, label in RASTERS:\n",
+    "    p = RASTER_DIR / fname\n",
+    "    if not p.exists():\n",
+    "        rows.append({'raster': fname, 'status': 'MISSING'})\n",
+    "        continue\n",
+    "    with rasterio.open(p) as ds:\n",
+    "        arr = ds.read(1)\n",
+    "        nodata = ds.nodata\n",
+    "        valid = arr if nodata is None else arr[arr != nodata]\n",
+    "        row = {\n",
+    "            'raster': fname,\n",
+    "            'label': label,\n",
+    "            'shape': f'{ds.height}x{ds.width}',\n",
+    "            'dtype': str(arr.dtype),\n",
+    "            'nodata': nodata,\n",
+    "            'valid_pct': round(100 * valid.size / arr.size, 2),\n",
+    "            'min': float(valid.min()) if valid.size else None,\n",
+    "            'max': float(valid.max()) if valid.size else None,\n",
+    "            'mean': float(valid.mean()) if valid.size else None,\n",
+    "        }\n",
+    "        if arr.dtype == np.uint8 and ds.nodata == 255:\n",
+    "            row['frac_ones'] = round(100 * (arr == 1).sum() / arr.size, 3)\n",
+    "        if 'regions' in fname:\n",
+    "            row['n_regions'] = int(valid.max()) if valid.size else 0\n",
+    "        rows.append(row)\n",
+    "\n",
+    "pd.DataFrame(rows)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Thumbnail grid (decimated)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axes = plt.subplots(2, 4, figsize=(18, 10))\n",
+    "for ax, (fname, label) in zip(axes.flat, RASTERS):\n",
+    "    p = RASTER_DIR / fname\n",
+    "    if not p.exists():\n",
+    "        ax.set_title(f'{fname}\\n(missing)')\n",
+    "        ax.axis('off')\n",
+    "        continue\n",
+    "    with rasterio.open(p) as ds:\n",
+    "        out_shape = (1, max(1, ds.height // 50), max(1, ds.width // 50))\n",
+    "        thumb = ds.read(out_shape=out_shape, resampling=Resampling.nearest)[0]\n",
+    "    masked = np.ma.masked_equal(thumb, 255) if thumb.dtype == np.uint8 else thumb\n",
+    "    ax.imshow(masked, cmap='viridis', interpolation='nearest')\n",
+    "    ax.set_title(f'{fname}\\n{label}')\n",
+    "    ax.axis('off')\n",
+    "axes.flat[-1].axis('off')\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Zonal CSV sanity checks"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "csv_rows = []\n",
+    "for src in ['dprst_frac', 'imperv_frac', 'onstream_storage_frac', 'drains_to_dprst_frac']:\n",
+    "    paths = sorted(glob.glob(str(PARAMS_DIR / src / '*.csv')))\n",
+    "    if not paths:\n",
+    "        csv_rows.append({'source': src, 'status': 'MISSING'})\n",
+    "        continue\n",
+    "    df = pd.concat([pd.read_csv(p) for p in paths], ignore_index=True)\n",
+    "    val_col = [c for c in df.columns if c != 'nat_hru_id'][0]\n",
+    "    vals = df[val_col]\n",
+    "    csv_rows.append({\n",
+    "        'source': src,\n",
+    "        'batch_files': len(paths),\n",
+    "        'rows': len(df),\n",
+    "        'unique_hrus': df['nat_hru_id'].nunique(),\n",
+    "        'nans': int(vals.isna().sum()),\n",
+    "        'min': float(vals.min(skipna=True)),\n",
+    "        'max': float(vals.max(skipna=True)),\n",
+    "        'mean': float(vals.mean(skipna=True)),\n",
+    "        'frac_zero': round(100 * (vals == 0).sum() / len(vals), 2),\n",
+    "        'in_range': bool(vals.between(0, 1).all()),\n",
+    "        'count_match': df['nat_hru_id'].nunique() == EXPECTED_HRU_COUNT,\n",
+    "    })\n",
+    "\n",
+    "pd.DataFrame(csv_rows)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axes = plt.subplots(1, 4, figsize=(18, 4))\n",
+    "for ax, src in zip(axes, ['dprst_frac', 'imperv_frac', 'onstream_storage_frac', 'drains_to_dprst_frac']):\n",
+    "    paths = sorted(glob.glob(str(PARAMS_DIR / src / '*.csv')))\n",
+    "    if not paths:\n",
+    "        ax.set_title(f'{src}\\n(missing)')\n",
+    "        continue\n",
+    "    df = pd.concat([pd.read_csv(p) for p in paths], ignore_index=True)\n",
+    "    val_col = [c for c in df.columns if c != 'nat_hru_id'][0]\n",
+    "    ax.hist(df[val_col].dropna(), bins=50)\n",
+    "    ax.set_yscale('log')\n",
+    "    ax.set_title(f'{src}\\n(n={len(df)})')\n",
+    "    ax.set_xlabel('fraction')\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.x"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/scripts/build_depstor_routing.py
+++ b/scripts/build_depstor_routing.py
@@ -142,10 +142,23 @@ def _watershed_to_binary(watershed_path: Path, info: RasterInfo, out_path: Path,
         valid = data != src_nodata
     binary = np.where(valid, np.uint8(1), np.uint8(255))
     n_in = int((binary == 1).sum())
+    pct_drains = 100 * n_in / binary.size
+    # Sanity check: most real drainage networks route <1% of cells into
+    # depressions (most flow paths terminate at streams or the basin outlet).
+    # Coverage > 50% almost certainly means pour-points were mis-encoded —
+    # see the WBT pour-points nodata bug fixed in PR #56 (the symptom was
+    # 100% coverage with `ExitCode=0` and an otherwise-valid GeoTIFF).
+    if pct_drains > 50:
+        logger.warning(
+            "Drains-to-dprst coverage is %.2f%% of the grid — unusually high. "
+            "Check that the pour-points raster uses nodata=0 (not 255) and "
+            "that the FDR is correctly aligned to the dprst grid.",
+            pct_drains,
+        )
     write_uint8_binary(binary, info, out_path)
     logger.info(
         "  Drains-to-dprst mask written: %s (%d cells, %.4f%% of grid)",
-        out_path, n_in, 100 * n_in / binary.size,
+        out_path, n_in, pct_drains,
     )
 
 

--- a/scripts/build_depstor_routing.py
+++ b/scripts/build_depstor_routing.py
@@ -78,6 +78,26 @@ def _reproject_fdr_with_rioxarray(fdr_path: Path, dprst_path: Path, out_path: Pa
     )
 
 
+def _prepare_pour_points(dprst_path: Path, out_path: Path, logger) -> None:
+    """Convert dprst_binary.tif (uint8: 1=pour, 255=nodata) into a 0/1 raster
+    with nodata=0 for WhiteboxTools.
+
+    WBT's Watershed tool reads the raw raster values and treats every non-zero
+    value as a pour-point — it does not consult the GeoTIFF NoData tag for the
+    pour-points input. The 255 (nodata) cells in dprst_binary.tif therefore
+    leak in as 76,878 watershed-1 cells + 811M watershed-255 cells, which
+    collapses the resulting binary to 100% coverage.
+    """
+    logger.info("  Converting dprst_binary.tif (1/255) -> 0/1 pour-points (nodata=0)...")
+    with rasterio.open(dprst_path) as src:
+        data = src.read(1)
+        profile = src.profile.copy()
+    pour = np.where(data == 1, np.uint8(1), np.uint8(0))
+    profile.update(nodata=0, compress="LZW")
+    with rasterio.open(out_path, "w", **profile) as dst:
+        dst.write(pour, 1)
+
+
 def _run_whitebox_watershed(fdr_path: Path, pour_pts_path: Path, output_path: Path, logger) -> None:
     runner = _find_whitebox_tools_binary()
     logger.info("  WhiteboxTools binary: %s", runner)
@@ -167,26 +187,30 @@ def main():
     info = RasterInfo.from_path(template_path)
     output_path.parent.mkdir(parents=True, exist_ok=True)
     fdr_aligned = output_path.parent / "fdr_aligned.tif"
+    pour_pts = output_path.parent / "dprst_pourpts.tif"
     watershed_raw = output_path.parent / "hru_to_dprst_labels.tif"
 
     try:
-        logger.info("--- Step 1/3: Align FDR to template grid ---")
+        logger.info("--- Step 1/4: Align FDR to template grid ---")
         t1 = time.time()
         _reproject_fdr_with_rioxarray(fdr_path, dprst_path, fdr_aligned, logger)
         logger.info("  FDR aligned in %s: %s", _elapsed(t1), fdr_aligned)
 
-        logger.info("--- Step 2/3: Run WhiteboxTools Watershed ---")
+        logger.info("--- Step 2/4: Prepare pour-points for WhiteboxTools ---")
+        _prepare_pour_points(dprst_path, pour_pts, logger)
+
+        logger.info("--- Step 3/4: Run WhiteboxTools Watershed ---")
         t2 = time.time()
-        _run_whitebox_watershed(fdr_aligned, dprst_path, watershed_raw, logger)
+        _run_whitebox_watershed(fdr_aligned, pour_pts, watershed_raw, logger)
         logger.info("  Watershed done in %s: %s", _elapsed(t2), watershed_raw)
 
-        logger.info("--- Step 3/3: Collapse labels to uint8 binary ---")
+        logger.info("--- Step 4/4: Collapse labels to uint8 binary ---")
         t3 = time.time()
         _watershed_to_binary(watershed_raw, info, output_path, logger)
         logger.info("  Binary mask written in %s", _elapsed(t3))
     finally:
         if not keep_intermediates:
-            for p in (fdr_aligned, watershed_raw):
+            for p in (fdr_aligned, pour_pts, watershed_raw):
                 if p.exists():
                     p.unlink()
                     logger.debug("  Cleaned up: %s", p)

--- a/scripts/build_depstor_routing.py
+++ b/scripts/build_depstor_routing.py
@@ -62,6 +62,9 @@ def _reproject_fdr_with_rioxarray(fdr_path: Path, dprst_path: Path, out_path: Pa
     dprst_da = xr.open_dataarray(dprst_path, engine="rasterio").squeeze("band", drop=True)
     fdr_aligned = fdr_da.rio.reproject_match(dprst_da)
     fdr_aligned = fdr_aligned.rio.write_nodata(np.uint8(255))
+    # xarray >= 2023 refuses to encode if _FillValue is in both attrs and
+    # encoding. reproject_match preserves it in attrs from the source raster.
+    fdr_aligned.attrs.pop("_FillValue", None)
     fdr_aligned.rio.to_raster(
         out_path,
         driver="GTiff",

--- a/scripts/create_zonal_params.py
+++ b/scripts/create_zonal_params.py
@@ -14,6 +14,10 @@ from gfv2_params.log import configure_logging
 # Opt into the GDAL 4.0 default behaviour of raising Python exceptions
 # instead of returning C-style error codes. Silences the FutureWarning
 # emitted by osgeo when neither UseExceptions/DontUseExceptions is set.
+# NB: GDAL state is process-global — importing this module from a notebook
+# or test harness will flip exception handling on for the whole process.
+# That is the desired behaviour (GDAL 4.0's default) and what the slurm
+# batches expect, but worth knowing if anyone embeds this script elsewhere.
 gdal.UseExceptions()
 osr.UseExceptions()
 

--- a/scripts/create_zonal_params.py
+++ b/scripts/create_zonal_params.py
@@ -6,9 +6,16 @@ from pathlib import Path
 import geopandas as gpd
 import rioxarray
 from gdptools import UserTiffData, ZonalGen
+from osgeo import gdal, osr
 
 from gfv2_params.config import load_config
 from gfv2_params.log import configure_logging
+
+# Opt into the GDAL 4.0 default behaviour of raising Python exceptions
+# instead of returning C-style error codes. Silences the FutureWarning
+# emitted by osgeo when neither UseExceptions/DontUseExceptions is set.
+gdal.UseExceptions()
+osr.UseExceptions()
 
 
 def main():
@@ -56,17 +63,17 @@ def main():
     # Build file prefix for output
     file_prefix = f"base_nhm_{source_type}_{fabric}_batch_{args.batch_id:04d}_param"
 
-    # Create zonal stats
+    # Create zonal stats (gdptools 0.3.13+ keyword names)
     data = UserTiffData(
-        var=source_type,
-        ds=ned_da,
-        proj_ds=ned_da.rio.crs,
-        x_coord="x",
-        y_coord="y",
+        source_var=source_type,
+        source_ds=ned_da,
+        source_crs=ned_da.rio.crs,
+        source_x_coord="x",
+        source_y_coord="y",
         band=1,
         bname="band",
-        f_feature=nhru_gdf,
-        id_feature=id_feature,
+        target_gdf=nhru_gdf,
+        target_id=id_feature,
     )
 
     zonal_gen = ZonalGen(

--- a/slurm_batch/build_depstor_dprst_vpu01.batch
+++ b/slurm_batch/build_depstor_dprst_vpu01.batch
@@ -1,0 +1,19 @@
+#!/bin/bash
+#SBATCH -p cpu
+#SBATCH -A impd
+#SBATCH --job-name=build_depstor_dprst_vpu01
+#SBATCH --output=logs/job_%j.out
+#SBATCH --error=logs/job_%j.err
+#SBATCH --time=01:00:00
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=32G
+
+cd "$SLURM_SUBMIT_DIR"
+[ -f .pixi-activate.sh ] || { echo "ERROR: missing .pixi-activate.sh — run scripts/refresh_pixi_activation.sh" >&2; exit 1; }
+source .pixi-activate.sh
+BASE_CONFIG=${BASE_CONFIG:-configs/base_config_vpu01.yml}
+
+python scripts/build_depstor_dprst.py \
+    --config configs/depstor_dprst_raster_vpu01.yml \
+    --base_config "$BASE_CONFIG"

--- a/slurm_batch/build_depstor_imperv_vpu01.batch
+++ b/slurm_batch/build_depstor_imperv_vpu01.batch
@@ -1,0 +1,19 @@
+#!/bin/bash
+#SBATCH -p cpu
+#SBATCH -A impd
+#SBATCH --job-name=build_depstor_imperv_vpu01
+#SBATCH --output=logs/job_%j.out
+#SBATCH --error=logs/job_%j.err
+#SBATCH --time=01:00:00
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=16G
+
+cd "$SLURM_SUBMIT_DIR"
+[ -f .pixi-activate.sh ] || { echo "ERROR: missing .pixi-activate.sh — run scripts/refresh_pixi_activation.sh" >&2; exit 1; }
+source .pixi-activate.sh
+BASE_CONFIG=${BASE_CONFIG:-configs/base_config_vpu01.yml}
+
+python scripts/build_depstor_imperv.py \
+    --config configs/depstor_imperv_raster_vpu01.yml \
+    --base_config "$BASE_CONFIG"

--- a/slurm_batch/build_depstor_routing_vpu01.batch
+++ b/slurm_batch/build_depstor_routing_vpu01.batch
@@ -1,0 +1,19 @@
+#!/bin/bash
+#SBATCH -p cpu
+#SBATCH -A impd
+#SBATCH --job-name=build_depstor_routing_vpu01
+#SBATCH --output=logs/job_%j.out
+#SBATCH --error=logs/job_%j.err
+#SBATCH --time=02:00:00
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=48G
+
+cd "$SLURM_SUBMIT_DIR"
+[ -f .pixi-activate.sh ] || { echo "ERROR: missing .pixi-activate.sh — run scripts/refresh_pixi_activation.sh" >&2; exit 1; }
+source .pixi-activate.sh
+BASE_CONFIG=${BASE_CONFIG:-configs/base_config_vpu01.yml}
+
+python scripts/build_depstor_routing.py \
+    --config configs/depstor_routing_raster_vpu01.yml \
+    --base_config "$BASE_CONFIG"

--- a/slurm_batch/build_depstor_streambuffer_vpu01.batch
+++ b/slurm_batch/build_depstor_streambuffer_vpu01.batch
@@ -1,0 +1,19 @@
+#!/bin/bash
+#SBATCH -p cpu
+#SBATCH -A impd
+#SBATCH --job-name=build_depstor_streambuffer_vpu01
+#SBATCH --output=logs/job_%j.out
+#SBATCH --error=logs/job_%j.err
+#SBATCH --time=01:00:00
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=16G
+
+cd "$SLURM_SUBMIT_DIR"
+[ -f .pixi-activate.sh ] || { echo "ERROR: missing .pixi-activate.sh — run scripts/refresh_pixi_activation.sh" >&2; exit 1; }
+source .pixi-activate.sh
+BASE_CONFIG=${BASE_CONFIG:-configs/base_config_vpu01.yml}
+
+python scripts/build_depstor_streambuffer.py \
+    --config configs/depstor_streambuffer_raster_vpu01.yml \
+    --base_config "$BASE_CONFIG"

--- a/slurm_batch/build_depstor_waterbody_vpu01.batch
+++ b/slurm_batch/build_depstor_waterbody_vpu01.batch
@@ -1,0 +1,19 @@
+#!/bin/bash
+#SBATCH -p cpu
+#SBATCH -A impd
+#SBATCH --job-name=build_depstor_waterbody_vpu01
+#SBATCH --output=logs/job_%j.out
+#SBATCH --error=logs/job_%j.err
+#SBATCH --time=02:00:00
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=32G
+
+cd "$SLURM_SUBMIT_DIR"
+[ -f .pixi-activate.sh ] || { echo "ERROR: missing .pixi-activate.sh — run scripts/refresh_pixi_activation.sh" >&2; exit 1; }
+source .pixi-activate.sh
+BASE_CONFIG=${BASE_CONFIG:-configs/base_config_vpu01.yml}
+
+python scripts/build_depstor_waterbody.py \
+    --config configs/depstor_waterbody_raster_vpu01.yml \
+    --base_config "$BASE_CONFIG"

--- a/slurm_batch/create_dprst_frac_params_vpu01.batch
+++ b/slurm_batch/create_dprst_frac_params_vpu01.batch
@@ -1,0 +1,20 @@
+#!/bin/bash
+#SBATCH -p cpu
+#SBATCH -A impd
+#SBATCH --job-name=dprst_zonal_vpu01
+#SBATCH --output=logs/job_%A_%a.out
+#SBATCH --error=logs/job_%A_%a.err
+#SBATCH --time=02:00:00
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=2
+#SBATCH --mem=32G
+
+cd "$SLURM_SUBMIT_DIR"
+[ -f .pixi-activate.sh ] || { echo "ERROR: missing .pixi-activate.sh — run scripts/refresh_pixi_activation.sh" >&2; exit 1; }
+source .pixi-activate.sh
+BASE_CONFIG=${BASE_CONFIG:-configs/base_config_vpu01.yml}
+
+python scripts/create_zonal_params.py \
+    --config configs/dprst_frac_param_vpu01.yml \
+    --base_config "$BASE_CONFIG" \
+    --batch_id $SLURM_ARRAY_TASK_ID

--- a/slurm_batch/create_drains_to_dprst_frac_params_vpu01.batch
+++ b/slurm_batch/create_drains_to_dprst_frac_params_vpu01.batch
@@ -1,0 +1,20 @@
+#!/bin/bash
+#SBATCH -p cpu
+#SBATCH -A impd
+#SBATCH --job-name=drains_dprst_zonal_vpu01
+#SBATCH --output=logs/job_%A_%a.out
+#SBATCH --error=logs/job_%A_%a.err
+#SBATCH --time=02:00:00
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=2
+#SBATCH --mem=32G
+
+cd "$SLURM_SUBMIT_DIR"
+[ -f .pixi-activate.sh ] || { echo "ERROR: missing .pixi-activate.sh — run scripts/refresh_pixi_activation.sh" >&2; exit 1; }
+source .pixi-activate.sh
+BASE_CONFIG=${BASE_CONFIG:-configs/base_config_vpu01.yml}
+
+python scripts/create_zonal_params.py \
+    --config configs/drains_to_dprst_frac_param_vpu01.yml \
+    --base_config "$BASE_CONFIG" \
+    --batch_id $SLURM_ARRAY_TASK_ID

--- a/slurm_batch/create_imperv_frac_params_vpu01.batch
+++ b/slurm_batch/create_imperv_frac_params_vpu01.batch
@@ -1,0 +1,20 @@
+#!/bin/bash
+#SBATCH -p cpu
+#SBATCH -A impd
+#SBATCH --job-name=imperv_zonal_vpu01
+#SBATCH --output=logs/job_%A_%a.out
+#SBATCH --error=logs/job_%A_%a.err
+#SBATCH --time=02:00:00
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=2
+#SBATCH --mem=32G
+
+cd "$SLURM_SUBMIT_DIR"
+[ -f .pixi-activate.sh ] || { echo "ERROR: missing .pixi-activate.sh — run scripts/refresh_pixi_activation.sh" >&2; exit 1; }
+source .pixi-activate.sh
+BASE_CONFIG=${BASE_CONFIG:-configs/base_config_vpu01.yml}
+
+python scripts/create_zonal_params.py \
+    --config configs/imperv_frac_param_vpu01.yml \
+    --base_config "$BASE_CONFIG" \
+    --batch_id $SLURM_ARRAY_TASK_ID

--- a/slurm_batch/create_onstream_storage_frac_params_vpu01.batch
+++ b/slurm_batch/create_onstream_storage_frac_params_vpu01.batch
@@ -1,0 +1,20 @@
+#!/bin/bash
+#SBATCH -p cpu
+#SBATCH -A impd
+#SBATCH --job-name=onstream_zonal_vpu01
+#SBATCH --output=logs/job_%A_%a.out
+#SBATCH --error=logs/job_%A_%a.err
+#SBATCH --time=02:00:00
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=2
+#SBATCH --mem=32G
+
+cd "$SLURM_SUBMIT_DIR"
+[ -f .pixi-activate.sh ] || { echo "ERROR: missing .pixi-activate.sh — run scripts/refresh_pixi_activation.sh" >&2; exit 1; }
+source .pixi-activate.sh
+BASE_CONFIG=${BASE_CONFIG:-configs/base_config_vpu01.yml}
+
+python scripts/create_zonal_params.py \
+    --config configs/onstream_storage_frac_param_vpu01.yml \
+    --base_config "$BASE_CONFIG" \
+    --batch_id $SLURM_ARRAY_TASK_ID

--- a/src/gfv2_params/depstor.py
+++ b/src/gfv2_params/depstor.py
@@ -8,7 +8,8 @@ over — gdptools handles HRU overlay directly during zonal aggregation.
 All raster outputs use the conventions:
 - uint8 binary masks: value 1 = present, value 255 = nodata
 - int32 region labels: value 0 = nodata
-- ZSTD-compressed, tiled 256x256
+- LZW-compressed, tiled 256x256 (LZW chosen over ZSTD because
+  WhiteboxTools only reads PACKBITS/LZW/DEFLATE)
 """
 
 from dataclasses import dataclass
@@ -142,7 +143,7 @@ def write_uint8_binary(arr: np.ndarray, info: RasterInfo, out_path: Path) -> Non
         "crs": info.crs,
         "transform": info.transform,
         "nodata": 255,
-        "compress": "ZSTD",
+        "compress": "LZW",
         "tiled": True,
         "blockxsize": 256,
         "blockysize": 256,
@@ -165,7 +166,7 @@ def write_int32_regions(arr: np.ndarray, info: RasterInfo, out_path: Path) -> No
         "crs": info.crs,
         "transform": info.transform,
         "nodata": 0,
-        "compress": "ZSTD",
+        "compress": "LZW",
         "tiled": True,
         "blockxsize": 256,
         "blockysize": 256,


### PR DESCRIPTION
Closes #38.

## Summary

Validates the depression-storage workflow end-to-end at VPU 01 scope, surfaced and fixed three latent bugs in the depstor port from PR #37, and captures the run outcomes in a results doc.

**End state on VPU01:** 9 of 9 SLURM jobs `COMPLETED`, 7 of 7 rasters and 4 of 4 zonal-stat CSV groups produced, sanity-checked, and physically plausible. Total cluster wall time ~3 min per run (the plan's 1-2h estimate was wildly over-budgeted at VPU01 scope).

## ⚠️ Scope expansion vs. original plan

The validation plan said *"no script changes in this PR — if validation surfaces a bug, file a new issue."* That guidance didn't survive contact with reality: validation surfaced three real script bugs that cascade into each other, and producing a usable `drains_to_dprst.tif` required fixing all three. With explicit user approval, **three source-code commits were added to this PR**:

- `9ec9cd6` — `fix(depstor): drop _FillValue from attrs before rioxarray.to_raster`
- `6638b8d` — `fix(depstor): switch raster compression ZSTD→LZW for WhiteboxTools compat`
- `116a4f9` — `fix(depstor): rewrite dprst pour-points as 0/1 with nodata=0 before WBT`

Each is tightly scoped (3-30 lines), has its rationale in the commit body, and was validated by re-running the affected pipeline step. Splitting them into atomic commits (vs. one combined fix) makes `git bisect` clean if any of these regress later.

A fourth source change, `f39bcb0 chore(zonal)`, migrates `scripts/create_zonal_params.py` to gdptools 0.3.13's new kwarg names and enables `gdal.UseExceptions()` / `osr.UseExceptions()` (silences 8 deprecation/future warnings per zonal invocation).

## What's in the PR

**Validation infrastructure** (commit `6b028c2`):
- 10 new configs (`base_config_vpu01.yml`, 5 raster overlays, 4 zonal overlays) — modeled on the existing `gfv2_oregon` fabric-overlay pattern, scoped to VPU 01 via the per-VPU `Hydrodem_merged_01.tif` template and `Fdr_merged_01.tif` (sidesteps issue #41 entirely for this validation pass).
- 9 new slurm batches — thin wrappers with right-sized resource asks (16-48G mem, 1-2h time vs. CONUS 192G/12h).
- `notebooks/check_depstor_vpu01.ipynb` — sanity-check notebook (raster summaries, decimated thumbnails, zonal CSV checks).

**Source-code fixes** (commits `9ec9cd6`, `6638b8d`, `116a4f9`) — see "Scope expansion" above.

**Zonal modernization** (commit `f39bcb0`).

**Results doc** (`docs/depstor_vpu01_validation_results.md`, commits `528196d` + `afae425`) — captures all 4 runs (initial + 3 debug iterations), final raster + CSV statistics, and a follow-ups list.

## Notable findings beyond the bug fixes

1. **Wall-time was 1/20th of the plan estimate** — VPU01 is small enough that even the heaviest step (WBT Watershed) ran in <2 min. CONUS resource asks (routing 192G/12h, waterbody 128G/8h) are placeholders; the actual numbers can come down a lot.

2. **50% imperv threshold drops 84% of developed land in VPU01.** Most of the 84% is roads at 30m resolution — a 2-lane road covers ~23% of a 30m pixel, below the cutoff. Faithful to legacy `0b_TB_depr_stor.py`, but propagates to a systematically under-counted `hru_percent_imperv`. **Filed as separate issue.**

3. **The WBT pour-points bug exited with code 0 and produced a valid GeoTIFF that passed every cheap check.** Only the value distribution (`100% == 1`) revealed the corruption. Adding a coverage-bound sanity assertion to `build_depstor_routing.py` would have caught it at job time, not at notebook-inspection time. Captured as follow-up #2 in the results doc.

## Compression change side-effect

`src/gfv2_params/depstor.py` writers now emit LZW instead of ZSTD. Existing CONUS outputs at `gfv2/depstor_rasters/*.tif` (from PR #37 runs) are still ZSTD on disk — they read fine, but will be rewritten as LZW on the next CONUS rebuild. No data loss; just a one-shot recompression at next run.

## Test plan

- [x] All 5 raster batches submit, dependency-chain correctly, COMPLETE
- [x] All 4 zonal-stat array jobs (32 array tasks total) COMPLETE
- [x] `drains_to_dprst.tif` shows sparse signal (~0.07% coverage, not 100%)
- [x] All 4 zonal CSV groups have 11,278 rows, no NaNs in `count`, ranges in expected magnitudes
- [x] `wbody = dprst + onstream` identity holds (0.630% ≈ 0.009% + 0.621%)
- [x] `drains_to_dprst_frac` non-zero HRU count (1.6%) exceeds `dprst_frac` non-zero HRU count (0.5%) — physically expected
- [ ] Independent review of the three bug fixes
- [ ] Smoke-test the build_depstor_imperv.py / build_depstor_dprst.py paths still work for the existing CONUS configs (no breaking changes expected; the only shared change is ZSTD→LZW)

## Follow-ups (filed as separate issues)

See [docs/depstor_vpu01_validation_results.md](docs/depstor_vpu01_validation_results.md) — the "Follow-ups" section enumerates 7 items: the imperv threshold issue (highest priority), coverage-bound sanity assertion, layer-naming standardization (`wbs` vs `v2_wb`), the deferred issue #41 (CONUS `fdr.vrt`), parity comparison vs. the standalone `depstor` repo, CONUS scale-up checklist, plus pour-points memory at CONUS scale, and slurm-batch consolidation (raised in review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)