### PR TITLE
fix(depstor): mask all rasters to HRU fabric (closes #68)

### DIFF
--- a/configs/base_config.yml
+++ b/configs/base_config.yml
@@ -17,6 +17,10 @@ fabrics:
     segments_gpkg: "{data_root}/input/depstor/{fabric}_segments_wbodies.gpkg"
     waterbody_gpkg: "{data_root}/input/depstor/{fabric}_segments_wbodies.gpkg"
     waterbody_layer: v2_wb
+    # HRU polygon fabric — authoritative land/domain mask for the depstor
+    # builders (build_depstor_landmask.py rasterizes this to land_mask.tif).
+    hru_gpkg: "{data_root}/{fabric}/fabric/gfv2_nhru_merged.gpkg"
+    hru_layer: nhru
 
   gfv2_vpu01:
     # VPU01 validation overlay (issue #38). Uses the per-VPU staged inputs
@@ -30,6 +34,8 @@ fabrics:
     segments_gpkg: "{data_root}/input/fabric/NHM_01_draft.gpkg"
     waterbody_gpkg: "{data_root}/input/fabric/NHM_01_draft.gpkg"
     waterbody_layer: wbs
+    hru_gpkg: "{data_root}/{fabric}/fabric/gfv2_vpu01_nhru.gpkg"
+    hru_layer: nhru
 
   oregon:
     # Depstor inputs not yet staged for oregon. Depstor scripts will raise

--- a/configs/depstor_carea_map_raster.yml
+++ b/configs/depstor_carea_map_raster.yml
@@ -18,6 +18,7 @@
 
 perv_raster: "{data_root}/{fabric}/depstor_rasters/perv_binary.tif"
 onstream_raster: "{data_root}/{fabric}/depstor_rasters/onstream_binary.tif"
+landmask_raster: "{data_root}/{fabric}/depstor_rasters/land_mask.tif"
 
 threshold_carea_max: 8.0
 output_raster_carea_max: "{data_root}/{fabric}/depstor_rasters/carea_map_t8_binary.tif"

--- a/configs/depstor_dprst_raster.yml
+++ b/configs/depstor_dprst_raster.yml
@@ -5,6 +5,7 @@
 #
 # template_raster comes from the active fabric profile in base_config.yml.
 
+landmask_raster: "{data_root}/{fabric}/depstor_rasters/land_mask.tif"
 wbody_binary_raster: "{data_root}/{fabric}/depstor_rasters/wbody_binary.tif"
 wbody_regions_raster: "{data_root}/{fabric}/depstor_rasters/wbody_regions.tif"
 stream_buffer_raster: "{data_root}/{fabric}/depstor_rasters/stream_buffer.tif"

--- a/configs/depstor_imperv_raster.yml
+++ b/configs/depstor_imperv_raster.yml
@@ -1,11 +1,18 @@
 # Build the depression-storage imperviousness binary raster.
 #
-# Threshold the staged Imperv.tif at imperv_threshold (default 50%), warp/snap
-# to the active fabric's template_raster grid, and write a uint8 binary raster
-# (1 = impervious, 255 = nodata) to {fabric}/depstor_rasters/imperv_binary.tif.
+# Threshold the source fractional-impervious raster at imperv_threshold
+# (default 50%), warp/snap to the active fabric's template_raster grid, and
+# write a uint8 binary raster (1 = impervious, 255 = nodata) to
+# {fabric}/depstor_rasters/imperv_binary.tif.
+#
+# imperv_raster: NLCD Annual Fractional Impervious Surface, 2015 (CONUS, 30 m,
+# 0-100 percent developed impervious, nodata 250, Albers/WGS84). build_depstor_
+# imperv.py reprojects it to the template CRS and reads its nodata dynamically,
+# so swapping the source raster needs no code change — but the source must be a
+# continuous 0-100 percentage on a 30 m grid.
 #
 # template_raster comes from the active fabric profile in base_config.yml.
 
-imperv_raster: "{data_root}/input/lulc_veg/Imperv.tif"
+imperv_raster: "{data_root}/input/lulc/nlcd_annual_imperv/Annual_NLCD_FctImp_2015_CU_C1V1.tif"
 output_raster: "{data_root}/{fabric}/depstor_rasters/imperv_binary.tif"
 imperv_threshold: 50

--- a/configs/depstor_imperv_raster.yml
+++ b/configs/depstor_imperv_raster.yml
@@ -14,5 +14,6 @@
 # template_raster comes from the active fabric profile in base_config.yml.
 
 imperv_raster: "{data_root}/input/lulc/nlcd_annual_imperv/Annual_NLCD_FctImp_2015_CU_C1V1.tif"
+landmask_raster: "{data_root}/{fabric}/depstor_rasters/land_mask.tif"
 output_raster: "{data_root}/{fabric}/depstor_rasters/imperv_binary.tif"
 imperv_threshold: 50

--- a/configs/depstor_landmask_raster.yml
+++ b/configs/depstor_landmask_raster.yml
@@ -1,0 +1,17 @@
+# Build the depression-storage land-mask raster.
+#
+# Rasterizes the HRU polygon fabric (the authoritative modeling domain) onto
+# the template grid -> land_mask.tif (uint8 binary, 1 = land/in-fabric,
+# 255 = ocean/off-domain). Every other depstor builder masks its output
+# against this raster, so build_depstor_landmask must run first.
+#
+# This replaces the earlier template-DEM-nodata land mask: the hydro-
+# conditioned DEM carries valid (often garbage) elevations over coastal ocean,
+# so its nodata footprint bulged into the sea and leaked into the dense outputs
+# (perv_binary, carea_map). The HRU fabric follows the real coastline and is
+# exactly the domain the depstor params are aggregated to.
+#
+# template_raster, hru_gpkg, and hru_layer come from the active fabric profile
+# in base_config.yml.
+
+output_raster: "{data_root}/{fabric}/depstor_rasters/land_mask.tif"

--- a/configs/depstor_perv_raster.yml
+++ b/configs/depstor_perv_raster.yml
@@ -1,6 +1,9 @@
 # Build the pervious-area binary raster.
 #
-# A cell is pervious where it is NOT impervious AND NOT depression-storage.
+# A cell is pervious where it is valid land (inside the template DEM's nodata
+# footprint) AND NOT impervious AND NOT depression-storage. The land mask is
+# required: this builder defaults every cell to pervious, so without it the
+# whole ocean inside the grid bounding box would be marked pervious.
 # Source: depstor workflow Level Three, `GetPervAreaTotal`
 # (docs/depstor_workflow.md) — "Get raster with HRU IDs in areas that are not
 # impervious or depressions. Basically a con operation to label stuff."
@@ -15,4 +18,5 @@
 
 imperv_raster: "{data_root}/{fabric}/depstor_rasters/imperv_binary.tif"
 dprst_raster: "{data_root}/{fabric}/depstor_rasters/dprst_binary.tif"
+landmask_raster: "{data_root}/{fabric}/depstor_rasters/land_mask.tif"
 perv_raster: "{data_root}/{fabric}/depstor_rasters/perv_binary.tif"

--- a/configs/depstor_routing_raster.yml
+++ b/configs/depstor_routing_raster.yml
@@ -10,5 +10,6 @@
 # base_config.yml.
 
 dprst_raster: "{data_root}/{fabric}/depstor_rasters/dprst_binary.tif"
+landmask_raster: "{data_root}/{fabric}/depstor_rasters/land_mask.tif"
 output_raster: "{data_root}/{fabric}/depstor_rasters/drains_to_dprst.tif"
 keep_intermediates: false

--- a/configs/depstor_streambuffer_raster.yml
+++ b/configs/depstor_streambuffer_raster.yml
@@ -8,5 +8,6 @@
 # base_config.yml.
 
 segments_layer: nsegment
+landmask_raster: "{data_root}/{fabric}/depstor_rasters/land_mask.tif"
 output_raster: "{data_root}/{fabric}/depstor_rasters/stream_buffer.tif"
 buffer_distance: 60

--- a/configs/depstor_waterbody_raster.yml
+++ b/configs/depstor_waterbody_raster.yml
@@ -10,6 +10,7 @@
 # template_raster, waterbody_gpkg, and waterbody_layer come from the active
 # fabric profile in base_config.yml.
 
+landmask_raster: "{data_root}/{fabric}/depstor_rasters/land_mask.tif"
 wbody_binary_raster: "{data_root}/{fabric}/depstor_rasters/wbody_binary.tif"
 wbody_regions_raster: "{data_root}/{fabric}/depstor_rasters/wbody_regions.tif"
 min_area_threshold: 900.0

--- a/docs/depstor_workflow.md
+++ b/docs/depstor_workflow.md
@@ -92,6 +92,15 @@ The workflow is broken up into 5 levels:
    and `carea_max` parameters that control runoff partitioning
 5. **Level Five:** Profit (i.e., generate the parameter files)
 
+**gfv2-params land mask (PR #69, issue #68):** Before any Level One/Two builder
+runs, `build_depstor_landmask.py` rasterises the `nhru` polygon fabric to the
+template grid → `land_mask.tif` (uint8 1/255). Every depstor raster builder
+masks its output against it. This replaced an earlier DEM-nodata mask that
+bulged into the ocean (the hydro-conditioned DEM carries valid elevations over
+coastal water; the FDR has the same blobs). The HRU fabric is the
+authoritative modeling domain and is exactly what `create_zonal_params`
+aggregates to downstream.
+
 ---
 
 ### Level One — Preprocessing and setting environments (Finished 2/17)

--- a/scripts/build_depstor_carea_map.py
+++ b/scripts/build_depstor_carea_map.py
@@ -18,6 +18,10 @@ so nearest-neighbour resampling is exact (no fractional shift). Template cells
 outside the source TWI extent receive the TWI nodata sentinel, so they fail
 the `twi_valid` check in compute_carea_map_binary and end up as 255 in the
 output regardless of their perv/onstream status.
+
+land_mask.tif (the rasterised HRU fabric) is also read: off-land cells are
+excluded explicitly so the on-stream branch can't rescue them and so a stale
+perv_binary can't leak ocean into carea_map.
 """
 
 import argparse
@@ -35,9 +39,9 @@ from gfv2_params.config import load_config, require_config_key
 from gfv2_params.depstor import RasterInfo, compute_carea_map_binary
 from gfv2_params.log import configure_logging
 
-# TWI is float32 — roughly 4x the per-strip memory of the uint8 inputs. At
-# CONUS width (~150k cols) one 1024-row strip is ~600 MB for TWI; well under
-# the default 32 G sbatch allocation but worth noting.
+# TWI is float32 — ~4x the per-strip memory of the uint8 inputs. At CONUS width
+# (~150k cols) one 1024-row strip is ~600 MB; well under the default 32 G
+# sbatch allocation but worth noting.
 STRIP_ROWS = 1024
 
 
@@ -96,6 +100,7 @@ def main():
 
     template_path = Path(require_config_key(config, "template_raster", "build_depstor_carea_map"))
     twi_path = Path(require_config_key(config, "twi_raster", "build_depstor_carea_map"))
+    landmask_path = Path(config["landmask_raster"])
     perv_path = Path(config["perv_raster"])
     onstream_path = Path(config["onstream_raster"])
 
@@ -112,12 +117,13 @@ def main():
         ),
     ]
 
-    for p in (template_path, twi_path, perv_path, onstream_path):
+    for p in (template_path, twi_path, landmask_path, perv_path, onstream_path):
         if not p.exists():
             raise FileNotFoundError(f"Required input not found: {p}")
 
     logger.info("=== build_depstor_carea_map ===")
     logger.info("Template : %s", template_path)
+    logger.info("Land mask: %s", landmask_path)
     logger.info("Perv     : %s", perv_path)
     logger.info("Onstream : %s", onstream_path)
     logger.info("TWI      : %s", twi_path)
@@ -138,9 +144,11 @@ def main():
     profile = _uint8_binary_profile(info)
 
     with ExitStack() as stack:
+        landmask_src = stack.enter_context(rasterio.open(landmask_path))
         perv_src = stack.enter_context(rasterio.open(perv_path))
         onstream_src = stack.enter_context(rasterio.open(onstream_path))
         twi_src = stack.enter_context(rasterio.open(twi_path))
+        _assert_aligned(landmask_src, info, "land_mask")
         _assert_aligned(perv_src, info, "perv")
         _assert_aligned(onstream_src, info, "onstream")
         if twi_src.crs != info.crs:
@@ -183,11 +191,14 @@ def main():
         for row_off in range(0, info.height, STRIP_ROWS):
             h = min(STRIP_ROWS, info.height - row_off)
             window = Window(0, row_off, info.width, h)
+            land_valid = landmask_src.read(1, window=window) == 1
             perv = perv_src.read(1, window=window)
             onstream = onstream_src.read(1, window=window)
             twi = twi_vrt.read(1, window=window)
             for i, (thresh, _, _) in enumerate(runs):
-                out = compute_carea_map_binary(perv, onstream, twi, thresh, twi_nodata)
+                out = compute_carea_map_binary(
+                    perv, onstream, twi, thresh, twi_nodata, land_valid
+                )
                 dsts[i].write(out, 1, window=window)
                 counts[i] += int((out == 1).sum())
 

--- a/scripts/build_depstor_dprst.py
+++ b/scripts/build_depstor_dprst.py
@@ -16,6 +16,10 @@ Outputs:
 - onstream_binary.tif : wbody cells that are NOT depression storage
                         (i.e. wbody_binary AND NOT dprst_binary).
 
+Both outputs are land-masked against land_mask.tif (the rasterised HRU
+fabric), so off-land (ocean) cells never become depression-storage pour points
+downstream or inflate the on-stream-storage fraction.
+
 Logic source: depstor/scripts/DepStor.py:666-701 (getDprst) and 768-791
 (onStreamStor non-imperv-wbody construction).
 """
@@ -31,6 +35,7 @@ from gfv2_params.config import load_config, require_config_key
 from gfv2_params.depstor import (
     RasterInfo,
     read_aligned_uint8,
+    read_land_mask,
     regions_to_binary,
     regions_touching_mask,
     write_uint8_binary,
@@ -62,6 +67,7 @@ def main():
     )
 
     template_path = Path(require_config_key(config, "template_raster", "build_depstor_dprst"))
+    landmask_path = Path(config["landmask_raster"])
     wbody_binary_path = Path(config["wbody_binary_raster"])
     wbody_regions_path = Path(config["wbody_regions_raster"])
     stream_buffer_path = Path(config["stream_buffer_raster"])
@@ -69,7 +75,7 @@ def main():
     dprst_path = Path(config["dprst_raster"])
     onstream_path = Path(config["onstream_raster"])
 
-    for p in (template_path, wbody_binary_path, wbody_regions_path, stream_buffer_path, imperv_path):
+    for p in (template_path, landmask_path, wbody_binary_path, wbody_regions_path, stream_buffer_path, imperv_path):
         if not p.exists():
             raise FileNotFoundError(f"Required input not found: {p}")
 
@@ -95,6 +101,7 @@ def main():
     imperv_binary = read_aligned_uint8(imperv_path, info)
     with rasterio.open(wbody_regions_path) as src:
         regions = src.read(1)
+    land_valid = read_land_mask(landmask_path)
     logger.info("  Inputs read in %s", _elapsed(t1))
 
     logger.info("--- Step 2/4: Identify regions touching stream or imperv ---")
@@ -113,6 +120,7 @@ def main():
     all_ids = set(int(v) for v in np.unique(regions) if v != 0)
     kept_ids = all_ids - excluded
     dprst_binary = regions_to_binary(regions, kept_ids)
+    dprst_binary[~land_valid] = 255  # drop off-land (ocean) cells
     write_uint8_binary(dprst_binary, info, dprst_path)
     n_dprst = int((dprst_binary == 1).sum())
     logger.info(
@@ -123,6 +131,7 @@ def main():
     logger.info("--- Step 4/4: Build onstream_binary (wbody AND NOT dprst) ---")
     t4 = time.time()
     onstream = np.where((wbody_binary == 1) & (dprst_binary != 1), np.uint8(1), np.uint8(255))
+    onstream[~land_valid] = 255  # drop off-land (ocean) cells
     write_uint8_binary(onstream, info, onstream_path)
     n_on = int((onstream == 1).sum())
     logger.info(

--- a/scripts/build_depstor_imperv.py
+++ b/scripts/build_depstor_imperv.py
@@ -10,6 +10,10 @@ The source CRS and nodata value are handled dynamically: gdal.Warp reprojects
 to the template CRS, and the source nodata is read back from the warped raster
 and passed to threshold_above. The source must be a continuous 0-100 percentage.
 
+Off-land cells are masked out of the result against land_mask.tif (the
+rasterised HRU fabric), so coastal impervious-surface cells outside the
+modeling domain do not leak into the binary.
+
 Logic ported from depstor/scripts/DepStor.py:452-518 — minus the HRU-tagging step.
 """
 
@@ -21,7 +25,7 @@ import rasterio
 from osgeo import gdal, gdalconst
 
 from gfv2_params.config import load_config, require_config_key
-from gfv2_params.depstor import RasterInfo, threshold_above, write_uint8_binary
+from gfv2_params.depstor import RasterInfo, read_land_mask, threshold_above, write_uint8_binary
 from gfv2_params.log import configure_logging
 
 
@@ -81,6 +85,7 @@ def main():
 
     template_path = Path(require_config_key(config, "template_raster", "build_depstor_imperv"))
     imperv_path = Path(config["imperv_raster"])
+    landmask_path = Path(config["landmask_raster"])
     output_path = Path(config["output_raster"])
     threshold = float(config.get("imperv_threshold", 50))
 
@@ -88,6 +93,8 @@ def main():
         raise FileNotFoundError(f"Template raster not found: {template_path}")
     if not imperv_path.exists():
         raise FileNotFoundError(f"Imperv raster not found: {imperv_path}")
+    if not landmask_path.exists():
+        raise FileNotFoundError(f"Land mask not found (run build_depstor_landmask first): {landmask_path}")
 
     logger.info("=== build_depstor_imperv ===")
     logger.info("Template : %s", template_path)
@@ -116,6 +123,7 @@ def main():
             data = src.read(1)
             src_nodata = src.nodata
         binary = threshold_above(data, threshold, src_nodata)
+        binary[~read_land_mask(landmask_path)] = 255  # drop off-land (ocean) cells
         write_uint8_binary(binary, info, output_path)
         n_impervious = int((binary == 1).sum())
         n_total = binary.size

--- a/scripts/build_depstor_imperv.py
+++ b/scripts/build_depstor_imperv.py
@@ -1,8 +1,14 @@
 """Build the imperviousness binary raster used by the depression-storage pipeline.
 
-Threshold the staged Imperv.tif at imperv_threshold (default 50%), warp/snap to the
-elevation-VRT template grid, and write a uint8 binary raster (1 = impervious,
-255 = nodata) to {fabric}/depstor_rasters/imperv_binary.tif.
+Threshold the source fractional-impervious raster (imperv_raster in
+configs/depstor_imperv_raster.yml — currently the 2015 NLCD Annual Fractional
+Impervious Surface) at imperv_threshold (default 50%), warp/snap to the
+template grid, and write a uint8 binary raster (1 = impervious, 255 = nodata)
+to {fabric}/depstor_rasters/imperv_binary.tif.
+
+The source CRS and nodata value are handled dynamically: gdal.Warp reprojects
+to the template CRS, and the source nodata is read back from the warped raster
+and passed to threshold_above. The source must be a continuous 0-100 percentage.
 
 Logic ported from depstor/scripts/DepStor.py:452-518 — minus the HRU-tagging step.
 """
@@ -28,7 +34,9 @@ def _elapsed(t0: float) -> str:
 def _warp_to_template(src_path: Path, info: RasterInfo, out_path: Path) -> None:
     """Warp src_path to the template grid (EPSG:5070, 30m, exact bounds).
 
-    Uses bilinear resampling (Imperv is a continuous percentage 0-100).
+    Uses bilinear resampling — the source is a continuous 0-100 percentage.
+    gdal.Warp auto-detects the source nodata and excludes it from the kernel,
+    so coastal cells are interpolated from valid land pixels only.
     """
     output_bounds = (info.bounds.left, info.bounds.bottom, info.bounds.right, info.bounds.top)
     warp_ds = gdal.Warp(

--- a/scripts/build_depstor_landmask.py
+++ b/scripts/build_depstor_landmask.py
@@ -1,0 +1,103 @@
+"""Build the land-mask raster for the depression-storage pipeline.
+
+Rasterizes the HRU polygon fabric (the authoritative modeling domain) onto the
+template grid, producing land_mask.tif — a uint8 binary raster where 1 = inside
+the HRU fabric (land), 255 = outside (ocean / off-domain).
+
+Every other depstor builder masks its output against this raster. It replaces
+the earlier template-DEM-nodata mask, which was unreliable: the hydro-
+conditioned DEM carries valid (often garbage) elevations over coastal ocean, so
+its nodata footprint bulged into the sea and those bulges leaked into the dense
+outputs (perv_binary, carea_map). The HRU fabric follows the real coastline and
+is exactly the domain the depstor params are aggregated to downstream.
+
+Output: {fabric}/depstor_rasters/land_mask.tif
+"""
+
+import argparse
+import time
+from pathlib import Path
+
+import geopandas as gpd
+
+from gfv2_params.config import load_config, require_config_key
+from gfv2_params.depstor import RasterInfo, rasterize_binary, write_uint8_binary
+from gfv2_params.log import configure_logging
+
+
+def _elapsed(t0: float) -> str:
+    secs = time.time() - t0
+    m, s = divmod(int(secs), 60)
+    return f"{m}m {s:02d}s" if m else f"{s}s"
+
+
+def _load_hru(path: Path, layer: str, logger):
+    try:
+        return gpd.read_file(path, layer=layer, use_arrow=True)
+    except Exception:
+        logger.warning("PyArrow unavailable for vector load; falling back to fiona.")
+        return gpd.read_file(path, layer=layer)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Build depstor land_mask.tif from the HRU fabric.")
+    parser.add_argument("--config", required=True, help="Path to depstor_landmask_raster.yml")
+    parser.add_argument("--base_config", default=None, help="Path to base_config.yml")
+    parser.add_argument("--fabric", default=None, help="Fabric name (overrides FABRIC env / default_fabric)")
+    parser.add_argument("--force", action="store_true", help="Overwrite existing output")
+    args = parser.parse_args()
+
+    logger = configure_logging("build_depstor_landmask")
+    t_start = time.time()
+
+    config = load_config(
+        Path(args.config),
+        base_config_path=Path(args.base_config) if args.base_config else None,
+        fabric=args.fabric,
+    )
+
+    template_path = Path(require_config_key(config, "template_raster", "build_depstor_landmask"))
+    hru_gpkg = Path(require_config_key(config, "hru_gpkg", "build_depstor_landmask"))
+    hru_layer = require_config_key(config, "hru_layer", "build_depstor_landmask")
+    output_path = Path(config["output_raster"])
+
+    if not template_path.exists():
+        raise FileNotFoundError(f"Template raster not found: {template_path}")
+    if not hru_gpkg.exists():
+        raise FileNotFoundError(f"HRU fabric gpkg not found: {hru_gpkg}")
+
+    logger.info("=== build_depstor_landmask ===")
+    logger.info("Template  : %s", template_path)
+    logger.info("HRU fabric: %s (layer=%s)", hru_gpkg, hru_layer)
+    logger.info("Output    : %s", output_path)
+
+    if output_path.exists() and not args.force:
+        logger.info("Output already exists — skipping (pass --force to rebuild)")
+        return
+
+    info = RasterInfo.from_path(template_path)
+    logger.info("Template grid: %dx%d, CRS=%s", info.width, info.height, info.crs)
+
+    logger.info("--- Step 1/2: Load HRU fabric ---")
+    t1 = time.time()
+    hru_gdf = _load_hru(hru_gpkg, hru_layer, logger)
+    hru_gdf = hru_gdf[hru_gdf.geometry.notna() & ~hru_gdf.geometry.is_empty]
+    logger.info("  Loaded %d HRU polygons in %s", len(hru_gdf), _elapsed(t1))
+
+    logger.info("--- Step 2/2: Rasterize HRU fabric to land mask ---")
+    t2 = time.time()
+    # all_touched=True: be inclusive at the outer coastline so thin edge HRUs
+    # are not clipped. create_zonal_params is the precise arbiter downstream.
+    binary = rasterize_binary(hru_gdf, info, all_touched=True)
+    write_uint8_binary(binary, info, output_path)
+    n_land = int((binary == 1).sum())
+    logger.info(
+        "  Rasterize + write done in %s | %d land cells (%.2f%% of grid)",
+        _elapsed(t2), n_land, 100 * n_land / binary.size,
+    )
+
+    logger.info("=== build_depstor_landmask complete in %s ===", _elapsed(t_start))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/build_depstor_landmask.py
+++ b/scripts/build_depstor_landmask.py
@@ -34,9 +34,31 @@ def _elapsed(t0: float) -> str:
 def _load_hru(path: Path, layer: str, logger):
     try:
         return gpd.read_file(path, layer=layer, use_arrow=True)
-    except Exception:
+    except ImportError:
         logger.warning("PyArrow unavailable for vector load; falling back to fiona.")
         return gpd.read_file(path, layer=layer)
+
+
+def build_landmask(
+    template_path: Path,
+    hru_gpkg: Path,
+    hru_layer: str,
+    output_path: Path,
+    logger,
+):
+    """Rasterise the HRU fabric to a uint8 1/255 land mask at the template grid.
+
+    Pulled out of main() so unit tests can exercise the build without going
+    through argument parsing and config-file resolution.
+    """
+    info = RasterInfo.from_path(template_path)
+    hru_gdf = _load_hru(hru_gpkg, hru_layer, logger)
+    hru_gdf = hru_gdf[hru_gdf.geometry.notna() & ~hru_gdf.geometry.is_empty]
+    # all_touched=True: be inclusive at the outer coastline so thin edge HRUs
+    # are not clipped. create_zonal_params is the precise arbiter downstream.
+    binary = rasterize_binary(hru_gdf, info, all_touched=True)
+    write_uint8_binary(binary, info, output_path)
+    return binary, len(hru_gdf)
 
 
 def main():
@@ -78,22 +100,12 @@ def main():
     info = RasterInfo.from_path(template_path)
     logger.info("Template grid: %dx%d, CRS=%s", info.width, info.height, info.crs)
 
-    logger.info("--- Step 1/2: Load HRU fabric ---")
     t1 = time.time()
-    hru_gdf = _load_hru(hru_gpkg, hru_layer, logger)
-    hru_gdf = hru_gdf[hru_gdf.geometry.notna() & ~hru_gdf.geometry.is_empty]
-    logger.info("  Loaded %d HRU polygons in %s", len(hru_gdf), _elapsed(t1))
-
-    logger.info("--- Step 2/2: Rasterize HRU fabric to land mask ---")
-    t2 = time.time()
-    # all_touched=True: be inclusive at the outer coastline so thin edge HRUs
-    # are not clipped. create_zonal_params is the precise arbiter downstream.
-    binary = rasterize_binary(hru_gdf, info, all_touched=True)
-    write_uint8_binary(binary, info, output_path)
+    binary, n_polys = build_landmask(template_path, hru_gpkg, hru_layer, output_path, logger)
     n_land = int((binary == 1).sum())
     logger.info(
-        "  Rasterize + write done in %s | %d land cells (%.2f%% of grid)",
-        _elapsed(t2), n_land, 100 * n_land / binary.size,
+        "  Rasterised %d HRU polygons in %s | %d land cells (%.2f%% of grid)",
+        n_polys, _elapsed(t1), n_land, 100 * n_land / binary.size,
     )
 
     logger.info("=== build_depstor_landmask complete in %s ===", _elapsed(t_start))

--- a/scripts/build_depstor_perv.py
+++ b/scripts/build_depstor_perv.py
@@ -1,17 +1,22 @@
 """Build the pervious-area binary raster from imperv and dprst inputs.
 
-A cell is pervious where it is neither impervious nor depression-storage.
-Implements the PRMS-standard cell-wise interpretation of depstor workflow
-Level Three step `GetPervAreaTotal` (docs/depstor_workflow.md) — NOT depstor's
-`remove_all_overlap=True` all-or-nothing exclusion, which diverges from the
-documented design intent.
+A cell is pervious where it is inside the modeling domain and neither
+impervious nor depression-storage. Implements the PRMS-standard cell-wise
+interpretation of depstor workflow Level Three step `GetPervAreaTotal`
+(docs/depstor_workflow.md) — NOT depstor's `remove_all_overlap=True`
+all-or-nothing exclusion, which diverges from the documented design intent.
 
-Inputs (both on the same template grid):
+The land mask is essential: this builder defaults every cell to pervious and
+only excludes imperv/dprst cells, so without masking against land_mask.tif
+(the rasterised HRU fabric) the entire ocean inside the grid is marked pervious.
+
+Inputs (all on the same template grid):
+- land_mask.tif     (uint8 1/255) [from build_depstor_landmask.py]
 - imperv_binary.tif (uint8 1/255) [from build_depstor_imperv.py]
 - dprst_binary.tif  (uint8 1/255) [from build_depstor_dprst.py]
 
 Output:
-- perv_binary.tif : 1 where (imperv != 1) AND (dprst != 1), else 255.
+- perv_binary.tif : 1 where land AND (imperv != 1) AND (dprst != 1), else 255.
 """
 
 import argparse
@@ -37,12 +42,22 @@ def _elapsed(t0: float) -> str:
     return f"{m}m {s:02d}s" if m else f"{s}s"
 
 
-def compute_perv_binary(imperv: np.ndarray, dprst: np.ndarray) -> np.ndarray:
-    """Cell is pervious where it is NOT impervious AND NOT depression-storage."""
-    mask = imperv == 1
-    mask |= dprst == 1
+def compute_perv_binary(
+    imperv: np.ndarray, dprst: np.ndarray, land_valid: np.ndarray
+) -> np.ndarray:
+    """Cell is pervious where it is valid land AND NOT impervious AND NOT
+    depression-storage.
+
+    `land_valid` is the HRU-fabric land mask (boolean, True = inside the
+    modeling domain — `land_mask.tif == 1`). It is required, not optional: this
+    function defaults every cell to pervious, so omitting the mask would
+    classify the whole ocean as pervious.
+    """
+    exclude = imperv == 1
+    exclude |= dprst == 1
+    exclude |= ~land_valid
     out = np.full_like(imperv, 1)
-    out[mask] = 255
+    out[exclude] = 255
     return out
 
 
@@ -94,16 +109,18 @@ def main():
     )
 
     template_path = Path(require_config_key(config, "template_raster", "build_depstor_perv"))
+    landmask_path = Path(config["landmask_raster"])
     imperv_path = Path(config["imperv_raster"])
     dprst_path = Path(config["dprst_raster"])
     perv_path = Path(config["perv_raster"])
 
-    for p in (template_path, imperv_path, dprst_path):
+    for p in (template_path, landmask_path, imperv_path, dprst_path):
         if not p.exists():
             raise FileNotFoundError(f"Required input not found: {p}")
 
     logger.info("=== build_depstor_perv ===")
     logger.info("Template      : %s", template_path)
+    logger.info("Land mask     : %s", landmask_path)
     logger.info("Imperv binary : %s", imperv_path)
     logger.info("Dprst binary  : %s", dprst_path)
     logger.info("Perv out      : %s", perv_path)
@@ -120,18 +137,21 @@ def main():
     n_perv = 0
     profile = _uint8_binary_profile(info)
 
-    with rasterio.open(imperv_path) as imperv_src, \
+    with rasterio.open(landmask_path) as landmask_src, \
+         rasterio.open(imperv_path) as imperv_src, \
          rasterio.open(dprst_path) as dprst_src, \
          rasterio.open(perv_path, "w", **profile) as dst:
+        _assert_aligned(landmask_src, info, "land_mask")
         _assert_aligned(imperv_src, info, "imperv")
         _assert_aligned(dprst_src, info, "dprst")
 
         for row_off in range(0, info.height, STRIP_ROWS):
             h = min(STRIP_ROWS, info.height - row_off)
             window = Window(0, row_off, info.width, h)
+            land_valid = landmask_src.read(1, window=window) == 1
             imperv = imperv_src.read(1, window=window)
             dprst = dprst_src.read(1, window=window)
-            perv = compute_perv_binary(imperv, dprst)
+            perv = compute_perv_binary(imperv, dprst, land_valid)
             dst.write(perv, 1, window=window)
             n_perv += int((perv == 1).sum())
 

--- a/scripts/build_depstor_routing.py
+++ b/scripts/build_depstor_routing.py
@@ -6,6 +6,11 @@ dprst_binary.tif as pour points to delineate, for every cell, which depression
 to a uint8 binary raster where 1 = drains to ANY depression, 255 = does not /
 nodata.
 
+The collapsed binary is land-masked against land_mask.tif (the rasterised HRU
+fabric). dprst_binary.tif is itself land-masked upstream, but masking here too
+keeps the output correct even against a stale dprst input and removes any
+off-land pour points WhiteboxTools labels as their own single-cell watershed.
+
 Outputs:
 - {fabric}/depstor_rasters/drains_to_dprst.tif (uint8 binary)
 
@@ -25,7 +30,7 @@ import rioxarray  # noqa: F401  (registers .rio accessor)
 import xarray as xr
 
 from gfv2_params.config import load_config, require_config_key
-from gfv2_params.depstor import RasterInfo, write_uint8_binary
+from gfv2_params.depstor import RasterInfo, read_land_mask, write_uint8_binary
 from gfv2_params.log import configure_logging
 
 
@@ -123,11 +128,14 @@ def _run_whitebox_watershed(fdr_path: Path, pour_pts_path: Path, output_path: Pa
         )
 
 
-def _watershed_to_binary(watershed_path: Path, info: RasterInfo, out_path: Path, logger) -> None:
+def _watershed_to_binary(
+    watershed_path: Path, landmask_path: Path, info: RasterInfo, out_path: Path, logger
+) -> None:
     """Collapse the per-depression watershed labels into a uint8 binary mask.
 
     Rule: any cell with a value not equal to the source nodata is "drains to a
-    depression" (1); all others become 255 (nodata).
+    depression" (1); all others become 255 (nodata). Off-land cells (outside
+    land_mask.tif) are then forced to 255 regardless of their label.
     """
     with rasterio.open(watershed_path) as src:
         data = src.read(1)
@@ -141,6 +149,7 @@ def _watershed_to_binary(watershed_path: Path, info: RasterInfo, out_path: Path,
     else:
         valid = data != src_nodata
     binary = np.where(valid, np.uint8(1), np.uint8(255))
+    binary[~read_land_mask(landmask_path)] = 255  # drop off-land (ocean) cells
     n_in = int((binary == 1).sum())
     pct_drains = 100 * n_in / binary.size
     # Sanity check: most real drainage networks route <1% of cells into
@@ -182,10 +191,11 @@ def main():
     template_path = Path(require_config_key(config, "template_raster", "build_depstor_routing"))
     fdr_path = Path(require_config_key(config, "fdr_raster", "build_depstor_routing"))
     dprst_path = Path(config["dprst_raster"])
+    landmask_path = Path(config["landmask_raster"])
     output_path = Path(config["output_raster"])
     keep_intermediates = bool(config.get("keep_intermediates", False))
 
-    for p in (template_path, fdr_path, dprst_path):
+    for p in (template_path, fdr_path, dprst_path, landmask_path):
         if not p.exists():
             raise FileNotFoundError(f"Required input not found: {p}")
 
@@ -193,6 +203,7 @@ def main():
     logger.info("Template : %s", template_path)
     logger.info("FDR      : %s", fdr_path)
     logger.info("Dprst    : %s", dprst_path)
+    logger.info("Land mask: %s", landmask_path)
     logger.info("Output   : %s", output_path)
 
     if output_path.exists() and not args.force:
@@ -221,7 +232,7 @@ def main():
 
         logger.info("--- Step 4/4: Collapse labels to uint8 binary ---")
         t3 = time.time()
-        _watershed_to_binary(watershed_raw, info, output_path, logger)
+        _watershed_to_binary(watershed_raw, landmask_path, info, output_path, logger)
         logger.info("  Binary mask written in %s", _elapsed(t3))
     finally:
         if not keep_intermediates:

--- a/scripts/build_depstor_streambuffer.py
+++ b/scripts/build_depstor_streambuffer.py
@@ -5,6 +5,11 @@ buffer_distance metres (default 60 m — 2 cell widths at 30 m), and burns the
 buffered polygons onto the elevation-VRT template grid as a uint8 binary mask
 (1 = inside any stream buffer, 255 = nodata).
 
+Off-land cells are masked out against land_mask.tif (the rasterised HRU
+fabric) so a coastal segment buffer cannot extend over open water — consistent
+with the rest of the depstor builders, even though stream segments are inland
+by nature.
+
 Output: {fabric}/depstor_rasters/stream_buffer.tif
 Logic source: depstor/scripts/DepStor.py:521-577 — minus the HRU-tagging step.
 """
@@ -16,7 +21,7 @@ from pathlib import Path
 import geopandas as gpd
 
 from gfv2_params.config import load_config, require_config_key
-from gfv2_params.depstor import RasterInfo, rasterize_binary, write_uint8_binary
+from gfv2_params.depstor import RasterInfo, rasterize_binary, read_land_mask, write_uint8_binary
 from gfv2_params.log import configure_logging
 
 
@@ -57,6 +62,7 @@ def main():
     template_path = Path(require_config_key(config, "template_raster", "build_depstor_streambuffer"))
     segments_gpkg = Path(require_config_key(config, "segments_gpkg", "build_depstor_streambuffer"))
     segments_layer = config.get("segments_layer", "nsegment")
+    landmask_path = Path(config["landmask_raster"])
     output_path = Path(config["output_raster"])
     buffer_distance = float(config.get("buffer_distance", 60))
 
@@ -64,6 +70,8 @@ def main():
         raise FileNotFoundError(f"Template raster not found: {template_path}")
     if not segments_gpkg.exists():
         raise FileNotFoundError(f"Segments gpkg not found: {segments_gpkg}")
+    if not landmask_path.exists():
+        raise FileNotFoundError(f"Land mask not found (run build_depstor_landmask first): {landmask_path}")
 
     logger.info("=== build_depstor_streambuffer ===")
     logger.info("Template     : %s", template_path)
@@ -95,6 +103,7 @@ def main():
     logger.info("--- Step 3/3: Rasterize buffer onto template grid ---")
     t3 = time.time()
     binary = rasterize_binary(seg_gdf, info, all_touched=True)
+    binary[~read_land_mask(landmask_path)] = 255  # drop off-land (ocean) cells
     write_uint8_binary(binary, info, output_path)
     n_in = int((binary == 1).sum())
     logger.info(

--- a/scripts/build_depstor_streambuffer.py
+++ b/scripts/build_depstor_streambuffer.py
@@ -34,7 +34,7 @@ def _elapsed(t0: float) -> str:
 def _load_segments(path: Path, layer: str | None, logger):
     try:
         return gpd.read_file(path, layer=layer, use_arrow=True)
-    except Exception:
+    except ImportError:
         logger.warning(
             "PyArrow unavailable for vector load; falling back to fiona. "
             "Install pyarrow for faster reads."

--- a/scripts/build_depstor_waterbody.py
+++ b/scripts/build_depstor_waterbody.py
@@ -4,6 +4,11 @@ Reads the staged water-body polygon layer, filters by minimum area, rasterizes
 to the elevation-VRT template grid, then runs a connected-component label step
 (8-connectivity) to give each contiguous water body a unique region ID.
 
+Off-land cells are masked out of the binary against land_mask.tif (the
+rasterised HRU fabric) *before* the connected-component step, so coastal
+water-body polygons that extend over open water cannot seed ocean regions or
+leak downstream into dprst/onstream.
+
 Outputs:
 - {fabric}/depstor_rasters/wbody_binary.tif  (uint8 0/1, 255 nodata)
 - {fabric}/depstor_rasters/wbody_regions.tif (int32 region IDs, 0 nodata)
@@ -23,6 +28,7 @@ from gfv2_params.depstor import (
     RasterInfo,
     clump_regions,
     rasterize_binary,
+    read_land_mask,
     write_int32_regions,
     write_uint8_binary,
 )
@@ -65,6 +71,7 @@ def main():
     template_path = Path(require_config_key(config, "template_raster", "build_depstor_waterbody"))
     waterbody_gpkg = Path(require_config_key(config, "waterbody_gpkg", "build_depstor_waterbody"))
     waterbody_layer = require_config_key(config, "waterbody_layer", "build_depstor_waterbody")
+    landmask_path = Path(config["landmask_raster"])
     binary_path = Path(config["wbody_binary_raster"])
     regions_path = Path(config["wbody_regions_raster"])
     min_area = float(config.get("min_area_threshold", 900.0))
@@ -73,6 +80,8 @@ def main():
         raise FileNotFoundError(f"Template raster not found: {template_path}")
     if not waterbody_gpkg.exists():
         raise FileNotFoundError(f"Waterbody gpkg not found: {waterbody_gpkg}")
+    if not landmask_path.exists():
+        raise FileNotFoundError(f"Land mask not found (run build_depstor_landmask first): {landmask_path}")
 
     logger.info("=== build_depstor_waterbody ===")
     logger.info("Template     : %s", template_path)
@@ -105,8 +114,9 @@ def main():
     logger.info("--- Step 2/4: Rasterize wbody polygons (binary) ---")
     t2 = time.time()
     binary = rasterize_binary(wb_gdf, info, all_touched=False)
+    binary[~read_land_mask(landmask_path)] = 255  # drop off-land (ocean) cells
     n_in = int((binary == 1).sum())
-    logger.info("  Rasterized in %s | %d wbody cells", _elapsed(t2), n_in)
+    logger.info("  Rasterized in %s | %d wbody cells (after land mask)", _elapsed(t2), n_in)
 
     logger.info("--- Step 3/4: Write binary raster ---")
     t3 = time.time()

--- a/scripts/build_depstor_waterbody.py
+++ b/scripts/build_depstor_waterbody.py
@@ -44,7 +44,7 @@ def _elapsed(t0: float) -> str:
 def _load_waterbodies(path: Path, layer: str | None, logger):
     try:
         return gpd.read_file(path, layer=layer, use_arrow=True)
-    except Exception:
+    except ImportError:
         logger.warning(
             "PyArrow unavailable for vector load; falling back to fiona."
         )

--- a/slurm_batch/RUNME.md
+++ b/slurm_batch/RUNME.md
@@ -275,15 +275,16 @@ zonal-stats jobs (`dprst_frac`, `imperv_frac`, `onstream_storage_frac`,
 Inputs (manually staged per fabric):
 - `input/depstor/<fabric>_segments_wbodies.gpkg` (layers `nsegment`, `v2_wb`)
 - `input/depstor/<fabric>_fdr.tif` (D8 flow direction, Esri pointer)
-- Per-fabric `twi_raster` (from `base_config.yml`) — issue #61 carea_map step.
-- Reuses existing `input/lulc_veg/Imperv.tif` and `work/nhd_merged/elevation.vrt`.
+- Per-fabric `hru_gpkg` / `twi_raster` (from `base_config.yml`).
+- Reuses the NLCD impervious raster and `work/nhd_merged/elevation.vrt`.
 
 Run in order — each step writes intermediates the next consumes:
 
 ```bash
-sbatch slurm_batch/build_depstor_imperv.batch
-sbatch slurm_batch/build_depstor_streambuffer.batch
-sbatch slurm_batch/build_depstor_waterbody.batch
+sbatch slurm_batch/build_depstor_landmask.batch       # land_mask.tif — must run first
+sbatch slurm_batch/build_depstor_imperv.batch         # depends on landmask
+sbatch slurm_batch/build_depstor_streambuffer.batch   # depends on landmask
+sbatch slurm_batch/build_depstor_waterbody.batch      # depends on landmask
 sbatch slurm_batch/build_depstor_dprst.batch          # depends on the three above
 sbatch slurm_batch/build_depstor_perv.batch           # depends on imperv + dprst
 sbatch slurm_batch/build_depstor_routing.batch        # depends on dprst + staged FDR
@@ -294,11 +295,12 @@ sbatch slurm_batch/build_depstor_drains_imperv.batch  # drains_to_dprst x imperv
 sbatch slurm_batch/build_depstor_carea_map.batch      # carea_map at TWI = 8.0 and 15.6
 ```
 
-Steps 1-3 are independent of each other and can run concurrently. Step 4
-combines them and must wait. Steps 5 and 6 both wait for Step 4 (`dprst`) to
-finish, then can run in parallel with one another. Step 6
-(`build_depstor_routing`) runs WhiteboxTools `Watershed` against the staged FDR
-+ the dprst output and is the most memory- and time-intensive.
+`build_depstor_landmask` rasterizes the HRU fabric to `land_mask.tif` — the
+authoritative land/domain mask **every** other depstor builder masks its output
+against, so it must run first. imperv/streambuffer/waterbody depend only on it
+and can then run concurrently. `dprst` combines those three. `perv` and
+`routing` both wait on `dprst`; `build_depstor_routing` runs WhiteboxTools
+`Watershed` against the staged FDR and is the most memory- and time-intensive.
 
 The three issue-#61 build steps depend on the outputs above (`drains_to_dprst`,
 `perv_binary`, `onstream_binary`) and on the per-fabric `twi_raster`. They are
@@ -506,6 +508,7 @@ sacct -j <JOBID> -o JobID,State,Elapsed,MaxRSS
 | download_rpu_rasters.batch | base_config.yml | gfv2_params.download.rpu_rasters |
 | download_nalcms.batch | base_config.yml | gfv2_params.download.nalcms_lulc |
 | download_nhm_v11.batch | base_config.yml | gfv2_params.download.nhm_v11_lulc |
+| build_depstor_landmask.batch | depstor_landmask_raster.yml | build_depstor_landmask.py |
 | build_depstor_imperv.batch | depstor_imperv_raster.yml | build_depstor_imperv.py |
 | build_depstor_streambuffer.batch | depstor_streambuffer_raster.yml | build_depstor_streambuffer.py |
 | build_depstor_waterbody.batch | depstor_waterbody_raster.yml | build_depstor_waterbody.py |

--- a/slurm_batch/build_depstor_landmask.batch
+++ b/slurm_batch/build_depstor_landmask.batch
@@ -1,0 +1,31 @@
+#!/bin/bash
+#SBATCH -p cpu
+#SBATCH -A impd
+#SBATCH --job-name=build_depstor_landmask
+#SBATCH --output=logs/job_%j.out
+#SBATCH --error=logs/job_%j.err
+#SBATCH --time=08:00:00
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=128G
+#
+# Rasterizes the HRU polygon fabric to land_mask.tif. Same cost profile as
+# build_depstor_waterbody (load a large polygon layer, rasterize to the
+# template grid). Must run BEFORE every other depstor builder — they all mask
+# their outputs against land_mask.tif.
+#
+# Defaults are CONUS-sized. For smaller fabrics, override resources at submission.
+# Extra args after the batch path are forwarded to the python script via "$@":
+#   FABRIC=gfv2_vpu01 sbatch --time=01:00:00 --mem=16G slurm_batch/build_depstor_landmask.batch --force
+
+cd "$SLURM_SUBMIT_DIR"
+[ -f .pixi-activate.sh ] || { echo "ERROR: missing .pixi-activate.sh — run scripts/refresh_pixi_activation.sh" >&2; exit 1; }
+source .pixi-activate.sh
+BASE_CONFIG=${BASE_CONFIG:-configs/base_config.yml}
+FABRIC=${FABRIC:-gfv2}
+
+python scripts/build_depstor_landmask.py \
+    --config configs/depstor_landmask_raster.yml \
+    --base_config "$BASE_CONFIG" \
+    --fabric "$FABRIC" \
+    "$@"

--- a/src/gfv2_params/depstor.py
+++ b/src/gfv2_params/depstor.py
@@ -94,6 +94,24 @@ def threshold_above(values: np.ndarray, threshold: float, src_nodata) -> np.ndar
     return np.where(above, np.uint8(1), np.uint8(255))
 
 
+def read_land_mask(landmask_path: Path) -> np.ndarray:
+    """Read land_mask.tif and return a boolean land mask (True = land/in-fabric).
+
+    `land_mask.tif` (built by `build_depstor_landmask.py`) is the uint8 1/255
+    rasterised HRU fabric — the authoritative depstor land/domain mask. Every
+    depstor builder masks its output against it so ocean / off-domain cells are
+    never marked present.
+
+    Whole-array builders call this helper once; streaming builders open
+    land_mask.tif themselves and test ``strip == 1`` per window. The mask is
+    NOT derived from the template DEM's nodata footprint — the hydro-
+    conditioned DEM carries valid elevations over coastal ocean, so its nodata
+    extent bulges into the sea.
+    """
+    with rasterio.open(landmask_path) as src:
+        return src.read(1) == 1
+
+
 def intersect_binaries(a: np.ndarray, b: np.ndarray) -> np.ndarray:
     """Return uint8 binary mask: 1 where both inputs are 1, else 255 (nodata).
 
@@ -111,13 +129,20 @@ def compute_carea_map_binary(
     twi: np.ndarray,
     threshold: float,
     twi_nodata: Optional[float],
+    land_valid: np.ndarray,
 ) -> np.ndarray:
     """Build the binary carea_map mask used for getCarea-style PRMS params.
 
-    Per cell, returns 1 where the cell is pervious AND either (a) TWI exceeds
-    the threshold or (b) the cell is on-stream storage; 255 otherwise. Mirrors
-    `getCareaMap` in the ArcPy reference (docs/0b_TB_depr_stor.py:315-350) but
-    drops HRU-ID tagging — HRU identity is recovered at zonal-stats time.
+    Per cell, returns 1 where the cell is valid land AND pervious AND either
+    (a) TWI exceeds the threshold or (b) the cell is on-stream storage; 255
+    otherwise. Mirrors `getCareaMap` in the ArcPy reference
+    (docs/0b_TB_depr_stor.py:315-350) but drops HRU-ID tagging — HRU identity
+    is recovered at zonal-stats time.
+
+    `land_valid` is the template-DEM land mask (see `land_mask`). It is applied
+    explicitly rather than relying on the perv gate alone — the on-stream
+    branch can otherwise rescue off-land cells, and a stale perv_binary should
+    not be able to leak ocean into carea_map.
 
     Short-circuits on the perv test first so NaN / sentinel TWI values in
     non-perv cells do not pollute the result. Handles both NaN and the
@@ -134,7 +159,7 @@ def compute_carea_map_binary(
         twi_valid = ~np.isnan(twi)
 
     above_thresh = twi_valid & (twi > threshold)
-    keep = is_perv & (above_thresh | is_onstream)
+    keep = land_valid & is_perv & (above_thresh | is_onstream)
 
     out = np.full(perv.shape, 255, dtype=np.uint8)
     out[keep] = 1

--- a/src/gfv2_params/depstor.py
+++ b/src/gfv2_params/depstor.py
@@ -139,10 +139,10 @@ def compute_carea_map_binary(
     (docs/0b_TB_depr_stor.py:315-350) but drops HRU-ID tagging — HRU identity
     is recovered at zonal-stats time.
 
-    `land_valid` is the template-DEM land mask (see `land_mask`). It is applied
-    explicitly rather than relying on the perv gate alone — the on-stream
-    branch can otherwise rescue off-land cells, and a stale perv_binary should
-    not be able to leak ocean into carea_map.
+    `land_valid` is the rasterised HRU-fabric land mask (see `read_land_mask`).
+    It is applied explicitly rather than relying on the perv gate alone — the
+    on-stream branch can otherwise rescue off-land cells, and a stale
+    perv_binary should not be able to leak ocean into carea_map.
 
     Short-circuits on the perv test first so NaN / sentinel TWI values in
     non-perv cells do not pollute the result. Handles both NaN and the

--- a/tests/test_build_depstor_landmask.py
+++ b/tests/test_build_depstor_landmask.py
@@ -1,0 +1,105 @@
+"""Smoke test for the build_landmask core function in build_depstor_landmask.
+
+Builds a 10x10 template raster and a 2-polygon HRU fixture, rasterises them,
+and asserts the resulting land mask uses the 1/255 convention with the right
+cells marked land.
+"""
+
+import importlib.util
+import logging
+from pathlib import Path
+
+import geopandas as gpd
+import numpy as np
+import rasterio
+from rasterio.transform import from_origin
+from shapely.geometry import Polygon
+
+
+_SCRIPT = Path(__file__).parent.parent / "scripts" / "build_depstor_landmask.py"
+_spec = importlib.util.spec_from_file_location("build_depstor_landmask", _SCRIPT)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+build_landmask = _mod.build_landmask
+
+
+def _write_template(path: Path, height: int = 10, width: int = 10) -> None:
+    """Write a tiny float32 template raster at 30 m on an EPSG:5070-like grid."""
+    transform = from_origin(0, height * 30, 30, 30)
+    data = np.full((height, width), 100.0, dtype=np.float32)
+    with rasterio.open(
+        path, "w", driver="GTiff", height=height, width=width, count=1,
+        dtype="float32", crs="EPSG:5070", transform=transform, nodata=-9999.0,
+    ) as dst:
+        dst.write(data, 1)
+
+
+def _write_two_polygon_gpkg(path: Path) -> None:
+    """Two squares occupying the top-left and bottom-right of a 10x10 30m grid.
+
+    Top-left square covers rows 0-1, cols 0-1 (origin at top); bottom-right
+    covers rows 8-9, cols 8-9. Everything else is "ocean" (outside the fabric).
+    """
+    # Grid is 10x10 cells at 30m, top at y=300, bottom at y=0.
+    top_left = Polygon([(0, 240), (60, 240), (60, 300), (0, 300)])      # rows 0-1, cols 0-1
+    bottom_right = Polygon([(240, 0), (300, 0), (300, 60), (240, 60)])  # rows 8-9, cols 8-9
+    gdf = gpd.GeoDataFrame(
+        {"nat_hru_id": [1, 2]}, geometry=[top_left, bottom_right], crs="EPSG:5070",
+    )
+    gdf.to_file(path, layer="nhru", driver="GPKG")
+
+
+def test_build_landmask_two_polygons(tmp_path):
+    """Smoke test: rasterising two HRU polygons produces a 1/255 land mask
+    with exactly those cells marked land and everything else as nodata."""
+    template_path = tmp_path / "template.tif"
+    hru_gpkg = tmp_path / "fabric.gpkg"
+    out_path = tmp_path / "land_mask.tif"
+
+    _write_template(template_path)
+    _write_two_polygon_gpkg(hru_gpkg)
+
+    binary, n_polys = build_landmask(
+        template_path, hru_gpkg, "nhru", out_path, logging.getLogger("test"),
+    )
+
+    assert n_polys == 2
+    assert binary.dtype == np.uint8
+    assert binary.shape == (10, 10)
+
+    # Re-read what was written so we exercise the full IO path.
+    with rasterio.open(out_path) as src:
+        assert src.nodata == 255
+        out = src.read(1)
+    np.testing.assert_array_equal(out, binary)
+
+    # Cells covered by either polygon are 1; everything else is 255.
+    land_count = int((out == 1).sum())
+    nodata_count = int((out == 255).sum())
+    assert land_count == 8                       # 2 polygons * 4 cells each
+    assert land_count + nodata_count == 100
+    # Top-left corner is land
+    assert out[0, 0] == 1
+    # Bottom-right corner is land
+    assert out[9, 9] == 1
+    # Middle is ocean
+    assert out[5, 5] == 255
+
+
+def test_build_landmask_empty_fabric(tmp_path):
+    """Empty fabric (no polygons after filtering) yields all-nodata mask."""
+    template_path = tmp_path / "template.tif"
+    hru_gpkg = tmp_path / "fabric.gpkg"
+    out_path = tmp_path / "land_mask.tif"
+
+    _write_template(template_path)
+    gpd.GeoDataFrame(
+        {"nat_hru_id": []}, geometry=[], crs="EPSG:5070",
+    ).to_file(hru_gpkg, layer="nhru", driver="GPKG")
+
+    binary, n_polys = build_landmask(
+        template_path, hru_gpkg, "nhru", out_path, logging.getLogger("test"),
+    )
+
+    assert n_polys == 0
+    assert (binary == 255).all()

--- a/tests/test_build_depstor_perv.py
+++ b/tests/test_build_depstor_perv.py
@@ -14,29 +14,47 @@ _spec.loader.exec_module(_mod)
 compute_perv_binary = _mod.compute_perv_binary
 
 
-# (imperv, dprst, expected_perv)
-# Convention: 1 = present, 255 = absent/nodata.
+# (imperv, dprst, land_valid, expected_perv)
+# Convention: imperv/dprst are 1 = present, 255 = absent/nodata.
+# land_valid is the boolean template-DEM land mask (True = on land).
 TRUTH_TABLE = [
-    (1, 1, 255),   # both flags set → not pervious
-    (1, 255, 255), # imperv only → not pervious
-    (255, 1, 255), # dprst only → not pervious
-    (255, 255, 1), # neither → pervious
+    (1, 1, True, 255),     # both flags set → not pervious
+    (1, 255, True, 255),   # imperv only → not pervious
+    (255, 1, True, 255),   # dprst only → not pervious
+    (255, 255, True, 1),   # neither, on land → pervious
+    (255, 255, False, 255),  # neither flag but OFF LAND (ocean) → not pervious
+    (1, 1, False, 255),    # off land → not pervious regardless of flags
 ]
 
 
-@pytest.mark.parametrize("imperv_val,dprst_val,expected", TRUTH_TABLE)
-def test_compute_perv_binary_truth_table(imperv_val, dprst_val, expected):
+@pytest.mark.parametrize("imperv_val,dprst_val,land_val,expected", TRUTH_TABLE)
+def test_compute_perv_binary_truth_table(imperv_val, dprst_val, land_val, expected):
     imperv = np.full((3, 3), imperv_val, dtype=np.uint8)
     dprst = np.full((3, 3), dprst_val, dtype=np.uint8)
-    out = compute_perv_binary(imperv, dprst)
+    land_valid = np.full((3, 3), land_val, dtype=bool)
+    out = compute_perv_binary(imperv, dprst, land_valid)
     assert out.dtype == np.uint8
     assert (out == expected).all()
 
 
 def test_compute_perv_binary_mixed_grid():
     """Independent flags per cell — verify element-wise application."""
-    imperv = np.array([[1, 1, 255, 255]], dtype=np.uint8)
-    dprst = np.array([[1, 255, 1, 255]], dtype=np.uint8)
-    out = compute_perv_binary(imperv, dprst)
+    imperv = np.array([[1, 1, 255, 255, 255]], dtype=np.uint8)
+    dprst = np.array([[1, 255, 1, 255, 255]], dtype=np.uint8)
+    land_valid = np.array([[True, True, True, True, False]], dtype=bool)
+    # cell 4 has neither flag set but is off-land → masked to 255.
+    out = compute_perv_binary(imperv, dprst, land_valid)
     assert out.dtype == np.uint8
-    np.testing.assert_array_equal(out, np.array([[255, 255, 255, 1]], dtype=np.uint8))
+    np.testing.assert_array_equal(
+        out, np.array([[255, 255, 255, 1, 255]], dtype=np.uint8)
+    )
+
+
+def test_compute_perv_binary_land_mask_overrides_clear_cell():
+    """An off-land cell that is neither impervious nor depression-storage —
+    the case that previously leaked the whole ocean in as pervious."""
+    imperv = np.full((2, 2), 255, dtype=np.uint8)
+    dprst = np.full((2, 2), 255, dtype=np.uint8)
+    land_valid = np.array([[True, False], [False, True]], dtype=bool)
+    out = compute_perv_binary(imperv, dprst, land_valid)
+    np.testing.assert_array_equal(out, np.array([[1, 255], [255, 1]], dtype=np.uint8))

--- a/tests/test_compute_carea_map_binary.py
+++ b/tests/test_compute_carea_map_binary.py
@@ -6,65 +6,75 @@ import pytest
 from gfv2_params.depstor import compute_carea_map_binary
 
 
-# (perv_val, onstream_val, twi_val, threshold, twi_nodata, expected_out)
+# (perv_val, onstream_val, twi_val, threshold, twi_nodata, land_val, expected_out)
 # Convention: perv/onstream are uint8 binary (1 = present, 255 = nodata).
-# twi is float32. Output is uint8: 1 = carea cell, 255 = excluded/nodata.
+# twi is float32. land_val is the boolean template-DEM land mask.
+# Output is uint8: 1 = carea cell, 255 = excluded/nodata.
 TRUTH_TABLE = [
     # perv=1, twi above threshold -> 1 (the "above-threshold" branch)
-    (1, 255, 10.0, 8.0, -9999.0, 1),
+    (1, 255, 10.0, 8.0, -9999.0, True, 1),
     # perv=1, twi at threshold (strict >) -> 255
-    (1, 255, 8.0, 8.0, -9999.0, 255),
+    (1, 255, 8.0, 8.0, -9999.0, True, 255),
     # perv=1, twi below threshold, onstream=1 -> 1 (the "onstream" branch)
-    (1, 1, 5.0, 8.0, -9999.0, 1),
+    (1, 1, 5.0, 8.0, -9999.0, True, 1),
     # perv=1, twi below threshold, onstream=255 -> 255
-    (1, 255, 5.0, 8.0, -9999.0, 255),
+    (1, 255, 5.0, 8.0, -9999.0, True, 255),
     # perv=255 (non-perv) -> 255 regardless of twi/onstream
-    (255, 1, 100.0, 8.0, -9999.0, 255),
-    (255, 255, 100.0, 8.0, -9999.0, 255),
+    (255, 1, 100.0, 8.0, -9999.0, True, 255),
+    (255, 255, 100.0, 8.0, -9999.0, True, 255),
     # perv=255 with TWI nodata sentinel must NOT cause spurious activation
-    (255, 255, -9999.0, 8.0, -9999.0, 255),
+    (255, 255, -9999.0, 8.0, -9999.0, True, 255),
     # perv=255 with TWI NaN must NOT cause spurious activation
-    (255, 255, np.nan, 8.0, -9999.0, 255),
+    (255, 255, np.nan, 8.0, -9999.0, True, 255),
     # perv=1 with TWI nodata sentinel: above_thresh is false (nodata),
     # but onstream=1 -> still 1 (onstream rescue branch).
-    (1, 1, -9999.0, 8.0, -9999.0, 1),
+    (1, 1, -9999.0, 8.0, -9999.0, True, 1),
     # perv=1 with TWI NaN, onstream=255 -> 255
-    (1, 255, np.nan, 8.0, -9999.0, 255),
+    (1, 255, np.nan, 8.0, -9999.0, True, 255),
     # Second threshold (smidx, 15.6): perv=1 twi=20 -> 1
-    (1, 255, 20.0, 15.6, -9999.0, 1),
+    (1, 255, 20.0, 15.6, -9999.0, True, 1),
     # Second threshold: perv=1 twi=10 (above carea_max thresh but NOT smidx) -> 255
-    (1, 255, 10.0, 15.6, -9999.0, 255),
+    (1, 255, 10.0, 15.6, -9999.0, True, 255),
+    # Off-land cells are masked out even when every other condition passes.
+    # (Both the above-threshold branch and the onstream rescue branch.)
+    (1, 255, 10.0, 8.0, -9999.0, False, 255),
+    (1, 1, 5.0, 8.0, -9999.0, False, 255),
 ]
 
 
 @pytest.mark.parametrize(
-    "perv_val,onstream_val,twi_val,threshold,twi_nodata,expected",
+    "perv_val,onstream_val,twi_val,threshold,twi_nodata,land_val,expected",
     TRUTH_TABLE,
 )
 def test_compute_carea_map_binary_truth_table(
-    perv_val, onstream_val, twi_val, threshold, twi_nodata, expected,
+    perv_val, onstream_val, twi_val, threshold, twi_nodata, land_val, expected,
 ):
     perv = np.full((3, 3), perv_val, dtype=np.uint8)
     onstream = np.full((3, 3), onstream_val, dtype=np.uint8)
     twi = np.full((3, 3), twi_val, dtype=np.float32)
-    out = compute_carea_map_binary(perv, onstream, twi, threshold, twi_nodata)
+    land_valid = np.full((3, 3), land_val, dtype=bool)
+    out = compute_carea_map_binary(perv, onstream, twi, threshold, twi_nodata, land_valid)
     assert out.dtype == np.uint8
     assert (out == expected).all(), f"expected {expected}, got {out}"
 
 
 def test_compute_carea_map_binary_mixed_grid():
     """Independent flags per cell — verify element-wise application."""
-    perv = np.array([[1, 1, 1, 1, 255]], dtype=np.uint8)
-    onstream = np.array([[255, 1, 255, 1, 1]], dtype=np.uint8)
-    twi = np.array([[10.0, 5.0, 5.0, np.nan, 100.0]], dtype=np.float32)
+    perv = np.array([[1, 1, 1, 1, 255, 1]], dtype=np.uint8)
+    onstream = np.array([[255, 1, 255, 1, 1, 1]], dtype=np.uint8)
+    twi = np.array([[10.0, 5.0, 5.0, np.nan, 100.0, 10.0]], dtype=np.float32)
+    land_valid = np.array([[True, True, True, True, True, False]], dtype=bool)
     # threshold=8.0, nodata=-9999.0
     # cell 0: perv=1, twi(10) > 8 -> 1
     # cell 1: perv=1, twi(5) <= 8, onstream=1 -> 1
     # cell 2: perv=1, twi(5) <= 8, onstream=255 -> 255
     # cell 3: perv=1, twi=NaN invalid, onstream=1 -> 1 (onstream rescue)
     # cell 4: perv=255 -> 255 (short-circuit on non-perv)
-    out = compute_carea_map_binary(perv, onstream, twi, 8.0, -9999.0)
-    np.testing.assert_array_equal(out, np.array([[1, 1, 255, 1, 255]], dtype=np.uint8))
+    # cell 5: every condition passes but land_valid=False -> 255 (off-land)
+    out = compute_carea_map_binary(perv, onstream, twi, 8.0, -9999.0, land_valid)
+    np.testing.assert_array_equal(
+        out, np.array([[1, 1, 255, 1, 255, 255]], dtype=np.uint8)
+    )
 
 
 def test_compute_carea_map_binary_handles_nan_nodata_kwarg():
@@ -73,5 +83,6 @@ def test_compute_carea_map_binary_handles_nan_nodata_kwarg():
     perv = np.array([[1, 1]], dtype=np.uint8)
     onstream = np.array([[255, 255]], dtype=np.uint8)
     twi = np.array([[10.0, np.nan]], dtype=np.float32)
-    out = compute_carea_map_binary(perv, onstream, twi, 8.0, np.nan)
+    land_valid = np.array([[True, True]], dtype=bool)
+    out = compute_carea_map_binary(perv, onstream, twi, 8.0, np.nan, land_valid)
     np.testing.assert_array_equal(out, np.array([[1, 255]], dtype=np.uint8))

--- a/tests/test_land_mask.py
+++ b/tests/test_land_mask.py
@@ -1,0 +1,40 @@
+"""Tests for the read_land_mask helper used by the depstor builders."""
+
+import numpy as np
+import rasterio
+from rasterio.transform import from_origin
+
+from gfv2_params.depstor import read_land_mask
+
+
+def _write_landmask(path, data):
+    """Write a uint8 1/255 land_mask.tif (the build_depstor_landmask convention)."""
+    with rasterio.open(
+        path, "w", driver="GTiff", height=data.shape[0], width=data.shape[1],
+        count=1, dtype="uint8", crs="EPSG:5070",
+        transform=from_origin(0, data.shape[0] * 30, 30, 30), nodata=255,
+    ) as dst:
+        dst.write(data, 1)
+
+
+def test_read_land_mask_returns_bool_in_fabric(tmp_path):
+    """land_mask.tif uses the 1/255 convention; read_land_mask returns True
+    only where the value is 1 (inside the HRU fabric)."""
+    data = np.array([[1, 255], [255, 1]], dtype=np.uint8)
+    path = tmp_path / "land_mask.tif"
+    _write_landmask(path, data)
+    out = read_land_mask(path)
+    assert out.dtype == np.bool_
+    np.testing.assert_array_equal(out, np.array([[True, False], [False, True]]))
+
+
+def test_read_land_mask_all_land(tmp_path):
+    path = tmp_path / "land_mask.tif"
+    _write_landmask(path, np.ones((3, 3), dtype=np.uint8))
+    assert read_land_mask(path).all()
+
+
+def test_read_land_mask_all_ocean(tmp_path):
+    path = tmp_path / "land_mask.tif"
+    _write_landmask(path, np.full((3, 3), 255, dtype=np.uint8))
+    assert not read_land_mask(path).any()


### PR DESCRIPTION
Closes #68.

## Land mask via HRU fabric (the main fix)

Every depstor binary raster was including cells over the ocean. The land mask used `template != nodata` against the hydro-conditioned DEM, but that DEM carries valid (often garbage) values over coastal water — its nodata footprint bulges into the sea with large rounded blobs. The FDR has the same blobs (derived from the same DEM), so neither is a valid land mask.

Replaced with a precomputed `land_mask.tif` rasterized from the `nhru` fabric — the authoritative modeling domain, with a clean coastline, and exactly what `create_zonal_params` aggregates to downstream.

**New:**
- `scripts/build_depstor_landmask.py` — rasterizes `nhru` to the template grid (`all_touched=True` to keep thin coastal HRU edges)
- `configs/depstor_landmask_raster.yml`, `slurm_batch/build_depstor_landmask.batch`
- `base_config.yml` — `hru_gpkg` / `hru_layer` added to the `gfv2` and `gfv2_vpu01` profiles

**Changed:**
- `src/gfv2_params/depstor.py` — `read_land_mask()` now reads `land_mask.tif` and returns `== 1`; the dead DEM-based `land_mask()` helper is removed
- 7 raster builders (`imperv`, `waterbody`, `streambuffer`, `dprst`, `routing`, `perv`, `carea_map`) now read `land_mask.tif` via a `landmask_raster` config key. Whole-array builders call `read_land_mask()`; streaming builders test `strip == 1` per window. `compute_perv_binary` / `compute_carea_map_binary` signatures unchanged (they already took a `land_valid` bool array)
- `build_depstor_intersect` needs no code change — `drains_perv` / `drains_imperv` are intersections of two already-masked rasters and so are structurally land-clean
- `slurm_batch/RUNME.md` — `build_depstor_landmask` documented as the new mandatory first step; depstor chain is now 10 jobs (was 9)

## Validation (VPU01)

- `land_mask.tif`: 23.19% coverage = exact match to the `nhru` fabric.
- Rendered against OSM shows a clean coastline — Cape Cod, islands, the jagged Maine coast all correct, no DEM blobs.
- Pre-fix `perv_binary` = 99% of grid; post-fix 23.4% (on-land minus imperv/dprst).

## Scope-expansion note: NLCD impervious source swap

Bundled commit (split out as a separate atomic commit for cherry-pick-ability): the impervious source is also swapped from `input/lulc_veg/Imperv.tif` to `input/lulc/nlcd_annual_imperv/Annual_NLCD_FctImp_2015_CU_C1V1.tif` (NLCD Annual Fractional Impervious Surface, 2015). This is a config-only change at the call site — `build_depstor_imperv.py` already handles arbitrary source CRS and nodata dynamically (Albers/WGS84 vs NAD83, nodata 250 vs 255).

## Updated sbatch recipe

The full depstor rebuild chain (VPU01):
```bash
export FABRIC=gfv2_vpu01
J0=$(sbatch --parsable --time=01:00:00 --mem=16G slurm_batch/build_depstor_landmask.batch --force)
J1=$(sbatch --parsable --time=01:00:00 --mem=16G --dependency=afterok:$J0 slurm_batch/build_depstor_imperv.batch --force)
J2=$(sbatch --parsable --time=01:00:00 --mem=16G --dependency=afterok:$J0 slurm_batch/build_depstor_streambuffer.batch --force)
J3=$(sbatch --parsable --time=01:00:00 --mem=16G --dependency=afterok:$J0 slurm_batch/build_depstor_waterbody.batch --force)
J4=$(sbatch --parsable --time=01:00:00 --mem=32G --dependency=afterok:$J1:$J2:$J3 slurm_batch/build_depstor_dprst.batch --force)
J5=$(sbatch --parsable --time=00:10:00 --mem=4G  --dependency=afterok:$J4 slurm_batch/build_depstor_perv.batch --force)
J6=$(sbatch --parsable --time=02:00:00 --mem=48G --dependency=afterok:$J4 slurm_batch/build_depstor_routing.batch --force)
J7=$(sbatch --parsable --dependency=afterok:$J5:$J6 slurm_batch/build_depstor_drains_perv.batch --force)
J8=$(sbatch --parsable --dependency=afterok:$J1:$J6 slurm_batch/build_depstor_drains_imperv.batch --force)
J9=$(sbatch --parsable --dependency=afterok:$J5 slurm_batch/build_depstor_carea_map.batch --force)
```

## Tests

`tests/test_land_mask.py` rewritten for `read_land_mask` against a `land_mask.tif` fixture (the old DEM-based `land_mask()` is removed). `tests/test_build_depstor_perv.py` and `tests/test_compute_carea_map_binary.py` unchanged — the `land_valid` array signatures didn't move. Local pytest run deferred to CI.

## Commits

1. `feat(depstor): swap impervious source to 2015 NLCD Annual FctImp` — config-only, split out so it can be cherry-picked independently.
2. `fix(depstor): mask all rasters to HRU fabric via land_mask.tif` — the main fix.