### PR TITLE
fix(build_border_dem): early-exit when Copernicus outputs already exist

### DIFF
--- a/src/gfv2_params/shared_rasters/build_border_dem.py
+++ b/src/gfv2_params/shared_rasters/build_border_dem.py
@@ -227,6 +227,31 @@ def build(step_cfg: dict, ctx: SharedRastersContext, logger) -> dict:
     slope_out = fill_dir / "NEDSnapshot_merged_slope_copernicus.tif"
     aspect_out = fill_dir / "NEDSnapshot_merged_aspect_copernicus.tif"
 
+    # Early-exit if every output is already on disk. Without this the
+    # orchestrator re-runs the Copernicus download on every walk, even
+    # when the three output tiles are cached — slow (network-bound) and
+    # fragile (the >20% shortfall guard at line ~259 trips intermittently
+    # on transient 404s from the deliberately-generous border bbox).
+    # Mirrors the skip-if-exists pattern every per-VPU builder uses.
+    if (
+        not ctx.force
+        and elev_out.exists()
+        and slope_out.exists()
+        and aspect_out.exists()
+    ):
+        logger.info(
+            "=== build_border_dem: all outputs exist, skipping "
+            "(use --force to rebuild) ==="
+        )
+        logger.info("  elevation: %s", elev_out)
+        logger.info("  slope    : %s", slope_out)
+        logger.info("  aspect   : %s", aspect_out)
+        return {
+            "border_elevation": elev_out,
+            "border_slope": slope_out,
+            "border_aspect": aspect_out,
+        }
+
     # --- Step 1: Compute tile list and download ---
     logger.info("=== Step 1/5: Download Copernicus GLO-30 tiles ===")
     all_labels = []


### PR DESCRIPTION
## Summary

`build_border_dem.build()` always ran Step 1 (Copernicus tile download) regardless of whether the three output tiles were already on disk. On warm-cache reruns this:
- wastes ~4 minutes hitting copernicus.eu for tiles we don't need
- intermittently fails when transient 404s push the shortfall over the 20% guard (the border bbox is deliberately generous — a chunk of the labelled tiles are ocean, and a 20.49% shortfall is just over the wall)

Add an existence check at the top of `build()` that skips the entire pipeline (download + warp + composite + slope/aspect + mask) when all three outputs are present and `--force` is not set. Matches the output-exists skip pattern every per-VPU builder uses.

## Repro

Job `20515986` (logs in this repo) — orchestrator walk on VPU 01 hit `build_border_dem` with `elev`/`slope`/`aspect` cached from April, did a 4-minute Copernicus download anyway, then raised `RuntimeError` on the 20.49% shortfall:

\`\`\`
Only 1238/1557 tiles downloaded (20% shortfall) — border DEM may have coverage gaps
\`\`\`

## Test plan

- [x] py_compile passes locally
- [ ] CI pytest gate (no test added — existence check is hard to unit-test without rasterio fixtures; the skip path is a straight-line guard)
- [ ] Smoke test: rerun `slurm_batch/pr74_smoke.batch` after this lands and verify the orchestrator walks through `build_border_dem` without re-downloading

## Followup (out of scope)

The 20% shortfall guard itself is still brittle — if a user ever needs to `--force` rebuild with a flaky network connection, they'll trip it again. A separate cleanup could either raise the threshold to ~30% (matching the actual ocean-tile fraction) or convert it to a warning + log the missing tile labels. Not addressing in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)