### PR TITLE
perf(raster_ops): multithreaded Warp + float32 output + atomic-rename guard

### DIFF
--- a/slurm_batch/build_derived_rasters.batch
+++ b/slurm_batch/build_derived_rasters.batch
@@ -6,7 +6,7 @@
 #SBATCH --error=logs/job_%j.err
 #SBATCH --time=02:00:00
 #SBATCH --ntasks=1
-#SBATCH --cpus-per-task=4
+#SBATCH --cpus-per-task=16
 #SBATCH --mem=96G
 
 cd "$SLURM_SUBMIT_DIR"

--- a/slurm_batch/build_lulc_rasters.batch
+++ b/slurm_batch/build_lulc_rasters.batch
@@ -6,7 +6,7 @@
 #SBATCH --error=logs/job_%j.err
 #SBATCH --time=04:00:00
 #SBATCH --ntasks=1
-#SBATCH --cpus-per-task=4
+#SBATCH --cpus-per-task=16
 #SBATCH --mem=96G
 
 cd "$SLURM_SUBMIT_DIR"

--- a/src/gfv2_params/raster_ops.py
+++ b/src/gfv2_params/raster_ops.py
@@ -38,11 +38,8 @@ def resample(
     if not Path(template_path).exists():
         raise FileNotFoundError(f"Template raster not found: {template_path}")
 
-    src = gdal.Open(src_path, gdalconst.GA_ReadOnly)
-    if src is None:
-        raise FileNotFoundError(f"Source raster not found: {src_path}")
-    src_proj = src.GetProjection()
-
+    # Read template geometry once, then close — gdal.Warp takes the spatial
+    # reference + bounds as parameters and opens the source itself.
     tmpl = gdal.Open(template_path, gdalconst.GA_ReadOnly)
     if tmpl is None:
         raise FileNotFoundError(f"Template raster not found: {template_path}")
@@ -50,60 +47,89 @@ def resample(
     tmpl_geotrans = tmpl.GetGeoTransform()
     width = tmpl.RasterXSize
     height = tmpl.RasterYSize
+    del tmpl
 
-    driver = gdal.GetDriverByName("GTiff")
-    if driver is None:
-        raise RuntimeError("GDAL GTiff driver not available")
-    dst = driver.Create(
-        intermediate_path,
-        width,
-        height,
-        1,
-        gdalconst.GDT_Float32,
-        options=["COMPRESS=LZW", "TILED=YES", "BLOCKXSIZE=512", "BLOCKYSIZE=512", "BIGTIFF=YES"],
-    )
-    if dst is None:
-        raise RuntimeError(f"Failed to create output raster: {intermediate_path}")
-    dst.SetGeoTransform(tmpl_geotrans)
-    dst.SetProjection(tmpl_proj)
+    output_bounds = [
+        tmpl_geotrans[0],                          # minx
+        tmpl_geotrans[3] + height * tmpl_geotrans[5],  # miny (geotrans[5] negative)
+        tmpl_geotrans[0] + width * tmpl_geotrans[1],   # maxx
+        tmpl_geotrans[3],                          # maxy
+    ]
 
+    # Atomic-rename: do every write to a `.tmp` companion path, rename to the
+    # final name only after the operation succeeds. Without this, a job killed
+    # mid-write leaves a partial file whose TIFF header is intact — rasterio
+    # opens it cleanly, the existence/validity check passes, and the next run
+    # silently consumes a corrupted output. See job 20515994 for the precise
+    # symptom (4.75 GB partial cnpy_resampled_nalcms.tif passed _is_valid_raster).
+    intermediate_tmp = Path(f"{intermediate_path}.tmp")
+    output_tmp = Path(f"{output_path}.tmp")
+    intermediate_tmp.unlink(missing_ok=True)
+    output_tmp.unlink(missing_ok=True)
+
+    # Stage 1: reproject source onto template grid via multithreaded GDAL Warp.
+    # `gdal.ReprojectImage` is single-threaded; switching to gdal.Warp with
+    # NUM_THREADS=ALL_CPUS yields a 4-8x speedup on CONUS-scale targets and
+    # unblocks first-time builds of the large-grid LULC sources (NALCMS, NLCD).
     logger.info(
-        "  GDAL ReprojectImage: %s -> %s  (%d x %d pixels)",
+        "  GDAL Warp (multithreaded): %s -> %s  (%d x %d pixels)",
         Path(src_path).name,
-        Path(intermediate_path).name,
+        intermediate_tmp.name,
         width,
         height,
     )
     t_gdal = time.time()
-    err = gdal.ReprojectImage(src, dst, src_proj, tmpl_proj, gdalconst.GRA_NearestNeighbour)
-    if err != 0:
-        raise RuntimeError(f"GDAL ReprojectImage failed with error code {err}")
-    del dst
-    del src
-    del tmpl
-    logger.info("  GDAL reproject done in %.0f s", time.time() - t_gdal)
+    warp_ds = gdal.Warp(
+        str(intermediate_tmp),
+        str(src_path),
+        format="GTiff",
+        dstSRS=tmpl_proj,
+        outputBounds=output_bounds,
+        xRes=abs(tmpl_geotrans[1]),
+        yRes=abs(tmpl_geotrans[5]),
+        resampleAlg=gdal.GRA_NearestNeighbour,
+        outputType=gdalconst.GDT_Float32,
+        multithread=True,
+        warpOptions=["NUM_THREADS=ALL_CPUS"],
+        creationOptions=[
+            "COMPRESS=LZW", "TILED=YES",
+            "BLOCKXSIZE=1024", "BLOCKYSIZE=1024",
+            "BIGTIFF=YES", "NUM_THREADS=ALL_CPUS",
+        ],
+    )
+    if warp_ds is None:
+        raise RuntimeError(f"gdal.Warp failed: {src_path} -> {intermediate_tmp}")
+    warp_ds.FlushCache()
+    del warp_ds
+    intermediate_tmp.replace(intermediate_path)
+    logger.info("  GDAL Warp done in %.0f s", time.time() - t_gdal)
 
+    # Stage 2: block-wise NoData mask + write final. Output is float32 (was
+    # float64) — the source data is uint8 with ~3-digit precision, so float64
+    # was wasting an entire bit-plane of disk + I/O for zero accuracy gain.
     logger.info("  Applying NoData mask (block-wise) and writing LZW output: %s", Path(output_path).name)
     t_mask = time.time()
     with rasterio.open(intermediate_path) as src_rio:
         profile = src_rio.profile
         profile.update(
-            dtype=rasterio.float64,
+            dtype=rasterio.float32,
             count=1,
             compress="lzw",
+            predictor=3,  # floating-point predictor — better ratio + faster decode for float data
             tiled=True,
-            blockxsize=512,
-            blockysize=512,
+            blockxsize=1024,
+            blockysize=1024,
             BIGTIFF="YES",
-            nodata=np.nan,  # declare NaN as nodata so GDAL excludes it from average resampling
+            num_threads="ALL_CPUS",
+            nodata=np.nan,
         )
         n_windows = sum(1 for _ in src_rio.block_windows(1))
         log_every = max(1, n_windows // 10)
         logger.info("  Masking %d windows", n_windows)
 
-        with rasterio.open(output_path, "w", **profile) as dst_rio:
+        with rasterio.open(output_tmp, "w", **profile) as dst_rio:
             for i, (_, window) in enumerate(src_rio.block_windows(1), start=1):
-                data = src_rio.read(1, window=window).astype(np.float64)
+                data = src_rio.read(1, window=window).astype(np.float32)
                 for val in mask_values:
                     data[data == val] = np.nan
                 if mask_negative:
@@ -118,6 +144,7 @@ def resample(
                         i, n_windows, 100 * i / n_windows, elapsed, eta,
                     )
     logger.info("  NoData mask + write done in %.0f s", time.time() - t_mask)
+    output_tmp.replace(output_path)
     # remove large intermediate
     Path(intermediate_path).unlink(missing_ok=True)
     logger.info("  Removed intermediate: %s", intermediate_path)

--- a/tests/test_raster_ops.py
+++ b/tests/test_raster_ops.py
@@ -113,6 +113,53 @@ def test_resample_file_not_found():
             )
 
 
+def test_resample_atomic_rename_clears_stale_tmp_and_leaves_no_tmp_on_success():
+    """Atomic-rename guard: stale .tmp files at the target paths are unlinked
+    before a fresh run, and no .tmp companions remain after success.
+
+    Regression test for the corruption mode in job 20515994: a previous job
+    killed mid-write left a 4.75 GB partial cnpy_resampled_nalcms.tif that
+    rasterio could still open, so the orchestrator's _is_valid_raster()
+    skipped the resample and the next run consumed a 96%-incomplete file.
+    With the .tmp + os.replace pattern, partial state lives at <path>.tmp
+    where the existence check at the final <path> never sees it.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir = Path(tmpdir)
+        src_path = tmpdir / "src.tif"
+        tmpl_path = tmpdir / "tmpl.tif"
+        intermediate_path = tmpdir / "intermediate.tif"
+        output_path = tmpdir / "output.tif"
+
+        data = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]], dtype=np.float32)
+        _write_tiff(src_path, data)
+        _write_tiff(tmpl_path, np.ones((3, 3), dtype=np.float32))
+
+        # Simulate the post-kill state: stale .tmp files from a previous
+        # interrupted run sitting at both expected paths. They should be
+        # unlinked at the top of resample() before any work begins.
+        stale_intermediate_tmp = Path(f"{intermediate_path}.tmp")
+        stale_output_tmp = Path(f"{output_path}.tmp")
+        stale_intermediate_tmp.write_bytes(b"garbage from prior killed run")
+        stale_output_tmp.write_bytes(b"garbage from prior killed run")
+        assert stale_intermediate_tmp.exists()
+        assert stale_output_tmp.exists()
+
+        resample(str(src_path), str(tmpl_path), str(intermediate_path), str(output_path))
+
+        # Final outputs are at the canonical paths, NOT at .tmp paths.
+        assert output_path.exists()
+        # The intermediate is deleted at the end of a successful run.
+        assert not intermediate_path.exists()
+        # No .tmp companions should survive a successful run.
+        assert not stale_intermediate_tmp.exists()
+        assert not stale_output_tmp.exists()
+        # And the output is a valid raster (sanity check — confirms the
+        # rename produced a real file, not just the absence of .tmp).
+        with rasterio.open(str(output_path)) as src:
+            assert src.read(1).shape == (3, 3)
+
+
 def test_mult_rasters_basic():
     """Element-wise multiplication of two 3x3 rasters."""
     with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

A CONUS-scale resample on the NALCMS LULC grid (255k × 259k cells) blew through a 4-hour wall time in job 20515994 — Stage 1 (GDAL reproject) alone took 3h31m. Three structural changes to `raster_ops.resample()` cut that:

1. **`gdal.ReprojectImage` → `gdal.Warp` with multithread=True** + `NUM_THREADS=ALL_CPUS` in both `warpOptions` and `creationOptions`. ReprojectImage is single-threaded by design; Warp respects the thread hints. Expected 4-8× speedup on Stage 1.
2. **Output dtype float64 → float32.** Every current caller feeds signed-integer source data — RootDepth is int8 (nodata=-128), keep is int8 (nodata=-128), CNPY is int16 (nodata=-32768). int16's ~5 decimal digits of meaningful precision sit well inside float32's 7-digit mantissa, so float64 was wasting an entire bit-plane of disk + I/O for zero accuracy gain. Also switch the LZW predictor to floating-point (3) for better ratio + faster decode on float data.
3. **Atomic-rename pattern.** Write to `<path>.tmp` throughout; `os.replace()` to the final name only after the stage succeeds. Without this, a job killed mid-write leaves a partial file whose TIFF header is intact — rasterio opens it cleanly, `build_lulc_rasters._is_valid_raster()` passes it, and the next run silently consumes a corrupted output. The repro: job 20515994 left a 4.75 GB `cnpy_resampled_nalcms.tif` (out of expected ~65 GB) that read NaN past the kill point and passed validation. With the rename, partial files live as `<path>.tmp` and are invisible to the existence check.

Block size bumped from 512 to 1024 to reduce compress/decompress overhead.

## Batch script changes (paired)

`slurm_batch/build_lulc_rasters.batch` and `slurm_batch/build_derived_rasters.batch` (both invoke `resample()`) bumped from `--cpus-per-task=4` to `16` so the multithreaded Warp actually has cores to use.

## Expected impact

| | Before | After (est.) |
|---|---:|---:|
| NALCMS cnpy Stage 1 | 3h31m | ~25-30 min |
| NALCMS cnpy Stage 2 (write ~130 GB float64 → ~65 GB float32) | ~30 min | ~12 min |
| NHM v1.1 cnpy total | 23m22s | ~5-8 min |

## Correctness notes

- **API unchanged** — same function signature, same masking semantics. Callers using the default `mask_values=(128, 0)` (RootDepth in `build_derived_rasters`) and the override `mask_values=(128,)` (CNPY/KEEP in `build_lulc_rasters`) both work identically. Note: for the actual int8/int16 sources the `128`/`0` literals are largely vestigial (the `-128`/`-32768` nodata sentinels are caught by `mask_negative=True`); follow-up #TBD will clean that up.
- **Output values within float32 precision** of the previous float64 outputs. The source data is int8/int16; float32 has 7 decimal digits of mantissa precision, more than the source itself carries.
- **Tests preserved.** The three existing `tests/test_raster_ops.py::test_resample_*` cases assert NaN masking + FileNotFoundError, which are dtype-agnostic. CI green at job 76434126332.

## Followup (out of scope)

Single-pass refactor (eliminate the intermediate entirely via `gdal.Warp` with the value-based mask folded into `srcNodata`) would be a larger change but would obviate the Stage 1/Stage 2 split entirely. Not addressed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)