### PR TITLE
fix(lulc): warn-and-skip missing input sources instead of raising

### DIFF
--- a/src/gfv2_params/shared_rasters/build_lulc_rasters.py
+++ b/src/gfv2_params/shared_rasters/build_lulc_rasters.py
@@ -114,10 +114,23 @@ def _build_one_source(source_yaml: Path, ctx: SharedRastersContext, logger) -> d
 
     lulc_raster = Path(config["source_raster"])
     cnpy_raster = Path(config["canopy_raster"])
+    # Missing inputs are warn-and-skip, not fatal. The orchestrator processes
+    # every LULC source in the `sources:` list; one source's data not being
+    # staged shouldn't take down the whole step (and the other sources). The
+    # warning is loud enough to surface in CI/log output, and the source is
+    # cleanly omitted from `produced` so downstream consumers see the gap.
     if not lulc_raster.exists():
-        raise FileNotFoundError(f"LULC raster not found: {lulc_raster}")
+        logger.warning(
+            "LULC raster not found for source=%s — skipping this source. "
+            "Missing: %s", lulc_source, lulc_raster,
+        )
+        return {}
     if not cnpy_raster.exists():
-        raise FileNotFoundError(f"Canopy raster not found: {cnpy_raster}")
+        logger.warning(
+            "Canopy raster not found for source=%s — skipping this source. "
+            "Missing: %s", lulc_source, cnpy_raster,
+        )
+        return {}
 
     radtrn_raster_str = config.get("radtrn_raster")
     radtrn_raster = Path(radtrn_raster_str) if radtrn_raster_str else None
@@ -161,7 +174,15 @@ def _build_one_source(source_yaml: Path, ctx: SharedRastersContext, logger) -> d
         return produced
 
     if not keep_raster.exists():
-        raise FileNotFoundError(f"Keep raster not found: {keep_raster}")
+        # Same warn-and-skip philosophy as source/canopy missing, but the
+        # cnpy resample already succeeded — return what we have so downstream
+        # consumers can still use the cnpy_resampled output.
+        logger.warning(
+            "Keep raster not found for source=%s — skipping Steps 2-3 "
+            "(keep resample + radtrn). Cnpy resample retained. Missing: %s",
+            lulc_source, keep_raster,
+        )
+        return produced
 
     # Step 2: Resample keep to LULC grid.
     keep_resampled = derived_dir / f"keep_resampled_{lulc_source}.tif"

--- a/tests/test_build_lulc_rasters.py
+++ b/tests/test_build_lulc_rasters.py
@@ -6,13 +6,29 @@ mid-walk after nalcms had already completed a 17-minute resample).
 """
 
 import logging
-import tempfile
 from pathlib import Path
 
+import numpy as np
+import rasterio
 import yaml
+from rasterio.crs import CRS
+from rasterio.transform import from_bounds
 
 from gfv2_params.shared_rasters.build_lulc_rasters import _build_one_source
 from gfv2_params.shared_rasters.context import SharedRastersContext
+
+
+def _write_tiny_tiff(path: Path) -> None:
+    """Write a 2x2 GeoTIFF so rasterio.open() succeeds. _build_one_source
+    calls _raster_info(...) for logging on every input that exists, so the
+    "existing" inputs in these tests have to be readable rasters, not
+    zero-byte placeholders."""
+    with rasterio.open(
+        str(path), "w", driver="GTiff", height=2, width=2, count=1,
+        dtype="float32", crs=CRS.from_string("EPSG:4326"),
+        transform=from_bounds(0, 0, 2, 2, 2, 2),
+    ) as dst:
+        dst.write(np.ones((2, 2), dtype=np.float32), 1)
 
 
 def _write_config(path: Path, cfg: dict) -> None:
@@ -51,11 +67,16 @@ def test_missing_lulc_source_raster_warns_and_skips(tmp_path, caplog):
 
 
 def test_missing_canopy_raster_warns_and_skips(tmp_path, caplog):
-    """Same warn-and-skip behavior when source_raster exists but canopy is missing."""
+    """Same warn-and-skip behavior when source_raster exists but canopy is missing.
+
+    source_raster must be a real GeoTIFF (not a zero-byte placeholder) because
+    _build_one_source calls _raster_info(lulc_raster) for logging before it
+    gets to check whether canopy_raster exists.
+    """
     data_root = tmp_path / "data_root"
     data_root.mkdir()
     fake_lulc = data_root / "lulc.tif"
-    fake_lulc.write_bytes(b"")  # existence check only; we never read it
+    _write_tiny_tiff(fake_lulc)
     cfg_path = tmp_path / "lulc_missing_cnpy.yml"
     _write_config(cfg_path, {
         "lulc_source": "fake_source",
@@ -71,38 +92,23 @@ def test_missing_canopy_raster_warns_and_skips(tmp_path, caplog):
     assert any("Canopy raster not found" in r.message for r in caplog.records)
 
 
-def test_missing_keep_raster_warns_and_retains_cnpy_output(tmp_path, caplog, monkeypatch):
+def test_missing_keep_raster_warns_and_retains_cnpy_output(tmp_path, caplog):
     """A configured but missing keep_raster yields a warning, skips Steps 2-3,
-    but retains the cnpy_resampled output from Step 1 in the produced dict.
-
-    Stubs resample() so we don't actually do CONUS-scale GDAL work in a test.
-    """
+    but retains the cnpy_resampled output from Step 1 in the produced dict."""
     data_root = tmp_path / "data_root"
     data_root.mkdir()
     derived_dir = data_root / "work" / "derived_rasters"
     derived_dir.mkdir(parents=True)
 
+    # source_raster, canopy_raster, AND cnpy_resampled all need to be real
+    # readable rasters: _build_one_source logs raster info for the first two
+    # (via _raster_info -> rasterio.open), and _is_valid_raster opens the
+    # third to decide whether to skip the Step 1 resample.
     fake_lulc = data_root / "lulc.tif"
-    fake_lulc.write_bytes(b"")
     fake_cnpy = data_root / "cnpy.tif"
-    fake_cnpy.write_bytes(b"")
-
-    # Pre-create a fake cnpy_resampled output so _is_valid_raster's path
-    # check passes and Step 1 takes the "already exists — skipping" branch.
-    # Use a real (tiny) GeoTIFF so rasterio.open() inside _is_valid_raster
-    # actually succeeds.
-    import numpy as np
-    import rasterio
-    from rasterio.crs import CRS
-    from rasterio.transform import from_bounds
-
     cnpy_resampled = derived_dir / "cnpy_resampled_fake_source.tif"
-    with rasterio.open(
-        str(cnpy_resampled), "w", driver="GTiff", height=2, width=2, count=1,
-        dtype="float32", crs=CRS.from_string("EPSG:4326"),
-        transform=from_bounds(0, 0, 2, 2, 2, 2),
-    ) as dst:
-        dst.write(np.ones((2, 2), dtype=np.float32), 1)
+    for p in (fake_lulc, fake_cnpy, cnpy_resampled):
+        _write_tiny_tiff(p)
 
     cfg_path = tmp_path / "lulc_missing_keep.yml"
     _write_config(cfg_path, {

--- a/tests/test_build_lulc_rasters.py
+++ b/tests/test_build_lulc_rasters.py
@@ -1,0 +1,124 @@
+"""Behavioral tests for src/gfv2_params/shared_rasters/build_lulc_rasters.py.
+
+Covers the warn-and-skip path for missing inputs (the failure mode in
+job 20516163, where an unstaged NLCD source took down the orchestrator
+mid-walk after nalcms had already completed a 17-minute resample).
+"""
+
+import logging
+import tempfile
+from pathlib import Path
+
+import yaml
+
+from gfv2_params.shared_rasters.build_lulc_rasters import _build_one_source
+from gfv2_params.shared_rasters.context import SharedRastersContext
+
+
+def _write_config(path: Path, cfg: dict) -> None:
+    with open(path, "w") as f:
+        yaml.safe_dump(cfg, f)
+
+
+def _make_ctx(data_root: Path) -> SharedRastersContext:
+    return SharedRastersContext(
+        data_root=data_root,
+        vpus=[],
+        output_dir=data_root / "work",
+    )
+
+
+def test_missing_lulc_source_raster_warns_and_skips(tmp_path, caplog):
+    """A configured but missing source_raster yields a warning + empty dict,
+    not a FileNotFoundError. The orchestrator must be able to continue to
+    the next source in the `sources:` list."""
+    data_root = tmp_path / "data_root"
+    data_root.mkdir()
+    cfg_path = tmp_path / "lulc_missing.yml"
+    _write_config(cfg_path, {
+        "lulc_source": "fake_source",
+        "source_raster": str(data_root / "input" / "lulc_veg" / "fake_source" / "missing.tif"),
+        "canopy_raster": str(data_root / "input" / "lulc_veg" / "CNPY.tif"),
+    })
+
+    logger = logging.getLogger("test_lulc_missing_source")
+    with caplog.at_level(logging.WARNING, logger=logger.name):
+        produced = _build_one_source(cfg_path, _make_ctx(data_root), logger)
+
+    assert produced == {}
+    assert any("LULC raster not found" in r.message for r in caplog.records)
+    assert any("fake_source" in r.message for r in caplog.records)
+
+
+def test_missing_canopy_raster_warns_and_skips(tmp_path, caplog):
+    """Same warn-and-skip behavior when source_raster exists but canopy is missing."""
+    data_root = tmp_path / "data_root"
+    data_root.mkdir()
+    fake_lulc = data_root / "lulc.tif"
+    fake_lulc.write_bytes(b"")  # existence check only; we never read it
+    cfg_path = tmp_path / "lulc_missing_cnpy.yml"
+    _write_config(cfg_path, {
+        "lulc_source": "fake_source",
+        "source_raster": str(fake_lulc),
+        "canopy_raster": str(data_root / "missing_cnpy.tif"),
+    })
+
+    logger = logging.getLogger("test_lulc_missing_cnpy")
+    with caplog.at_level(logging.WARNING, logger=logger.name):
+        produced = _build_one_source(cfg_path, _make_ctx(data_root), logger)
+
+    assert produced == {}
+    assert any("Canopy raster not found" in r.message for r in caplog.records)
+
+
+def test_missing_keep_raster_warns_and_retains_cnpy_output(tmp_path, caplog, monkeypatch):
+    """A configured but missing keep_raster yields a warning, skips Steps 2-3,
+    but retains the cnpy_resampled output from Step 1 in the produced dict.
+
+    Stubs resample() so we don't actually do CONUS-scale GDAL work in a test.
+    """
+    data_root = tmp_path / "data_root"
+    data_root.mkdir()
+    derived_dir = data_root / "work" / "derived_rasters"
+    derived_dir.mkdir(parents=True)
+
+    fake_lulc = data_root / "lulc.tif"
+    fake_lulc.write_bytes(b"")
+    fake_cnpy = data_root / "cnpy.tif"
+    fake_cnpy.write_bytes(b"")
+
+    # Pre-create a fake cnpy_resampled output so _is_valid_raster's path
+    # check passes and Step 1 takes the "already exists — skipping" branch.
+    # Use a real (tiny) GeoTIFF so rasterio.open() inside _is_valid_raster
+    # actually succeeds.
+    import numpy as np
+    import rasterio
+    from rasterio.crs import CRS
+    from rasterio.transform import from_bounds
+
+    cnpy_resampled = derived_dir / "cnpy_resampled_fake_source.tif"
+    with rasterio.open(
+        str(cnpy_resampled), "w", driver="GTiff", height=2, width=2, count=1,
+        dtype="float32", crs=CRS.from_string("EPSG:4326"),
+        transform=from_bounds(0, 0, 2, 2, 2, 2),
+    ) as dst:
+        dst.write(np.ones((2, 2), dtype=np.float32), 1)
+
+    cfg_path = tmp_path / "lulc_missing_keep.yml"
+    _write_config(cfg_path, {
+        "lulc_source": "fake_source",
+        "source_raster": str(fake_lulc),
+        "canopy_raster": str(fake_cnpy),
+        "keep_raster": str(data_root / "missing_keep.tif"),
+        "radtrn_raster": str(derived_dir / "radtrn_fake_source.tif"),
+    })
+
+    logger = logging.getLogger("test_lulc_missing_keep")
+    with caplog.at_level(logging.WARNING, logger=logger.name):
+        produced = _build_one_source(cfg_path, _make_ctx(data_root), logger)
+
+    assert "cnpy_resampled_fake_source" in produced
+    assert "keep_resampled_fake_source" not in produced
+    assert "radtrn_fake_source" not in produced
+    assert any("Keep raster not found" in r.message for r in caplog.records)
+    assert any("Cnpy resample retained" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

\`build_lulc_rasters\` processes every LULC source in the orchestrator's \`sources:\` list (currently nhm_v11, nalcms, nlcd, foresce). A single missing input was a fatal \`FileNotFoundError\` that took down the whole step plus every source after it.

**Repro (job 20516163):**
- 17m23s spent successfully resampling NALCMS cnpy (the first-time build)
- Then NLCD's unstaged \`nlcd_2021_land_cover.tif\` raised \`FileNotFoundError\`
- Orchestrator caught it as a step failure → \`sys.exit(1)\`
- FORE-SCE never attempted, despite being independent of NLCD

## Behavior change

In \`_build_one_source()\`, missing inputs are now warn-and-skip instead of fatal:

| Missing input | Old | New |
|---|---|---|
| \`source_raster\` | \`FileNotFoundError\` | \`logger.warning(...)\` + \`return {}\` |
| \`canopy_raster\` | \`FileNotFoundError\` | \`logger.warning(...)\` + \`return {}\` |
| \`keep_raster\` (configured but missing) | \`FileNotFoundError\` | \`logger.warning(...)\` + return \`{cnpy_resampled_...: path}\` (Steps 2-3 skipped, Step 1 cnpy output retained) |
| \`keep_raster\` (not configured) | log info + return produced | unchanged — same path |

Warnings surface in CI / log output. Missing sources are cleanly omitted from the \`produced\` dict so downstream consumers see a gap rather than a corrupted output.

## Tests

New \`tests/test_build_lulc_rasters.py\` (3 cases):

- \`test_missing_lulc_source_raster_warns_and_skips\` — \`source_raster\` not on disk → empty produced + WARNING logged
- \`test_missing_canopy_raster_warns_and_skips\` — \`source\` present, \`canopy\` missing → empty produced + WARNING
- \`test_missing_keep_raster_warns_and_retains_cnpy_output\` — \`keep\` missing but \`source\`/\`canopy\` present → produced contains \`cnpy_resampled_*\` only, WARNING mentions \"Cnpy resample retained\"

## Risk

Low. Three new \`return\` statements + two demoted log levels. No change to the happy path (every test in the existing suite continues to apply).

The one philosophical question: should a missing input ever be a hard error? Argument for: catches \"oops, I forgot to stage X.\" Argument against (taken here): the orchestrator already iterates a list of sources, and \"failing fast on the first missing\" defeats the iteration. Loud warnings + clean per-source skip preserves the iteration semantics. If a downstream step actually requires e.g. \`radtrn_nlcd\` and it's missing from \`ctx.paths\`, that consumer will raise — which is the right time and place to fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)