### PR TITLE
refactor(raster_ops): drop vestigial mask_values=(128, 0) default

### DIFF
--- a/src/gfv2_params/raster_ops.py
+++ b/src/gfv2_params/raster_ops.py
@@ -15,7 +15,7 @@ def resample(
     template_path: str,
     intermediate_path: str,
     output_path: str,
-    mask_values=(128, 0),
+    mask_values=(),
     mask_negative=True,
 ) -> None:
     """Reproject and resample src_path raster to match template_path's spatial reference.
@@ -23,10 +23,14 @@ def resample(
     Writes the result to intermediate_path, applies NoData masking,
     and saves the final raster to output_path.
 
-    WARNING — default mask_values=(128, 0) masks pixel value 0:
-      - Correct for RootDepth (0 = cropland = no natural root depth)
-      - WRONG for CNPY (0 = no tree canopy, a valid measurement)
-    Pass mask_values=(128,) when resampling CNPY to preserve non-forest pixels.
+    ``mask_values`` is the tuple of pixel values that get rewritten to NaN in
+    the output (in addition to whatever ``mask_negative=True`` catches —
+    typically the signed-integer nodata sentinel like int8's -128). Empty by
+    default; pass an explicit tuple per-call to document the intent at the
+    call site, e.g.:
+      - RootDepth: ``mask_values=(0,)``  — 0 = cropland = no natural root depth
+      - CNPY/keep: ``mask_values=()``    — 0 is a valid measurement (no canopy /
+                                            fully deciduous), so do NOT mask it
     """
     # Explicit existence checks up front: newer osgeo enables GDAL exceptions
     # by default, so gdal.Open() raises RuntimeError on a missing file rather

--- a/src/gfv2_params/shared_rasters/build_derived_rasters.py
+++ b/src/gfv2_params/shared_rasters/build_derived_rasters.py
@@ -42,10 +42,14 @@ def build(step_cfg: dict, ctx: SharedRastersContext, logger) -> dict:
     if not awc_rast.exists():
         raise FileNotFoundError(f"AWC raster not found: {awc_rast}")
 
-    # Step 1: Resample RootDepth to match AWC grid
+    # Step 1: Resample RootDepth to match AWC grid.
+    # mask_values=(0,) — 0 = cropland = no natural root depth; mask it to
+    # NaN so downstream soil_moist_max doesn't multiply zeros through. The
+    # int8 -128 nodata sentinel is caught separately by mask_negative=True.
     if not rd_resampled.exists() or ctx.force:
         logger.info("Resampling RootDepth to AWC grid...")
-        resample(str(rd_rast), str(awc_rast), str(intermediate_rast), str(rd_resampled))
+        resample(str(rd_rast), str(awc_rast), str(intermediate_rast), str(rd_resampled),
+                 mask_values=(0,))
         logger.info("Written: %s", rd_resampled)
     else:
         logger.info("Resampled RootDepth already exists: %s", rd_resampled)

--- a/src/gfv2_params/shared_rasters/build_lulc_rasters.py
+++ b/src/gfv2_params/shared_rasters/build_lulc_rasters.py
@@ -159,9 +159,10 @@ def _build_one_source(source_yaml: Path, ctx: SharedRastersContext, logger) -> d
         logger.info("--- Step 1/3: Resample canopy raster to LULC grid ---")
         logger.info("  (CONUS-scale GeoTIFF; may take 30-60 min)")
         t1 = time.time()
-        # mask_values=(128,) — do NOT mask 0; value 0 = no canopy, a valid measurement
+        # mask_values=() — value 0 is a valid canopy measurement (no canopy);
+        # the int16 nodata sentinel (-32768) is caught by mask_negative=True.
         resample(str(cnpy_raster), str(lulc_raster), str(intermediate), str(cnpy_resampled),
-                 mask_values=(128,))
+                 mask_values=())
         logger.info("  Done in %s — written: %s", _elapsed(t1), cnpy_resampled)
         logger.info("  Result: %s", _raster_info(cnpy_resampled))
     else:
@@ -191,9 +192,11 @@ def _build_one_source(source_yaml: Path, ctx: SharedRastersContext, logger) -> d
         logger.info("--- Step 2/3: Resample keep raster to LULC grid ---")
         logger.info("  (CONUS-scale GeoTIFF; may take 30-60 min)")
         t2 = time.time()
-        # mask_values=(128,) — do NOT mask 0; value 0 = fully deciduous, a valid measurement
+        # mask_values=() — value 0 is a valid retention measurement (fully
+        # deciduous); the int8 nodata sentinel (-128) is caught by
+        # mask_negative=True.
         resample(str(keep_raster), str(lulc_raster), str(intermediate), str(keep_resampled),
-                 mask_values=(128,))
+                 mask_values=())
         logger.info("  Done in %s — written: %s", _elapsed(t2), keep_resampled)
         logger.info("  Result: %s", _raster_info(keep_resampled))
     else:

--- a/tests/test_raster_ops.py
+++ b/tests/test_raster_ops.py
@@ -57,7 +57,7 @@ def _write_tiff(path, data, crs="EPSG:4326", transform=None, nodata=None):
 
 
 def test_resample_masks_nodata_values():
-    """Values 128 and 0 should become NaN after resample."""
+    """Explicit mask_values=(128, 0) should rewrite both pixel values to NaN."""
     with tempfile.TemporaryDirectory() as tmpdir:
         tmpdir = Path(tmpdir)
         src_path = tmpdir / "src.tif"
@@ -69,12 +69,40 @@ def test_resample_masks_nodata_values():
         _write_tiff(src_path, data)
         _write_tiff(tmpl_path, np.ones((3, 3), dtype=np.float32))
 
-        resample(str(src_path), str(tmpl_path), str(intermediate_path), str(output_path))
+        resample(str(src_path), str(tmpl_path), str(intermediate_path), str(output_path),
+                 mask_values=(128, 0))
 
         with rasterio.open(str(output_path)) as src:
             result = src.read(1)
             assert np.isnan(result[0, 1])  # was 128
             assert np.isnan(result[1, 0])  # was 0
+
+
+def test_resample_default_mask_values_is_no_op():
+    """Default mask_values=() preserves all non-negative pixel values."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir = Path(tmpdir)
+        src_path = tmpdir / "src.tif"
+        tmpl_path = tmpdir / "tmpl.tif"
+        intermediate_path = tmpdir / "intermediate.tif"
+        output_path = tmpdir / "output.tif"
+
+        # 0, 128, and other positives should all survive when mask_values is unset.
+        data = np.array([[1.0, 128.0, 5.0], [0.0, 3.0, 7.0], [2.0, 4.0, 6.0]], dtype=np.float32)
+        _write_tiff(src_path, data)
+        _write_tiff(tmpl_path, np.ones((3, 3), dtype=np.float32))
+
+        resample(str(src_path), str(tmpl_path), str(intermediate_path), str(output_path))
+
+        with rasterio.open(str(output_path)) as src:
+            result = src.read(1)
+            # No value-mask applied — every input value reaches the output.
+            assert result[0, 1] == 128.0
+            assert result[1, 0] == 0.0
+            assert result[2, 2] == 6.0
+            # mask_negative=True is still on by default; no negatives in this
+            # input, so the output should be NaN-free.
+            assert not np.any(np.isnan(result))
 
 
 def test_resample_masks_negative_values():


### PR DESCRIPTION
Closes #78.

## Summary

The previous default of \`(128, 0)\` for \`resample(..., mask_values=...)\` was inherited from a uint8-source era and no longer matches the actual data:

| Source | dtype | Why the old default was wrong |
|---|---|---|
| RootDepth.tif | int8 | \`128\` is out of range (int8: -128..127), so the value-mask never fired for it. Only \`0\` (cropland) was meaningfully masked. |
| CNPY.tif | int16 | \`0\` is a **valid** canopy measurement (no canopy). The call site already overrode to \`mask_values=(128,)\` to avoid the wrong default. |
| keep.tif | int8 | Same story — \`0\` is a valid retention measurement (fully deciduous). |

All three rely on \`mask_negative=True\` to catch their actual nodata sentinels (-128 / -32768).

## Behavior change at the API

\`\`\`python
# before
def resample(..., mask_values=(128, 0), mask_negative=True): ...

# after
def resample(..., mask_values=(), mask_negative=True): ...
\`\`\`

The default is now a no-op for value-masking; \`mask_negative=True\` still catches signed-integer sentinels. Every caller in the codebase has been updated to declare its intent explicitly.

## Call site updates

| File | Before | After |
|---|---|---|
| [build_derived_rasters.py](src/gfv2_params/shared_rasters/build_derived_rasters.py) RootDepth | (default) | \`mask_values=(0,)\` |
| [build_lulc_rasters.py](src/gfv2_params/shared_rasters/build_lulc_rasters.py) CNPY | \`(128,)\` | \`()\` |
| [build_lulc_rasters.py](src/gfv2_params/shared_rasters/build_lulc_rasters.py) keep | \`(128,)\` | \`()\` |

The RootDepth call now correctly preserves the "cropland = no natural root depth" semantic that the docstring claims and the old default partially provided. The CNPY/keep calls drop \`128\` (which was unreachable in valid int8 data anyway) and document that 0 is intentionally kept.

## Tests

- \`test_resample_masks_nodata_values\` updated to pass \`mask_values=(128, 0)\` explicitly. Original test intent (verify the masking works when configured) preserved; only the API contract change.
- New \`test_resample_default_mask_values_is_no_op\` asserts that 0, 128, and other positive values all pass through unchanged when \`mask_values\` is left at the default.
- \`test_resample_masks_negative_values\` unchanged — \`mask_negative=True\` still default.

## No production-data behavioral change

- RootDepth: previously masked \`0\` via default; now masks \`0\` via explicit arg. **Same behavior.**
- CNPY: previously masked \`128\` (no valid int16 canopy hits 128); now masks nothing. Production data has no value-128 cells, so **no observable change**. Any future corruption of CNPY to value 128 would now silently pass through — that's a tradeoff worth knowing about.
- keep: previously masked \`128\` (unreachable in int8); now masks nothing. **No observable change.**

## Verification

I recommend a regression on a single VPU's outputs before/after this lands, but the inert-default analysis above suggests it'll be a byte-identical diff. CI green is sufficient to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)