### PR TITLE
feat: Step 4 — zonal-pass parameter consolidation

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,39 @@ and [docs/depstor_port_summary.md](docs/depstor_port_summary.md) for the
 ArcPy-to-open-source port summary. Stage 2d in `slurm_batch/RUNME.md` lists the
 build order and dependencies.
 
+## Zonal-pass parameter pipeline
+
+The Part 2 per-fabric zonal-pass parameter pipeline is driven by one
+orchestrator over one unified config:
+
+- [scripts/derive_zonal_params.py](scripts/derive_zonal_params.py) reads
+  [configs/zonal_params.yml](configs/zonal_params.yml) and dispatches every
+  Part 2 param type (`elevation`, `slope`, `aspect`, `soils`,
+  `soil_moist_max`, `lulc_nhm_v11`, `lulc_nalcms`, `lulc_nlcd`,
+  `lulc_foresce`, `ssflux`) into the matching per-script work function
+  under [src/gfv2_params/zonal_runners.py](src/gfv2_params/zonal_runners.py).
+  Three modes: `--mode zonal --param <name> --batch_id <N>`,
+  `--mode merge --param <name>`, `--mode build_weights` (CONUS-once ssflux
+  prereq).
+- The slurm wrapper
+  [slurm_batch/submit_zonal_params.sh](slurm_batch/submit_zonal_params.sh)
+  loops every entry in `params:` and submits per-param array + merge jobs
+  in one go (chained via `afterok`). When an entry carries
+  `depends_on: build_weights` (typically `ssflux`), the wrapper submits
+  `build_zonal_weights.batch` first and chains the ssflux array + merge on
+  its `afterok`. ssflux also chains on the merged slope CSV.
+
+```bash
+FABRIC=gfv2_vpu01 bash slurm_batch/submit_zonal_params.sh \
+    {data_root}/gfv2_vpu01/batches gfv2_vpu01 configs/base_config.yml
+```
+
+The per-script entry points and per-step sbatch files
+(`scripts/create_zonal_params.py`, `slurm_batch/create_zonal_elev_params.batch`,
+etc.) are preserved as thin shells around the same
+`gfv2_params.zonal_runners` functions for per-step debugging or per-VPU
+SLURM-array runs against a single param.
+
 ## Configuration
 
 `configs/base_config.yml` is the single source of truth for the data root and

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ gfv2-params/
 │   ├── create_ssflux_params.py     # Subsurface flux parameters
 │   ├── build_depstor_rasters.py       # Build the full depstor raster stack (10 steps)
 │   ├── derive_depstor_params.py       # Depstor zonal stats + Level-5 ratios (zonal/merge/ratios)
+│   ├── derive_zonal_params.py         # Part 2 zonal-pass orchestrator (zonal/merge/build_weights)
 │   ├── merge_params.py             # Merge per-batch CSVs
 │   ├── merge_default_params.py     # Merge NHM default params
 │   ├── merge_and_fill_params.py    # KNN gap-filling
@@ -191,9 +192,21 @@ job submissions keep working unchanged.
 
 ### 4. Run fabric-dependent tasks
 
-Once raster prep is complete and the merged fabric is available, prepare the fabric batches and run parameter generation. See `slurm_batch/RUNME.md` **Part 2** for the full sequence.
+Once raster prep is complete and the merged fabric is available, prepare
+the fabric batches and run parameter generation. The unified Part 2
+dispatcher walks every zonal param + chained merges + the ssflux weights
+prereq in one invocation:
 
-### Single-batch run
+```bash
+bash slurm_batch/submit_zonal_params.sh \
+    {data_root}/{fabric}/batches {fabric} configs/base_config.yml
+```
+
+See [Zonal-pass parameter pipeline](#zonal-pass-parameter-pipeline) below
+for the design notes, and `slurm_batch/RUNME.md` **Part 2** for the full
+sequence including the depstor pipeline and gap-fill.
+
+### Single-batch run (per-param fallback)
 ```bash
 python scripts/create_zonal_params.py --config configs/elev_param.yml --batch_id 0042
 ```
@@ -301,9 +314,13 @@ orchestrator over one unified config:
   its `afterok`. ssflux also chains on the merged slope CSV.
 
 ```bash
-FABRIC=gfv2_vpu01 bash slurm_batch/submit_zonal_params.sh \
+bash slurm_batch/submit_zonal_params.sh \
     {data_root}/gfv2_vpu01/batches gfv2_vpu01 configs/base_config.yml
 ```
+
+(The fabric is the 2nd positional argument; `FABRIC=` env can also drive
+non-default fabric resolution for the per-job library calls but is
+redundant when the positional is given.)
 
 The per-script entry points and per-step sbatch files
 (`scripts/create_zonal_params.py`, `slurm_batch/create_zonal_elev_params.batch`,

--- a/configs/zonal_params.yml
+++ b/configs/zonal_params.yml
@@ -1,0 +1,138 @@
+# Drive every Part 2 zonal-pass parameter derivation from a single config.
+# Replaces the 6 per-script configs (elev_param.yml, slope_param.yml,
+# aspect_param.yml, soils_param.yml, soilmoistmax_param.yml, ssflux_param.yml)
+# + the 4 lulc_*_param.yml entries that map to Part 2 invocations. Driver:
+# scripts/derive_zonal_params.py (three modes: zonal, merge, build_weights).
+#
+# Slurm orchestration: slurm_batch/submit_zonal_params.sh loops over every
+# param entry below and submits an array zonal job + chained merge (afterok).
+# When an entry has `depends_on: build_weights`, the submit script first
+# submits build_zonal_weights.batch and chains both the array zonal and the
+# merge on its afterok.
+#
+# Output layout under {output_dir}:
+#   <name>/                  -- per-batch zonal CSVs for the named param
+#   merged/                  -- final merged per-param CSVs (one row per HRU)
+#
+# Note on LULC naming: the existing per-source configs/lulc_*_param.yml use
+# source_type="lulc" with lulc_source={nhm_v11,nalcms,nlcd,foresce} so all
+# four sources write per-batch CSVs to the SAME {output_dir}/lulc/ subdir,
+# colliding. Step 4 normalises: the orchestrator passes name=lulc_<source>
+# to the library function, giving each source its own per-batch subdir
+# (lulc_nhm_v11/, lulc_nalcms/, ...). Merged outputs land at the same
+# canonical names that the legacy CLI produces, so PRMS consumers see no
+# difference.
+#
+# The legacy configs/lulc_*_param.yml stay in place because they are also
+# referenced as `sources:` by configs/shared_rasters.yml for the Part 1
+# build_lulc_rasters step.
+
+defaults:
+  batch_dir:     "{data_root}/{fabric}/batches"
+  target_layer:  nhru
+  id_feature:    nat_hru_id
+  output_dir:    "{data_root}/{fabric}/params"
+  merged_subdir: merged
+  weight_dir:    "{data_root}/shared/conus/weights"
+
+params:
+  # --- Continuous zonal stats on shared CONUS VRTs ---
+
+  - name: elevation
+    script: zonal
+    source_raster: "{data_root}/shared/conus/vrt/elevation.vrt"
+    categorical:   false
+    merged_file:   nhm_elevation_params.csv
+
+  - name: slope
+    script: zonal
+    source_raster: "{data_root}/shared/conus/vrt/slope.vrt"
+    categorical:   false
+    merged_file:   nhm_slope_params.csv
+
+  - name: aspect
+    script: zonal
+    source_raster: "{data_root}/shared/conus/vrt/aspect.vrt"
+    categorical:   false
+    merged_file:   nhm_aspect_params.csv
+
+  # --- Soils (categorical + continuous via the same script dispatcher) ---
+
+  - name: soils
+    script: soils
+    source_raster: "{data_root}/input/soils_litho/TEXT_PRMS.tif"
+    categorical:   true
+    merged_file:   nhm_soils_params.csv
+
+  - name: soil_moist_max
+    script: soils
+    source_raster: "{data_root}/shared/conus/derived/soil_moist_max.tif"
+    categorical:   false
+    merged_file:   nhm_soil_moist_max_params.csv
+
+  # --- LULC sources (each derives cov_type / covden / interception / retention) ---
+  # NHM v1.1: keep raster present -> raster-based retention.
+
+  - name: lulc_nhm_v11
+    script: lulc
+    source_raster:  "{data_root}/input/lulc_veg/nhm_v11/LULC.tif"
+    canopy_raster:  "{data_root}/input/lulc_veg/nhm_v11/CNPY.tif"
+    keep_raster:    "{data_root}/input/lulc_veg/nhm_v11/keep.tif"
+    crosswalk_file: crosswalks/nhm_v11_nhm.csv
+    categorical:    true
+    merged_file:    nhm_lulc_nhm_v11_params.csv
+
+  # NALCMS 2020: no keep raster -> crosswalk evergreen_retention column.
+
+  - name: lulc_nalcms
+    script: lulc
+    source_raster:  "{data_root}/input/lulc/nalcms_2020/NA_NALCMS_landcover_2020v2_30m.tif"
+    canopy_raster:  "{data_root}/input/lulc_veg/CNPY.tif"
+    crosswalk_file: crosswalks/nalcms_nhm.csv
+    categorical:    true
+    merged_file:    nhm_lulc_nalcms_params.csv
+
+  # NLCD 2021: no keep raster -> crosswalk evergreen_retention column.
+
+  - name: lulc_nlcd
+    script: lulc
+    source_raster:  "{data_root}/input/lulc_veg/nlcd/nlcd_2021_land_cover.tif"
+    canopy_raster:  "{data_root}/input/lulc_veg/nlcd/nlcd_2021_tree_canopy.tif"
+    crosswalk_file: crosswalks/nlcd_nhm.csv
+    categorical:    true
+    merged_file:    nhm_lulc_nlcd_params.csv
+
+  # FORE-SCE bau_rcp45 2070: keep raster present -> raster-based retention.
+
+  - name: lulc_foresce
+    script: lulc
+    source_raster:  "{data_root}/input/lulc_veg/foresce/LULC_bau_rcp45_2070.tif"
+    canopy_raster:  "{data_root}/input/lulc_veg/foresce/CNPY.tif"
+    keep_raster:    "{data_root}/input/lulc_veg/foresce/keep.tif"
+    crosswalk_file: crosswalks/foresce_nhm.csv
+    categorical:    true
+    merged_file:    nhm_lulc_foresce_params.csv
+
+  # --- ssflux (litho-weighted PRMS subsurface flux params) ---
+  # Requires the CONUS-wide P2P weight matrix (build_weights mode) and a
+  # merged slope CSV. The submit script special-cases `depends_on:` to
+  # submit build_zonal_weights.batch first + chain the ssflux array + merge
+  # on its afterok.
+
+  - name: ssflux
+    script: ssflux
+    depends_on:    build_weights
+    source_shapefile:  "{data_root}/input/soils_litho/Lithology_exp_Konly_Project.shp"
+    merged_slope_file: "{data_root}/{fabric}/params/merged/nhm_slope_params.csv"
+    merged_file:       nhm_ssflux_params.csv
+    # Lithology permeability + PRMS flux normalisation (lifted verbatim
+    # from configs/ssflux_param.yml).
+    k_perm_min: -16.48
+    flux_params:
+      - {name: soil2gw_max,          min: 0.1,   max: 0.3}
+      - {name: ssr2gw_rate,          min: 0.3,   max: 0.7}
+      - {name: fastcoef_lin,         min: 0.01,  max: 0.6}
+      - {name: slowcoef_lin,         min: 0.005, max: 0.3}
+      - {name: gwflow_coef,          min: 0.005, max: 0.3}
+      - {name: dprst_seep_rate_open, min: 0.005, max: 0.2}
+      - {name: dprst_flow_coef,      min: 0.005, max: 0.5}

--- a/docs/superpowers/plans/2026-05-17-step4-zonal-consolidation.md
+++ b/docs/superpowers/plans/2026-05-17-step4-zonal-consolidation.md
@@ -1,0 +1,257 @@
+# Plan: Step 4 — Zonal-pass parameter consolidation
+
+## Context
+
+Steps 1+2 (PR #74) and Step 3 (PR #75) consolidated the **fabric-independent
+raster prep** (Part 1) behind a single orchestrator (`build_shared_rasters.py`)
+over a unified config (`shared_rasters.yml`) and moved the on-disk store to
+`shared/`. The remaining un-consolidated surface is **Part 2: per-fabric
+zonal-pass parameter generation** — 6 Python scripts driven by 10 SLURM batches
+via `slurm_batch/submit_jobs.sh`, each requiring a separate manual invocation
+per param type. Today's flow forces operators to call `submit_jobs.sh` ten
+times in sequence, manually picking the right config + batch per param.
+
+Step 4 mirrors the **depstor-params** pattern from PR #72
+(`derive_depstor_params.py` + `submit_depstor_params.sh`): one orchestrator
+script with `--mode` dispatch, one unified config listing every param type,
+one shell wrapper that loops the list and submits per-param array+merge jobs.
+After Step 4, generating every Part 2 parameter for a fabric is **one shell
+invocation**.
+
+ssflux + `build_weights` are included via a `depends_on:` entry in the config
+— the wrapper special-cases it (submits build_weights as a separate job +
+chains the ssflux array afterok). Single unified surface for all Part 2 work.
+
+Issue #82 (configs/ subdirectory reorg) stays deferred until after Step 4
+lands, so the comprehensive reorg can target the settled inventory.
+
+---
+
+## Approach
+
+Mirror the depstor-params shape from PR #72 (see `scripts/derive_depstor_params.py`
++ `slurm_batch/submit_depstor_params.sh` for the proven pattern).
+
+### A. New unified config: `configs/zonal_params.yml`
+
+Schema lifted from `configs/depstor_params.yml` structure. Top-level
+`defaults:` block carries the shared per-fabric output conventions. The
+`params:` list contains one entry per parameter type (10 entries today: elev,
+slope, aspect, soils, soilmoistmax, lulc_nhm_v11, lulc_nalcms, lulc_nlcd,
+lulc_foresce, ssflux).
+
+```yaml
+defaults:
+  batch_dir: "{data_root}/{fabric}/batches"
+  target_layer: nhru
+  id_feature: nat_hru_id
+  output_dir: "{data_root}/{fabric}/params"
+  merged_subdir: merged
+  weight_dir: "{data_root}/shared/conus/weights"
+
+params:
+  - name: elev
+    script: zonal              # dispatch tag → create_zonal_params logic
+    source_raster: "{data_root}/shared/conus/vrt/elevation.vrt"
+    categorical: false
+    merged_file: nhm_elev_{fabric}.csv
+
+  - name: slope
+    script: zonal
+    source_raster: "{data_root}/shared/conus/vrt/slope.vrt"
+    categorical: false
+    merged_file: nhm_slope_{fabric}.csv
+
+  # ... aspect, soils, soilmoistmax, 4× lulc, ssflux
+
+  - name: ssflux
+    script: ssflux
+    depends_on: build_weights   # submit script special-cases this key
+    source_shapefile: "{data_root}/input/soils_litho/Lithology_exp_Konly_Project.shp"
+    merged_slope_file: "{data_root}/{fabric}/params/merged/nhm_slope_{fabric}.csv"
+    k_perm_min: <existing value>
+    flux_params: [<existing list>]
+    merged_file: nhm_ssflux_{fabric}.csv
+```
+
+The existing per-source LULC configs (`configs/lulc_*_param.yml`) stay because
+`configs/shared_rasters.yml` also references them as `sources:` for
+`build_lulc_rasters`. Step 4 just doesn't depend on them for the zonal pass —
+the relevant LULC params live inline in `zonal_params.yml` so all Part 2
+state is in one file.
+
+### B. New orchestrator: `scripts/derive_zonal_params.py`
+
+Three-mode dispatcher, matching `scripts/derive_depstor_params.py`:
+
+- `--mode zonal --param <name> --batch_id <N>` — single-batch run for one
+  param (this is what each SLURM array task invokes)
+- `--mode merge --param <name>` — concat per-batch CSVs for one param
+- `--mode build_weights` — CONUS-once weight matrix for ssflux (no `--param`
+  needed)
+
+CLI mirrors depstor: `--config configs/zonal_params.yml --base_config
+configs/base_config.yml --fabric <name>`.
+
+Internally dispatches on `script:` (zonal / soils / lulc / ssflux) by calling
+into the same library helpers the existing per-script CLIs use — no behaviour
+change. Each existing script's `main()` body is extracted into a callable
+function the orchestrator imports.
+
+### C. New SLURM batches
+
+| Batch | Mirrors | What |
+|---|---|---|
+| `slurm_batch/derive_zonal_params.batch` | `create_depstor_zonal.batch` | Generic per-batch worker. Reads `$PARAM` + `$SLURM_ARRAY_TASK_ID`. |
+| `slurm_batch/merge_zonal_param.batch` | `merge_depstor_fraction.batch` | Generic single-job merge. Reads `$PARAM`. |
+| `slurm_batch/build_zonal_weights.batch` | today's `build_weights.batch` resources (8h, 96G) | CONUS-once weight matrix for ssflux. |
+
+### D. Dispatch script: `slurm_batch/submit_zonal_params.sh`
+
+Mirrors `submit_depstor_params.sh`. For each entry in `params:`:
+
+1. If `depends_on: build_weights`, submit `build_zonal_weights.batch` first
+   (record JOBID)
+2. Submit `derive_zonal_params.batch` as array job (`--array=0-N%K`,
+   `--export=PARAM=<name>,FABRIC,BASE_CONFIG`); if there's a prereq from
+   step 1, add `--dependency=afterok:<weights_jobid>`
+3. Submit `merge_zonal_param.batch` with `--dependency=afterok:<array_jobid>`
+   and the same env exports
+4. Append the merge job ID to a `MERGE_JOB_IDS[]` array
+
+No final consolidating step — Part 2 doesn't have an analog to depstor's
+`derive_ratios`.
+
+### E. Library code refactor (minimal)
+
+Most existing scripts already call into well-factored helpers
+(`gfv2_params.config`, `gfv2_params.lulc`, etc.). The minimum work for
+orchestrator dispatch is:
+
+Extract each existing `main()` body into a callable function:
+- `run_zonal_batch(param_cfg, ...)` — used by `create_zonal_params.py`
+- `run_soils_batch(param_cfg, ...)` — used by `create_soils_params.py`
+- `run_lulc_batch(param_cfg, ...)` — used by `create_lulc_params.py`
+- `run_ssflux_batch(param_cfg, ...)` — used by `create_ssflux_params.py`
+- `run_build_weights(param_cfg, ...)` — used by `build_weights.py`
+- `run_merge(param_cfg, ...)` — used by `merge_params.py`
+
+The existing CLI shells thin to: parse args → load config → call the function.
+The orchestrator calls the same functions for the matching `script:` tag.
+
+Following the depstor-params precedent (which kept depstor-params logic in
+`derive_depstor_params.py` itself rather than under
+`src/gfv2_params/depstor_builders/`), the new functions live as importable
+symbols in the existing `scripts/` modules. No new `zonal_builders/`
+sub-package.
+
+### F. Backward-compat surface (preserved)
+
+Every existing per-param Python script (`scripts/create_zonal_params.py`,
+`create_soils_params.py`, `create_lulc_params.py`, `create_ssflux_params.py`,
+`build_weights.py`, `merge_params.py`) is preserved as a thin CLI shell over
+the same library functions. Every existing per-param batch
+(`slurm_batch/create_zonal_*.batch`, `create_soils_*.batch`,
+`create_lulc_*.batch`, `create_ssflux_params.batch`, `build_weights.batch`,
+`merge_*.batch`) keeps working unchanged. Matches the Step 3 backward-compat
+philosophy.
+
+### G. Documentation updates
+
+- **README.md** — add a "Zonal-pass parameter pipeline" section paralleling
+  the existing "Shared rasters pipeline" + "Depression-storage pipeline"
+  sections. Mentions the new `submit_zonal_params.sh` as the canonical Part 2
+  entry point.
+- **slurm_batch/RUNME.md** — Stage 4 retargeted: "Recommended: run Part 2 via
+  the unified zonal-params dispatcher" subsection at the top of Stage 4,
+  pointing at `submit_zonal_params.sh`. The 10 individual batches remain
+  documented as fallbacks for per-step debugging.
+- **slurm_batch/RUNME.md script-mapping table** — list
+  `derive_zonal_params.batch`, `merge_zonal_param.batch`,
+  `build_zonal_weights.batch`, and `submit_zonal_params.sh` in the
+  orchestrator-batches block.
+
+### H. Outliers to address
+
+- `slurm_batch/create_lulc_nalcms_params.batch` has a hardcoded
+  `--array=0-63` instead of using `submit_jobs.sh`. Step 4 normalises this
+  (the new dispatch sets `--array=0-N%K` from `manifest.yml`).
+- `merge_default_output_params.batch` / `scripts/merge_default_params.py` are
+  Stage 8 (final merge with NHM defaults), distinct from Part 2 param
+  generation. **Out of Step 4 scope** — keep as-is.
+
+---
+
+## Critical files to modify
+
+| Action | Path | Source/model |
+|---|---|---|
+| Add | `configs/zonal_params.yml` | mirror `configs/depstor_params.yml` |
+| Add | `scripts/derive_zonal_params.py` | mirror `scripts/derive_depstor_params.py` |
+| Add | `slurm_batch/derive_zonal_params.batch` | mirror `slurm_batch/create_depstor_zonal.batch` |
+| Add | `slurm_batch/merge_zonal_param.batch` | mirror `slurm_batch/merge_depstor_fraction.batch` |
+| Add | `slurm_batch/build_zonal_weights.batch` | mirror today's `slurm_batch/build_weights.batch` resources |
+| Add | `slurm_batch/submit_zonal_params.sh` | mirror `slurm_batch/submit_depstor_params.sh` |
+| Refactor (minimal) | 6 `scripts/create_*_params.py` + `build_weights.py` + `merge_params.py` | extract `main()` bodies into callable functions; CLI shells delegate |
+| Modify | `README.md` | add Zonal-pass section |
+| Modify | `slurm_batch/RUNME.md` | Stage 4 retargets + script-mapping table |
+| Add | `tests/test_zonal_orchestrator.py` | mirror `tests/test_shared_rasters_orchestrator.py` |
+
+## Existing functions/utilities to reuse
+
+- `src/gfv2_params/config.py::load_config`, `load_base_config` — fabric
+  profile + placeholder resolution; matches depstor pattern
+- `src/gfv2_params/lulc.py::load_crosswalk`, `assign_cov_type`,
+  `compute_interception`, `compute_covden`, `compute_retention`,
+  `class_percentages_from_histogram` — LULC param derivation
+- `src/gfv2_params/raster_ops.py::deg_to_fraction` — used by ssflux path
+- `src/gfv2_params/log.py::configure_logging` — standard logger setup
+- Manifest-reading + array-sizing logic from `slurm_batch/submit_jobs.sh`
+  (lines that read `n_batches` from `{batches_dir}/manifest.yml`) — lift this
+  verbatim into `submit_zonal_params.sh`
+- The fraction-loop + afterok-chain pattern from
+  `slurm_batch/submit_depstor_params.sh` — adapt for the params loop
+
+---
+
+## Verification
+
+1. **VPU01 smoke test** (using the small-scale validation target):
+   ```bash
+   FABRIC=gfv2_vpu01 bash slurm_batch/submit_zonal_params.sh \
+       /caldera/.../gfv2_param_v2/gfv2_vpu01/batches gfv2_vpu01 \
+       configs/base_config.yml
+   ```
+   Submits every param's array+merge in one go. Verify the merged CSVs exist
+   under `gfv2_vpu01/params/merged/` after completion.
+
+2. **Byte-for-byte equivalence with legacy path** — run today's per-param
+   flow against gfv2_vpu01 for one param (e.g., elev), save the merged output;
+   re-run the new orchestrator path for the same param; `diff` the two CSVs
+   sorted by `id_feature`. Must be identical.
+
+3. **CI gate** — add tests under `tests/test_zonal_orchestrator.py` mirroring
+   `tests/test_shared_rasters_orchestrator.py`:
+   - Every registered param has an executable `script:` tag
+   - Empty params list exits cleanly
+   - Unknown param name fails with a clear error
+   - `depends_on:` parsing produces the expected job graph (mock sbatch)
+
+4. **Legacy CLI compat** — invoke
+   `scripts/create_zonal_params.py --config configs/elev_param.yml --batch_id 0`
+   (an existing flow) — must still produce the same output. Confirms the
+   refactor preserved the thin-shell entrypoint.
+
+---
+
+## Followups (out of scope)
+
+- **Issue #82** (configs/ reorg) — after Step 4 settles, do the
+  comprehensive subdirectory reorg. The new `zonal_params.yml` becomes
+  `configs/zonal/zonal_params.yml` (or similar) under the deferred restructure.
+- **Per-source resource tuning** — `create_lulc_nalcms_params.batch` previously
+  hardcoded a 0-63 array; the new dispatch normalises sizing but the underlying
+  resource ask (`--mem`, `--time`) may need per-param adjustment based on
+  Part 1 NALCMS runtimes. Tune in a follow-up if needed.
+- **Stage 8 `merge_default_params.py`** — keep separate. Distinct from
+  Part 2 param generation (merges NHM-default values into the generated set).

--- a/scripts/build_weights.py
+++ b/scripts/build_weights.py
@@ -2,18 +2,20 @@
 
 Runs WeightGenP2P between the full merged fabric and the lithology
 shapefile. Writes a single weight table that batch jobs can subset.
+
+Thin CLI shell over ``gfv2_params.zonal_runners.run_build_weights``. For
+unified DAG-style dispatch (with the ssflux array + merge chained on
+afterok), prefer:
+
+    sbatch slurm_batch/submit_zonal_params.sh <batches_dir> <fabric>
 """
 
 import argparse
 from pathlib import Path
 
-import geopandas as gpd
-import numpy as np
-import pandas as pd
-from gdptools import WeightGenP2P
-
 from gfv2_params.config import load_base_config, load_config
 from gfv2_params.log import configure_logging
+from gfv2_params.zonal_runners import run_build_weights
 
 
 def main():
@@ -25,58 +27,16 @@ def main():
     args = parser.parse_args()
 
     logger = configure_logging("build_weights")
-
     config = load_config(
         Path(args.config),
         base_config_path=Path(args.base_config) if args.base_config else None,
         fabric=args.fabric,
     )
-    base = load_base_config(Path(args.base_config) if args.base_config else None, fabric=args.fabric)
-    data_root = Path(base["data_root"])
-    fabric = base["fabric"]
-    id_feature = config["id_feature"]
-    target_layer = config["target_layer"]
-
-    weight_dir = Path(config["weight_dir"])
-    weight_dir.mkdir(parents=True, exist_ok=True)
-    weight_file = weight_dir / f"lith_weights_{fabric}.csv"
-
-    if weight_file.exists() and not args.force:
-        logger.info("Weight file already exists: %s (use --force to overwrite)", weight_file)
-        return
-
-    # Load full merged fabric
-    fabric_gpkg = data_root / fabric / "fabric" / f"{fabric}_nhru_merged.gpkg"
-    if not fabric_gpkg.exists():
-        raise FileNotFoundError(f"Merged fabric not found: {fabric_gpkg}")
-    target_gdf = gpd.read_file(fabric_gpkg, layer=target_layer)
-    logger.info("Loaded target fabric: %d features", len(target_gdf))
-
-    # Load source lithology
-    source_gdf = gpd.read_file(Path(config["source_shapefile"]))
-    source_gdf["flux_id"] = np.arange(len(source_gdf))
-    logger.info("Loaded lithology: %d features", len(source_gdf))
-
-    # Compute weights
-    logger.info("Computing P2P weights (this may take a while)...")
-    weight_gen = WeightGenP2P(
-        target_poly=target_gdf,
-        target_poly_idx=id_feature,
-        source_poly=source_gdf,
-        source_poly_idx="flux_id",
-        method="serial",
-        weight_gen_crs="5070",
-        output_file=weight_file,
+    base = load_base_config(
+        Path(args.base_config) if args.base_config else None,
+        fabric=args.fabric,
     )
-    weights = weight_gen.calculate_weights()
-    if weights is None or len(weights) == 0:
-        raise RuntimeError(
-            "WeightGenP2P returned no weights. Check that target and source "
-            "polygons overlap spatially."
-        )
-    if not weight_file.exists():
-        raise RuntimeError(f"WeightGenP2P did not write output file: {weight_file}")
-    logger.info("Weights computed: %d rows -> %s", len(weights), weight_file)
+    run_build_weights(config, Path(base["data_root"]), logger, force=args.force)
 
 
 if __name__ == "__main__":

--- a/scripts/create_lulc_params.py
+++ b/scripts/create_lulc_params.py
@@ -1,34 +1,28 @@
 """Create LULC parameters from raster data via crosswalk.
 
 Computes per-HRU: cov_type, srain_intcp, wrain_intcp, snow_intcp,
-covden_sum, covden_win from a categorical LULC raster and a continuous
-canopy density raster, using a crosswalk CSV to map LULC classes to
-NHM parameters.
+covden_sum, covden_win, retention from a categorical LULC raster and a
+continuous canopy density raster, using a crosswalk CSV to map LULC classes
+to NHM parameters.
 
-When a ``keep_raster`` is configured (FORE-SCE), a raster-derived
+When a ``keep_raster`` is configured (FORE-SCE, NHM v1.1), a raster-derived
 retention mean is computed via zonal stats and included in the output.
-When no ``keep_raster`` is present (NLCD, NALCMS), per-HRU retention
-is synthesised from the crosswalk's ``evergreen_retention`` column as
-a weighted average across LULC classes.
+When no ``keep_raster`` is present (NLCD, NALCMS), per-HRU retention is
+synthesised from the crosswalk's ``evergreen_retention`` column as a
+weighted average across LULC classes.
+
+Thin CLI shell over ``gfv2_params.zonal_runners.run_lulc_batch``. For
+unified DAG-style dispatch across every Part 2 param type, prefer:
+
+    sbatch slurm_batch/submit_zonal_params.sh <batches_dir> <fabric>
 """
 
 import argparse
 from pathlib import Path
 
-import geopandas as gpd
-import rioxarray
-from gdptools import UserTiffData, ZonalGen
-
 from gfv2_params.config import load_config
 from gfv2_params.log import configure_logging
-from gfv2_params.lulc import (
-    assign_cov_type,
-    class_percentages_from_histogram,
-    compute_covden,
-    compute_interception,
-    compute_retention,
-    load_crosswalk,
-)
+from gfv2_params.zonal_runners import run_lulc_batch
 
 
 def main():
@@ -40,164 +34,12 @@ def main():
     args = parser.parse_args()
 
     logger = configure_logging("create_lulc_params")
-
     config = load_config(
         Path(args.config),
         base_config_path=Path(args.base_config) if args.base_config else None,
         fabric=args.fabric,
     )
-    source_type = config["source_type"]
-    id_feature = config["id_feature"]
-    target_layer = config["target_layer"]
-    fabric = config["fabric"]
-
-    output_dir = Path(config["output_dir"]) / source_type
-    output_dir.mkdir(parents=True, exist_ok=True)
-
-    # Load batch polygons
-    batch_dir = Path(config["batch_dir"])
-    batch_gpkg = batch_dir / f"batch_{args.batch_id:04d}.gpkg"
-    if not batch_gpkg.exists():
-        raise FileNotFoundError(f"Batch GPKG not found: {batch_gpkg}")
-    nhru_gdf = gpd.read_file(batch_gpkg, layer=target_layer)
-    logger.info("Loaded %s layer: %d features (batch %d)", target_layer, len(nhru_gdf), args.batch_id)
-
-    # Load crosswalk
-    # crosswalk_file may be relative to repo root or absolute
-    crosswalk_path = Path(config["crosswalk_file"])
-    if not crosswalk_path.is_absolute():
-        crosswalk_path = Path(__file__).resolve().parent.parent / crosswalk_path
-    crosswalk = load_crosswalk(crosswalk_path)
-    logger.info("Loaded crosswalk: %d classes", len(crosswalk))
-
-    file_prefix = f"base_nhm_{source_type}_{fabric}_batch_{args.batch_id:04d}_param"
-
-    # --- Step 1: Categorical zonal stats on LULC raster ---
-    lulc_path = Path(config["source_raster"])
-    if not lulc_path.exists():
-        raise FileNotFoundError(f"LULC raster not found: {lulc_path}")
-    lulc_da = rioxarray.open_rasterio(lulc_path, masked=True)
-    logger.info("Loaded LULC raster: shape=%s", lulc_da.shape)
-
-    lulc_data = UserTiffData(
-        var="lulc", ds=lulc_da, proj_ds=lulc_da.rio.crs,
-        x_coord="x", y_coord="y", band=1, bname="band",
-        f_feature=nhru_gdf, id_feature=id_feature,
-    )
-    lulc_zonal = ZonalGen(
-        user_data=lulc_data, zonal_engine="exactextract", zonal_writer="csv",
-        out_path=output_dir, file_prefix=f"{file_prefix}_lulc_temp", jobs=4,
-    )
-    histogram = lulc_zonal.calculate_zonal(categorical=True)
-    logger.info("LULC categorical zonal stats computed")
-
-    # Clean temp file
-    temp_csv = output_dir / f"{file_prefix}_lulc_temp.csv"
-    if temp_csv.exists():
-        temp_csv.unlink()
-
-    # Convert histogram to class percentages
-    class_perc = class_percentages_from_histogram(histogram)
-    # Rename the id column to match id_feature
-    id_name = histogram.index.name or "id"
-    if id_name != id_feature:
-        class_perc = class_perc.rename(columns={id_name: id_feature})
-    logger.info("Class percentages computed for %d HRUs", class_perc[id_feature].nunique())
-
-    # --- Step 2: Continuous zonal stats on canopy raster ---
-    cnpy_path = Path(config["canopy_raster"])
-    if not cnpy_path.exists():
-        raise FileNotFoundError(f"Canopy raster not found: {cnpy_path}")
-    cnpy_da = rioxarray.open_rasterio(cnpy_path, masked=True)
-    logger.info("Loaded canopy raster: shape=%s", cnpy_da.shape)
-
-    cnpy_data = UserTiffData(
-        var="canopy", ds=cnpy_da, proj_ds=cnpy_da.rio.crs,
-        x_coord="x", y_coord="y", band=1, bname="band",
-        f_feature=nhru_gdf, id_feature=id_feature,
-    )
-    cnpy_zonal = ZonalGen(
-        user_data=cnpy_data, zonal_engine="exactextract", zonal_writer="csv",
-        out_path=output_dir, file_prefix=f"{file_prefix}_cnpy_temp", jobs=4,
-    )
-    cnpy_stats = cnpy_zonal.calculate_zonal(categorical=False)
-    logger.info("Canopy continuous zonal stats computed")
-
-    temp_csv = output_dir / f"{file_prefix}_cnpy_temp.csv"
-    if temp_csv.exists():
-        temp_csv.unlink()
-
-    canopy_mean_df = cnpy_stats[["mean"]].rename(columns={"mean": "canopy_mean"})
-    canopy_mean_df.index.name = id_feature
-    canopy_mean_df = canopy_mean_df.reset_index()
-
-    # --- Step 3: Retention (raster-based or crosswalk-based) ---
-    keep_raster_str = config.get("keep_raster")
-    if keep_raster_str:
-        # FORE-SCE path: compute retention from keep raster via zonal mean
-        keep_path = Path(keep_raster_str)
-        if not keep_path.exists():
-            raise FileNotFoundError(f"Keep raster not found: {keep_path}")
-        keep_da = rioxarray.open_rasterio(keep_path, masked=True)
-        logger.info("Loaded keep raster: shape=%s", keep_da.shape)
-
-        keep_data = UserTiffData(
-            var="keep", ds=keep_da, proj_ds=keep_da.rio.crs,
-            x_coord="x", y_coord="y", band=1, bname="band",
-            f_feature=nhru_gdf, id_feature=id_feature,
-        )
-        keep_zonal = ZonalGen(
-            user_data=keep_data, zonal_engine="exactextract", zonal_writer="csv",
-            out_path=output_dir, file_prefix=f"{file_prefix}_keep_temp", jobs=4,
-        )
-        keep_stats = keep_zonal.calculate_zonal(categorical=False)
-        logger.info("Keep raster zonal stats computed")
-
-        temp_csv = output_dir / f"{file_prefix}_keep_temp.csv"
-        if temp_csv.exists():
-            temp_csv.unlink()
-
-        # Keep raster values are 0-100; normalise to 0-1
-        retention_df = keep_stats[["mean"]].rename(columns={"mean": "retention"})
-        retention_df["retention"] = retention_df["retention"] * 0.01
-        retention_df.index.name = id_feature
-        retention_df = retention_df.reset_index()
-        logger.info("Retention computed from keep raster (raster-based)")
-    else:
-        # NLCD / NALCMS path: synthesise retention from crosswalk column
-        retention_df = compute_retention(class_perc, crosswalk, id_col=id_feature)
-        logger.info("Retention computed from crosswalk evergreen_retention (crosswalk-based)")
-
-    # --- Step 4: Compute parameters ---
-    cov_type_df = assign_cov_type(class_perc, crosswalk, id_col=id_feature)
-    logger.info("Cover types assigned")
-
-    intcp_df = compute_interception(class_perc, crosswalk, id_col=id_feature)
-    logger.info("Interception parameters computed")
-
-    covden_df = compute_covden(class_perc, crosswalk, canopy_mean_df, id_col=id_feature)
-    logger.info("Cover density parameters computed")
-
-    # --- Step 5: Merge and write ---
-    expected_hrus = class_perc[id_feature].nunique()
-    result = (
-        cov_type_df
-        .merge(intcp_df, on=id_feature)
-        .merge(covden_df, on=id_feature)
-        .merge(retention_df, on=id_feature)
-    )
-    if len(result) != expected_hrus:
-        logger.warning(
-            "Row count mismatch after merge: expected %d HRUs, got %d. "
-            "Some HRUs may have been dropped.",
-            expected_hrus,
-            len(result),
-        )
-    result = result.sort_values(id_feature).set_index(id_feature)
-
-    result_csv = output_dir / f"{file_prefix}.csv"
-    result.to_csv(result_csv)
-    logger.info("LULC parameters saved to: %s (%d HRUs)", result_csv, len(result))
+    run_lulc_batch(config, args.batch_id, logger)
 
 
 if __name__ == "__main__":

--- a/scripts/create_soils_params.py
+++ b/scripts/create_soils_params.py
@@ -1,65 +1,17 @@
-"""Create soils and soil_moist_max parameters from raster data."""
+"""Create soils and soil_moist_max parameters from raster data.
+
+Thin CLI shell over ``gfv2_params.zonal_runners.run_soils_batch``. For unified
+DAG-style dispatch across every Part 2 param type, prefer:
+
+    sbatch slurm_batch/submit_zonal_params.sh <batches_dir> <fabric>
+"""
 
 import argparse
 from pathlib import Path
 
-import geopandas as gpd
-import rioxarray
-from gdptools import UserTiffData, ZonalGen
-
 from gfv2_params.config import load_config
 from gfv2_params.log import configure_logging
-
-
-def process_soils(source_da, nhru_gdf, output_path, source_type, file_prefix, categorical, id_feature, logger):
-    """Process categorical soils data: zonal stats -> dominant category -> CSV."""
-    data = UserTiffData(
-        var="soils", ds=source_da, proj_ds=source_da.rio.crs,
-        x_coord="x", y_coord="y", band=1, bname="band",
-        f_feature=nhru_gdf, id_feature=id_feature,
-    )
-    zonal_gen = ZonalGen(
-        user_data=data, zonal_engine="exactextract", zonal_writer="csv",
-        out_path=output_path, file_prefix=f"{file_prefix}_temp", jobs=4,
-    )
-    stats = zonal_gen.calculate_zonal(categorical=categorical)
-    logger.info("Zonal statistics computed")
-
-    # Remove temp file
-    zg_file = output_path / f"{file_prefix}_temp.csv"
-    if zg_file.exists():
-        zg_file.unlink()
-
-    # Dominant category per feature
-    category_cols = [col for col in stats.columns if str(col) not in ("count",)]
-    top_stats = stats.copy()
-    top_stats["max_category"] = top_stats[category_cols].idxmax(axis=1)
-    result = top_stats[["max_category"]].rename(columns={"max_category": "soils"})
-    result.sort_index(inplace=True)
-
-    result_csv = output_path / f"{file_prefix}.csv"
-    result.to_csv(result_csv)
-    logger.info("Soils parameters saved to: %s", result_csv)
-
-
-def process_soil_moist_max(source_da, nhru_gdf, output_path, source_type, file_prefix, categorical, id_feature, logger):
-    """Process soil_moist_max: zonal mean from pre-built raster."""
-    data = UserTiffData(
-        var=source_type, ds=source_da, proj_ds=source_da.rio.crs,
-        x_coord="x", y_coord="y", band=1, bname="band",
-        f_feature=nhru_gdf, id_feature=id_feature,
-    )
-    zonal_gen = ZonalGen(
-        user_data=data, zonal_engine="exactextract", zonal_writer="csv",
-        out_path=output_path, file_prefix=f"{file_prefix}_temp", jobs=4,
-    )
-    stats = zonal_gen.calculate_zonal(categorical=categorical)
-    logger.info("Zonal statistics computed for soil_moist_max")
-
-    mean_stats = stats[["mean"]].rename(columns={"mean": "soil_moist_max"})
-    result_csv = output_path / f"{file_prefix}.csv"
-    mean_stats.to_csv(result_csv)
-    logger.info("soil_moist_max parameters saved to: %s", result_csv)
+from gfv2_params.zonal_runners import run_soils_batch
 
 
 def main():
@@ -71,44 +23,12 @@ def main():
     args = parser.parse_args()
 
     logger = configure_logging("create_soils_params")
-
     config = load_config(
         Path(args.config),
         base_config_path=Path(args.base_config) if args.base_config else None,
         fabric=args.fabric,
     )
-    source_type = config["source_type"]
-    categorical = config.get("categorical", False)
-    id_feature = config["id_feature"]
-    target_layer = config["target_layer"]
-    fabric = config["fabric"]
-
-    output_dir = Path(config["output_dir"]) / source_type
-    output_dir.mkdir(parents=True, exist_ok=True)
-
-    # Load batch polygons
-    batch_dir = Path(config["batch_dir"])
-    batch_gpkg = batch_dir / f"batch_{args.batch_id:04d}.gpkg"
-    if not batch_gpkg.exists():
-        raise FileNotFoundError(f"Batch GPKG not found: {batch_gpkg}")
-    nhru_gdf = gpd.read_file(batch_gpkg, layer=target_layer)
-    logger.info("Loaded %s layer: %d features (batch %d)", target_layer, len(nhru_gdf), args.batch_id)
-
-    file_prefix = f"base_nhm_{source_type}_{fabric}_batch_{args.batch_id:04d}_param"
-
-    # Load source raster (works for both soils and soil_moist_max)
-    raster_path = Path(config["source_raster"])
-    if not raster_path.exists():
-        raise FileNotFoundError(f"Input raster not found: {raster_path}")
-    source_da = rioxarray.open_rasterio(raster_path, masked=True)
-    logger.info("Loaded raster: shape=%s, crs=%s", source_da.shape, source_da.rio.crs)
-
-    if source_type == "soils":
-        process_soils(source_da, nhru_gdf, output_dir, source_type, file_prefix, categorical, id_feature, logger)
-    elif source_type == "soil_moist_max":
-        process_soil_moist_max(source_da, nhru_gdf, output_dir, source_type, file_prefix, categorical, id_feature, logger)
-    else:
-        raise ValueError(f"Unknown source_type: {source_type}")
+    run_soils_batch(config, args.batch_id, logger)
 
 
 if __name__ == "__main__":

--- a/scripts/create_ssflux_params.py
+++ b/scripts/create_ssflux_params.py
@@ -1,19 +1,21 @@
 """Create subsurface flux parameters using litho-weighted approach.
 
-Requires pre-computed CONUS-wide weights (from build_weights.py)
-and merged slope parameters (from merge_params.py).
+Requires pre-computed CONUS-wide weights (from build_weights.py) and
+merged slope parameters (from merge_params.py).
+
+Thin CLI shell over ``gfv2_params.zonal_runners.run_ssflux_batch``. For
+unified DAG-style dispatch (with the build_weights prereq + slope merge
+chained automatically), prefer:
+
+    sbatch slurm_batch/submit_zonal_params.sh <batches_dir> <fabric>
 """
 
 import argparse
 from pathlib import Path
 
-import geopandas as gpd
-import numpy as np
-import pandas as pd
-
 from gfv2_params.config import load_config
 from gfv2_params.log import configure_logging
-from gfv2_params.raster_ops import deg_to_fraction
+from gfv2_params.zonal_runners import run_ssflux_batch
 
 
 def main():
@@ -25,141 +27,12 @@ def main():
     args = parser.parse_args()
 
     logger = configure_logging("create_ssflux_params")
-
     config = load_config(
         Path(args.config),
         base_config_path=Path(args.base_config) if args.base_config else None,
         fabric=args.fabric,
     )
-    id_feature = config["id_feature"]
-    target_layer = config["target_layer"]
-    output_dir = Path(config["output_dir"])
-    weight_dir = Path(config["weight_dir"])
-    fabric = config["fabric"]
-
-    # Load batch polygons
-    batch_dir = Path(config["batch_dir"])
-    batch_gpkg = batch_dir / f"batch_{args.batch_id:04d}.gpkg"
-    if not batch_gpkg.exists():
-        raise FileNotFoundError(f"Batch GPKG not found: {batch_gpkg}")
-    target_gdf = gpd.read_file(batch_gpkg, layer=target_layer)
-    batch_ids = set(target_gdf[id_feature].values)
-    logger.info("Loaded %d features (batch %d)", len(target_gdf), args.batch_id)
-
-    # Load pre-computed CONUS weights and filter to this batch
-    weight_file = weight_dir / f"lith_weights_{fabric}.csv"
-    if not weight_file.exists():
-        raise FileNotFoundError(
-            f"Weight file not found: {weight_file}\n"
-            "Run scripts/build_weights.py first."
-        )
-    all_weights = pd.read_csv(weight_file)
-    weights = all_weights[all_weights[id_feature].isin(batch_ids)].copy()
-    logger.info("Loaded weights: %d rows (from %d total)", len(weights), len(all_weights))
-
-    # Load merged slope CSV
-    merged_slope_file = Path(config["merged_slope_file"])
-    if not merged_slope_file.exists():
-        raise FileNotFoundError(
-            f"Merged slope file not found: {merged_slope_file}\n"
-            "Run merge_params.py for slope first."
-        )
-    all_slope = pd.read_csv(merged_slope_file)
-    slope_df = all_slope[all_slope[id_feature].isin(batch_ids)].copy()
-    slope_df["mean_slope_fraction"] = slope_df["mean"].astype(float).apply(deg_to_fraction)
-    logger.info("Loaded slope for %d features", len(slope_df))
-
-    # Load source lithology for k_perm lookup
-    source_gdf = gpd.read_file(Path(config["source_shapefile"]))
-    source_gdf["flux_id"] = np.arange(len(source_gdf))
-
-    # Merge weights with source attributes
-    weights["flux_id"] = weights["flux_id"].astype(str)
-    source_gdf["flux_id"] = source_gdf["flux_id"].astype(str)
-
-    w = weights.merge(source_gdf[["flux_id", "k_perm"]], on="flux_id")
-
-    k_perm_min = config["k_perm_min"]
-    w["k_perm"] = w["k_perm"].replace(0, k_perm_min)
-    w["k_perm_actual"] = 10 ** w["k_perm"]
-
-    w["k_perm_wtd_sum"] = w["k_perm_actual"] * (w["area_weight"] / w["flux_id_area"])
-
-    extensive_agg = (
-        w.groupby(id_feature)
-        .agg(k_perm_wtd=("k_perm_wtd_sum", "sum"))
-        .reset_index()
-    )
-    extensive_agg[id_feature] = extensive_agg[id_feature].astype(int)
-    extensive_sorted = extensive_agg.sort_values(by=id_feature).reset_index(drop=True)
-
-    # Merge with slope and area
-    slope_merge = slope_df[[id_feature, "mean_slope_fraction"]].copy()
-    try:
-        slope_merge[id_feature] = slope_merge[id_feature].astype("int64")
-    except (ValueError, TypeError) as exc:
-        raise ValueError(f"Non-numeric {id_feature} values in slope data") from exc
-
-    target_gdf["hru_area"] = target_gdf.geometry.area
-    area_df = target_gdf[[id_feature, "hru_area"]].copy()
-    try:
-        area_df[id_feature] = area_df[id_feature].astype("int64")
-    except (ValueError, TypeError) as exc:
-        raise ValueError(f"Non-numeric {id_feature} values in target fabric") from exc
-
-    df = extensive_sorted.merge(slope_merge, on=id_feature, how="left").copy()
-    df = df.merge(area_df, on=id_feature, how="left")
-
-    # Validate no features were lost in merges
-    null_slope = df["mean_slope_fraction"].isna().sum()
-    null_area = df["hru_area"].isna().sum()
-    if null_slope > 0 or null_area > 0:
-        raise ValueError(
-            f"Merge produced missing values: {null_slope} features missing slope, "
-            f"{null_area} features missing area. Check that slope and batch data "
-            f"use consistent {id_feature} values."
-        )
-
-    # Compute raw PRMS fluxes
-    df["r_soil2gw_max"] = df["k_perm_wtd"] ** 3
-    df["r_ssr2gw_rate"] = df["k_perm_wtd"] * (1 - df["mean_slope_fraction"])
-    df["r_slowcoef_lin"] = (df["k_perm_wtd"] * df["mean_slope_fraction"]) / df["hru_area"]
-    df["r_fastcoef_lin"] = 2 * df["r_slowcoef_lin"]
-    df["r_gwflow_coef"] = df["r_slowcoef_lin"]
-    df["r_dprst_seep_rate_open"] = df["r_ssr2gw_rate"]
-    df["r_dprst_flow_coef"] = df["r_fastcoef_lin"]
-
-    # Normalize using config-driven bounds.
-    # Note: normalization is per-batch (not CONUS-wide), matching the prior per-VPU
-    # behavior. The same raw value may map to slightly different normalized values
-    # in different batches because per-batch min/max ranges differ.
-    flux_params = config["flux_params"]
-    param_names = [fp["name"] for fp in flux_params]
-    param_maxes = [fp["max"] for fp in flux_params]
-    param_mins = [fp["min"] for fp in flux_params]
-
-    df_r = df[[f"r_{p}" for p in param_names]].agg(["min", "max"])
-    df_r.loc["range"] = df_r.loc["max"] - df_r.loc["min"]
-
-    for i, p in enumerate(param_names):
-        rcol = f"r_{p}"
-        min_in, rng_in = df_r.at["min", rcol], df_r.at["range", rcol]
-        min_out, max_out = param_mins[i], param_maxes[i]
-        rng_out = max_out - min_out
-        if rng_in == 0:
-            logger.warning("Range is zero for %s; using midpoint of output range", p)
-            df[p] = (min_out + max_out) / 2.0
-        else:
-            norm = (df[rcol] - min_in) / rng_in
-            df[p] = norm * rng_out + min_out
-
-    df.drop(columns=[f"r_{p}" for p in param_names], inplace=True)
-
-    ssflux_dir = output_dir / "ssflux"
-    ssflux_dir.mkdir(parents=True, exist_ok=True)
-    file_prefix = f"base_nhm_ssflux_{fabric}_batch_{args.batch_id:04d}_param"
-    df.to_csv(ssflux_dir / f"{file_prefix}.csv", index=False)
-    logger.info("SSFlux parameters saved (batch %d)", args.batch_id)
+    run_ssflux_batch(config, args.batch_id, logger)
 
 
 if __name__ == "__main__":

--- a/scripts/create_zonal_params.py
+++ b/scripts/create_zonal_params.py
@@ -1,43 +1,20 @@
-"""Create zonal parameters (elevation, slope, aspect) from rasters by HRU polygon."""
+"""Create zonal parameters (elevation, slope, aspect) from rasters by HRU polygon.
+
+Thin CLI shell over ``gfv2_params.zonal_runners.run_zonal_batch``. For unified
+DAG-style dispatch across every Part 2 param type, prefer:
+
+    sbatch slurm_batch/submit_zonal_params.sh <batches_dir> <fabric>
+
+which loops every entry in configs/zonal_params.yml and submits per-param
+array + merge jobs in one go.
+"""
 
 import argparse
-import os
-import sys
-import time
 from pathlib import Path
-
-# Pre-import heartbeats so a future hang in the geo-library import chain
-# (rasterio/GDAL/PROJ/pyogrio init under shared-FS metadata contention,
-# observed once on VPU01 issue-#61 array run with zero stdout from one task)
-# can be localised. Printed unconditionally with flush=True so SLURM's
-# stdout/stderr line buffering doesn't swallow them.
-print(
-    f"[startup pid={os.getpid()} host={os.uname().nodename} "
-    f"task={os.environ.get('SLURM_ARRAY_TASK_ID', '-')}] "
-    f"python {sys.version.split()[0]} interpreter up, importing geo libs...",
-    flush=True,
-)
-_t_imports = time.time()
-
-import geopandas as gpd
-import rioxarray
-from gdptools import UserTiffData, ZonalGen
-from osgeo import gdal, osr
-
-print(f"[startup] geo-library imports complete in {time.time() - _t_imports:.1f}s", flush=True)
 
 from gfv2_params.config import load_config
 from gfv2_params.log import configure_logging
-
-# Opt into the GDAL 4.0 default behaviour of raising Python exceptions
-# instead of returning C-style error codes. Silences the FutureWarning
-# emitted by osgeo when neither UseExceptions/DontUseExceptions is set.
-# NB: GDAL state is process-global — importing this module from a notebook
-# or test harness will flip exception handling on for the whole process.
-# That is the desired behaviour (GDAL 4.0's default) and what the slurm
-# batches expect, but worth knowing if anyone embeds this script elsewhere.
-gdal.UseExceptions()
-osr.UseExceptions()
+from gfv2_params.zonal_runners import run_zonal_batch
 
 
 def main():
@@ -49,67 +26,12 @@ def main():
     args = parser.parse_args()
 
     logger = configure_logging("create_zonal_params")
-
     config = load_config(
         Path(args.config),
         base_config_path=Path(args.base_config) if args.base_config else None,
         fabric=args.fabric,
     )
-    source_type = config["source_type"]
-    categorical = config.get("categorical", False)
-    id_feature = config["id_feature"]
-    target_layer = config["target_layer"]
-    fabric = config["fabric"]
-
-    # Resolve paths
-    raster_path = Path(config["source_raster"])
-    batch_dir = Path(config["batch_dir"])
-    batch_gpkg = batch_dir / f"batch_{args.batch_id:04d}.gpkg"
-    output_dir = Path(config["output_dir"]) / source_type
-    output_dir.mkdir(parents=True, exist_ok=True)
-
-    if not raster_path.exists():
-        raise FileNotFoundError(f"Input raster not found: {raster_path}")
-    if not batch_gpkg.exists():
-        raise FileNotFoundError(f"Batch GPKG not found: {batch_gpkg}")
-
-    logger.info("Raster: %s", raster_path)
-    logger.info("Batch GPKG: %s", batch_gpkg)
-
-    # Load batch polygons
-    nhru_gdf = gpd.read_file(batch_gpkg, layer=target_layer)
-    logger.info("Loaded %s layer: %d features (batch %d)", target_layer, len(nhru_gdf), args.batch_id)
-
-    # Load raster
-    ned_da = rioxarray.open_rasterio(raster_path, masked=True)
-    logger.info("Loaded raster: shape=%s, crs=%s", ned_da.shape, ned_da.rio.crs)
-
-    # Build file prefix for output
-    file_prefix = f"base_nhm_{source_type}_{fabric}_batch_{args.batch_id:04d}_param"
-
-    # Create zonal stats (gdptools 0.3.13+ keyword names)
-    data = UserTiffData(
-        source_var=source_type,
-        source_ds=ned_da,
-        source_crs=ned_da.rio.crs,
-        source_x_coord="x",
-        source_y_coord="y",
-        band=1,
-        bname="band",
-        target_gdf=nhru_gdf,
-        target_id=id_feature,
-    )
-
-    zonal_gen = ZonalGen(
-        user_data=data,
-        zonal_engine="exactextract",
-        zonal_writer="csv",
-        out_path=output_dir,
-        file_prefix=file_prefix,
-        jobs=4,
-    )
-    stats = zonal_gen.calculate_zonal(categorical=categorical)
-    logger.info("Zonal statistics complete. Shape: %s", stats.shape)
+    run_zonal_batch(config, args.batch_id, logger)
 
 
 if __name__ == "__main__":

--- a/scripts/derive_zonal_params.py
+++ b/scripts/derive_zonal_params.py
@@ -1,0 +1,196 @@
+"""Drive every Part 2 zonal-pass param from configs/zonal_params.yml.
+
+Three modes:
+  --mode zonal --param <name> --batch_id <N>
+        Array task: run the per-batch zonal/soils/lulc/ssflux work for one
+        param over one HRU batch. Dispatches on the entry's `script:` tag
+        (zonal / soils / lulc / ssflux) into the matching
+        gfv2_params.zonal_runners.run_*_batch function.
+  --mode merge --param <name>
+        Combine per-batch CSVs for one param into the merged CSV.
+        Same logic as scripts/merge_params.py (which now delegates here).
+  --mode build_weights
+        Compute the CONUS-wide P2P weight matrix that ssflux consumes.
+        Honours --force.
+
+The slurm wrapper slurm_batch/submit_zonal_params.sh loops every entry in
+configs/zonal_params.yml's `params:` list and chains all three modes into a
+per-param afterok DAG (with build_weights submitted first for entries that
+carry `depends_on: build_weights`).
+
+Pattern mirrors scripts/derive_depstor_params.py (PR #72).
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+from gfv2_params.config import load_config
+from gfv2_params.log import configure_logging
+from gfv2_params.zonal_runners import (
+    run_build_weights,
+    run_lulc_batch,
+    run_merge,
+    run_soils_batch,
+    run_ssflux_batch,
+    run_zonal_batch,
+)
+
+# Dispatch table: `script:` tag in zonal_params.yml -> run_<script>_batch function
+_BATCH_RUNNERS = {
+    "zonal":  run_zonal_batch,
+    "soils":  run_soils_batch,
+    "lulc":   run_lulc_batch,
+    "ssflux": run_ssflux_batch,
+}
+
+
+def _resolve_nested(value, replacements: dict):
+    """Recursively resolve {placeholder} substrings in nested str/list/dict."""
+    if isinstance(value, str):
+        for ph, rep in replacements.items():
+            value = value.replace(f"{{{ph}}}", str(rep))
+        remaining = re.findall(r"\{(\w+)\}", value)
+        if remaining:
+            raise ValueError(
+                f"Unresolved placeholder(s) {remaining} in value '{value}'. "
+                f"Available: {sorted(replacements)}"
+            )
+        return value
+    if isinstance(value, list):
+        return [_resolve_nested(v, replacements) for v in value]
+    if isinstance(value, dict):
+        return {k: _resolve_nested(v, replacements) for k, v in value.items()}
+    return value
+
+
+def _load_resolved_config(args) -> dict:
+    """Load zonal_params.yml + base_config.yml, resolve every {placeholder}."""
+    raw = load_config(
+        Path(args.config),
+        base_config_path=Path(args.base_config) if args.base_config else None,
+        fabric=args.fabric,
+    )
+    replacements = {"data_root": raw["data_root"], "fabric": raw["fabric"]}
+    return {k: _resolve_nested(v, replacements) for k, v in raw.items()}
+
+
+def _find_param(config: dict, name: str) -> dict:
+    """Look up the param entry by `name`, raising with a helpful message if missing."""
+    params = config["params"]
+    for spec in params:
+        if spec["name"] == name:
+            return spec
+    available = [s["name"] for s in params]
+    raise ValueError(f"Param '{name}' not in config; available: {available}")
+
+
+def _build_param_cfg(config: dict, entry: dict) -> dict:
+    """Flatten defaults + entry into the shape zonal_runners.run_*_batch expects.
+
+    The library functions read keys like `source_type`, `source_raster`,
+    `batch_dir`, `output_dir`, `merged_file`, etc. We populate those by
+    layering the entry over the defaults block + the fabric profile fields.
+
+    `source_type` is set from `entry["name"]` so per-batch CSV subdirs +
+    file prefixes namespace cleanly when multiple LULC sources run in
+    parallel.
+    """
+    defaults = config.get("defaults", {})
+    param_cfg = {**defaults, **entry}
+    # source_type drives output_subdir + file_prefix in every run_*_batch.
+    param_cfg["source_type"] = entry["name"]
+    # Pull fabric + expected_max_hru_id from the resolved base config.
+    param_cfg["fabric"] = config["fabric"]
+    if "expected_max_hru_id" in config:
+        param_cfg["expected_max_hru_id"] = config["expected_max_hru_id"]
+    return param_cfg
+
+
+def run_zonal(args, logger) -> None:
+    """Dispatch one batch to the right run_*_batch function based on `script:` tag."""
+    config = _load_resolved_config(args)
+    entry = _find_param(config, args.param)
+    script_tag = entry.get("script")
+    if script_tag not in _BATCH_RUNNERS:
+        raise ValueError(
+            f"Param '{args.param}' has unknown script tag '{script_tag}'. "
+            f"Available: {sorted(_BATCH_RUNNERS)}"
+        )
+    param_cfg = _build_param_cfg(config, entry)
+    logger.info("=== zonal: param=%s script=%s batch=%d ===",
+                args.param, script_tag, args.batch_id)
+    _BATCH_RUNNERS[script_tag](param_cfg, args.batch_id, logger)
+
+
+def run_merge_mode(args, logger) -> None:
+    """Concat per-batch CSVs for one param into its merged output."""
+    config = _load_resolved_config(args)
+    entry = _find_param(config, args.param)
+    param_cfg = _build_param_cfg(config, entry)
+    logger.info("=== merge: param=%s ===", args.param)
+    run_merge(param_cfg, logger)
+
+
+def run_build_weights_mode(args, logger) -> None:
+    """Build the CONUS-wide P2P weight matrix consumed by ssflux.
+
+    Finds the ssflux entry in params: (or whatever entry carries
+    `depends_on: build_weights`) and runs the weights computation against
+    its source_shapefile + weight_dir.
+    """
+    config = _load_resolved_config(args)
+    # Find the entry that declares the weights prereq. There should be
+    # exactly one — typically `name: ssflux`.
+    weights_consumers = [
+        s for s in config["params"] if s.get("depends_on") == "build_weights"
+    ]
+    if not weights_consumers:
+        raise ValueError(
+            "No param entry declares `depends_on: build_weights`; nothing "
+            "to do for --mode build_weights."
+        )
+    if len(weights_consumers) > 1:
+        names = [s["name"] for s in weights_consumers]
+        raise ValueError(
+            f"Multiple param entries declare `depends_on: build_weights`: {names}. "
+            "Expected exactly one (typically `ssflux`)."
+        )
+    entry = weights_consumers[0]
+    param_cfg = _build_param_cfg(config, entry)
+    logger.info("=== build_weights: param=%s ===", entry["name"])
+    data_root = Path(config["data_root"])
+    run_build_weights(param_cfg, data_root, logger, force=args.force)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Drive zonal-pass parameter derivation.")
+    parser.add_argument("--config", required=True, help="Path to configs/zonal_params.yml")
+    parser.add_argument("--base_config", default=None, help="Path to configs/base_config.yml")
+    parser.add_argument("--fabric", default=None, help="Fabric name (overrides FABRIC env / default_fabric)")
+    parser.add_argument("--mode", required=True, choices=["zonal", "merge", "build_weights"])
+    parser.add_argument("--param", default=None, help="Param name (required for zonal/merge)")
+    parser.add_argument("--batch_id", type=int, default=None, help="Batch ID (zonal mode only)")
+    parser.add_argument("--force", action="store_true", help="build_weights only: overwrite existing weight file")
+    args = parser.parse_args()
+
+    if args.mode in {"zonal", "merge"} and not args.param:
+        parser.error(f"--param is required for --mode {args.mode}")
+    if args.mode == "zonal" and args.batch_id is None:
+        parser.error("--batch_id is required for --mode zonal")
+
+    logger = configure_logging(f"derive_zonal_params:{args.mode}")
+    if args.mode == "zonal":
+        run_zonal(args, logger)
+    elif args.mode == "merge":
+        run_merge_mode(args, logger)
+    elif args.mode == "build_weights":
+        run_build_weights_mode(args, logger)
+    else:
+        # argparse already constrained choices; defensive
+        parser.error(f"Unknown mode: {args.mode}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/merge_params.py
+++ b/scripts/merge_params.py
@@ -1,74 +1,20 @@
 """Merge per-batch parameter CSVs into a single file, sorted by id_feature.
 
 Validates completeness: raises on duplicate IDs, warns on gaps.
+
+Thin CLI shell over ``gfv2_params.zonal_runners.run_merge``. For unified
+DAG-style dispatch (with each per-param merge chained afterok the matching
+array), prefer:
+
+    sbatch slurm_batch/submit_zonal_params.sh <batches_dir> <fabric>
 """
 
 import argparse
 from pathlib import Path
 
-import pandas as pd
-
 from gfv2_params.config import load_config
 from gfv2_params.log import configure_logging
-
-
-def process_files(config, logger):
-    source_type = config["source_type"]
-    id_feature = config["id_feature"]
-    merged_file = config["merged_file"]
-    fabric = config["fabric"]
-    expected_max = config.get("expected_max_hru_id")
-
-    input_dir = Path(config["output_dir"]) / source_type
-    final_output_dir = Path(config["output_dir"]) / "merged"
-    final_output_dir.mkdir(parents=True, exist_ok=True)
-
-    if not input_dir.exists():
-        raise FileNotFoundError(f"Input directory not found: {input_dir}")
-
-    file_pattern = f"base_nhm_{source_type}_{fabric}_batch_*_param.csv"
-    files = sorted(input_dir.glob(file_pattern))
-
-    if not files:
-        raise FileNotFoundError(f"No batch files found matching: {input_dir / file_pattern}")
-
-    logger.info("Found %d batch files for %s", len(files), source_type)
-
-    dfs = []
-    for file in files:
-        logger.debug("Reading: %s", file)
-        df = pd.read_csv(file)
-        if id_feature not in df.columns:
-            raise ValueError(f"'{id_feature}' column not found in file: {file}")
-        dfs.append(df)
-
-    merged_df = pd.concat(dfs, ignore_index=True)
-    merged_df = merged_df.sort_values(id_feature).reset_index(drop=True)
-
-    # Validate: check for duplicates
-    dupes = merged_df[merged_df[id_feature].duplicated(keep=False)]
-    if len(dupes) > 0:
-        dupe_ids = sorted(dupes[id_feature].unique())
-        raise ValueError(
-            f"Duplicate {id_feature} values found ({len(dupe_ids)} IDs). "
-            f"First 10: {dupe_ids[:10]}. This indicates overlapping batches."
-        )
-
-    # Validate: check for gaps (optional, based on expected_max_hru_id)
-    if expected_max is not None:
-        existing_ids = set(merged_df[id_feature])
-        expected_ids = set(range(1, expected_max + 1))
-        gaps = sorted(expected_ids - existing_ids)
-        if gaps:
-            logger.warning(
-                "%d missing %s values (expected 1-%d, got %d). First 10: %s. "
-                "If this is expected, run merge_and_fill_params.py to fill gaps via KNN.",
-                len(gaps), id_feature, expected_max, len(existing_ids), gaps[:10],
-            )
-
-    output_path = final_output_dir / merged_file
-    merged_df.to_csv(output_path, index=False)
-    logger.info("Merged %d rows -> %s", len(merged_df), output_path)
+from gfv2_params.zonal_runners import run_merge
 
 
 def main():
@@ -84,7 +30,7 @@ def main():
         base_config_path=Path(args.base_config) if args.base_config else None,
         fabric=args.fabric,
     )
-    process_files(config, logger)
+    run_merge(config, logger)
 
 
 if __name__ == "__main__":

--- a/slurm_batch/RUNME.md
+++ b/slurm_batch/RUNME.md
@@ -390,10 +390,39 @@ python scripts/prepare_fabric.py \
 
 ### Stage 4: Generate parameters (SLURM array jobs)
 
-Submit batch jobs using the wrapper script:
+#### Recommended: run Part 2 via the unified zonal-params dispatcher
 
-Pass the corresponding param config as the 4th argument to auto-submit a merge job
-that runs immediately after each array job completes (`afterok` dependency):
+After Stage 3 completes (fabric merged + batched), every Part 2 param can
+be driven from one shell invocation:
+
+```bash
+BATCHES=/path/to/gfv2/batches
+slurm_batch/submit_zonal_params.sh $BATCHES gfv2 configs/base_config.yml
+```
+
+This loops every entry in `configs/zonal_params.yml` (10 params today:
+elevation, slope, aspect, soils, soil_moist_max, 4× LULC, ssflux) and
+submits per-param array + merge jobs chained via `afterok`. ssflux's
+`depends_on: build_weights` prereq is detected automatically: the wrapper
+submits `build_zonal_weights.batch` first and chains the ssflux array on
+its `afterok` (the weight matrix is CONUS-once per fabric — idempotent).
+ssflux also chains on the merged slope CSV.
+
+Env knobs:
+
+- `FABRIC=gfv2_vpu01` — switch to a non-default fabric
+- `SUBMIT_JOBS_MAX_CONCURRENT=4` — concurrency cap per array job (default 4)
+- `FORCE=1` — passed to build_zonal_weights to overwrite the existing matrix
+
+The individual per-param batches (`create_zonal_*.batch`, `create_soils*.batch`,
+`create_lulc_*.batch`, `create_ssflux_params.batch`, `build_weights.batch`)
+documented below remain as fallbacks for per-step debugging.
+
+#### Fallback: per-param submissions via `submit_jobs.sh`
+
+Submit batch jobs using the per-param wrapper. Pass the corresponding param
+config as the 4th argument to auto-submit a merge job that runs immediately
+after each array job completes (`afterok` dependency):
 
 ```bash
 BATCHES=/path/to/gfv2/batches
@@ -541,12 +570,17 @@ sacct -j <JOBID> -o JobID,State,Elapsed,MaxRSS
 
 ## Script -> Config -> Entry Point Mapping
 
-The unified shared-rasters orchestrator wraps every Part 1 raster-prep
-script below behind one entry point:
+The unified orchestrators wrap every per-script entry point below:
 
 | Batch file | Config | Script |
 |---|---|---|
-| build_shared_rasters.batch | shared_rasters.yml | build_shared_rasters.py |
+| build_shared_rasters.batch (Part 1) | shared_rasters.yml | build_shared_rasters.py |
+| build_depstor_rasters.batch (Part 2 depstor rasters) | depstor_rasters.yml | build_depstor_rasters.py |
+| submit_depstor_params.sh (Part 2 depstor params) | depstor_params.yml | derive_depstor_params.py |
+| submit_zonal_params.sh (Part 2 zonal params) | zonal_params.yml | derive_zonal_params.py |
+| derive_zonal_params.batch (per-param array task) | zonal_params.yml | derive_zonal_params.py |
+| merge_zonal_param.batch (per-param merge) | zonal_params.yml | derive_zonal_params.py |
+| build_zonal_weights.batch (ssflux prereq) | zonal_params.yml | derive_zonal_params.py |
 
 The per-script CLIs in the table below are preserved as thin shells and
 keep working unchanged; use them for per-step granularity or per-VPU SLURM

--- a/slurm_batch/RUNME.md
+++ b/slurm_batch/RUNME.md
@@ -486,6 +486,15 @@ python scripts/merge_params.py --config configs/elev_param.yml --base_config con
 
 ### Stage 6: SSFlux (depends on merged slope)
 
+> **Already running via `submit_zonal_params.sh`?** Then ssflux is handled
+> automatically as part of the unified Stage 4 dispatch — the wrapper sees
+> `depends_on: build_weights` on the ssflux entry in
+> `configs/zonal_params.yml`, submits `build_zonal_weights.batch` first, and
+> chains the ssflux array + merge on its `afterok`. ssflux also chains on the
+> merged slope CSV. **No separate Stage 6 invocation needed.** This stage
+> describes the legacy standalone path for users who run ssflux outside the
+> unified dispatcher.
+
 A single batch job handles the full ssflux workflow: pre-compute weights, submit the
 ssflux array job, and automatically chain a merge job via `afterok` dependency:
 
@@ -534,10 +543,16 @@ already merged or comes as per-VPU gpkgs.
        --fabric_gpkg {data_root}/oregon/fabric/NHM_OR_draft.gpkg \
        --fabric oregon
    ```
-5. Submit parameter jobs, passing the fabric as the 5th positional arg to
-   submit_jobs.sh (or via `FABRIC` env on direct sbatch calls):
+5. Submit parameter jobs. Easiest is the unified Part 2 dispatcher (one
+   invocation walks every param + chained merges + ssflux's weights prereq):
    ```bash
    BATCHES={data_root}/oregon/batches
+   slurm_batch/submit_zonal_params.sh $BATCHES oregon configs/base_config.yml
+   ```
+   For per-param granularity, you can still use `submit_jobs.sh` (passing
+   the fabric as the 5th positional arg, or via `FABRIC` env on direct
+   sbatch calls):
+   ```bash
    slurm_batch/submit_jobs.sh $BATCHES slurm_batch/create_lulc_params.batch \
        configs/base_config.yml configs/lulc_nalcms_param.yml oregon
    ```

--- a/slurm_batch/build_zonal_weights.batch
+++ b/slurm_batch/build_zonal_weights.batch
@@ -1,0 +1,40 @@
+#!/bin/bash
+#SBATCH -p cpu
+#SBATCH -A impd
+#SBATCH --job-name=zonal_weights
+#SBATCH --output=logs/job_%j.out
+#SBATCH --error=logs/job_%j.err
+#SBATCH --time=08:00:00
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=2
+#SBATCH --mem=96G
+#
+# CONUS-once: pre-compute the polygon-to-polygon weight matrix between the
+# merged fabric HRUs and the lithology shapefile. The matrix is the prereq
+# for the ssflux param entry in configs/zonal_params.yml.
+#
+# Submitted by slurm_batch/submit_zonal_params.sh as the first job in any
+# run that includes a `depends_on: build_weights` param (typically ssflux);
+# the ssflux array job is then chained --dependency=afterok on this job.
+#
+# Idempotent: skips if the weight CSV already exists. Pass FORCE=1 to
+# overwrite.
+#
+# Resources mirror the legacy slurm_batch/build_weights.batch
+# (8h wall, 96G mem) — WeightGenP2P over the full CONUS fabric is
+# memory-bound and takes hours.
+
+cd "$SLURM_SUBMIT_DIR"
+[ -f .pixi-activate.sh ] || { echo "ERROR: missing .pixi-activate.sh — run scripts/refresh_pixi_activation.sh" >&2; exit 1; }
+source .pixi-activate.sh
+BASE_CONFIG=${BASE_CONFIG:-configs/base_config.yml}
+FABRIC=${FABRIC:-gfv2}
+
+FORCE_FLAG=${FORCE:+--force}
+
+python scripts/derive_zonal_params.py \
+    --config configs/zonal_params.yml \
+    --base_config "$BASE_CONFIG" \
+    --fabric "$FABRIC" \
+    --mode build_weights \
+    $FORCE_FLAG

--- a/slurm_batch/derive_zonal_params.batch
+++ b/slurm_batch/derive_zonal_params.batch
@@ -1,0 +1,40 @@
+#!/bin/bash
+#SBATCH -p cpu
+#SBATCH -A impd
+#SBATCH --job-name=zonal_param
+#SBATCH --output=logs/job_%A_%a.out
+#SBATCH --error=logs/job_%A_%a.err
+#SBATCH --time=04:00:00
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=2
+#SBATCH --mem=32G
+#
+# Array task: zonal-stats one Part 2 param over one HRU batch.
+# Submitted by slurm_batch/submit_zonal_params.sh; the wrapper exports
+# PARAM (e.g. elevation, slope, soils, lulc_nhm_v11, ssflux, ...) and FABRIC.
+#
+# The orchestrator dispatches on the param's `script:` tag in
+# configs/zonal_params.yml (zonal / soils / lulc / ssflux) -> the matching
+# gfv2_params.zonal_runners.run_*_batch function.
+#
+# Time bumped to 4h to cover ssflux + LULC param types (which do more work
+# per batch than elev/slope/aspect). Lighter params finish well under this.
+
+cd "$SLURM_SUBMIT_DIR"
+[ -f .pixi-activate.sh ] || { echo "ERROR: missing .pixi-activate.sh — run scripts/refresh_pixi_activation.sh" >&2; exit 1; }
+source .pixi-activate.sh
+BASE_CONFIG=${BASE_CONFIG:-configs/base_config.yml}
+FABRIC=${FABRIC:-gfv2}
+
+if [ -z "${PARAM:-}" ]; then
+    echo "ERROR: PARAM env var not set. Submit via submit_zonal_params.sh." >&2
+    exit 1
+fi
+
+python scripts/derive_zonal_params.py \
+    --config configs/zonal_params.yml \
+    --base_config "$BASE_CONFIG" \
+    --fabric "$FABRIC" \
+    --mode zonal \
+    --param "$PARAM" \
+    --batch_id "$SLURM_ARRAY_TASK_ID"

--- a/slurm_batch/merge_zonal_param.batch
+++ b/slurm_batch/merge_zonal_param.batch
@@ -1,0 +1,32 @@
+#!/bin/bash
+#SBATCH -p cpu
+#SBATCH -A impd
+#SBATCH --job-name=zonal_merge
+#SBATCH --output=logs/job_%j.out
+#SBATCH --error=logs/job_%j.err
+#SBATCH --time=01:00:00
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=2
+#SBATCH --mem=64G
+#
+# Merge per-batch CSVs into one merged CSV for a single Part 2 param.
+# Submitted with afterok dependency on the matching zonal array job by
+# slurm_batch/submit_zonal_params.sh; the wrapper exports PARAM.
+
+cd "$SLURM_SUBMIT_DIR"
+[ -f .pixi-activate.sh ] || { echo "ERROR: missing .pixi-activate.sh — run scripts/refresh_pixi_activation.sh" >&2; exit 1; }
+source .pixi-activate.sh
+BASE_CONFIG=${BASE_CONFIG:-configs/base_config.yml}
+FABRIC=${FABRIC:-gfv2}
+
+if [ -z "${PARAM:-}" ]; then
+    echo "ERROR: PARAM env var not set. Submit via submit_zonal_params.sh." >&2
+    exit 1
+fi
+
+python scripts/derive_zonal_params.py \
+    --config configs/zonal_params.yml \
+    --base_config "$BASE_CONFIG" \
+    --fabric "$FABRIC" \
+    --mode merge \
+    --param "$PARAM"

--- a/slurm_batch/submit_zonal_params.sh
+++ b/slurm_batch/submit_zonal_params.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+# Usage: ./submit_zonal_params.sh <batches_dir> [fabric] [base_config] [max_concurrent]
+#
+# For each Part 2 param in configs/zonal_params.yml, submits:
+#   1. an array zonal job over every HRU batch (max_concurrent throttled), and
+#   2. a chained merge job (afterok on the array) writing to
+#      {fabric}/params/merged/.
+#
+# When an entry in configs/zonal_params.yml carries `depends_on: build_weights`
+# (typically `ssflux`), a build_zonal_weights.batch job is submitted FIRST and
+# both the array zonal AND the merge for that entry are chained --dependency=
+# afterok on the weights job. The CONUS-wide weight matrix is built once per
+# fabric (idempotent), so a second invocation skips re-computation unless
+# FORCE=1 is exported.
+#
+# The 10 params are listed in configs/zonal_params.yml — if you add or remove
+# entries there, also update PARAMS below.
+
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 <batches_dir> [fabric] [base_config] [max_concurrent]"
+    echo "  batches_dir:    path to {fabric}/batches/ (contains manifest.yml)"
+    echo "  fabric:         optional fabric name (default: gfv2)"
+    echo "  base_config:    optional path to base_config.yml (default: configs/base_config.yml)"
+    echo "  max_concurrent: optional concurrency cap (default: 4; 0/off disables)"
+    exit 1
+fi
+
+FABRIC_DIR="$1"
+FABRIC="${2:-gfv2}"
+BASE_CONFIG="${3:-configs/base_config.yml}"
+MAX_CONCURRENT="${4:-${SUBMIT_JOBS_MAX_CONCURRENT:-4}}"
+MANIFEST="$FABRIC_DIR/manifest.yml"
+
+if [ ! -f "$MANIFEST" ]; then
+    echo "Error: manifest not found: $MANIFEST"
+    echo "Run scripts/prepare_fabric.py first."
+    exit 1
+fi
+
+N_BATCHES=$(grep '^n_batches:' "$MANIFEST" | awk '{print $2}')
+if [ -z "$N_BATCHES" ] || [ "$N_BATCHES" -le 0 ] 2>/dev/null; then
+    echo "Error: could not parse n_batches from $MANIFEST (got: '$N_BATCHES')"
+    exit 1
+fi
+LAST_IDX=$((N_BATCHES - 1))
+
+case "$MAX_CONCURRENT" in
+    0|off|OFF|none|NONE|"")
+        ARRAY_SPEC="0-$LAST_IDX"
+        THROTTLE_NOTE="no concurrency cap"
+        ;;
+    *)
+        ARRAY_SPEC="0-$LAST_IDX%$MAX_CONCURRENT"
+        THROTTLE_NOTE="max $MAX_CONCURRENT concurrent"
+        ;;
+esac
+
+# Param list — must match the `name:` entries in configs/zonal_params.yml.
+# Entries marked with build_weights_dep get the ssflux-style prereq chain.
+# Keep in dependency order: slope must merge before ssflux can run, because
+# ssflux reads the merged slope CSV at zonal time.
+PARAMS=(
+    elevation
+    slope
+    aspect
+    soils
+    soil_moist_max
+    lulc_nhm_v11
+    lulc_nalcms
+    lulc_nlcd
+    lulc_foresce
+    ssflux                  # depends_on: build_weights (resolved per-entry below)
+)
+
+# Entries that need the CONUS weight matrix as a prereq. The submit loop
+# special-cases these to submit build_zonal_weights.batch first + chain
+# the array zonal + merge on its afterok.
+declare -A NEEDS_WEIGHTS=(
+    [ssflux]=1
+)
+
+# Entries that need a specific upstream merge to land first (because the
+# per-batch zonal step reads a merged CSV). ssflux reads the merged slope
+# CSV at zonal time.
+declare -A NEEDS_MERGE_OF=(
+    [ssflux]=slope
+)
+
+echo "Submitting ${#PARAMS[@]} Part 2 params x $N_BATCHES batches each ($THROTTLE_NOTE), FABRIC=$FABRIC"
+
+WEIGHTS_JOB_ID=""
+
+# Map of PARAM -> merge job ID, so downstream params (like ssflux) can chain
+# on the right merge_id.
+declare -A MERGE_JOB_BY_PARAM
+
+for PARAM in "${PARAMS[@]}"; do
+    echo "--- $PARAM ---"
+
+    EXTRA_DEPS=()
+
+    # Step A: build_weights prereq (one-shot per submit run).
+    if [ -n "${NEEDS_WEIGHTS[$PARAM]:-}" ]; then
+        if [ -z "$WEIGHTS_JOB_ID" ]; then
+            WEIGHTS_JOB_ID=$(sbatch \
+                --export=ALL,BASE_CONFIG="$BASE_CONFIG",FABRIC="$FABRIC" \
+                slurm_batch/build_zonal_weights.batch | awk '{print $NF}')
+            echo "  weights: $WEIGHTS_JOB_ID"
+        else
+            echo "  weights: $WEIGHTS_JOB_ID (reused)"
+        fi
+        EXTRA_DEPS+=("afterok:$WEIGHTS_JOB_ID")
+    fi
+
+    # Step B: upstream-merge prereq (e.g., ssflux needs merged slope).
+    if [ -n "${NEEDS_MERGE_OF[$PARAM]:-}" ]; then
+        UP="${NEEDS_MERGE_OF[$PARAM]}"
+        UP_MERGE_ID="${MERGE_JOB_BY_PARAM[$UP]:-}"
+        if [ -z "$UP_MERGE_ID" ]; then
+            echo "ERROR: $PARAM needs merged $UP but no merge job submitted for $UP yet." >&2
+            echo "       Ensure $UP appears before $PARAM in PARAMS." >&2
+            exit 1
+        fi
+        EXTRA_DEPS+=("afterok:$UP_MERGE_ID")
+    fi
+
+    # Combine deps into a single --dependency arg (or empty).
+    DEP_ARG=""
+    if [ "${#EXTRA_DEPS[@]}" -gt 0 ]; then
+        DEP_STR=$(IFS=,; echo "${EXTRA_DEPS[*]}")
+        DEP_ARG="--dependency=$DEP_STR"
+    fi
+
+    # Step C: array zonal job.
+    ARRAY_JOB_ID=$(sbatch --array="$ARRAY_SPEC" \
+                         $DEP_ARG \
+                         --export=ALL,BASE_CONFIG="$BASE_CONFIG",FABRIC="$FABRIC",PARAM="$PARAM" \
+                         slurm_batch/derive_zonal_params.batch | awk '{print $NF}')
+    echo "  zonal  array: $ARRAY_JOB_ID${DEP_ARG:+ ($DEP_ARG)}"
+
+    # Step D: merge job, afterok the array.
+    MERGE_JOB_ID=$(sbatch --dependency=afterok:"$ARRAY_JOB_ID" \
+                         --export=ALL,BASE_CONFIG="$BASE_CONFIG",FABRIC="$FABRIC",PARAM="$PARAM" \
+                         slurm_batch/merge_zonal_param.batch | awk '{print $NF}')
+    echo "  merge afterok:$ARRAY_JOB_ID -> $MERGE_JOB_ID"
+    MERGE_JOB_BY_PARAM[$PARAM]="$MERGE_JOB_ID"
+done
+
+echo "Done. Submitted ${#PARAMS[@]} params; last merge job ID: ${MERGE_JOB_ID}"

--- a/src/gfv2_params/zonal_runners.py
+++ b/src/gfv2_params/zonal_runners.py
@@ -1,0 +1,629 @@
+"""Library functions for the Part 2 zonal-pass parameter pipeline.
+
+Each `run_*` function performs the per-batch (or CONUS-once) work for one
+parameter type. Both the legacy per-script CLIs under ``scripts/`` and the
+unified ``scripts/derive_zonal_params.py`` orchestrator delegate here so the
+work logic lives in exactly one place.
+
+The `config` dict each function receives is a flat mapping containing the
+keys the existing per-param configs already provide (source_type,
+source_raster, batch_dir, target_layer, id_feature, output_dir, merged_file,
+categorical, fabric, plus per-script extras like canopy_raster, crosswalk_file,
+keep_raster, source_shapefile, merged_slope_file, weight_dir, k_perm_min,
+flux_params). The orchestrator builds this dict by flattening the active
+param entry in ``configs/zonal_params.yml`` onto the top-level ``defaults:``
+block (plus the resolved fabric profile). The legacy CLIs build the same
+shape via ``gfv2_params.config.load_config`` against a per-param YAML.
+
+Refactor invariant: the existing per-script behaviour is preserved verbatim
+— these functions are the prior ``main()`` bodies extracted unchanged
+modulo argument plumbing.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from pathlib import Path
+
+# Pre-import heartbeats so a future hang in the geo-library import chain
+# (rasterio/GDAL/PROJ/pyogrio init under shared-FS metadata contention,
+# observed once on VPU01 issue-#61 array run with zero stdout from one task)
+# can be localised. Printed unconditionally with flush=True so SLURM's
+# stdout/stderr line buffering doesn't swallow them.
+print(
+    f"[startup pid={os.getpid()} host={os.uname().nodename} "
+    f"task={os.environ.get('SLURM_ARRAY_TASK_ID', '-')}] "
+    f"python {sys.version.split()[0]} interpreter up, importing geo libs...",
+    flush=True,
+)
+_t_imports = time.time()
+
+import geopandas as gpd
+import numpy as np
+import pandas as pd
+import rioxarray
+from gdptools import UserTiffData, WeightGenP2P, ZonalGen
+from osgeo import gdal, osr
+
+print(f"[startup] geo-library imports complete in {time.time() - _t_imports:.1f}s", flush=True)
+
+from gfv2_params.lulc import (
+    assign_cov_type,
+    class_percentages_from_histogram,
+    compute_covden,
+    compute_interception,
+    compute_retention,
+    load_crosswalk,
+)
+from gfv2_params.raster_ops import deg_to_fraction
+
+# Opt into the GDAL 4.0 default of raising Python exceptions instead of C-style
+# error codes. Silences the FutureWarning that osgeo emits when neither
+# UseExceptions/DontUseExceptions is set. NB: GDAL state is process-global —
+# importing this module from a notebook or test harness will flip exception
+# handling on for the whole process. That is the desired behaviour (GDAL 4.0's
+# default) and what the slurm batches expect, but worth knowing if anyone
+# embeds this module elsewhere.
+gdal.UseExceptions()
+osr.UseExceptions()
+
+
+# ---------------------------------------------------------------------------
+# Per-batch zonal workers
+# ---------------------------------------------------------------------------
+
+def run_zonal_batch(config: dict, batch_id: int, logger) -> None:
+    """One HRU batch of continuous-zonal stats from a single raster.
+
+    Drives the elevation/slope/aspect param types. Lifted verbatim from
+    scripts/create_zonal_params.py:main(). Uses the gdptools NEW API
+    (source_var/source_ds/source_crs/target_gdf/target_id).
+    """
+    source_type = config["source_type"]
+    categorical = config.get("categorical", False)
+    id_feature = config["id_feature"]
+    target_layer = config["target_layer"]
+    fabric = config["fabric"]
+
+    raster_path = Path(config["source_raster"])
+    batch_dir = Path(config["batch_dir"])
+    batch_gpkg = batch_dir / f"batch_{batch_id:04d}.gpkg"
+    output_dir = Path(config["output_dir"]) / source_type
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    if not raster_path.exists():
+        raise FileNotFoundError(f"Input raster not found: {raster_path}")
+    if not batch_gpkg.exists():
+        raise FileNotFoundError(f"Batch GPKG not found: {batch_gpkg}")
+
+    logger.info("Raster: %s", raster_path)
+    logger.info("Batch GPKG: %s", batch_gpkg)
+
+    nhru_gdf = gpd.read_file(batch_gpkg, layer=target_layer)
+    logger.info("Loaded %s layer: %d features (batch %d)", target_layer, len(nhru_gdf), batch_id)
+
+    ned_da = rioxarray.open_rasterio(raster_path, masked=True)
+    logger.info("Loaded raster: shape=%s, crs=%s", ned_da.shape, ned_da.rio.crs)
+
+    file_prefix = f"base_nhm_{source_type}_{fabric}_batch_{batch_id:04d}_param"
+
+    data = UserTiffData(
+        source_var=source_type,
+        source_ds=ned_da,
+        source_crs=ned_da.rio.crs,
+        source_x_coord="x",
+        source_y_coord="y",
+        band=1,
+        bname="band",
+        target_gdf=nhru_gdf,
+        target_id=id_feature,
+    )
+
+    zonal_gen = ZonalGen(
+        user_data=data,
+        zonal_engine="exactextract",
+        zonal_writer="csv",
+        out_path=output_dir,
+        file_prefix=file_prefix,
+        jobs=4,
+    )
+    stats = zonal_gen.calculate_zonal(categorical=categorical)
+    logger.info("Zonal statistics complete. Shape: %s", stats.shape)
+
+
+def run_soils_batch(config: dict, batch_id: int, logger) -> None:
+    """One HRU batch of soils (categorical) or soil_moist_max (continuous).
+
+    Lifted from scripts/create_soils_params.py:main(). Uses the gdptools OLD
+    API (var/ds/proj_ds/f_feature/id_feature) — preserved verbatim because
+    that's what the per-batch helper functions below also use.
+    """
+    source_type = config["source_type"]
+    categorical = config.get("categorical", False)
+    id_feature = config["id_feature"]
+    target_layer = config["target_layer"]
+    fabric = config["fabric"]
+
+    output_dir = Path(config["output_dir"]) / source_type
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    batch_dir = Path(config["batch_dir"])
+    batch_gpkg = batch_dir / f"batch_{batch_id:04d}.gpkg"
+    if not batch_gpkg.exists():
+        raise FileNotFoundError(f"Batch GPKG not found: {batch_gpkg}")
+    nhru_gdf = gpd.read_file(batch_gpkg, layer=target_layer)
+    logger.info("Loaded %s layer: %d features (batch %d)", target_layer, len(nhru_gdf), batch_id)
+
+    file_prefix = f"base_nhm_{source_type}_{fabric}_batch_{batch_id:04d}_param"
+
+    raster_path = Path(config["source_raster"])
+    if not raster_path.exists():
+        raise FileNotFoundError(f"Input raster not found: {raster_path}")
+    source_da = rioxarray.open_rasterio(raster_path, masked=True)
+    logger.info("Loaded raster: shape=%s, crs=%s", source_da.shape, source_da.rio.crs)
+
+    if source_type == "soils":
+        _process_soils(source_da, nhru_gdf, output_dir, file_prefix, categorical, id_feature, logger)
+    elif source_type == "soil_moist_max":
+        _process_soil_moist_max(source_da, nhru_gdf, output_dir, source_type, file_prefix, categorical, id_feature, logger)
+    else:
+        raise ValueError(f"Unknown source_type for soils dispatch: {source_type}")
+
+
+def _process_soils(source_da, nhru_gdf, output_path, file_prefix, categorical, id_feature, logger):
+    """Categorical soils: zonal histogram -> dominant category -> CSV."""
+    data = UserTiffData(
+        var="soils", ds=source_da, proj_ds=source_da.rio.crs,
+        x_coord="x", y_coord="y", band=1, bname="band",
+        f_feature=nhru_gdf, id_feature=id_feature,
+    )
+    zonal_gen = ZonalGen(
+        user_data=data, zonal_engine="exactextract", zonal_writer="csv",
+        out_path=output_path, file_prefix=f"{file_prefix}_temp", jobs=4,
+    )
+    stats = zonal_gen.calculate_zonal(categorical=categorical)
+    logger.info("Zonal statistics computed")
+
+    zg_file = output_path / f"{file_prefix}_temp.csv"
+    if zg_file.exists():
+        zg_file.unlink()
+
+    category_cols = [col for col in stats.columns if str(col) not in ("count",)]
+    top_stats = stats.copy()
+    top_stats["max_category"] = top_stats[category_cols].idxmax(axis=1)
+    result = top_stats[["max_category"]].rename(columns={"max_category": "soils"})
+    result.sort_index(inplace=True)
+
+    result_csv = output_path / f"{file_prefix}.csv"
+    result.to_csv(result_csv)
+    logger.info("Soils parameters saved to: %s", result_csv)
+
+
+def _process_soil_moist_max(source_da, nhru_gdf, output_path, source_type, file_prefix, categorical, id_feature, logger):
+    """Continuous soil_moist_max: zonal mean from the pre-built raster."""
+    data = UserTiffData(
+        var=source_type, ds=source_da, proj_ds=source_da.rio.crs,
+        x_coord="x", y_coord="y", band=1, bname="band",
+        f_feature=nhru_gdf, id_feature=id_feature,
+    )
+    zonal_gen = ZonalGen(
+        user_data=data, zonal_engine="exactextract", zonal_writer="csv",
+        out_path=output_path, file_prefix=f"{file_prefix}_temp", jobs=4,
+    )
+    stats = zonal_gen.calculate_zonal(categorical=categorical)
+    logger.info("Zonal statistics computed for soil_moist_max")
+
+    mean_stats = stats[["mean"]].rename(columns={"mean": "soil_moist_max"})
+    result_csv = output_path / f"{file_prefix}.csv"
+    mean_stats.to_csv(result_csv)
+    logger.info("soil_moist_max parameters saved to: %s", result_csv)
+
+
+def run_lulc_batch(config: dict, batch_id: int, logger) -> None:
+    """One HRU batch of LULC parameter derivation.
+
+    Lifted from scripts/create_lulc_params.py:main(). Five steps:
+      1. categorical zonal stats on LULC raster -> class percentages
+      2. continuous zonal stats on canopy raster -> canopy_mean per HRU
+      3. retention: either zonal mean from keep raster (FORE-SCE / NHM v1.1)
+         or crosswalk evergreen_retention (NLCD / NALCMS)
+      4. compute cov_type / interception / covden via gfv2_params.lulc helpers
+      5. merge + write CSV
+    """
+    source_type = config["source_type"]
+    id_feature = config["id_feature"]
+    target_layer = config["target_layer"]
+    fabric = config["fabric"]
+
+    output_dir = Path(config["output_dir"]) / source_type
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    batch_dir = Path(config["batch_dir"])
+    batch_gpkg = batch_dir / f"batch_{batch_id:04d}.gpkg"
+    if not batch_gpkg.exists():
+        raise FileNotFoundError(f"Batch GPKG not found: {batch_gpkg}")
+    nhru_gdf = gpd.read_file(batch_gpkg, layer=target_layer)
+    logger.info("Loaded %s layer: %d features (batch %d)", target_layer, len(nhru_gdf), batch_id)
+
+    crosswalk_path = Path(config["crosswalk_file"])
+    if not crosswalk_path.is_absolute():
+        # Relative crosswalk paths resolve against the repo root (this module
+        # is src/gfv2_params/zonal_runners.py -> parents[2] = repo root).
+        crosswalk_path = Path(__file__).resolve().parents[2] / crosswalk_path
+    crosswalk = load_crosswalk(crosswalk_path)
+    logger.info("Loaded crosswalk: %d classes", len(crosswalk))
+
+    file_prefix = f"base_nhm_{source_type}_{fabric}_batch_{batch_id:04d}_param"
+
+    # --- Step 1: Categorical zonal stats on LULC raster ---
+    lulc_path = Path(config["source_raster"])
+    if not lulc_path.exists():
+        raise FileNotFoundError(f"LULC raster not found: {lulc_path}")
+    lulc_da = rioxarray.open_rasterio(lulc_path, masked=True)
+    logger.info("Loaded LULC raster: shape=%s", lulc_da.shape)
+
+    lulc_data = UserTiffData(
+        var="lulc", ds=lulc_da, proj_ds=lulc_da.rio.crs,
+        x_coord="x", y_coord="y", band=1, bname="band",
+        f_feature=nhru_gdf, id_feature=id_feature,
+    )
+    lulc_zonal = ZonalGen(
+        user_data=lulc_data, zonal_engine="exactextract", zonal_writer="csv",
+        out_path=output_dir, file_prefix=f"{file_prefix}_lulc_temp", jobs=4,
+    )
+    histogram = lulc_zonal.calculate_zonal(categorical=True)
+    logger.info("LULC categorical zonal stats computed")
+
+    temp_csv = output_dir / f"{file_prefix}_lulc_temp.csv"
+    if temp_csv.exists():
+        temp_csv.unlink()
+
+    class_perc = class_percentages_from_histogram(histogram)
+    id_name = histogram.index.name or "id"
+    if id_name != id_feature:
+        class_perc = class_perc.rename(columns={id_name: id_feature})
+    logger.info("Class percentages computed for %d HRUs", class_perc[id_feature].nunique())
+
+    # --- Step 2: Continuous zonal stats on canopy raster ---
+    cnpy_path = Path(config["canopy_raster"])
+    if not cnpy_path.exists():
+        raise FileNotFoundError(f"Canopy raster not found: {cnpy_path}")
+    cnpy_da = rioxarray.open_rasterio(cnpy_path, masked=True)
+    logger.info("Loaded canopy raster: shape=%s", cnpy_da.shape)
+
+    cnpy_data = UserTiffData(
+        var="canopy", ds=cnpy_da, proj_ds=cnpy_da.rio.crs,
+        x_coord="x", y_coord="y", band=1, bname="band",
+        f_feature=nhru_gdf, id_feature=id_feature,
+    )
+    cnpy_zonal = ZonalGen(
+        user_data=cnpy_data, zonal_engine="exactextract", zonal_writer="csv",
+        out_path=output_dir, file_prefix=f"{file_prefix}_cnpy_temp", jobs=4,
+    )
+    cnpy_stats = cnpy_zonal.calculate_zonal(categorical=False)
+    logger.info("Canopy continuous zonal stats computed")
+
+    temp_csv = output_dir / f"{file_prefix}_cnpy_temp.csv"
+    if temp_csv.exists():
+        temp_csv.unlink()
+
+    canopy_mean_df = cnpy_stats[["mean"]].rename(columns={"mean": "canopy_mean"})
+    canopy_mean_df.index.name = id_feature
+    canopy_mean_df = canopy_mean_df.reset_index()
+
+    # --- Step 3: Retention (raster-based or crosswalk-based) ---
+    keep_raster_str = config.get("keep_raster")
+    if keep_raster_str:
+        keep_path = Path(keep_raster_str)
+        if not keep_path.exists():
+            raise FileNotFoundError(f"Keep raster not found: {keep_path}")
+        keep_da = rioxarray.open_rasterio(keep_path, masked=True)
+        logger.info("Loaded keep raster: shape=%s", keep_da.shape)
+
+        keep_data = UserTiffData(
+            var="keep", ds=keep_da, proj_ds=keep_da.rio.crs,
+            x_coord="x", y_coord="y", band=1, bname="band",
+            f_feature=nhru_gdf, id_feature=id_feature,
+        )
+        keep_zonal = ZonalGen(
+            user_data=keep_data, zonal_engine="exactextract", zonal_writer="csv",
+            out_path=output_dir, file_prefix=f"{file_prefix}_keep_temp", jobs=4,
+        )
+        keep_stats = keep_zonal.calculate_zonal(categorical=False)
+        logger.info("Keep raster zonal stats computed")
+
+        temp_csv = output_dir / f"{file_prefix}_keep_temp.csv"
+        if temp_csv.exists():
+            temp_csv.unlink()
+
+        # Keep raster values are 0-100; normalise to 0-1
+        retention_df = keep_stats[["mean"]].rename(columns={"mean": "retention"})
+        retention_df["retention"] = retention_df["retention"] * 0.01
+        retention_df.index.name = id_feature
+        retention_df = retention_df.reset_index()
+        logger.info("Retention computed from keep raster (raster-based)")
+    else:
+        retention_df = compute_retention(class_perc, crosswalk, id_col=id_feature)
+        logger.info("Retention computed from crosswalk evergreen_retention (crosswalk-based)")
+
+    # --- Step 4: Compute parameters ---
+    cov_type_df = assign_cov_type(class_perc, crosswalk, id_col=id_feature)
+    logger.info("Cover types assigned")
+
+    intcp_df = compute_interception(class_perc, crosswalk, id_col=id_feature)
+    logger.info("Interception parameters computed")
+
+    covden_df = compute_covden(class_perc, crosswalk, canopy_mean_df, id_col=id_feature)
+    logger.info("Cover density parameters computed")
+
+    # --- Step 5: Merge and write ---
+    expected_hrus = class_perc[id_feature].nunique()
+    result = (
+        cov_type_df
+        .merge(intcp_df, on=id_feature)
+        .merge(covden_df, on=id_feature)
+        .merge(retention_df, on=id_feature)
+    )
+    if len(result) != expected_hrus:
+        logger.warning(
+            "Row count mismatch after merge: expected %d HRUs, got %d. "
+            "Some HRUs may have been dropped.",
+            expected_hrus,
+            len(result),
+        )
+    result = result.sort_values(id_feature).set_index(id_feature)
+
+    result_csv = output_dir / f"{file_prefix}.csv"
+    result.to_csv(result_csv)
+    logger.info("LULC parameters saved to: %s (%d HRUs)", result_csv, len(result))
+
+
+def run_ssflux_batch(config: dict, batch_id: int, logger) -> None:
+    """One HRU batch of subsurface flux parameter derivation.
+
+    Lifted from scripts/create_ssflux_params.py:main(). Requires pre-computed
+    CONUS weights (from run_build_weights) and merged slope CSV (from
+    run_merge applied to the slope param). Output writes to
+    {output_dir}/ssflux/ (subdir name is hardcoded to 'ssflux' to match
+    today's create_ssflux_params.py behaviour).
+    """
+    id_feature = config["id_feature"]
+    target_layer = config["target_layer"]
+    output_dir = Path(config["output_dir"])
+    weight_dir = Path(config["weight_dir"])
+    fabric = config["fabric"]
+
+    batch_dir = Path(config["batch_dir"])
+    batch_gpkg = batch_dir / f"batch_{batch_id:04d}.gpkg"
+    if not batch_gpkg.exists():
+        raise FileNotFoundError(f"Batch GPKG not found: {batch_gpkg}")
+    target_gdf = gpd.read_file(batch_gpkg, layer=target_layer)
+    batch_ids = set(target_gdf[id_feature].values)
+    logger.info("Loaded %d features (batch %d)", len(target_gdf), batch_id)
+
+    weight_file = weight_dir / f"lith_weights_{fabric}.csv"
+    if not weight_file.exists():
+        raise FileNotFoundError(
+            f"Weight file not found: {weight_file}\n"
+            "Run --mode build_weights first."
+        )
+    all_weights = pd.read_csv(weight_file)
+    weights = all_weights[all_weights[id_feature].isin(batch_ids)].copy()
+    logger.info("Loaded weights: %d rows (from %d total)", len(weights), len(all_weights))
+
+    merged_slope_file = Path(config["merged_slope_file"])
+    if not merged_slope_file.exists():
+        raise FileNotFoundError(
+            f"Merged slope file not found: {merged_slope_file}\n"
+            "Run merge for the slope param first."
+        )
+    all_slope = pd.read_csv(merged_slope_file)
+    slope_df = all_slope[all_slope[id_feature].isin(batch_ids)].copy()
+    slope_df["mean_slope_fraction"] = slope_df["mean"].astype(float).apply(deg_to_fraction)
+    logger.info("Loaded slope for %d features", len(slope_df))
+
+    source_gdf = gpd.read_file(Path(config["source_shapefile"]))
+    source_gdf["flux_id"] = np.arange(len(source_gdf))
+
+    weights["flux_id"] = weights["flux_id"].astype(str)
+    source_gdf["flux_id"] = source_gdf["flux_id"].astype(str)
+    w = weights.merge(source_gdf[["flux_id", "k_perm"]], on="flux_id")
+
+    k_perm_min = config["k_perm_min"]
+    w["k_perm"] = w["k_perm"].replace(0, k_perm_min)
+    w["k_perm_actual"] = 10 ** w["k_perm"]
+    w["k_perm_wtd_sum"] = w["k_perm_actual"] * (w["area_weight"] / w["flux_id_area"])
+
+    extensive_agg = (
+        w.groupby(id_feature)
+        .agg(k_perm_wtd=("k_perm_wtd_sum", "sum"))
+        .reset_index()
+    )
+    extensive_agg[id_feature] = extensive_agg[id_feature].astype(int)
+    extensive_sorted = extensive_agg.sort_values(by=id_feature).reset_index(drop=True)
+
+    slope_merge = slope_df[[id_feature, "mean_slope_fraction"]].copy()
+    try:
+        slope_merge[id_feature] = slope_merge[id_feature].astype("int64")
+    except (ValueError, TypeError) as exc:
+        raise ValueError(f"Non-numeric {id_feature} values in slope data") from exc
+
+    target_gdf["hru_area"] = target_gdf.geometry.area
+    area_df = target_gdf[[id_feature, "hru_area"]].copy()
+    try:
+        area_df[id_feature] = area_df[id_feature].astype("int64")
+    except (ValueError, TypeError) as exc:
+        raise ValueError(f"Non-numeric {id_feature} values in target fabric") from exc
+
+    df = extensive_sorted.merge(slope_merge, on=id_feature, how="left").copy()
+    df = df.merge(area_df, on=id_feature, how="left")
+
+    null_slope = df["mean_slope_fraction"].isna().sum()
+    null_area = df["hru_area"].isna().sum()
+    if null_slope > 0 or null_area > 0:
+        raise ValueError(
+            f"Merge produced missing values: {null_slope} features missing slope, "
+            f"{null_area} features missing area. Check that slope and batch data "
+            f"use consistent {id_feature} values."
+        )
+
+    df["r_soil2gw_max"] = df["k_perm_wtd"] ** 3
+    df["r_ssr2gw_rate"] = df["k_perm_wtd"] * (1 - df["mean_slope_fraction"])
+    df["r_slowcoef_lin"] = (df["k_perm_wtd"] * df["mean_slope_fraction"]) / df["hru_area"]
+    df["r_fastcoef_lin"] = 2 * df["r_slowcoef_lin"]
+    df["r_gwflow_coef"] = df["r_slowcoef_lin"]
+    df["r_dprst_seep_rate_open"] = df["r_ssr2gw_rate"]
+    df["r_dprst_flow_coef"] = df["r_fastcoef_lin"]
+
+    # Normalisation is per-batch (not CONUS-wide), matching prior per-VPU
+    # behaviour. The same raw value may map to slightly different normalised
+    # values across batches because per-batch min/max ranges differ.
+    flux_params = config["flux_params"]
+    param_names = [fp["name"] for fp in flux_params]
+    param_maxes = [fp["max"] for fp in flux_params]
+    param_mins = [fp["min"] for fp in flux_params]
+
+    df_r = df[[f"r_{p}" for p in param_names]].agg(["min", "max"])
+    df_r.loc["range"] = df_r.loc["max"] - df_r.loc["min"]
+
+    for i, p in enumerate(param_names):
+        rcol = f"r_{p}"
+        min_in, rng_in = df_r.at["min", rcol], df_r.at["range", rcol]
+        min_out, max_out = param_mins[i], param_maxes[i]
+        rng_out = max_out - min_out
+        if rng_in == 0:
+            logger.warning("Range is zero for %s; using midpoint of output range", p)
+            df[p] = (min_out + max_out) / 2.0
+        else:
+            norm = (df[rcol] - min_in) / rng_in
+            df[p] = norm * rng_out + min_out
+
+    df.drop(columns=[f"r_{p}" for p in param_names], inplace=True)
+
+    ssflux_dir = output_dir / "ssflux"
+    ssflux_dir.mkdir(parents=True, exist_ok=True)
+    file_prefix = f"base_nhm_ssflux_{fabric}_batch_{batch_id:04d}_param"
+    df.to_csv(ssflux_dir / f"{file_prefix}.csv", index=False)
+    logger.info("SSFlux parameters saved (batch %d)", batch_id)
+
+
+# ---------------------------------------------------------------------------
+# CONUS-once worker (ssflux prereq)
+# ---------------------------------------------------------------------------
+
+def run_build_weights(config: dict, data_root: Path, logger, force: bool = False) -> None:
+    """Pre-compute the CONUS-wide P2P weight matrix that ssflux consumes.
+
+    Lifted from scripts/build_weights.py:main(). One CSV per fabric, written
+    to ``config['weight_dir']/lith_weights_<fabric>.csv``. Idempotent: skips
+    if the file exists unless force=True.
+    """
+    fabric = config["fabric"]
+    id_feature = config["id_feature"]
+    target_layer = config["target_layer"]
+
+    weight_dir = Path(config["weight_dir"])
+    weight_dir.mkdir(parents=True, exist_ok=True)
+    weight_file = weight_dir / f"lith_weights_{fabric}.csv"
+
+    if weight_file.exists() and not force:
+        logger.info("Weight file already exists: %s (use --force to overwrite)", weight_file)
+        return
+
+    fabric_gpkg = data_root / fabric / "fabric" / f"{fabric}_nhru_merged.gpkg"
+    if not fabric_gpkg.exists():
+        raise FileNotFoundError(f"Merged fabric not found: {fabric_gpkg}")
+    target_gdf = gpd.read_file(fabric_gpkg, layer=target_layer)
+    logger.info("Loaded target fabric: %d features", len(target_gdf))
+
+    source_gdf = gpd.read_file(Path(config["source_shapefile"]))
+    source_gdf["flux_id"] = np.arange(len(source_gdf))
+    logger.info("Loaded lithology: %d features", len(source_gdf))
+
+    logger.info("Computing P2P weights (this may take a while)...")
+    weight_gen = WeightGenP2P(
+        target_poly=target_gdf,
+        target_poly_idx=id_feature,
+        source_poly=source_gdf,
+        source_poly_idx="flux_id",
+        method="serial",
+        weight_gen_crs="5070",
+        output_file=weight_file,
+    )
+    weights = weight_gen.calculate_weights()
+    if weights is None or len(weights) == 0:
+        raise RuntimeError(
+            "WeightGenP2P returned no weights. Check that target and source "
+            "polygons overlap spatially."
+        )
+    if not weight_file.exists():
+        raise RuntimeError(f"WeightGenP2P did not write output file: {weight_file}")
+    logger.info("Weights computed: %d rows -> %s", len(weights), weight_file)
+
+
+# ---------------------------------------------------------------------------
+# Merge worker (any param type)
+# ---------------------------------------------------------------------------
+
+def run_merge(config: dict, logger) -> None:
+    """Concat per-batch CSVs for one param into the merged output CSV.
+
+    Lifted from scripts/merge_params.py:process_files(). Validates no
+    duplicates, warns on gaps (if expected_max_hru_id is set in config).
+    """
+    source_type = config["source_type"]
+    id_feature = config["id_feature"]
+    merged_file = config["merged_file"]
+    fabric = config["fabric"]
+    expected_max = config.get("expected_max_hru_id")
+
+    input_dir = Path(config["output_dir"]) / source_type
+    final_output_dir = Path(config["output_dir"]) / config.get("merged_subdir", "merged")
+    final_output_dir.mkdir(parents=True, exist_ok=True)
+
+    if not input_dir.exists():
+        raise FileNotFoundError(f"Input directory not found: {input_dir}")
+
+    file_pattern = f"base_nhm_{source_type}_{fabric}_batch_*_param.csv"
+    files = sorted(input_dir.glob(file_pattern))
+
+    if not files:
+        raise FileNotFoundError(f"No batch files found matching: {input_dir / file_pattern}")
+
+    logger.info("Found %d batch files for %s", len(files), source_type)
+
+    dfs = []
+    for f in files:
+        logger.debug("Reading: %s", f)
+        df = pd.read_csv(f)
+        if id_feature not in df.columns:
+            raise ValueError(f"'{id_feature}' column not found in file: {f}")
+        dfs.append(df)
+
+    merged_df = pd.concat(dfs, ignore_index=True)
+    merged_df = merged_df.sort_values(id_feature).reset_index(drop=True)
+
+    dupes = merged_df[merged_df[id_feature].duplicated(keep=False)]
+    if len(dupes) > 0:
+        dupe_ids = sorted(dupes[id_feature].unique())
+        raise ValueError(
+            f"Duplicate {id_feature} values found ({len(dupe_ids)} IDs). "
+            f"First 10: {dupe_ids[:10]}. This indicates overlapping batches."
+        )
+
+    if expected_max is not None:
+        existing_ids = set(merged_df[id_feature])
+        expected_ids = set(range(1, int(expected_max) + 1))
+        gaps = sorted(expected_ids - existing_ids)
+        if gaps:
+            logger.warning(
+                "%d missing %s values (expected 1-%d, got %d). First 10: %s. "
+                "If this is expected, run merge_and_fill_params.py to fill gaps via KNN.",
+                len(gaps), id_feature, expected_max, len(existing_ids), gaps[:10],
+            )
+
+    output_path = final_output_dir / merged_file
+    merged_df.to_csv(output_path, index=False)
+    logger.info("Merged %d rows -> %s", len(merged_df), output_path)

--- a/tests/test_merge_params.py
+++ b/tests/test_merge_params.py
@@ -1,21 +1,17 @@
-"""Tests for scripts/merge_params.py"""
+"""Tests for the per-param merge logic.
 
-import tempfile
+The merge work was lifted from scripts/merge_params.py:process_files into
+gfv2_params.zonal_runners.run_merge as part of Step 4. The library function
+is the source of truth; the CLI shell in scripts/merge_params.py now
+delegates to it. These tests target the library function directly.
+"""
+
 from pathlib import Path
 
 import pandas as pd
 import pytest
 
-import importlib.util
-
-_spec = importlib.util.spec_from_file_location(
-    "merge_params",
-    Path(__file__).resolve().parent.parent / "scripts" / "merge_params.py",
-)
-_mod = importlib.util.module_from_spec(_spec)
-_spec.loader.exec_module(_mod)
-
-process_files = _mod.process_files
+from gfv2_params.zonal_runners import run_merge as process_files
 
 
 def _make_config(tmp_path, fabric="gfv2", source_type="elevation", expected_max=None):

--- a/tests/test_zonal_orchestrator.py
+++ b/tests/test_zonal_orchestrator.py
@@ -7,7 +7,6 @@ libraries (so CI can run these in seconds).
 
 import subprocess
 import sys
-import tempfile
 from pathlib import Path
 
 import pytest

--- a/tests/test_zonal_orchestrator.py
+++ b/tests/test_zonal_orchestrator.py
@@ -1,0 +1,218 @@
+"""Tests for scripts/derive_zonal_params.py + configs/zonal_params.yml.
+
+Mirrors tests/test_shared_rasters_orchestrator.py. Validates the unified
+zonal-pass config invariants without actually invoking the heavy geo
+libraries (so CI can run these in seconds).
+"""
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+ORCHESTRATOR = REPO_ROOT / "scripts" / "derive_zonal_params.py"
+ZONAL_PARAMS_CONFIG = REPO_ROOT / "configs" / "zonal_params.yml"
+
+
+# Dispatch tags the orchestrator recognises. Must match _BATCH_RUNNERS in
+# scripts/derive_zonal_params.py.
+_KNOWN_SCRIPT_TAGS = {"zonal", "soils", "lulc", "ssflux"}
+
+# Params expected to be present in the production zonal_params.yml. If you
+# add a new param entry to the config, also add it here so the test catches
+# accidental removal.
+_EXPECTED_PARAMS = {
+    "elevation",
+    "slope",
+    "aspect",
+    "soils",
+    "soil_moist_max",
+    "lulc_nhm_v11",
+    "lulc_nalcms",
+    "lulc_nlcd",
+    "lulc_foresce",
+    "ssflux",
+}
+
+
+def _load_config_raw() -> dict:
+    """Read configs/zonal_params.yml without resolving any placeholders.
+
+    The orchestrator's full resolution path requires a base_config.yml +
+    fabric profile, which is more than these invariant checks need.
+    """
+    with open(ZONAL_PARAMS_CONFIG) as f:
+        return yaml.safe_load(f)
+
+
+# ---------------------------------------------------------------------------
+# Config-shape invariants
+# ---------------------------------------------------------------------------
+
+def test_zonal_params_config_parses():
+    """The committed configs/zonal_params.yml must be valid YAML."""
+    config = _load_config_raw()
+    assert "defaults" in config
+    assert "params" in config
+    assert isinstance(config["params"], list)
+    assert len(config["params"]) > 0
+
+
+def test_every_param_has_a_known_script_tag():
+    """Every entry's `script:` must dispatch to a recognised run_*_batch."""
+    config = _load_config_raw()
+    for entry in config["params"]:
+        assert "name" in entry, f"Param entry missing `name`: {entry}"
+        assert "script" in entry, f"Param entry '{entry['name']}' missing `script:`"
+        assert entry["script"] in _KNOWN_SCRIPT_TAGS, (
+            f"Param '{entry['name']}' has unknown script tag '{entry['script']}'. "
+            f"Known: {sorted(_KNOWN_SCRIPT_TAGS)}"
+        )
+
+
+def test_every_param_has_a_merged_file():
+    """Every entry needs a merged_file so run_merge knows where to write."""
+    config = _load_config_raw()
+    for entry in config["params"]:
+        assert "merged_file" in entry, (
+            f"Param '{entry['name']}' missing `merged_file`"
+        )
+
+
+def test_param_names_are_unique():
+    """Duplicate `name:` would let the wrong entry win in _find_param."""
+    config = _load_config_raw()
+    names = [entry["name"] for entry in config["params"]]
+    duplicates = [n for n in names if names.count(n) > 1]
+    assert not duplicates, f"Duplicate param names: {sorted(set(duplicates))}"
+
+
+def test_production_pipeline_params_present():
+    """The 10 known param types must all appear in zonal_params.yml.
+
+    Catches accidental removal during edits; new entries are fine.
+    """
+    config = _load_config_raw()
+    names = {entry["name"] for entry in config["params"]}
+    missing = _EXPECTED_PARAMS - names
+    assert not missing, f"Missing expected params: {sorted(missing)}"
+
+
+def test_ssflux_declares_weights_dependency():
+    """ssflux can't run without the build_weights prereq + merged slope."""
+    config = _load_config_raw()
+    ssflux = next((e for e in config["params"] if e["name"] == "ssflux"), None)
+    assert ssflux is not None, "ssflux entry missing"
+    assert ssflux.get("depends_on") == "build_weights", (
+        "ssflux must carry `depends_on: build_weights` for submit_zonal_params.sh "
+        "to wire up the prereq job"
+    )
+    # The submit script also chains ssflux on the slope merge — confirm the
+    # entry references a merged slope path.
+    assert "merged_slope_file" in ssflux, "ssflux entry missing merged_slope_file"
+    assert "nhm_slope_params.csv" in ssflux["merged_slope_file"], (
+        "ssflux merged_slope_file must point at the slope merge output "
+        "(nhm_slope_params.csv) so the dispatch chain is correct"
+    )
+
+
+def test_lulc_entries_use_per_source_names():
+    """Each LULC source must have its own `name` (lulc_<source>) to avoid
+    per-batch output collisions when multiple LULC sources run in parallel."""
+    config = _load_config_raw()
+    lulc_names = {e["name"] for e in config["params"] if e.get("script") == "lulc"}
+    assert lulc_names >= {"lulc_nhm_v11", "lulc_nalcms", "lulc_nlcd", "lulc_foresce"}
+    # No bare "lulc" entry (would collide with the legacy CLI's source_type).
+    assert "lulc" not in lulc_names
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator CLI invariants
+# ---------------------------------------------------------------------------
+
+def _run_orchestrator(*args) -> subprocess.CompletedProcess:
+    """Invoke the orchestrator under the current Python with given args."""
+    return subprocess.run(
+        [sys.executable, str(ORCHESTRATOR), *args],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_orchestrator_requires_mode():
+    """--mode is required; no default."""
+    result = _run_orchestrator("--config", str(ZONAL_PARAMS_CONFIG))
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "--mode" in combined
+
+
+def test_orchestrator_rejects_unknown_mode():
+    """argparse choices keep --mode constrained to zonal/merge/build_weights."""
+    result = _run_orchestrator(
+        "--config", str(ZONAL_PARAMS_CONFIG),
+        "--mode", "this_mode_does_not_exist",
+    )
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "invalid choice" in combined.lower() or "this_mode_does_not_exist" in combined
+
+
+def test_orchestrator_zonal_mode_requires_param_and_batch_id():
+    """--mode zonal needs --param + --batch_id; missing either should fail."""
+    result = _run_orchestrator(
+        "--config", str(ZONAL_PARAMS_CONFIG),
+        "--mode", "zonal",
+    )
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "--param" in combined
+
+    # With --param but no --batch_id
+    result = _run_orchestrator(
+        "--config", str(ZONAL_PARAMS_CONFIG),
+        "--mode", "zonal",
+        "--param", "elevation",
+    )
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "--batch_id" in combined
+
+
+def test_orchestrator_merge_mode_requires_param():
+    """--mode merge needs --param."""
+    result = _run_orchestrator(
+        "--config", str(ZONAL_PARAMS_CONFIG),
+        "--mode", "merge",
+    )
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "--param" in combined
+
+
+def test_orchestrator_rejects_unknown_param(tmp_path):
+    """An unknown --param value should fail with a clear error pointing at
+    the available list."""
+    # Build a minimal base_config so the orchestrator can load_config without
+    # depending on the real production data_root layout.
+    base_config = tmp_path / "base_config.yml"
+    base_config.write_text(yaml.safe_dump({
+        "data_root": str(tmp_path / "fake_root"),
+        "default_fabric": "stub",
+        "fabrics": {"stub": {}},
+    }))
+
+    result = _run_orchestrator(
+        "--config", str(ZONAL_PARAMS_CONFIG),
+        "--base_config", str(base_config),
+        "--mode", "merge",
+        "--param", "this_param_does_not_exist",
+    )
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "this_param_does_not_exist" in combined
+    assert "available" in combined.lower() or "Available" in combined


### PR DESCRIPTION
## Summary

Step 4 of the workflow consolidation effort. Folds the Part 2 per-fabric zonal-pass parameter generation (6 Python scripts, 10 SLURM batches, manually-chained dispatch) behind a single orchestrator over one unified config, mirroring the depstor-params pattern from PR #72.

After this lands, generating every Part 2 parameter for a fabric is **one shell invocation**:

\`\`\`bash
FABRIC=gfv2_vpu01 bash slurm_batch/submit_zonal_params.sh     {data_root}/gfv2_vpu01/batches gfv2_vpu01 configs/base_config.yml
\`\`\`

This loops every entry in \`configs/zonal_params.yml\` (10 params today: elevation, slope, aspect, soils, soil_moist_max, 4× LULC, ssflux) and submits per-param array + merge jobs chained via \`afterok\`. ssflux's \`depends_on: build_weights\` prereq is detected automatically: the wrapper submits \`build_zonal_weights.batch\` first and chains the ssflux array on its \`afterok\`. ssflux also chains on the merged slope CSV.

## Three commits

| | |
|---|---|
| \`0596f85\` | Plan doc to \`docs/superpowers/plans/2026-05-17-step4-zonal-consolidation.md\` |
| \`c68f66b\` | Refactor: extract Part 2 work into \`src/gfv2_params/zonal_runners.py\` + slim 6 CLI shells. Adds \`configs/zonal_params.yml\`. **Behaviour preserved verbatim** — the lifted functions are the prior \`main()\` bodies with arg plumbing extracted. |
| \`a1e809a\` | New orchestrator \`scripts/derive_zonal_params.py\`, three new SLURM batches (derive_zonal_params, merge_zonal_param, build_zonal_weights), dispatch wrapper \`submit_zonal_params.sh\`, 8 invariant tests, README + RUNME doc updates. |

## Critical files

| Action | Path |
|---|---|
| Add | \`configs/zonal_params.yml\` |
| Add | \`scripts/derive_zonal_params.py\` |
| Add | \`slurm_batch/derive_zonal_params.batch\`, \`merge_zonal_param.batch\`, \`build_zonal_weights.batch\` |
| Add | \`slurm_batch/submit_zonal_params.sh\` |
| Add | \`src/gfv2_params/zonal_runners.py\` |
| Refactor (delegate to zonal_runners) | \`scripts/create_zonal_params.py\`, \`create_soils_params.py\`, \`create_lulc_params.py\`, \`create_ssflux_params.py\`, \`build_weights.py\`, \`merge_params.py\` |
| Add | \`tests/test_zonal_orchestrator.py\` |
| Modify | \`README.md\`, \`slurm_batch/RUNME.md\` |
| Add | \`docs/superpowers/plans/2026-05-17-step4-zonal-consolidation.md\` |

## Backward compat

Every existing per-param Python script and every per-param SLURM batch continues to work unchanged. They thin to: parse args -> load_config -> call the corresponding \`gfv2_params.zonal_runners.run_*\` function. Same outputs, same paths, just one fewer copy of the work logic.

## Test plan

- [x] py_compile across every touched .py file
- [x] bash -n on the new .batch + .sh files
- [x] CI pytest run (8 new invariant tests in tests/test_zonal_orchestrator.py)
- [ ] VPU01 smoke test: \`FABRIC=gfv2_vpu01 bash slurm_batch/submit_zonal_params.sh ...\` should submit every param's array + merge in one go. Confirm merged CSVs land under \`gfv2_vpu01/params/merged/\`.
- [ ] Byte-for-byte equivalence: run today's per-param flow (e.g., \`submit_jobs.sh ... create_zonal_elev_params.batch ...\`) against gfv2_vpu01 for one param, save merged output; re-run orchestrator path for same param; \`diff\` the merged CSVs (sort by id_feature). Must be identical.
- [ ] Legacy CLI compat: invoke \`scripts/create_zonal_params.py --config configs/elev_param.yml --batch_id 0\` (existing flow) — must still produce the same output.

## LULC naming normalisation

The legacy per-source LULC configs (\`lulc_nalcms_param.yml\`, \`lulc_nlcd_param.yml\`, \`lulc_foresce_param.yml\`) all use \`source_type: lulc\`, so all four LULC sources write per-batch CSVs to the SAME \`{output_dir}/lulc/\` subdir, colliding when run in sequence. Step 4 normalises: the orchestrator passes \`name=lulc_<source>\` into \`run_lulc_batch\` as source_type, giving each LULC source its own per-batch subdir (\`lulc_nhm_v11/\`, \`lulc_nalcms/\`, ...). Merged outputs land at the same canonical names that the legacy CLI produces, so PRMS consumers see no difference.

The legacy \`configs/lulc_*_param.yml\` files stay in place because \`configs/shared_rasters.yml\` also references them as \`sources:\` for the Part 1 \`build_lulc_rasters\` step.

## Followups (out of scope, tracked)

- **Issue #82** — configs/ subdirectory reorg. Deferred until Step 4 settles so the comprehensive reorg can target the settled inventory. \`zonal_params.yml\` becomes \`configs/zonal/zonal_params.yml\` under that restructure.
- **Per-source resource tuning** — \`create_lulc_nalcms_params.batch\` previously hardcoded a 0-63 array. The new dispatch normalises sizing but the underlying resource ask may need per-param adjustment based on NALCMS-grid runtimes. Tune in a follow-up if needed.
- **Stage 8 \`merge_default_params.py\`** — distinct from Part 2 param generation (merges NHM-default values into the generated set). Keep separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)