### PR TITLE
feat(config): make fabric gpkg fully config-driven via profile hru_gpkg (#88)

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,15 +220,22 @@ via (highest precedence first):
 
 **Pre-merged fabric** (single gpkg covering the full domain — e.g., Oregon):
 
-1. Add a profile under `fabrics:` in `configs/base_config.yml`. Required keys
-   are `expected_max_hru_id`, `batch_size`, and `id_feature` (the HRU id column
-   present in the fabric — e.g. `nat_hru_id` for gfv2, `hru_id` for oregon —
-   which flows through to the merged parameter CSVs). If the depstor pipeline will be
-   run, also set `template_raster`, `fdr_raster`, `twi_raster`, `segments_gpkg`,
-   `waterbody_gpkg`, and `waterbody_layer`.
+1. Add a profile under `fabrics:` in `configs/base_config.yml`. **All shared,
+   required fabric inputs live in the profile** — no required path on a CLI arg
+   or inferred from a naming convention. Every fabric needs `expected_max_hru_id`,
+   `batch_size`, `id_feature` (the HRU id column present in the fabric — e.g.
+   `nat_hru_id` for gfv2, `hru_id` for oregon — which flows through to the merged
+   parameter CSVs), and `hru_gpkg`/`hru_layer` (the fabric geopackage + layer,
+   authoritative for `prepare_fabric`, the ssflux `build_weights` step, and
+   gap-fill). If the depstor pipeline will be run, also set `template_raster`,
+   `fdr_raster`, `twi_raster`, `segments_gpkg`/`segments_layer`, and
+   `waterbody_gpkg`/`waterbody_layer` (waterbody is **required** for depstor —
+   the step raises if it is unset). For a single-file fabric, `segments_gpkg`
+   can point at the same gpkg as `hru_gpkg` with `segments_layer: nsegment`.
 2. Scaffold output dirs: `python scripts/init_data_root.py --fabric oregon`
 3. Place the fabric gpkg directly in `{data_root}/oregon/fabric/` (NOT in `input/fabric/`)
-4. Run `prepare_fabric.py --fabric oregon`, then submit Part 2 jobs via
+4. Run `prepare_fabric.py --fabric oregon` (reads `hru_gpkg` from the profile —
+   no `--fabric_gpkg` needed), then submit Part 2 jobs via
    `slurm_batch/submit_zonal_params.sh $BATCHES oregon configs/base_config.yml`
    (loops every entry in `configs/zonal/zonal_params.yml` and chains array
    + merge per param). For Part 1 raster prep, `sbatch slurm_batch/build_shared_rasters.batch`.

--- a/configs/base_config.yml
+++ b/configs/base_config.yml
@@ -61,3 +61,11 @@ fabrics:
     # Oregon's pre-merged fabric uses `hru_id` (contiguous 1..16814, matching
     # expected_max_hru_id) as its HRU id column — it has no `nat_hru_id`.
     id_feature: hru_id
+    # Single-file fabric: one gpkg holds nhru/nsegment/... layers. hru_gpkg is
+    # authoritative for prepare_fabric, the ssflux build_weights step, and
+    # gap-fill (merge_and_fill_params) — no {fabric}_nhru_merged.gpkg naming
+    # convention. When depstor is staged, segments_gpkg can point at this same
+    # file with segments_layer: nsegment; a waterbody source still needs
+    # staging (this gpkg has no waterbody layer).
+    hru_gpkg: "{data_root}/oregon/fabric/model_layers 9.gpkg"
+    hru_layer: nhru

--- a/configs/base_config.yml
+++ b/configs/base_config.yml
@@ -1,9 +1,11 @@
 # Single source of truth for fabric identities and per-fabric inputs.
 # Active fabric resolution: --fabric CLI arg -> FABRIC env var -> default_fabric.
 # Process configs (configs/*.yml) are fabric-agnostic; they pull
-# template_raster, fdr_raster, segments/waterbody gpkg+layer, and id_feature
-# (the HRU id column, which must exist in the fabric and flows through to the
-# final parameter CSVs) from the active profile via load_config().
+# hru_gpkg/hru_layer (the fabric geopackage + layer, authoritative for
+# prepare_fabric, the ssflux build_weights step, and gap-fill), template_raster,
+# fdr_raster, segments/waterbody gpkg+layer, and id_feature (the HRU id column,
+# which must exist in the fabric and flows through to the final parameter CSVs)
+# from the active profile via load_config().
 
 data_root: /caldera/hovenweep/projects/usgs/water/impd/nhgf/gfv2_param_v2
 default_fabric: gfv2

--- a/scripts/derive_zonal_params.py
+++ b/scripts/derive_zonal_params.py
@@ -110,6 +110,12 @@ def _build_param_cfg(config: dict, entry: dict) -> dict:
     # default — pull it from the resolved base config so it flows through to
     # the merged parameter CSVs.
     param_cfg["id_feature"] = require_config_key(config, "id_feature", "derive_zonal_params")
+    # hru_gpkg/hru_layer are also fabric properties (base_config.yml profile).
+    # run_build_weights reads them off param_cfg instead of inferring a
+    # {fabric}_nhru_merged.gpkg path. Required for every fabric (mirrors
+    # id_feature), since the gpkg is also what prepare_fabric batched.
+    param_cfg["hru_gpkg"] = require_config_key(config, "hru_gpkg", "derive_zonal_params")
+    param_cfg["hru_layer"] = config.get("hru_layer", "nhru")
     return param_cfg
 
 
@@ -165,8 +171,7 @@ def run_build_weights_mode(args, logger) -> None:
     entry = weights_consumers[0]
     param_cfg = _build_param_cfg(config, entry)
     logger.info("=== build_weights: param=%s ===", entry["name"])
-    data_root = Path(config["data_root"])
-    run_build_weights(param_cfg, data_root, logger, force=args.force)
+    run_build_weights(param_cfg, logger, force=args.force)
 
 
 def main():

--- a/scripts/merge_and_fill_params.py
+++ b/scripts/merge_and_fill_params.py
@@ -107,9 +107,12 @@ def main():
     expected_max = base["expected_max_hru_id"]
     id_feature = require_config_key(base, "id_feature", "merge_and_fill_params")
 
-    # Resolve defaults from fabric namespace
+    # The merged fabric gpkg is authoritative in the active base_config.yml
+    # profile (hru_gpkg/hru_layer) — read it from there, not a
+    # {fabric}_nhru_merged.gpkg naming convention. --merged_gpkg is an override.
+    hru_layer = base.get("hru_layer", "nhru")
     if args.merged_gpkg is None:
-        args.merged_gpkg = f"{data_root}/{fabric}/fabric/{fabric}_nhru_merged.gpkg"
+        args.merged_gpkg = require_config_key(base, "hru_gpkg", "merge_and_fill_params")
     if args.param_file is None:
         args.param_file = f"{data_root}/{fabric}/params/merged/nhm_ssflux_params.csv"
     if args.output_dir is None:
@@ -132,9 +135,9 @@ def main():
             "Run notebooks/merge_vpu_targets.py or scripts/prepare_fabric.py first."
         )
 
-    logger.info("Loading merged geopackage: %s", merged_gpkg)
+    logger.info("Loading merged geopackage: %s (layer=%s)", merged_gpkg, hru_layer)
     try:
-        merged_gdf = gpd.read_file(merged_gpkg, layer="nhru")
+        merged_gdf = gpd.read_file(merged_gpkg, layer=hru_layer)
     except Exception as exc:
         raise RuntimeError(
             f"Failed to read merged geopackage: {merged_gpkg}\n"

--- a/scripts/merge_and_fill_params.py
+++ b/scripts/merge_and_fill_params.py
@@ -1,7 +1,11 @@
-"""Fill missing parameter values using KNN interpolation against a merged nhru geopackage.
+"""Fill missing parameter values using KNN interpolation against the fabric geopackage.
 
-The merged geopackage is produced by the notebooks/merge_vpu_targets.py notebook
-and serves as input to prepare_fabric.py for batching.
+The fabric geopackage is read from the active base_config.yml profile's
+hru_gpkg/hru_layer (the same gpkg prepare_fabric.py batched) — the single
+source of truth, not a {fabric}_nhru_merged.gpkg naming convention. For
+VPU-based fabrics that gpkg is produced by notebooks/merge_vpu_targets.py; for
+single-file fabrics (e.g. oregon) it is a pre-existing gpkg declared in the
+profile.
 """
 
 import argparse
@@ -131,8 +135,10 @@ def main():
 
     if not merged_gpkg.exists():
         raise FileNotFoundError(
-            f"Merged geopackage not found: {merged_gpkg}\n"
-            "Run notebooks/merge_vpu_targets.py or scripts/prepare_fabric.py first."
+            f"Fabric geopackage not found: {merged_gpkg}\n"
+            "Check the active fabric profile's hru_gpkg in configs/base_config.yml. "
+            "For VPU-based fabrics, run notebooks/merge_vpu_targets.py to produce it; "
+            "for single-file fabrics, place the gpkg at the hru_gpkg path."
         )
 
     logger.info("Loading merged geopackage: %s (layer=%s)", merged_gpkg, hru_layer)

--- a/scripts/prepare_fabric.py
+++ b/scripts/prepare_fabric.py
@@ -17,11 +17,11 @@ from gfv2_params.log import configure_logging
 
 def main():
     parser = argparse.ArgumentParser(description="Prepare fabric for batch processing.")
-    parser.add_argument("--fabric_gpkg", required=True, help="Path to merged fabric geopackage")
+    parser.add_argument("--fabric_gpkg", default=None, help="Path to fabric geopackage (default: active profile's hru_gpkg)")
     parser.add_argument("--base_config", default=None, help="Path to base_config.yml")
     parser.add_argument("--fabric", default=None, help="Fabric name (overrides FABRIC env / default_fabric)")
     parser.add_argument("--batch_size", type=int, default=None, help="Target features per batch (overrides base_config.yml)")
-    parser.add_argument("--layer", default="nhru", help="Layer name in the geopackage (default nhru)")
+    parser.add_argument("--layer", default=None, help="Layer name in the geopackage (default: active profile's hru_layer)")
     args = parser.parse_args()
 
     logger = configure_logging("prepare_fabric")
@@ -34,19 +34,27 @@ def main():
     data_root = base["data_root"]
     fabric = base["fabric"]
 
-    fabric_gpkg = Path(args.fabric_gpkg)
+    # Fabric gpkg + layer come from the active profile's hru_gpkg/hru_layer in
+    # base_config.yml; --fabric_gpkg/--layer are optional overrides. This is the
+    # single source of truth — no {fabric}_nhru_merged.gpkg naming convention.
+    if args.fabric_gpkg:
+        fabric_gpkg = Path(args.fabric_gpkg)
+    else:
+        fabric_gpkg = Path(require_config_key(base, "hru_gpkg", "prepare_fabric"))
+    layer = args.layer if args.layer is not None else base.get("hru_layer", "nhru")
+
     if not fabric_gpkg.exists():
         raise FileNotFoundError(f"Fabric geopackage not found: {fabric_gpkg}")
 
-    logger.info("Reading fabric: %s (layer=%s)", fabric_gpkg, args.layer)
-    gdf = gpd.read_file(fabric_gpkg, layer=args.layer)
+    logger.info("Reading fabric: %s (layer=%s)", fabric_gpkg, layer)
+    gdf = gpd.read_file(fabric_gpkg, layer=layer)
     logger.info("Loaded %d features", len(gdf))
 
     batched = spatial_batch(gdf, batch_size=batch_size)
 
     batch_dir = Path(data_root) / fabric / "batches"
     id_feature = require_config_key(base, "id_feature", "prepare_fabric")
-    manifest = write_batches(batched, batch_dir, fabric, id_feature, batch_size=batch_size, target_layer=args.layer)
+    manifest = write_batches(batched, batch_dir, fabric, id_feature, batch_size=batch_size, target_layer=layer)
 
     n = manifest["n_batches"]
     logger.info("Fabric '%s' prepared: %d features -> %d batches in %s", fabric, len(gdf), n, batch_dir)

--- a/slurm_batch/RUNME.md
+++ b/slurm_batch/RUNME.md
@@ -77,10 +77,14 @@ gfv2_param/
 
 ## Selecting a fabric
 
-Fabric identities and their per-fabric inputs (`template_raster`, `fdr_raster`,
-`waterbody_gpkg`/layer, `expected_max_hru_id`, `batch_size`, `id_feature`) live as profiles
-in a single `configs/base_config.yml` under a `fabrics:` mapping. The active
-profile is selected via:
+Fabric identities and **all shared, required per-fabric inputs** live as profiles
+in a single `configs/base_config.yml` under a `fabrics:` mapping — nothing
+required lives only on a CLI arg or is inferred from a naming convention. Every
+profile carries `hru_gpkg`/`hru_layer` (the fabric geopackage + layer),
+`id_feature`, `expected_max_hru_id`, and `batch_size`; depstor fabrics add
+`template_raster`, `fdr_raster`, `twi_raster`, `segments_gpkg`/`segments_layer`,
+and the required `waterbody_gpkg`/`waterbody_layer`. The active profile is
+selected via:
 
 1. `--fabric <name>` CLI flag on any script, OR
 2. `FABRIC` env var passed through sbatch, OR
@@ -343,13 +347,17 @@ Merge per-VPU fabric geopackages into a single CONUS fabric:
 marimo run notebooks/merge_vpu_targets.py
 ```
 
-Then spatially batch the merged fabric into per-batch geopackages (`batch_size` is read from `base_config.yml`):
+Then spatially batch the merged fabric into per-batch geopackages. The fabric
+gpkg + layer and `batch_size` are read from the active profile in
+`base_config.yml` (`hru_gpkg`/`hru_layer`), so no `--fabric_gpkg` is needed:
 
 ```bash
 python scripts/prepare_fabric.py \
-    --fabric_gpkg {data_root}/gfv2/fabric/gfv2_nhru_merged.gpkg \
+    --fabric gfv2 \
     --base_config configs/base_config.yml
 ```
+
+`--fabric_gpkg`/`--layer` remain as optional overrides for one-off runs.
 
 ### Stage 4: Generate parameters (SLURM array jobs)
 
@@ -461,23 +469,29 @@ already merged or comes as per-VPU gpkgs.
 
 **Case A: Pre-merged fabric** (single gpkg covering the full domain — e.g., Oregon)
 
-1. Add a profile under `fabrics:` in `configs/base_config.yml`. Required keys
-   are `expected_max_hru_id`, `batch_size`, and `id_feature` (the HRU id column
-   present in the fabric — e.g. `nat_hru_id` for gfv2, `hru_id` for oregon —
-   which flows through to the merged parameter CSVs). If the depstor pipeline will be
-   run for this fabric, also set `template_raster`, `fdr_raster`,
-   `segments_gpkg`, `waterbody_gpkg`, and `waterbody_layer`. The `oregon`
-   profile shows the minimum (no depstor inputs yet).
+1. Add a profile under `fabrics:` in `configs/base_config.yml`. **All shared,
+   required fabric inputs live in the profile.** Every fabric needs
+   `expected_max_hru_id`, `batch_size`, `id_feature` (the HRU id column present
+   in the fabric — e.g. `nat_hru_id` for gfv2, `hru_id` for oregon — which flows
+   through to the merged parameter CSVs), and `hru_gpkg`/`hru_layer` (the fabric
+   geopackage + layer, authoritative for `prepare_fabric`, the ssflux
+   `build_weights` step, and gap-fill). If the depstor pipeline will be run for
+   this fabric, also set `template_raster`, `fdr_raster`, `twi_raster`,
+   `segments_gpkg`/`segments_layer`, and `waterbody_gpkg`/`waterbody_layer`
+   (waterbody is **required** for depstor — the step raises if unset). For a
+   single-file fabric like `oregon`, `segments_gpkg` can point at the same gpkg
+   as `hru_gpkg` with `segments_layer: nsegment`; the `oregon` profile shows the
+   zonal-only minimum (depstor inputs, including a waterbody source, not yet
+   staged).
 2. Scaffold the fabric's output directories:
    ```bash
    python scripts/init_data_root.py --fabric oregon
    ```
 3. Place the fabric gpkg directly in `{data_root}/oregon/fabric/` (NOT in `input/fabric/`)
-4. Prepare batches:
+4. Prepare batches (the fabric gpkg + layer come from the profile's
+   `hru_gpkg`/`hru_layer` — no `--fabric_gpkg` needed):
    ```bash
-   python scripts/prepare_fabric.py \
-       --fabric_gpkg {data_root}/oregon/fabric/NHM_OR_draft.gpkg \
-       --fabric oregon
+   python scripts/prepare_fabric.py --fabric oregon
    ```
 5. Submit parameter jobs. Easiest is the unified Part 2 dispatcher (one
    invocation walks every param + chained merges + ssflux's weights prereq):

--- a/src/gfv2_params/zonal_runners.py
+++ b/src/gfv2_params/zonal_runners.py
@@ -515,17 +515,22 @@ def run_ssflux_batch(config: dict, batch_id: int, logger) -> None:
 # CONUS-once worker (ssflux prereq)
 # ---------------------------------------------------------------------------
 
-def run_build_weights(config: dict, data_root: Path, logger, force: bool = False) -> None:
+def run_build_weights(config: dict, logger, force: bool = False) -> None:
     """Pre-compute the CONUS-wide P2P weight matrix that ssflux consumes.
 
     Originally extracted from the now-retired scripts/build_weights.py
     (see PR #85). One CSV per fabric, written
     to ``config['weight_dir']/lith_weights_<fabric>.csv``. Idempotent: skips
     if the file exists unless force=True.
+
+    The target fabric is read from ``config['hru_gpkg']``/``hru_layer`` (the
+    active base_config.yml profile, threaded in via _build_param_cfg) — the
+    single source of truth, not a {fabric}_nhru_merged.gpkg naming convention.
     """
     fabric = config["fabric"]
     id_feature = config["id_feature"]
-    target_layer = config["target_layer"]
+    hru_gpkg = Path(config["hru_gpkg"])
+    hru_layer = config.get("hru_layer", "nhru")
 
     weight_dir = Path(config["weight_dir"])
     weight_dir.mkdir(parents=True, exist_ok=True)
@@ -535,10 +540,9 @@ def run_build_weights(config: dict, data_root: Path, logger, force: bool = False
         logger.info("Weight file already exists: %s (use --force to overwrite)", weight_file)
         return
 
-    fabric_gpkg = data_root / fabric / "fabric" / f"{fabric}_nhru_merged.gpkg"
-    if not fabric_gpkg.exists():
-        raise FileNotFoundError(f"Merged fabric not found: {fabric_gpkg}")
-    target_gdf = gpd.read_file(fabric_gpkg, layer=target_layer)
+    if not hru_gpkg.exists():
+        raise FileNotFoundError(f"HRU fabric gpkg not found: {hru_gpkg}")
+    target_gdf = gpd.read_file(hru_gpkg, layer=hru_layer)
     logger.info("Loaded target fabric: %d features", len(target_gdf))
 
     source_gdf = gpd.read_file(Path(config["source_shapefile"]))

--- a/src/gfv2_params/zonal_runners.py
+++ b/src/gfv2_params/zonal_runners.py
@@ -8,7 +8,8 @@ work logic lives in exactly one place.
 The `config` dict each function receives is a flat mapping containing the
 keys the existing per-param configs already provide (source_type,
 source_raster, batch_dir, target_layer, id_feature, output_dir, merged_file,
-categorical, fabric, plus per-script extras like canopy_raster, crosswalk_file,
+categorical, fabric, the fabric-profile hru_gpkg/hru_layer that run_build_weights
+reads, plus per-script extras like canopy_raster, crosswalk_file,
 keep_raster, source_shapefile, merged_slope_file, weight_dir, k_perm_min,
 flux_params). The orchestrator builds this dict by flattening the active
 param entry in ``configs/zonal/zonal_params.yml`` onto the top-level ``defaults:``

--- a/tests/test_hru_gpkg_config.py
+++ b/tests/test_hru_gpkg_config.py
@@ -1,0 +1,116 @@
+"""The fabric gpkg is config-driven via the active profile's hru_gpkg/hru_layer.
+
+Issue #88: prepare_fabric, the ssflux build_weights step, and gap-fill
+(merge_and_fill_params) must all resolve the fabric geopackage from
+configs/base_config.yml's `hru_gpkg` (read with `hru_layer`) — never from a
+required --fabric_gpkg CLI arg or a {fabric}_nhru_merged.gpkg naming
+convention. These are subprocess invariants (mirroring
+tests/test_zonal_orchestrator.py) so CI runs them without the heavy geo libs
+actually loading a real fabric.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PREPARE_FABRIC = REPO_ROOT / "scripts" / "prepare_fabric.py"
+MERGE_AND_FILL = REPO_ROOT / "scripts" / "merge_and_fill_params.py"
+ZONAL_ORCHESTRATOR = REPO_ROOT / "scripts" / "derive_zonal_params.py"
+ZONAL_PARAMS_CONFIG = REPO_ROOT / "configs" / "zonal" / "zonal_params.yml"
+
+
+def _write_base_config(tmp_path, profile: dict, *, data_root=None) -> Path:
+    """Write a minimal base_config.yml with a single `stub` fabric profile."""
+    base_config = tmp_path / "base_config.yml"
+    base_config.write_text(yaml.safe_dump({
+        "data_root": str(data_root or (tmp_path / "fake_root")),
+        "default_fabric": "stub",
+        "fabrics": {"stub": profile},
+    }))
+    return base_config
+
+
+def _run(script: Path, *args) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(script), *args],
+        capture_output=True,
+        text=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# prepare_fabric: --fabric_gpkg is now an optional override of hru_gpkg
+# ---------------------------------------------------------------------------
+
+def test_prepare_fabric_gpkg_arg_is_optional():
+    """--fabric_gpkg must no longer be a required CLI arg (it defaults to the
+    profile's hru_gpkg)."""
+    result = _run(PREPARE_FABRIC, "--help")
+    assert result.returncode == 0
+    # argparse marks required args in usage with no surrounding brackets;
+    # an optional arg appears as [--fabric_gpkg ...].
+    assert "[--fabric_gpkg" in result.stdout
+
+
+def test_prepare_fabric_requires_hru_gpkg_when_no_override(tmp_path):
+    """No --fabric_gpkg and no profile hru_gpkg -> clear, profile-pointing error."""
+    base_config = _write_base_config(tmp_path, {"id_feature": "hru_id"})
+    result = _run(PREPARE_FABRIC, "--base_config", str(base_config), "--fabric", "stub")
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "hru_gpkg" in combined
+    assert "base_config" in combined
+
+
+def test_prepare_fabric_reads_hru_gpkg_from_profile(tmp_path):
+    """With hru_gpkg set (but the file absent), prepare_fabric resolves it from
+    the profile — proven by the missing-file error naming that exact path."""
+    base_config = _write_base_config(
+        tmp_path,
+        {"id_feature": "hru_id", "hru_gpkg": "{data_root}/from_profile.gpkg", "hru_layer": "nhru"},
+    )
+    result = _run(PREPARE_FABRIC, "--base_config", str(base_config), "--fabric", "stub")
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "Fabric geopackage not found" in combined
+    assert "from_profile.gpkg" in combined
+
+
+# ---------------------------------------------------------------------------
+# merge_and_fill_params: --merged_gpkg defaults to hru_gpkg
+# ---------------------------------------------------------------------------
+
+def test_merge_and_fill_requires_hru_gpkg_when_no_override(tmp_path):
+    """No --merged_gpkg and no profile hru_gpkg -> clear, profile-pointing error
+    (not a {fabric}_nhru_merged.gpkg guess)."""
+    base_config = _write_base_config(
+        tmp_path, {"id_feature": "hru_id", "expected_max_hru_id": 10}
+    )
+    result = _run(MERGE_AND_FILL, "--base_config", str(base_config), "--fabric", "stub")
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "hru_gpkg" in combined
+    assert "base_config" in combined
+
+
+# ---------------------------------------------------------------------------
+# derive_zonal_params build_weights: reads hru_gpkg threaded via _build_param_cfg
+# ---------------------------------------------------------------------------
+
+def test_build_weights_requires_hru_gpkg(tmp_path):
+    """build_weights flows through _build_param_cfg, which now requires hru_gpkg
+    (same pattern as id_feature). A profile missing it fails loudly."""
+    base_config = _write_base_config(tmp_path, {"id_feature": "hru_id"})
+    result = _run(
+        ZONAL_ORCHESTRATOR,
+        "--config", str(ZONAL_PARAMS_CONFIG),
+        "--base_config", str(base_config),
+        "--mode", "build_weights",
+    )
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "hru_gpkg" in combined
+    assert "base_config" in combined

--- a/tests/test_merge_and_fill_params.py
+++ b/tests/test_merge_and_fill_params.py
@@ -68,13 +68,20 @@ class TestFindMissingIds:
 
 
 class TestMergedGpkgPathResolution:
-    def test_default_path_uses_new_filename(self, tmp_path):
-        targets_dir = tmp_path / "targets"
-        targets_dir.mkdir()
-        expected = targets_dir / "gfv2_nhru_merged.gpkg"
-        old_name = targets_dir / "gfv2_merged_simplified.gpkg"
-        assert expected.name == "gfv2_nhru_merged.gpkg"
-        assert expected.name != old_name.name
+    """The merged gpkg default now comes from the active profile's hru_gpkg
+    (configs/base_config.yml), not a {fabric}_nhru_merged.gpkg naming
+    convention. End-to-end resolution + error behavior is covered by
+    tests/test_hru_gpkg_config.py; here we pin the source-of-truth contract."""
+
+    def test_default_is_profile_hru_gpkg_not_convention(self):
+        src = (
+            Path(__file__).resolve().parent.parent
+            / "scripts" / "merge_and_fill_params.py"
+        ).read_text()
+        # The merged gpkg is read from the profile via require_config_key,
+        # never assembled from the retired {fabric}_nhru_merged.gpkg convention.
+        assert 'require_config_key(base, "hru_gpkg"' in src
+        assert "_nhru_merged.gpkg" not in src
 
 
 class TestFileNotFoundBehavior:

--- a/tests/test_merge_and_fill_params.py
+++ b/tests/test_merge_and_fill_params.py
@@ -73,26 +73,31 @@ class TestMergedGpkgPathResolution:
     convention. End-to-end resolution + error behavior is covered by
     tests/test_hru_gpkg_config.py; here we pin the source-of-truth contract."""
 
-    def test_default_is_profile_hru_gpkg_not_convention(self):
+    def test_default_is_profile_hru_gpkg(self):
         src = (
             Path(__file__).resolve().parent.parent
             / "scripts" / "merge_and_fill_params.py"
         ).read_text()
-        # The merged gpkg is read from the profile via require_config_key,
-        # never assembled from the retired {fabric}_nhru_merged.gpkg convention.
+        # The merged gpkg default is sourced from the active profile's hru_gpkg
+        # via require_config_key — not the retired {fabric}_nhru_merged.gpkg
+        # path convention. Assert on code (not a substring scan of the whole
+        # file, which would also match explanatory comments); end-to-end
+        # resolution is covered by tests/test_hru_gpkg_config.py.
         assert 'require_config_key(base, "hru_gpkg"' in src
-        assert "_nhru_merged.gpkg" not in src
+        assert 'f"{data_root}/{fabric}/fabric/{fabric}_nhru_merged.gpkg"' not in src
 
 
 class TestFileNotFoundBehavior:
     def test_raises_when_gpkg_missing(self, tmp_path):
         merged_gpkg = tmp_path / "nonexistent.gpkg"
         assert not merged_gpkg.exists()
-        with pytest.raises(FileNotFoundError, match="prepare_fabric.py"):
+        with pytest.raises(FileNotFoundError, match="base_config.yml"):
             if not merged_gpkg.exists():
                 raise FileNotFoundError(
-                    f"Merged geopackage not found: {merged_gpkg}\n"
-                    "Run notebooks/merge_vpu_targets.py or scripts/prepare_fabric.py first."
+                    f"Fabric geopackage not found: {merged_gpkg}\n"
+                    "Check the active fabric profile's hru_gpkg in configs/base_config.yml. "
+                    "For VPU-based fabrics, run notebooks/merge_vpu_targets.py to produce it; "
+                    "for single-file fabrics, place the gpkg at the hru_gpkg path."
                 )
 
 


### PR DESCRIPTION
Closes #88.

## Problem

The fabric geopackage location was not consistently config-driven, even though the profile already had `hru_gpkg`/`hru_layer`:

- `scripts/prepare_fabric.py` took the gpkg as a **required `--fabric_gpkg` CLI arg** — the location lived only on the command line.
- `run_build_weights` (ssflux prereq) and `merge_and_fill_params.py` (gap-fill) resolved it by the **hardcoded `{fabric}_nhru_merged.gpkg` convention**. This broke Oregon ssflux (`Merged fabric not found: .../oregon/fabric/oregon_nhru_merged.gpkg`) and was **latently wrong for `gfv2_vpu01`** (whose `hru_gpkg` is `gfv2_vpu01_nhru.gpkg`, not `..._nhru_merged.gpkg`).

## Fix

The active profile's `hru_gpkg`/`hru_layer` (`configs/base_config.yml`) is now the single source of truth, read by every consumer — mirroring how `id_feature` was made profile-driven in #87.

- **`base_config.yml`** — added `hru_gpkg`/`hru_layer` to the `oregon` profile (`model_layers 9.gpkg`, layer `nhru`).
- **`prepare_fabric.py`** — `--fabric_gpkg`/`--layer` are now optional overrides, defaulting to the profile via `require_config_key`. `prepare_fabric --fabric oregon` needs no path.
- **`derive_zonal_params._build_param_cfg`** — threads `hru_gpkg`/`hru_layer` (same pattern as `id_feature`); dropped the now-unused `data_root` arg to `run_build_weights`.
- **`zonal_runners.run_build_weights`** — reads `config["hru_gpkg"]`/`hru_layer` instead of the convention.
- **`merge_and_fill_params.py`** — `--merged_gpkg` defaults to `hru_gpkg`, read with `hru_layer` (was a hardcoded `"nhru"`).

A profile missing `hru_gpkg` now fails loudly with a `base_config`-pointing `require_config_key` error. **Fixes the latent `gfv2_vpu01` mismatch and unblocks Oregon ssflux.**

## Decisions

- **Waterbody is required (per the pinned decision on #88).** No code change was needed: the waterbody depstor builder already raises when `waterbody_gpkg`/`waterbody_layer` are unset. Oregon stays zonal-only at its minimum (`hru_gpkg`/`hru_layer` only); a waterbody source must still be staged before Oregon depstor — the required-key error makes that obvious.
- **Kept per-feature `*_gpkg` keys** rather than introducing a unifying `fabric_gpkg` key (evaluated per #88's "food for thought"). The per-feature keys already keep everything declared in the profile; single-file fabrics point `segments_gpkg` at the same path with `segments_layer: nsegment`. A `fabric_gpkg` rename would churn config resolution + migrate gfv2 for marginal gain.

## Behavior note (scope)

`hru_gpkg` is now required by `_build_param_cfg`, so **every** zonal/merge/build_weights invocation requires it in the profile — not just ssflux. This is consistent with #88's "mirror `id_feature`" instruction and the guiding principle (all shared required inputs live in the profile); every fabric reaching the zonal stage already needs `hru_gpkg` for `prepare_fabric`.

## Tests

- New `tests/test_hru_gpkg_config.py` — subprocess invariants for all three consumers: `--fabric_gpkg` is optional, the profile `hru_gpkg` is read, and a missing key fails loudly pointing at `base_config.yml`.
- Updated the stale `TestMergedGpkgPathResolution` in `tests/test_merge_and_fill_params.py` to pin the source-of-truth contract (no `{fabric}_nhru_merged.gpkg` convention).

## Docs

- README + `slurm_batch/RUNME.md` ("Selecting a fabric" / "Adding a new fabric" / Stage 3): all shared required inputs live in `base_config.yml` — `hru_gpkg`/`hru_layer` required for every fabric, `waterbody_gpkg`/`waterbody_layer` (+ `segments_gpkg`/`segments_layer`) required for depstor; `prepare_fabric` examples drop `--fabric_gpkg`; single-file pattern documented.
- Swept `docs/`: `depstor_workflow.md:112`'s reference to `gfv2/fabric/gfv2_nhru_merged.gpkg` is a factual reference to gfv2's actual fabric file (its `hru_gpkg`) and remains accurate — left unchanged. `docs/superpowers/` are point-in-time specs/plans, not touched.

## Verification

Per repo convention the CI suite (`.github/workflows/ci.yml`) is the test gate; no pytest was run on the HPC head node. Local checks:
- `py_compile` clean on all touched scripts + tests; `base_config.yml` valid YAML.
- Inline runs confirmed: missing `hru_gpkg` → clear `KeyError` pointing at `base_config.yml` for prepare_fabric, merge_and_fill_params, and derive_zonal_params build_weights; profile `hru_gpkg` is read (missing-file error names the resolved path); `--fabric_gpkg` optional in `--help`.
- Profile resolution: `gfv2_vpu01` → `gfv2_vpu01_nhru.gpkg` (latent `_merged` mismatch fixed); `oregon` → `model_layers 9.gpkg`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)