### PR TITLE
feat(config): add commented depstor keys to oregon profile + docs (#90)

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,8 +232,11 @@ via (highest precedence first):
    gap-fill). If the depstor pipeline will be run, also uncomment + set
    `template_raster`, `fdr_raster`, `twi_raster`, `segments_gpkg`/`segments_layer`,
    and `waterbody_gpkg`/`waterbody_layer` (waterbody is **required** for depstor —
-   the step raises if it is unset). For a single-file fabric, `segments_gpkg`
-   can point at the same gpkg as `hru_gpkg` with `segments_layer: nsegment`.
+   the step raises if it is unset). The rasters use the CONUS VRTs (depstor clips
+   to the HRU fabric via `land_mask`, so no VPU scoping is needed). For a
+   single-file fabric, `segments_gpkg` can point at the same gpkg as `hru_gpkg`
+   with `segments_layer: nsegment`. The `oregon` profile carries these keys
+   commented out, gated on staging a waterbody source (issue #90).
 2. Place the fabric gpkg at the `hru_gpkg` path you set, under
    `{data_root}/oregon/fabric/` (NOT in `input/fabric/`)
 3. Run `prepare_fabric.py --fabric oregon` (reads `hru_gpkg` from the profile —
@@ -241,11 +244,13 @@ via (highest precedence first):
    `slurm_batch/submit_zonal_params.sh $BATCHES oregon configs/base_config.yml`
    (loops every entry in `configs/zonal/zonal_params.yml` and chains array
    + merge per param). For Part 1 raster prep, `sbatch slurm_batch/build_shared_rasters.batch`.
-   The Part 2 zonal pass reads the CONUS shared rasters from Part 1, so scope
-   Part 1 to the VPUs your fabric overlaps — Oregon HRUs fall in VPU 17, so
+   The Part 2 zonal pass (and depstor) read the CONUS shared rasters from Part 1
+   and clip to the HRU fabric, so scope Part 1 to the VPUs your fabric overlaps —
+   Oregon HRUs fall in VPU 17 (incidental), so
    `VPUS=17 sbatch slurm_batch/build_shared_rasters.batch` avoids rebuilding all
    of CONUS for a regional test. Stage 2d depstor is unavailable for `oregon`
-   until its depstor inputs + profile keys are staged.
+   until its depstor inputs + profile keys are staged (gated on a waterbody
+   source — issue #90).
 
 **VPU-based fabric** (per-VPU gpkgs that need merging — e.g., gfv2):
 

--- a/configs/base_config.yml
+++ b/configs/base_config.yml
@@ -71,3 +71,24 @@ fabrics:
     # staging (this gpkg has no waterbody layer).
     hru_gpkg: "{data_root}/oregon/fabric/model_layers 9.gpkg"
     hru_layer: nhru
+    # --- depstor inputs (COMMENTED; oregon stays zonal-only until staged) ---
+    # Tracked in issue #90. Do NOT uncomment until the waterbody source below
+    # is staged: the waterbody builder raises if waterbody_gpkg/waterbody_layer
+    # are unset (#88 decision).
+    #
+    # Rasters use the CONUS VRTs, exactly like the gfv2 profile: depstor clips
+    # every output to the HRU fabric via land_mask.tif (rasterised from
+    # hru_gpkg), so the rasters only need to *cover* the Oregon domain — no VPU
+    # scoping required. Oregon's HRUs happen to fall in VPU 17 and per-VPU Part 1
+    # tiles exist (shared/per_vpu/17/*_merged_17.tif), but using them is only a
+    # Part 1 compute-scoping optimization, not part of this fabric's identity.
+    # template_raster: "{data_root}/shared/conus/vrt/elevation.vrt"
+    # fdr_raster:      "{data_root}/shared/conus/vrt/fdr.vrt"
+    # twi_raster:      "{data_root}/shared/conus/vrt/twi.vrt"
+    # segments_gpkg:   "{data_root}/oregon/fabric/model_layers 9.gpkg"  # nsegment layer exists
+    # segments_layer:  nsegment
+    # BLOCKER (#90): the Oregon gpkg has no waterbody layer (layers are
+    # domain/main/nhru/npoi/npoigages/nsegment). A real waterbody source must be
+    # staged (NHDPlusV2 v2_wb-style, like gfv2) before depstor can run.
+    # waterbody_gpkg:  "{data_root}/input/depstor/oregon_waterbodies.gpkg"
+    # waterbody_layer: <layer-name>   # set once the waterbody source is staged

--- a/slurm_batch/RUNME.md
+++ b/slurm_batch/RUNME.md
@@ -496,10 +496,13 @@ already merged or comes as per-VPU gpkgs.
    `segments_gpkg`/`segments_layer`, and `waterbody_gpkg`/`waterbody_layer`
    (waterbody is **required** for depstor — the step raises if unset). For a
    single-file fabric like `oregon`, `segments_gpkg` can point at the same gpkg
-   as `hru_gpkg` with `segments_layer: nsegment`; the `oregon` profile shows the
-   zonal-only minimum (depstor inputs, including a waterbody source, not yet
-   staged). (Prefer hand-editing? Just add the profile block directly — the
-   stub is only a convenience.)
+   as `hru_gpkg` with `segments_layer: nsegment`. The `oregon` profile now
+   carries the depstor keys **commented out** — CONUS VRTs for the rasters (like
+   `gfv2`) and `segments_gpkg` pointing at the model gpkg — with the waterbody
+   source called out as the staging blocker (issue #90: the Oregon gpkg has no
+   waterbody layer). It stays zonal-only until that source is staged. (Prefer
+   hand-editing? Just add the profile block directly — the stub is only a
+   convenience.)
 2. Place the fabric gpkg at the `hru_gpkg` path you set, under
    `{data_root}/oregon/fabric/` (NOT in `input/fabric/`)
 3. Prepare batches (the fabric gpkg + layer come from the profile's
@@ -517,14 +520,17 @@ already merged or comes as per-VPU gpkgs.
    `--mode zonal --param <name> --batch_id <N>` (see "Single-batch run"
    in README.md or Stage 4 above).
 
-> **Scoping a regional test (e.g. Oregon = VPU 17):** the Part 2 zonal pass
-> reads the CONUS shared rasters from Part 1, so those VRTs must cover the
-> region your fabric overlaps. Oregon HRUs fall in VPU 17, so you can build
-> Part 1 for just that VPU rather than all of CONUS — pass `VPUS=17` to
-> `sbatch slurm_batch/build_shared_rasters.batch` (or `--vpus 17` to the
-> orchestrator). Stage 2d depstor is intentionally unavailable for `oregon`
-> until its depstor inputs + profile keys are staged; the zonal pass above
-> runs without them.
+> **Scoping a regional test (e.g. Oregon, whose HRUs fall in VPU 17):** the
+> Part 2 zonal pass — and depstor (Stage 2d) — read the **CONUS** shared rasters
+> from Part 1 and clip to the HRU fabric, so those VRTs only need to *cover* the
+> region your fabric overlaps. VPU 17 is incidental here: Oregon's HRUs happen
+> to fall in it, so you can build Part 1 for just that VPU rather than all of
+> CONUS (pass `VPUS=17` to `sbatch slurm_batch/build_shared_rasters.batch`, or
+> `--vpus 17` to the orchestrator) — but the fabric configs still point at the
+> CONUS VRTs, not per-VPU tiles. Stage 2d depstor is intentionally unavailable
+> for `oregon` until its depstor inputs + profile keys are staged (the commented
+> keys in the profile, gated on a waterbody source — issue #90); the zonal pass
+> above runs without them.
 
 **Case B: VPU-based fabric** (per-VPU gpkgs that need merging — e.g., gfv2)
 


### PR DESCRIPTION
Closes #90.

First deliverable for standing up the depstor pipeline on the `oregon` fabric.
Adds the depstor profile keys to `oregon` **commented out** — oregon stays
**zonal-only** — and reconciles the docs.

## What changed

- **`configs/base_config.yml`** — commented depstor block in the `oregon`
  profile: `template_raster`/`fdr_raster`/`twi_raster` point at the **CONUS
  VRTs** (like `gfv2`; depstor clips to the HRU fabric via `land_mask`, so no
  VPU scoping is needed), `segments_gpkg` at the model gpkg's `nsegment` layer,
  and `waterbody_gpkg`/`waterbody_layer` left as a TODO with the blocker named.
- **`README.md`, `slurm_batch/RUNME.md`** — CONUS-VRT framing for oregon
  depstor; clarify that **VPU 17 is incidental** (a Part-1 compute-scoping
  option, not a depstor requirement); name the waterbody blocker.

## Blocker (the only real gate)

The Oregon gpkg (`model_layers 9.gpkg`) has no waterbody layer
(domain/main/nhru/npoi/npoigages/nsegment) and the waterbody builder raises if
`waterbody_gpkg`/`waterbody_layer` are unset (#88 decision). A real waterbody
source must be staged before depstor can run — that's the follow-up work.

## Verification

- `--fabric oregon` still resolves **zonal-only**: all depstor keys absent from
  the merged config.
- The depstor require-key path still raises the clean
  `"...missing... Expected from fabric profile 'oregon'..."` error.
- No source code changed (config + docs only) — **no scope expansion**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
