### PR TITLE
feat(depstor): fabric-bounds clip step + activate oregon depstor + fix gfv2 template lattice (#92)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ gfv2-params/
 │   ├── prepare_fabric.py             # Spatially batch fabric into per-batch gpkgs
 │   ├── migrate_to_shared_layout.py   # One-shot: legacy work/ → shared/ on-disk migration
 │   ├── build_shared_rasters.py       # Part 1 orchestrator (CONUS shared raster prep)
+│   ├── clip_shared_to_fabric.py      # Stage a fabric-bounds FDR clip → depstor template/fdr
 │   ├── build_depstor_rasters.py      # Part 2a depstor raster stack (10 steps)
 │   ├── derive_depstor_params.py      # Part 2a depstor params (zonal/merge/ratios)
 │   ├── derive_zonal_params.py        # Part 2b zonal-pass orchestrator (zonal/merge/build_weights)
@@ -229,14 +230,23 @@ via (highest precedence first):
    for gfv2, `hru_id` for oregon — which flows through to the merged parameter
    CSVs), and `hru_gpkg`/`hru_layer` (the fabric geopackage + layer,
    authoritative for `prepare_fabric`, the ssflux `build_weights` step, and
-   gap-fill). If the depstor pipeline will be run, also uncomment + set
-   `template_raster`, `fdr_raster`, `twi_raster`, `segments_gpkg`/`segments_layer`,
-   and `waterbody_gpkg`/`waterbody_layer` (waterbody is **required** for depstor —
-   the step raises if it is unset). The rasters use the CONUS VRTs (depstor clips
-   to the HRU fabric via `land_mask`, so no VPU scoping is needed). For a
-   single-file fabric, `segments_gpkg` can point at the same gpkg as `hru_gpkg`
-   with `segments_layer: nsegment`. The `oregon` profile carries these keys
-   commented out, gated on staging a waterbody source (issue #90).
+   gap-fill). If the depstor pipeline will be run, also set `template_raster`,
+   `fdr_raster`, `twi_raster`, `segments_gpkg`/`segments_layer`, and
+   `waterbody_gpkg`/`waterbody_layer` (waterbody is **required** for depstor —
+   the step raises if it is unset). For `template_raster`/`fdr_raster`, stage a
+   fabric-bounds clip of the CONUS FDR with
+   `pixi run --as-is python scripts/clip_shared_to_fabric.py --fabric <name>`
+   (writes `{data_root}/<name>/shared/<name>_fdr.vrt`) and point both keys at it.
+   Every depstor builder sizes its arrays to the `template_raster` grid, so the
+   clip scopes compute to the fabric extent while staying VPU-agnostic (works for
+   fabrics that straddle VPU boundaries). The clip comes from `fdr.vrt` — the
+   hydrology lattice `carea_map` requires the template to share with `twi.vrt`
+   (`elevation.vrt` is on the offset DEM lattice and is rejected). `twi_raster`
+   uses the CONUS `twi.vrt` (warp-windowed onto the template). For a single-file
+   fabric, `segments_gpkg` can point at the same gpkg as `hru_gpkg` with
+   `segments_layer: nsegment`. The `oregon` profile has these keys active
+   (issue #90), using the CONUS NHDPlusV2 waterbodies at
+   `input/nhd/conus_waterbodies.gpkg` (layer `waterbodies`).
 2. Place the fabric gpkg at the `hru_gpkg` path you set, under
    `{data_root}/oregon/fabric/` (NOT in `input/fabric/`)
 3. Run `prepare_fabric.py --fabric oregon` (reads `hru_gpkg` from the profile —
@@ -244,13 +254,12 @@ via (highest precedence first):
    `slurm_batch/submit_zonal_params.sh $BATCHES oregon configs/base_config.yml`
    (loops every entry in `configs/zonal/zonal_params.yml` and chains array
    + merge per param). For Part 1 raster prep, `sbatch slurm_batch/build_shared_rasters.batch`.
-   The Part 2 zonal pass (and depstor) read the CONUS shared rasters from Part 1
-   and clip to the HRU fabric, so scope Part 1 to the VPUs your fabric overlaps —
-   Oregon HRUs fall in VPU 17 (incidental), so
-   `VPUS=17 sbatch slurm_batch/build_shared_rasters.batch` avoids rebuilding all
-   of CONUS for a regional test. Stage 2d depstor is unavailable for `oregon`
-   until its depstor inputs + profile keys are staged (gated on a waterbody
-   source — issue #90).
+   The Part 2 zonal pass (and depstor) read the CONUS shared rasters from Part 1,
+   so scope Part 1 to the VPUs your fabric overlaps — Oregon HRUs fall in VPU 17
+   (incidental), so `VPUS=17 sbatch slurm_batch/build_shared_rasters.batch`
+   avoids rebuilding all of CONUS for a regional test. Stage 2d depstor is
+   **active** for `oregon` (issue #90); after staging the FDR clip (step 1),
+   run `FABRIC=oregon sbatch slurm_batch/build_depstor_rasters.batch`.
 
 **VPU-based fabric** (per-VPU gpkgs that need merging — e.g., gfv2):
 

--- a/README.md
+++ b/README.md
@@ -246,7 +246,10 @@ via (highest precedence first):
    fabric, `segments_gpkg` can point at the same gpkg as `hru_gpkg` with
    `segments_layer: nsegment`. The `oregon` profile has these keys active
    (issue #90), using the CONUS NHDPlusV2 waterbodies at
-   `input/nhd/conus_waterbodies.gpkg` (layer `waterbodies`).
+   `input/nhd/conus_waterbodies.gpkg` (layer `waterbodies`). Caveat: `twi.vrt`
+   only carries ArcPy TWI for VPU 01 (issue #94), so for any other fabric Stage 2d
+   builds the raster stack and the non-TWI params correctly, but `carea_max`/
+   `smidx_coef` are degenerate until that gap is resolved.
 2. Place the fabric gpkg at the `hru_gpkg` path you set, under
    `{data_root}/oregon/fabric/` (NOT in `input/fabric/`)
 3. Run `prepare_fabric.py --fabric oregon` (reads `hru_gpkg` from the profile —
@@ -259,7 +262,8 @@ via (highest precedence first):
    (incidental), so `VPUS=17 sbatch slurm_batch/build_shared_rasters.batch`
    avoids rebuilding all of CONUS for a regional test. Stage 2d depstor is
    **active** for `oregon` (issue #90); after staging the FDR clip (step 1),
-   run `FABRIC=oregon sbatch slurm_batch/build_depstor_rasters.batch`.
+   run `FABRIC=oregon sbatch slurm_batch/build_depstor_rasters.batch`. (As above,
+   the TWI-derived `carea_max`/`smidx_coef` await issue #94; the rest is valid.)
 
 **VPU-based fabric** (per-VPU gpkgs that need merging — e.g., gfv2):
 

--- a/configs/base_config.yml
+++ b/configs/base_config.yml
@@ -14,12 +14,19 @@ fabrics:
   gfv2:
     expected_max_hru_id: 361471
     batch_size: 10000
-    template_raster: "{data_root}/shared/conus/vrt/elevation.vrt"
-    # FDR is CONUS hydrology, not fabric-specific. Use the shared open-source
-    # VRT assembled by build_vrt.py from per-VPU Fdr_merged_*.tif. (Contrast
-    # with twi_raster, where the ArcPy `Twi_merged_*` source is preferred over
-    # the open-source `Twi_hydrodem_*` for PRMS calibration thresholds.)
-    fdr_raster: "{data_root}/shared/conus/vrt/fdr.vrt"
+    # template_raster + fdr_raster point at a fabric-bounds clip of the CONUS
+    # fdr.vrt (here ~CONUS, since gfv2 is CONUS), staged by
+    # scripts/clip_shared_to_fabric.py. The template MUST share the hydrology
+    # (Lattice-B) grid with twi.vrt — carea_map rejects a template that is not
+    # whole-cell aligned with TWI. The former elevation.vrt template is on the
+    # DEM lattice (a fractional-cell offset from twi.vrt) and would fail that
+    # check at CONUS scale. The clip is also the FDR source (open-source CONUS
+    # FDR, the same data the VRT mosaics — not a per-fabric ArcPy FDR).
+    # Run: pixi run --as-is python scripts/clip_shared_to_fabric.py --fabric gfv2
+    template_raster: "{data_root}/gfv2/shared/gfv2_fdr.vrt"
+    fdr_raster: "{data_root}/gfv2/shared/gfv2_fdr.vrt"
+    # NOTE: twi.vrt does not cover gfv2's northernmost HRUs (a TWI data-coverage
+    # gap, tracked separately from the template-lattice fix above).
     twi_raster: "{data_root}/shared/conus/vrt/twi.vrt"
     segments_gpkg: "{data_root}/input/depstor/{fabric}_segments_wbodies.gpkg"
     waterbody_gpkg: "{data_root}/input/depstor/{fabric}_segments_wbodies.gpkg"
@@ -55,9 +62,6 @@ fabrics:
     id_feature: nat_hru_id
 
   oregon:
-    # Depstor inputs not yet staged for oregon. Depstor scripts will raise
-    # a clear "fabric profile 'oregon' missing 'template_raster'" error if
-    # invoked with --fabric oregon until the inputs are wired up.
     expected_max_hru_id: 16814
     batch_size: 10000
     # Oregon's pre-merged fabric uses `hru_id` (contiguous 1..16814, matching
@@ -66,29 +70,29 @@ fabrics:
     # Single-file fabric: one gpkg holds nhru/nsegment/... layers. hru_gpkg is
     # authoritative for prepare_fabric, the ssflux build_weights step, and
     # gap-fill (merge_and_fill_params) — no {fabric}_nhru_merged.gpkg naming
-    # convention. When depstor is staged, segments_gpkg can point at this same
-    # file with segments_layer: nsegment; a waterbody source still needs
-    # staging (this gpkg has no waterbody layer).
+    # convention. segments_gpkg points at this same file (segments_layer:
+    # nsegment).
     hru_gpkg: "{data_root}/oregon/fabric/model_layers 9.gpkg"
     hru_layer: nhru
-    # --- depstor inputs (COMMENTED; oregon stays zonal-only until staged) ---
-    # Tracked in issue #90. Do NOT uncomment until the waterbody source below
-    # is staged: the waterbody builder raises if waterbody_gpkg/waterbody_layer
-    # are unset (#88 decision).
-    #
-    # Rasters use the CONUS VRTs, exactly like the gfv2 profile: depstor clips
-    # every output to the HRU fabric via land_mask.tif (rasterised from
-    # hru_gpkg), so the rasters only need to *cover* the Oregon domain — no VPU
-    # scoping required. Oregon's HRUs happen to fall in VPU 17 and per-VPU Part 1
-    # tiles exist (shared/per_vpu/17/*_merged_17.tif), but using them is only a
-    # Part 1 compute-scoping optimization, not part of this fabric's identity.
-    # template_raster: "{data_root}/shared/conus/vrt/elevation.vrt"
-    # fdr_raster:      "{data_root}/shared/conus/vrt/fdr.vrt"
-    # twi_raster:      "{data_root}/shared/conus/vrt/twi.vrt"
-    # segments_gpkg:   "{data_root}/oregon/fabric/model_layers 9.gpkg"  # nsegment layer exists
-    # segments_layer:  nsegment
-    # BLOCKER (#90): the Oregon gpkg has no waterbody layer (layers are
-    # domain/main/nhru/npoi/npoigages/nsegment). A real waterbody source must be
-    # staged (NHDPlusV2 v2_wb-style, like gfv2) before depstor can run.
-    # waterbody_gpkg:  "{data_root}/input/depstor/oregon_waterbodies.gpkg"
-    # waterbody_layer: <layer-name>   # set once the waterbody source is staged
+    # --- depstor inputs (active; see issue #90) ---
+    # template_raster + fdr_raster both point at a fabric-bounds clip of the
+    # CONUS fdr.vrt, staged by scripts/clip_shared_to_fabric.py. Every depstor
+    # builder sizes its arrays to the template grid, so clipping scopes compute
+    # to the fabric extent (~0.56B cells here vs ~15B CONUS) while staying
+    # VPU-agnostic (works for fabrics that straddle VPU boundaries). The clip
+    # comes from fdr.vrt — the hydrology (Lattice-B) grid that carea_map requires
+    # the template to share with twi.vrt; elevation.vrt is on a different lattice.
+    # The same VRT serves as fdr_raster: routing's whole-source reproject_match
+    # then reads only the fabric window, not the full ~18 GB CONUS FDR.
+    # Run: pixi run --as-is python scripts/clip_shared_to_fabric.py --fabric oregon
+    template_raster: "{data_root}/oregon/shared/oregon_fdr.vrt"
+    fdr_raster: "{data_root}/oregon/shared/oregon_fdr.vrt"
+    # TWI: carea_map WarpedVRT-windows the source onto the template grid, so the
+    # CONUS twi.vrt is read lazily and fully covers the Oregon fabric.
+    twi_raster: "{data_root}/shared/conus/vrt/twi.vrt"
+    segments_gpkg: "{data_root}/oregon/fabric/model_layers 9.gpkg"
+    segments_layer: nsegment
+    # CONUS NHDPlusV2 waterbodies (POLYGON, EPSG:5070); the waterbody builder
+    # reprojects to the template grid and clips to the Oregon land mask.
+    waterbody_gpkg: "{data_root}/input/nhd/conus_waterbodies.gpkg"
+    waterbody_layer: waterbodies

--- a/configs/base_config.yml
+++ b/configs/base_config.yml
@@ -87,8 +87,12 @@ fabrics:
     # Run: pixi run --as-is python scripts/clip_shared_to_fabric.py --fabric oregon
     template_raster: "{data_root}/oregon/shared/oregon_fdr.vrt"
     fdr_raster: "{data_root}/oregon/shared/oregon_fdr.vrt"
-    # TWI: carea_map WarpedVRT-windows the source onto the template grid, so the
-    # CONUS twi.vrt is read lazily and fully covers the Oregon fabric.
+    # TWI: carea_map WarpedVRT-windows the CONUS twi.vrt onto the template grid
+    # (its footprint covers the Oregon extent). ⚠️ But twi.vrt currently carries
+    # ArcPy TWI for VPU 01 ONLY (issue #94) — over Oregon (VPU 17) every TWI cell
+    # is nodata, so carea_max/smidx_coef come out degenerate. Stage 2d still
+    # builds the full raster stack and the non-TWI params correctly; do not treat
+    # carea_max/smidx_coef as valid here until #94 is resolved.
     twi_raster: "{data_root}/shared/conus/vrt/twi.vrt"
     segments_gpkg: "{data_root}/oregon/fabric/model_layers 9.gpkg"
     segments_layer: nsegment

--- a/scripts/clip_shared_to_fabric.py
+++ b/scripts/clip_shared_to_fabric.py
@@ -52,6 +52,14 @@ def _snap_bounds_to_grid(bounds, transform, buffer_cells: int):
     py = transform.e          # -cellsize
     ox = transform.c          # left edge of column 0
     oy = transform.f          # top edge of row 0
+    # The floor/ceil snapping below is only correct for an axis-aligned, north-up
+    # raster. Fail loudly on a rotated/flipped --source rather than emitting a
+    # silently-wrong window.
+    if transform.b != 0 or transform.d != 0 or px <= 0 or py >= 0:
+        raise ValueError(
+            f"Source raster is not axis-aligned north-up (a={px}, e={py}, "
+            f"b={transform.b}, d={transform.d}); _snap_bounds_to_grid assumes it."
+        )
     cell_x = abs(px)
     cell_y = abs(py)
 
@@ -123,7 +131,15 @@ def main() -> int:
         src_bounds = src.bounds
 
     hru = gpd.read_file(hru_gpkg, layer=hru_layer)
+    n_all = len(hru)
     hru = hru[hru.geometry.notna() & ~hru.geometry.is_empty]
+    if len(hru) == 0:
+        raise ValueError(
+            f"HRU layer '{hru_layer}' in {hru_gpkg} has no valid geometries "
+            f"(read {n_all} rows; all null/empty). Check the hru_layer name."
+        )
+    if len(hru) < n_all:
+        logger.info("  Dropped %d null/empty HRU geometries (%d remain)", n_all - len(hru), len(hru))
     if hru.crs != src_crs:
         logger.info("  Reprojecting HRU bounds from %s to source CRS %s", hru.crs, src_crs)
         hru = hru.to_crs(src_crs)
@@ -149,7 +165,13 @@ def main() -> int:
     )
 
     output.parent.mkdir(parents=True, exist_ok=True)
-    gdal.Translate(str(output), str(source), projWin=[ulx, uly, lrx, lry], format="VRT")
+    # gdal.UseExceptions() makes error-level GDAL failures raise, but some failure
+    # modes return a None dataset without raising — check explicitly so a botched
+    # clip can't leave a stale/missing VRT that the self-checks then read.
+    ds = gdal.Translate(str(output), str(source), projWin=[ulx, uly, lrx, lry], format="VRT")
+    if ds is None:
+        raise RuntimeError(f"gdal.Translate produced no dataset for {output} — clip failed.")
+    ds = None  # close/flush
 
     # Self-checks: clip covers the fabric and is whole-cell aligned with twi.vrt.
     with rasterio.open(output) as clip:
@@ -169,6 +191,12 @@ def main() -> int:
                     "Clip is not whole-cell aligned with twi.vrt; carea_map would "
                     "reject it. Is the source on the hydrology (fdr/twi) lattice?"
                 )
+        else:
+            logger.warning(
+                "  twi.vrt not found at %s — SKIPPED the whole-cell alignment check. "
+                "Clip lattice is UNVERIFIED; if the source is not on the hydrology "
+                "(fdr/twi) lattice, carea_map will reject the template downstream.", twi,
+            )
     logger.info("  Wrote fabric-scoped VRT: %s (%dx%d)", output, width, height)
     logger.info("  Point the profile's template_raster AND fdr_raster at this file.")
     return 0

--- a/scripts/clip_shared_to_fabric.py
+++ b/scripts/clip_shared_to_fabric.py
@@ -1,0 +1,178 @@
+"""Clip a shared CONUS raster to a fabric's bounds as a zero-copy VRT.
+
+Depression-storage builders size every array to the *template* grid and warp
+each source raster onto it, so the template choice controls compute extent.
+A CONUS template forces CONUS-scale memory/time even for a regional fabric;
+a per-VPU tile is cheap but does not generalise to fabrics that straddle VPU
+boundaries. This script produces a fabric-scoped template by clipping a shared
+CONUS raster to the fabric's HRU bounds (snapped outward to the source grid,
+plus a cell buffer for `all_touched` edge HRUs).
+
+Why clip `fdr.vrt` specifically (the default source):
+  - The shared CONUS VRTs sit on two lattices: the DEM family (elevation,
+    slope, aspect) is offset by a fractional cell from the hydrology family
+    (fdr, twi). `carea_map` hard-requires the template and TWI to be
+    whole-cell aligned, so the template must come from the hydrology lattice.
+  - Of the hydrology rasters, `fdr.vrt` has the larger extent and covers every
+    current fabric (gfv2, oregon); `twi.vrt` does not (it misses gfv2's
+    northern HRUs). So `fdr.vrt` is the universal Lattice-B template source.
+
+The output VRT serves as BOTH `template_raster` (grid only — pixel values are
+never read) and `fdr_raster` (D8 values, read by the routing step). Because it
+is a windowed VRT, `routing`'s whole-source `reproject_match` reads only the
+fabric window rather than the full ~18 GB CONUS FDR.
+
+Usage:
+  pixi run --as-is python scripts/clip_shared_to_fabric.py --fabric oregon
+"""
+
+import argparse
+import math
+from pathlib import Path
+
+import geopandas as gpd
+import rasterio
+from osgeo import gdal
+
+from gfv2_params.config import load_base_config, require_config_key
+from gfv2_params.log import configure_logging
+
+gdal.UseExceptions()
+
+
+def _snap_bounds_to_grid(bounds, transform, buffer_cells: int):
+    """Expand HRU bounds by `buffer_cells` then snap OUTWARD to the source grid.
+
+    Returns (ulx, uly, lrx, lry) on the source pixel lattice, guaranteed to
+    fully contain the (buffered) input bounds. Works for a north-up raster
+    (transform.a > 0, transform.e < 0).
+    """
+    minx, miny, maxx, maxy = bounds
+    px = transform.a          # +cellsize
+    py = transform.e          # -cellsize
+    ox = transform.c          # left edge of column 0
+    oy = transform.f          # top edge of row 0
+    cell_x = abs(px)
+    cell_y = abs(py)
+
+    minx -= buffer_cells * cell_x
+    maxx += buffer_cells * cell_x
+    miny -= buffer_cells * cell_y
+    maxy += buffer_cells * cell_y
+
+    c_left = math.floor((minx - ox) / cell_x)
+    c_right = math.ceil((maxx - ox) / cell_x)
+    r_top = math.floor((oy - maxy) / cell_y)
+    r_bot = math.ceil((oy - miny) / cell_y)
+
+    ulx = ox + c_left * cell_x
+    lrx = ox + c_right * cell_x
+    uly = oy - r_top * cell_y
+    lry = oy - r_bot * cell_y
+    return ulx, uly, lrx, lry
+
+
+def _whole_cell_offset(t_a, ref_transform):
+    """Fractional-cell offset of transform origin vs a reference lattice."""
+    col = (t_a.c - ref_transform.c) / ref_transform.a
+    row = (t_a.f - ref_transform.f) / ref_transform.e
+    return col - round(col), row - round(row)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--fabric", required=True, help="Active fabric name (profile in base_config.yml).")
+    parser.add_argument("--base_config", default=None, help="Path to base_config.yml (default: packaged configs/base_config.yml).")
+    parser.add_argument("--source", default=None,
+                        help="Shared raster to clip (default: {data_root}/shared/conus/vrt/fdr.vrt).")
+    parser.add_argument("--output", default=None,
+                        help="Output VRT path (default: {data_root}/{fabric}/shared/{fabric}_fdr.vrt).")
+    parser.add_argument("--buffer-cells", type=int, default=8,
+                        help="Cells of margin added around the HRU bounds before snapping (default: 8).")
+    parser.add_argument("--force", action="store_true", help="Overwrite the output VRT if it exists.")
+    args = parser.parse_args()
+
+    logger = configure_logging("clip_shared_to_fabric")
+    base_config = Path(args.base_config) if args.base_config else None
+    config = load_base_config(base_config, fabric=args.fabric)
+
+    data_root = config["data_root"]
+    fabric = config["fabric"]
+    source = Path(args.source) if args.source else Path(data_root) / "shared" / "conus" / "vrt" / "fdr.vrt"
+    output = Path(args.output) if args.output else Path(data_root) / fabric / "shared" / f"{fabric}_fdr.vrt"
+    hru_gpkg = Path(require_config_key(config, "hru_gpkg", "clip_shared_to_fabric"))
+    hru_layer = require_config_key(config, "hru_layer", "clip_shared_to_fabric")
+
+    logger.info("--- clip_shared_to_fabric ---")
+    logger.info("  Fabric : %s", fabric)
+    logger.info("  Source : %s", source)
+    logger.info("  HRU    : %s (layer=%s)", hru_gpkg, hru_layer)
+    logger.info("  Output : %s", output)
+
+    if not source.exists():
+        raise FileNotFoundError(f"Source raster not found: {source}")
+    if not hru_gpkg.exists():
+        raise FileNotFoundError(f"HRU fabric gpkg not found: {hru_gpkg}")
+    if output.exists() and not args.force:
+        logger.info("  Output exists — skipping (pass --force to rebuild)")
+        return 0
+
+    with rasterio.open(source) as src:
+        src_transform = src.transform
+        src_crs = src.crs
+        src_bounds = src.bounds
+
+    hru = gpd.read_file(hru_gpkg, layer=hru_layer)
+    hru = hru[hru.geometry.notna() & ~hru.geometry.is_empty]
+    if hru.crs != src_crs:
+        logger.info("  Reprojecting HRU bounds from %s to source CRS %s", hru.crs, src_crs)
+        hru = hru.to_crs(src_crs)
+    hb = tuple(hru.total_bounds)
+    logger.info("  HRU bounds (source CRS): %s", [round(x) for x in hb])
+
+    # Fail loudly if the fabric falls outside the source extent — a clip cannot
+    # recover data the source does not have.
+    if not (hb[0] >= src_bounds.left and hb[1] >= src_bounds.bottom
+            and hb[2] <= src_bounds.right and hb[3] <= src_bounds.top):
+        raise ValueError(
+            f"Fabric '{fabric}' bounds {[round(x) for x in hb]} are not fully "
+            f"inside the source raster extent {[round(x) for x in src_bounds]}. "
+            f"Pick a source raster that covers the fabric."
+        )
+
+    ulx, uly, lrx, lry = _snap_bounds_to_grid(hb, src_transform, args.buffer_cells)
+    width = int(round((lrx - ulx) / abs(src_transform.a)))
+    height = int(round((uly - lry) / abs(src_transform.e)))
+    logger.info(
+        "  Clip window: ul=(%.0f, %.0f) lr=(%.0f, %.0f) -> %dx%d cells (%.3fB)",
+        ulx, uly, lrx, lry, width, height, width * height / 1e9,
+    )
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    gdal.Translate(str(output), str(source), projWin=[ulx, uly, lrx, lry], format="VRT")
+
+    # Self-checks: clip covers the fabric and is whole-cell aligned with twi.vrt.
+    with rasterio.open(output) as clip:
+        cb = clip.bounds
+        covers = (hb[0] >= cb.left and hb[1] >= cb.bottom and hb[2] <= cb.right and hb[3] <= cb.top)
+        if not covers:
+            raise RuntimeError(f"Clip {[round(x) for x in cb]} does not cover HRU bounds — snapping bug.")
+        twi = Path(data_root) / "shared" / "conus" / "vrt" / "twi.vrt"
+        if twi.exists():
+            with rasterio.open(twi) as t:
+                col_frac, row_frac = _whole_cell_offset(clip.transform, t.transform)
+            aligned = abs(col_frac) < 1e-6 and abs(row_frac) < 1e-6
+            logger.info("  twi.vrt whole-cell aligned: %s (col_frac=%.2e, row_frac=%.2e)",
+                        aligned, col_frac, row_frac)
+            if not aligned:
+                raise RuntimeError(
+                    "Clip is not whole-cell aligned with twi.vrt; carea_map would "
+                    "reject it. Is the source on the hydrology (fdr/twi) lattice?"
+                )
+    logger.info("  Wrote fabric-scoped VRT: %s (%dx%d)", output, width, height)
+    logger.info("  Point the profile's template_raster AND fdr_raster at this file.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/init_data_root.py
+++ b/scripts/init_data_root.py
@@ -245,9 +245,13 @@ def _fabric_profile_stub(fabric: str) -> str:
         f"    # fabric, point it at the gpkg you staged (any name).\n"
         f'    hru_gpkg: "{{data_root}}/{{fabric}}/fabric/{{fabric}}_nhru_merged.gpkg"  # TODO: set to your fabric gpkg\n'
         f"    hru_layer: nhru\n"
-        f"    # Uncomment + set these only if the depstor pipeline is run for this fabric:\n"
-        f'    # template_raster: "{{data_root}}/shared/conus/vrt/elevation.vrt"\n'
-        f'    # fdr_raster: "{{data_root}}/shared/conus/vrt/fdr.vrt"\n'
+        f"    # Uncomment + set these only if the depstor pipeline is run for this fabric.\n"
+        f"    # template_raster + fdr_raster: stage a fabric-bounds FDR clip first with\n"
+        f"    #   pixi run --as-is python scripts/clip_shared_to_fabric.py --fabric {fabric}\n"
+        f"    # then point BOTH at the clip (it sizes depstor compute to the fabric and\n"
+        f"    # shares the hydrology lattice carea_map requires vs twi.vrt).\n"
+        f'    # template_raster: "{{data_root}}/{{fabric}}/shared/{{fabric}}_fdr.vrt"\n'
+        f'    # fdr_raster: "{{data_root}}/{{fabric}}/shared/{{fabric}}_fdr.vrt"\n'
         f'    # twi_raster: "{{data_root}}/shared/conus/vrt/twi.vrt"\n'
         f'    # segments_gpkg: "{{data_root}}/input/depstor/{{fabric}}_segments_wbodies.gpkg"\n'
         f"    # segments_layer: nsegment\n"

--- a/slurm_batch/RUNME.md
+++ b/slurm_batch/RUNME.md
@@ -508,7 +508,10 @@ already merged or comes as per-VPU gpkgs.
    `segments_layer: nsegment`. The `oregon` profile has the depstor keys
    **active** (issue #90) — the FDR clip for template/fdr, CONUS `twi.vrt`,
    `segments_gpkg` at the model gpkg, and the CONUS NHDPlusV2 waterbodies at
-   `input/nhd/conus_waterbodies.gpkg` (layer `waterbodies`). (Prefer
+   `input/nhd/conus_waterbodies.gpkg` (layer `waterbodies`). ⚠️ `twi.vrt` only
+   carries ArcPy TWI for VPU 01 (issue #94), so for `oregon` (and any non-VPU-01
+   fabric) Stage 2d builds the raster stack + non-TWI params correctly but
+   `carea_max`/`smidx_coef` are degenerate until #94 is resolved. (Prefer
    hand-editing? Just add the profile block directly — the stub is a convenience.)
 2. Place the fabric gpkg at the `hru_gpkg` path you set, under
    `{data_root}/oregon/fabric/` (NOT in `input/fabric/`)
@@ -543,6 +546,11 @@ already merged or comes as per-VPU gpkgs.
 > scoped per-VPU (`VPUS=17 sbatch slurm_batch/build_shared_rasters.batch`) to
 > avoid rebuilding all of CONUS. Then run Stage 2d:
 > `FABRIC=oregon sbatch slurm_batch/build_depstor_rasters.batch`.
+>
+> ⚠️ **TWI gap (issue #94):** `twi.vrt` only carries ArcPy TWI for VPU 01, so for
+> any other fabric the TWI-derived params (`carea_max`, `smidx_coef`) are
+> degenerate. Stage 2d still builds the full raster stack and the non-TWI params
+> correctly — just don't trust `carea_max`/`smidx_coef` until #94 is resolved.
 
 **Case B: VPU-based fabric** (per-VPU gpkgs that need merging — e.g., gfv2)
 

--- a/slurm_batch/RUNME.md
+++ b/slurm_batch/RUNME.md
@@ -306,17 +306,20 @@ sbatch command.
 
 ### Stage 2d: Build depstor rasters (per fabric)
 
-Build the full depression-storage raster stack on the elevation-VRT template
+Build the full depression-storage raster stack on a fabric-bounds template
 grid. Outputs go to `{fabric}/depstor_rasters/` and feed the Stage 4 depstor
 zonal-stats orchestrator below.
 
-Inputs (manually staged per fabric):
-- `input/depstor/<fabric>_segments_wbodies.gpkg` (layers `nsegment`, `v2_wb`)
-- Per-fabric `hru_gpkg` / `twi_raster` (from `base_config.yml`).
-- Shared `fdr_raster` from `shared/conus/vrt/fdr.vrt` (Part 1 output; no per-fabric FDR needed).
-- The NLCD 2015 fractional-impervious raster (path set in
-  `configs/depstor/depstor_rasters.yml` under `imperv_source`) and
-  `shared/conus/vrt/elevation.vrt`.
+Inputs (per fabric, from `base_config.yml`):
+- `template_raster` **and** `fdr_raster`: a fabric-bounds clip of the CONUS FDR,
+  staged with `pixi run --as-is python scripts/clip_shared_to_fabric.py --fabric <name>`
+  (writes `{data_root}/<name>/shared/<name>_fdr.vrt`). The template grid sizes
+  every builder's arrays, so this scopes compute to the fabric; the clip is on
+  the hydrology lattice `carea_map` requires the template to share with `twi.vrt`.
+- `twi_raster` (CONUS `shared/conus/vrt/twi.vrt`; warp-windowed onto the template).
+- `hru_gpkg`, `segments_gpkg`/`segments_layer`, `waterbody_gpkg`/`waterbody_layer`.
+- The NLCD fractional-impervious raster (`imperv_source` in
+  `configs/depstor/depstor_rasters.yml`).
 
 One sbatch builds the entire stack in dependency order
 (landmask → imperv/streambuffer/waterbody → dprst → perv/routing →
@@ -339,9 +342,10 @@ Default resources size the job for the long pole (`routing` — WhiteboxTools
 Watershed on CONUS). For VPU01 / smaller fabrics, override `--time` and
 `--mem` at submission as shown above.
 
-Note: Stage 2d depends on Stage 2a (the elevation VRT exists) but is otherwise
-fabric-independent of the rest of Part 1. It can run in parallel with Part 2's
-fabric prep.
+Note: Stage 2d depends on the Part 1 FDR VRT (`shared/conus/vrt/fdr.vrt`, the
+source the per-fabric clip is cut from) but is otherwise fabric-independent of
+the rest of Part 1. Stage the clip (`clip_shared_to_fabric.py`) first; it can
+run in parallel with Part 2's fabric prep.
 
 ---
 
@@ -491,18 +495,21 @@ already merged or comes as per-VPU gpkgs.
    for gfv2, `hru_id` for oregon — which flows through to the merged parameter
    CSVs), and `hru_gpkg`/`hru_layer` (the fabric geopackage + layer,
    authoritative for `prepare_fabric`, the ssflux `build_weights` step, and
-   gap-fill). If the depstor pipeline will be run for this fabric, also
-   uncomment + set `template_raster`, `fdr_raster`, `twi_raster`,
-   `segments_gpkg`/`segments_layer`, and `waterbody_gpkg`/`waterbody_layer`
-   (waterbody is **required** for depstor — the step raises if unset). For a
-   single-file fabric like `oregon`, `segments_gpkg` can point at the same gpkg
-   as `hru_gpkg` with `segments_layer: nsegment`. The `oregon` profile now
-   carries the depstor keys **commented out** — CONUS VRTs for the rasters (like
-   `gfv2`) and `segments_gpkg` pointing at the model gpkg — with the waterbody
-   source called out as the staging blocker (issue #90: the Oregon gpkg has no
-   waterbody layer). It stays zonal-only until that source is staged. (Prefer
-   hand-editing? Just add the profile block directly — the stub is only a
-   convenience.)
+   gap-fill). If the depstor pipeline will be run for this fabric, also set
+   `template_raster`, `fdr_raster`, `twi_raster`, `segments_gpkg`/`segments_layer`,
+   and `waterbody_gpkg`/`waterbody_layer` (waterbody is **required** for depstor —
+   the step raises if unset). Stage the `template_raster`/`fdr_raster` clip with
+   `pixi run --as-is python scripts/clip_shared_to_fabric.py --fabric <name>`
+   (writes `{data_root}/<name>/shared/<name>_fdr.vrt`, a fabric-bounds clip of
+   the CONUS FDR) and point both keys at it — this scopes depstor compute to the
+   fabric extent and stays VPU-agnostic (see the boxed note below). `twi_raster`
+   uses the CONUS `twi.vrt`. For a single-file fabric like `oregon`,
+   `segments_gpkg` can point at the same gpkg as `hru_gpkg` with
+   `segments_layer: nsegment`. The `oregon` profile has the depstor keys
+   **active** (issue #90) — the FDR clip for template/fdr, CONUS `twi.vrt`,
+   `segments_gpkg` at the model gpkg, and the CONUS NHDPlusV2 waterbodies at
+   `input/nhd/conus_waterbodies.gpkg` (layer `waterbodies`). (Prefer
+   hand-editing? Just add the profile block directly — the stub is a convenience.)
 2. Place the fabric gpkg at the `hru_gpkg` path you set, under
    `{data_root}/oregon/fabric/` (NOT in `input/fabric/`)
 3. Prepare batches (the fabric gpkg + layer come from the profile's
@@ -520,17 +527,22 @@ already merged or comes as per-VPU gpkgs.
    `--mode zonal --param <name> --batch_id <N>` (see "Single-batch run"
    in README.md or Stage 4 above).
 
-> **Scoping a regional test (e.g. Oregon, whose HRUs fall in VPU 17):** the
-> Part 2 zonal pass — and depstor (Stage 2d) — read the **CONUS** shared rasters
-> from Part 1 and clip to the HRU fabric, so those VRTs only need to *cover* the
-> region your fabric overlaps. VPU 17 is incidental here: Oregon's HRUs happen
-> to fall in it, so you can build Part 1 for just that VPU rather than all of
-> CONUS (pass `VPUS=17` to `sbatch slurm_batch/build_shared_rasters.batch`, or
-> `--vpus 17` to the orchestrator) — but the fabric configs still point at the
-> CONUS VRTs, not per-VPU tiles. Stage 2d depstor is intentionally unavailable
-> for `oregon` until its depstor inputs + profile keys are staged (the commented
-> keys in the profile, gated on a waterbody source — issue #90); the zonal pass
-> above runs without them.
+> **Scoping depstor to a fabric (e.g. Oregon):** every depstor builder sizes its
+> arrays to the `template_raster` grid, so the template controls compute extent.
+> A CONUS template would force CONUS-scale memory/time; a per-VPU tile is cheap
+> but breaks for fabrics that straddle VPU boundaries. Instead, clip the CONUS
+> FDR to the fabric bounds with
+> `pixi run --as-is python scripts/clip_shared_to_fabric.py --fabric oregon`
+> (a tiny zero-copy VRT) and use it for `template_raster`/`fdr_raster`. Oregon's
+> clip is ~0.56B cells vs ~15B CONUS. The clip comes from `fdr.vrt` because
+> `carea_map` requires the template to share the hydrology lattice with
+> `twi.vrt`; `elevation.vrt` is on the offset DEM lattice and is rejected. The
+> `fdr.vrt` source also lets `routing` read only the fabric window. `twi_raster`
+> and `imperv` stay CONUS (their builders warp-window them onto the template);
+> the waterbody source is the CONUS NHDPlusV2 gpkg. Part 1 itself can still be
+> scoped per-VPU (`VPUS=17 sbatch slurm_batch/build_shared_rasters.batch`) to
+> avoid rebuilding all of CONUS. Then run Stage 2d:
+> `FABRIC=oregon sbatch slurm_batch/build_depstor_rasters.batch`.
 
 **Case B: VPU-based fabric** (per-VPU gpkgs that need merging — e.g., gfv2)
 

--- a/tests/test_clip_shared_to_fabric.py
+++ b/tests/test_clip_shared_to_fabric.py
@@ -1,0 +1,105 @@
+"""Unit tests for the pure grid-math helpers in scripts/clip_shared_to_fabric.py.
+
+These functions decide the fabric-bounds template grid for the depstor pipeline.
+A wrong snap silently produces a misaligned or under-covering template that only
+fails after a long CONUS-scale run (or, worse, passes carea_map's alignment check
+on the wrong lattice), so the math is worth pinning at CI speed with synthetic
+transforms — no staged rasters or GDAL I/O required.
+
+scripts/ is not an importable package, so the module is loaded by path.
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+from rasterio.transform import Affine
+
+_SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "clip_shared_to_fabric.py"
+_spec = importlib.util.spec_from_file_location("clip_shared_to_fabric", _SCRIPT)
+clip = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(clip)
+
+CELL = 30.0
+
+
+def _on_lattice(value, origin, cell, tol=1e-6):
+    """True if `value` sits on the {origin + k*cell} lattice."""
+    k = (value - origin) / cell
+    return abs(k - round(k)) < tol
+
+
+class TestSnapBoundsToGrid:
+    # A north-up transform whose origin is deliberately NOT a round multiple of
+    # the cell size, to catch any code that forgets to subtract the origin.
+    OX, OY = -2_356_109.7, 3_166_613.3
+    TRANSFORM = Affine(CELL, 0.0, OX, 0.0, -CELL, OY)
+
+    def test_contains_buffered_bounds(self):
+        # bounds chosen to fall mid-cell on every side
+        bounds = (self.OX + 100.7, self.OY - 9_000.3, self.OX + 5_000.4, self.OY - 100.9)
+        buf = 8
+        ulx, uly, lrx, lry = clip._snap_bounds_to_grid(bounds, self.TRANSFORM, buf)
+        minx, miny, maxx, maxy = bounds
+        assert ulx <= minx - buf * CELL
+        assert lrx >= maxx + buf * CELL
+        assert uly >= maxy + buf * CELL
+        assert lry <= miny - buf * CELL
+
+    def test_edges_land_on_source_lattice(self):
+        bounds = (self.OX + 100.7, self.OY - 9_000.3, self.OX + 5_000.4, self.OY - 100.9)
+        ulx, uly, lrx, lry = clip._snap_bounds_to_grid(bounds, self.TRANSFORM, 8)
+        assert _on_lattice(ulx, self.OX, CELL)
+        assert _on_lattice(lrx, self.OX, CELL)
+        assert _on_lattice(uly, self.OY, CELL)
+        assert _on_lattice(lry, self.OY, CELL)
+
+    def test_width_height_are_whole_cells(self):
+        bounds = (self.OX + 100.7, self.OY - 9_000.3, self.OX + 5_000.4, self.OY - 100.9)
+        ulx, uly, lrx, lry = clip._snap_bounds_to_grid(bounds, self.TRANSFORM, 8)
+        width = (lrx - ulx) / CELL
+        height = (uly - lry) / CELL
+        assert abs(width - round(width)) < 1e-6
+        assert abs(height - round(height)) < 1e-6
+
+    def test_zero_buffer_still_contains(self):
+        bounds = (self.OX + 100.7, self.OY - 9_000.3, self.OX + 5_000.4, self.OY - 100.9)
+        ulx, uly, lrx, lry = clip._snap_bounds_to_grid(bounds, self.TRANSFORM, 0)
+        assert ulx <= bounds[0] and lry <= bounds[1]
+        assert lrx >= bounds[2] and uly >= bounds[3]
+
+    def test_bounds_already_on_lattice_no_spurious_expansion(self):
+        # With zero buffer and edges exactly on the lattice, snapping must be a
+        # no-op (no off-by-one full-cell expansion).
+        minx = self.OX + 3 * CELL
+        maxx = self.OX + 10 * CELL
+        maxy = self.OY - 2 * CELL
+        miny = self.OY - 7 * CELL
+        ulx, uly, lrx, lry = clip._snap_bounds_to_grid((minx, miny, maxx, maxy), self.TRANSFORM, 0)
+        assert (ulx, uly, lrx, lry) == pytest.approx((minx, maxy, maxx, miny))
+
+    def test_rejects_non_north_up_transform(self):
+        rotated = Affine(CELL, 0.5, self.OX, 0.5, -CELL, self.OY)  # nonzero b, d
+        with pytest.raises(ValueError, match="north-up"):
+            clip._snap_bounds_to_grid((0, 0, 100, 100), rotated, 4)
+
+    def test_rejects_positive_e_transform(self):
+        flipped = Affine(CELL, 0.0, self.OX, 0.0, CELL, self.OY)  # e > 0 (south-up)
+        with pytest.raises(ValueError, match="north-up"):
+            clip._snap_bounds_to_grid((0, 0, 100, 100), flipped, 4)
+
+
+class TestWholeCellOffset:
+    REF = Affine(CELL, 0.0, -2_356_125.0, 0.0, -CELL, 3_166_605.0)
+
+    def test_aligned_when_shifted_by_integer_cells(self):
+        clip_t = Affine(CELL, 0.0, self.REF.c + 469 * CELL, 0.0, -CELL, self.REF.f - 15159 * CELL)
+        col_frac, row_frac = clip._whole_cell_offset(clip_t, self.REF)
+        assert abs(col_frac) < 1e-6
+        assert abs(row_frac) < 1e-6
+
+    def test_detects_half_cell_offset(self):
+        clip_t = Affine(CELL, 0.0, self.REF.c + 0.5 * CELL, 0.0, -CELL, self.REF.f - 0.5 * CELL)
+        col_frac, row_frac = clip._whole_cell_offset(clip_t, self.REF)
+        assert abs(abs(col_frac) - 0.5) < 1e-6
+        assert abs(abs(row_frac) - 0.5) < 1e-6


### PR DESCRIPTION
Refs #92. Activates depression-storage for the `oregon` fabric and adds a
reusable, VPU-agnostic way to scope depstor compute to any fabric.

## What changed

- **New `scripts/clip_shared_to_fabric.py`** — clips a shared CONUS raster
  (default `fdr.vrt`) to a fabric's HRU bounds as a zero-copy VRT, used as both
  `template_raster` and `fdr_raster`. Every depstor builder sizes its arrays to
  the template grid, so this scopes compute to the fabric extent (oregon ≈ 0.56B
  cells vs ~15B CONUS) while staying **VPU-agnostic** — works for fabrics that
  straddle VPU boundaries, unlike per-VPU tiles.
- **oregon depstor activated** — clip template/fdr, CONUS `twi.vrt`, model-gpkg
  `nsegment`, and the CONUS NHDPlusV2 waterbodies (`input/nhd/conus_waterbodies.gpkg`,
  layer `waterbodies`).
- **gfv2 template-lattice fix** — gfv2's `template_raster` was `elevation.vrt`,
  which sits on the DEM lattice (a fractional-cell offset from `twi.vrt`'s
  hydrology lattice). `carea_map` hard-requires the template and TWI to be
  whole-cell aligned, so gfv2 `carea_map` would fail at CONUS scale. Repointed
  gfv2 template/fdr at a fabric clip on the hydrology lattice (verified aligned).
- **docs** — README + RUNME: the clip step, the DEM-vs-hydrology lattice split
  and why the template is clipped from `fdr.vrt`, and the gfv2 follow-up. The
  `--add-fabric` stub now scaffolds the clip-based keys.

## Scope note (beyond the original "activate oregon")

This grew past wiring the oregon profile: the lattice analysis showed a CONUS
template is cost-prohibitive and a per-VPU template breaks for cross-VPU fabrics
and under-covers TWI — so we added the clip step, and the same analysis exposed
(and fixes) a latent gfv2 template-lattice bug. Called out per the
atomic-commits/scope-creep convention.

## Verification

- `clip_shared_to_fabric.py --fabric oregon` → 23697×23692 VRT, twi-aligned.
- Both profiles resolve; `carea_map`'s exact alignment check passes for oregon
  **and** gfv2 (`whole_cell_aligned=True`); BuildContext validates.
- **Stage 2d ran end-to-end for oregon** (job 20677039, 6m50s, MaxRSS 16 GB):
  all 13 rasters built; waterbody step reprojected 448k CONUS waterbodies and
  clipped to the Oregon land mask (4.59M cells, 4278 components).

## Known limitation (tracked separately, Refs #92)

`carea_map_t8` and `carea_map_t156` came out identical because the canonical
ArcPy `Twi_merged_17.tif` is empty (0% valid) — so `twi.vrt` carries no TWI over
VPU 17, and oregon's `carea_max`/`smidx_coef` are degenerate. This is an upstream
Part-1 TWI-staging gap, independent of the changes here; the non-TWI depstor
params are unaffected. Do not run Stage 4 `carea_max`/`smidx_coef` for oregon
until the VPU-17 TWI is resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
