### PR TITLE
Distribution-invariant carea_max/smidx_coef: TWI percentile thresholds (#55/#94)

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,10 +246,13 @@ via (highest precedence first):
    fabric, `segments_gpkg` can point at the same gpkg as `hru_gpkg` with
    `segments_layer: nsegment`. The `oregon` profile has these keys active
    (issue #90), using the CONUS NHDPlusV2 waterbodies at
-   `input/nhd/conus_waterbodies.gpkg` (layer `waterbodies`). Caveat: `twi.vrt`
-   only carries ArcPy TWI for VPU 01 (issue #94), so for any other fabric Stage 2d
-   builds the raster stack and the non-TWI params correctly, but `carea_max`/
-   `smidx_coef` are degenerate until that gap is resolved.
+   `input/nhd/conus_waterbodies.gpkg` (layer `waterbodies`). To obtain valid
+   `carea_max`/`smidx_coef` for non-VPU-01 fabrics, use
+   `threshold_mode: percentile` with `twi_raster` pointing at
+   `twi_hydrodem.vrt` (the CONUS-complete open-source source built by
+   `build_vrt`) and build the `twi_reference` percentile table first (Stage
+   2a' in `slurm_batch/RUNME.md`); see
+   `docs/superpowers/specs/2026-05-21-carea-smidx-twi-percentile-design.md`.
 2. Place the fabric gpkg at the `hru_gpkg` path you set, under
    `{data_root}/oregon/fabric/` (NOT in `input/fabric/`)
 3. Run `prepare_fabric.py --fabric oregon` (reads `hru_gpkg` from the profile —
@@ -262,8 +265,9 @@ via (highest precedence first):
    (incidental), so `VPUS=17 sbatch slurm_batch/build_shared_rasters.batch`
    avoids rebuilding all of CONUS for a regional test. Stage 2d depstor is
    **active** for `oregon` (issue #90); after staging the FDR clip (step 1),
-   run `FABRIC=oregon sbatch slurm_batch/build_depstor_rasters.batch`. (As above,
-   the TWI-derived `carea_max`/`smidx_coef` await issue #94; the rest is valid.)
+   run `FABRIC=oregon sbatch slurm_batch/build_depstor_rasters.batch`. For valid
+   `carea_max`/`smidx_coef`, use `threshold_mode: percentile` with
+   `twi_hydrodem.vrt` after completing Stage 2a' (`twi_reference`).
 
 **VPU-based fabric** (per-VPU gpkgs that need merging — e.g., gfv2):
 
@@ -290,9 +294,16 @@ one orchestrator and one unified config:
   (`merge_rpu_by_vpu_twi`), CONUS VRT assembly (`build_vrt`), and CONUS
   derived rasters (`build_derived_rasters`, `build_lulc_rasters`).
 - `compute_dem_derivatives` is registered as an opt-in step (parallel
-  open-source TWI pipeline; not in the default `steps:` list because PRMS
-  calibration thresholds reference the canonical ArcPy-derived TWI — see
-  the [module docstring](src/gfv2_params/shared_rasters/compute_dem_derivatives.py)).
+  open-source TWI pipeline). The absolute calibration thresholds (8.0/15.6)
+  used by `carea_max`/`smidx_coef` still require the ArcPy-derived
+  `twi.vrt` when `threshold_mode: absolute`. However, `carea_map` now also
+  supports `threshold_mode: percentile` (configured in
+  `configs/depstor/depstor_rasters.yml`): it derives the TWI cutoff from the
+  data via the per-VPU reference table produced by the `twi_reference`
+  shared-raster step, making the open-source `twi_hydrodem.vrt` a first-class
+  source that is safe to use. See
+  `docs/superpowers/specs/2026-05-21-carea-smidx-twi-percentile-design.md`
+  for the full design rationale.
 
 These outputs live under `{data_root}/shared/` and are **fabric-independent**:
 every fabric reuses the same CONUS rasters. Per-VPU iteration happens

--- a/configs/base_config.yml
+++ b/configs/base_config.yml
@@ -25,9 +25,11 @@ fabrics:
     # Run: pixi run --as-is python scripts/clip_shared_to_fabric.py --fabric gfv2
     template_raster: "{data_root}/gfv2/shared/gfv2_fdr.vrt"
     fdr_raster: "{data_root}/gfv2/shared/gfv2_fdr.vrt"
-    # NOTE: twi.vrt does not cover gfv2's northernmost HRUs (a TWI data-coverage
-    # gap, tracked separately from the template-lattice fix above).
-    twi_raster: "{data_root}/shared/conus/vrt/twi.vrt"
+    # Depstor TWI source: open-source Twi_hydrodem (CONUS-complete; #94), which
+    # also covers gfv2's northernmost HRUs that twi.vrt (ArcPy) misses. carea_map
+    # runs in percentile mode; per-VPU thresholds are keyed by the per-HRU `vpu`
+    # attribute on this fabric (no profile `vpu` scalar — gfv2 is multi-VPU).
+    twi_raster: "{data_root}/shared/conus/vrt/twi_hydrodem.vrt"
     segments_gpkg: "{data_root}/input/depstor/{fabric}_segments_wbodies.gpkg"
     waterbody_gpkg: "{data_root}/input/depstor/{fabric}_segments_wbodies.gpkg"
     waterbody_layer: v2_wb
@@ -87,13 +89,16 @@ fabrics:
     # Run: pixi run --as-is python scripts/clip_shared_to_fabric.py --fabric oregon
     template_raster: "{data_root}/oregon/shared/oregon_fdr.vrt"
     fdr_raster: "{data_root}/oregon/shared/oregon_fdr.vrt"
-    # TWI: carea_map WarpedVRT-windows the CONUS twi.vrt onto the template grid
-    # (its footprint covers the Oregon extent). ⚠️ But twi.vrt currently carries
-    # ArcPy TWI for VPU 01 ONLY (issue #94) — over Oregon (VPU 17) every TWI cell
-    # is nodata, so carea_max/smidx_coef come out degenerate. Stage 2d still
-    # builds the full raster stack and the non-TWI params correctly; do not treat
-    # carea_max/smidx_coef as valid here until #94 is resolved.
-    twi_raster: "{data_root}/shared/conus/vrt/twi.vrt"
+    # Single-VPU fabric: declare the VPU so vpu_id is a constant fill and the
+    # per-VPU reference threshold resolves to VPU 17.
+    vpu: "17"
+    # Depstor TWI source: open-source Twi_hydrodem (CONUS-complete; #94).
+    # carea_map runs in percentile mode (threshold_mode: percentile,
+    # reference_scope: vpu in depstor_rasters.yml), deriving the TWI cutoff from
+    # the data, so carea_max/smidx_coef are no longer degenerate over VPU 17 —
+    # this resolves the former #94 caveat. Reference table:
+    # twi_reference_percentiles.hydrodem.csv.
+    twi_raster: "{data_root}/shared/conus/vrt/twi_hydrodem.vrt"
     segments_gpkg: "{data_root}/oregon/fabric/model_layers 9.gpkg"
     segments_layer: nsegment
     # CONUS NHDPlusV2 waterbodies (POLYGON, EPSG:5070); the waterbody builder

--- a/configs/depstor/depstor_rasters.yml
+++ b/configs/depstor/depstor_rasters.yml
@@ -67,12 +67,12 @@ steps:
     # Percentile reads the reference table for the matching twi_source; pick the
     # source by pointing the profile's twi_raster at twi.vrt or twi_hydrodem.vrt.
     threshold_mode: percentile
-    reference_scope: vpu          # vpu | conus
+    reference_scope: vpu # vpu | conus
     reference_table: "{data_root}/shared/conus/twi_reference_percentiles.hydrodem.csv"
     # Used only when threshold_mode: absolute
     thresholds:
       carea_max: 8.0
-      smidx:     15.6
+      smidx: 15.6
     outputs:
       carea_max: carea_map_t8_binary.tif
-      smidx:     carea_map_t156_binary.tif
+      smidx: carea_map_t156_binary.tif

--- a/configs/depstor/depstor_rasters.yml
+++ b/configs/depstor/depstor_rasters.yml
@@ -59,10 +59,20 @@ steps:
     output_key: drains_imperv
     output: drains_imperv_binary.tif
 
+  - name: vpu_id
+    output: vpu_id.tif
+
   - name: carea_map
+    # threshold_mode: absolute (legacy 8.0/15.6, ArcPy TWI) | percentile (#55).
+    # Percentile reads the reference table for the matching twi_source; pick the
+    # source by pointing the profile's twi_raster at twi.vrt or twi_hydrodem.vrt.
+    threshold_mode: percentile
+    reference_scope: vpu          # vpu | conus
+    reference_table: "{data_root}/shared/conus/twi_reference_percentiles.hydrodem.csv"
+    # Used only when threshold_mode: absolute
     thresholds:
-      carea_max: 8.0   # feeds PRMS carea_max
-      smidx:     15.6  # feeds PRMS smidx_coef
+      carea_max: 8.0
+      smidx:     15.6
     outputs:
       carea_max: carea_map_t8_binary.tif
       smidx:     carea_map_t156_binary.tif

--- a/configs/depstor/depstor_rasters.yml
+++ b/configs/depstor/depstor_rasters.yml
@@ -64,8 +64,9 @@ steps:
 
   - name: carea_map
     # threshold_mode: absolute (legacy 8.0/15.6, ArcPy TWI) | percentile (#55).
-    # Percentile reads the reference table for the matching twi_source; pick the
-    # source by pointing the profile's twi_raster at twi.vrt or twi_hydrodem.vrt.
+    # Percentile uses reference_table: below; twi_raster (in the fabric profile)
+    # and reference_table must be set to the same source together — there is no
+    # auto-selection or guard for the pairing.
     threshold_mode: percentile
     reference_scope: vpu # vpu | conus
     reference_table: "{data_root}/shared/conus/twi_reference_percentiles.hydrodem.csv"

--- a/configs/shared_rasters/shared_rasters.yml
+++ b/configs/shared_rasters/shared_rasters.yml
@@ -82,6 +82,13 @@ steps:
   # (GDAL last-source-wins), writes VRTs to ctx.vrt_dir.
   - name: build_vrt
 
+  # Stage 2a': valid-land TWI percentile cutoffs per source (issue #55/#94).
+  # Defaults derived by inverting 8.0/15.6 on ArcPy VPU 01; override with
+  # `percentiles: {carea_max: <P>, smidx: <P>}`.
+  - name: twi_reference
+    sources: [arcpy, hydrodem]
+    decimate: 20
+
   # Stage 2b: derived rasters (soil_moist_max = RootDepth * AWC).
   - name: build_derived_rasters
 

--- a/docs/superpowers/plans/2026-05-21-twi-percentile-carea-smidx.md
+++ b/docs/superpowers/plans/2026-05-21-twi-percentile-carea-smidx.md
@@ -1328,7 +1328,7 @@ Expected: percentile-mode parameters barely move between ArcPy and hydrodem (sma
 
 - [ ] **Step 1: Update docs**
 
-- `slurm_batch/RUNME.md`: add a stage for `submit_twi_completion.sh` (finish `twi.vrt` + build `twi_hydrodem.vrt`), the `twi_reference` step, and percentile-mode carea_map (note the `vpu_id` step + mode↔source pairing). 
+- `slurm_batch/RUNME.md`: add a stage for `submit_twi_completion.sh` (finish `twi.vrt` + build `twi_hydrodem.vrt`), the `twi_reference` step, and percentile-mode carea_map (note the `vpu_id` step + mode↔source pairing).
 - `README.md`: replace the line that says the calibration thresholds reference the canonical ArcPy TWI with a pointer to the percentile refactor + the spec; note `twi_hydrodem.vrt` is now a first-class source.
 - `build_vrt.py`: soften the "DO NOT SWAP" comment on the `twi` type to: absolute mode still requires ArcPy TWI, but percentile mode (`twi_reference` + carea_map `threshold_mode: percentile`) makes `twi_hydrodem` safe — cross-reference the spec.
 - `configs/base_config.yml`: replace the oregon `⚠️ #94` carea-degenerate caveat with a note that percentile mode + `twi_hydrodem.vrt` resolves it.

--- a/docs/superpowers/plans/2026-05-21-twi-percentile-carea-smidx.md
+++ b/docs/superpowers/plans/2026-05-21-twi-percentile-carea-smidx.md
@@ -1,0 +1,1370 @@
+# Distribution-Invariant `carea_max` / `smidx_coef` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make PRMS `carea_max`/`smidx_coef` invariant to the TWI source by deriving the TWI cutoff from the data (a percentile) instead of the hardcoded 8.0/15.6, and adopt the CONUS-complete open-source `Twi_hydrodem` — fixing the #94 coverage gap (degenerate carea outside VPU 01) and #55 Stage 1 in one branch.
+
+**Architecture:** Reuse the existing `carea_map` binary builder + zonal-count + ratio pipeline unchanged; only the *threshold number* changes. A new shared pre-step computes valid-land TWI percentile cutoffs (`T_P`) per VPU and CONUS for each TWI source; the `carea_map` builder gains a `threshold_mode` switch (`absolute` = 8.0/15.6; `percentile` = `T_P`, scalar for conus/single-VPU or a per-cell array via a rasterised HRU→VPU lookup). Defaults for the percentile are derived by inverting 8.0/15.6 through VPU 01's ArcPy-TWI CDF.
+
+**Tech Stack:** Python 3, numpy, rasterio/GDAL (osgeo), geopandas/pyogrio, gdptools (exactextract), pixi env, SLURM. Tests run under `pixi run -e dev pytest` (CI gate — never on the HPC head node).
+
+**Spec:** `docs/superpowers/specs/2026-05-21-carea-smidx-twi-percentile-design.md`
+**Branch:** `feat/twi-percentile-carea-smidx`
+
+---
+
+## Conventions for every task
+
+- Run python in-env: `pixi run --as-is python ...`. Run tests: `pixi run -e dev pytest <path> -v`.
+- **Never run the full `pytest` on the HPC head node interactively** beyond the single-file invocations below; CI is the gate. Single-file unit runs of pure-function tests are fine.
+- Paths/fabric inputs come from the active profile in `configs/base_config.yml` via `require_config_key(config, key, script_name)` — never hardcoded.
+- Commit after each task with the message shown. Keep commits atomic.
+
+---
+
+## File structure (created / modified)
+
+**Created:**
+- `src/gfv2_params/shared_rasters/twi_reference.py` — pure percentile/CDF math + the `build_twi_reference` shared-raster builder.
+- `src/gfv2_params/depstor_builders/vpu_id.py` — rasterise HRU→VPU code onto the template grid.
+- `tests/test_twi_reference.py`, `tests/test_vpu_id.py`, `tests/test_carea_map_threshold.py` — unit tests.
+- `slurm_batch/submit_twi_completion.sh` — finish `twi.vrt` (VPUs 02–18) + build both TWI VRTs.
+
+**Modified:**
+- `src/gfv2_params/shared_rasters/build_vrt.py` — add `twi_hydrodem` VRT type + named-CRS (EPSG:5070) assignment.
+- `src/gfv2_params/shared_rasters/__init__.py`, `configs/shared_rasters/shared_rasters.yml` — register `build_twi_reference`.
+- `src/gfv2_params/depstor.py` — `compute_carea_map_binary` accepts a scalar **or** per-cell-array threshold.
+- `src/gfv2_params/depstor_builders/__init__.py`, `configs/depstor/depstor_rasters.yml` — register `vpu_id`; add `threshold_mode`/percentile keys to `carea_map`.
+- `src/gfv2_params/depstor_builders/context.py` — add `vpu` (profile scalar) field.
+- `src/gfv2_params/depstor_builders/carea_map.py` — threshold-mode resolution.
+- `scripts/build_depstor_rasters.py` — pass `vpu` into `BuildContext`.
+- `configs/base_config.yml` — oregon `vpu: "17"`; percentile keys; #94 caveat update.
+- `README.md`, `slurm_batch/RUNME.md` — document the new stages.
+
+---
+
+# PHASE A — TWI source completion
+
+Build `twi_hydrodem.vrt` and finish the ArcPy `twi.vrt` for VPUs 02–18 so both sources exist for the A/B and so percentile mode has CONUS-complete TWI.
+
+## Task A1: Add `twi_hydrodem` VRT type with a named CRS
+
+**Files:**
+- Modify: `src/gfv2_params/shared_rasters/build_vrt.py`
+- Test: `tests/test_build_vrt_srs.py` (create)
+
+The `Twi_hydrodem_*.tif` tiles report an `"unnamed"` Albers CRS; carea_map's strict `src.crs != template.crs` check needs a *named* EPSG:5070. Add the VRT type and a small pure helper that maps a VRT name to the SRS it must be stamped with.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_build_vrt_srs.py`:
+
+```python
+"""Unit tests for build_vrt's per-type SRS override (twi_hydrodem needs a
+named EPSG:5070 because the source tiles report an 'unnamed' Albers CRS)."""
+
+import importlib
+
+build_vrt = importlib.import_module("gfv2_params.shared_rasters.build_vrt")
+
+
+def test_twi_hydrodem_registered_with_nodata():
+    assert "twi_hydrodem" in build_vrt.RASTER_TYPES
+    pattern, src_nodata = build_vrt.RASTER_TYPES["twi_hydrodem"][:2]
+    assert pattern == "Twi_hydrodem_*.tif"
+    assert src_nodata == "-9999"
+
+
+def test_srs_override_only_for_twi_hydrodem():
+    assert build_vrt._srs_override("twi_hydrodem") == "EPSG:5070"
+    assert build_vrt._srs_override("twi") is None
+    assert build_vrt._srs_override("fdr") is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run -e dev pytest tests/test_build_vrt_srs.py -v`
+Expected: FAIL (`twi_hydrodem` not in RASTER_TYPES / `_srs_override` undefined).
+
+- [ ] **Step 3: Implement**
+
+In `build_vrt.py`, add the new type to `RASTER_TYPES` (after the `twi` entry):
+
+```python
+    "twi":         ("Twi_merged_*.tif", "-9999"),
+    # Open-source WhiteboxTools TWI (issue #94): CONUS-complete, drop-in grid
+    # with fdr.vrt. Tiles report an "unnamed" Albers CRS, so the VRT must be
+    # stamped with a named EPSG:5070 to satisfy carea_map's CRS-equality check.
+    "twi_hydrodem": ("Twi_hydrodem_*.tif", "-9999"),
+```
+
+Add the helper above `build()`:
+
+```python
+# VRT types whose source tiles carry an unnamed/implicit CRS and must be
+# stamped with an explicit EPSG so strict CRS-equality checks downstream pass.
+_SRS_OVERRIDES = {"twi_hydrodem": "EPSG:5070"}
+
+
+def _srs_override(vrt_name: str) -> str | None:
+    """EPSG string to force onto the built VRT, or None to keep source CRS."""
+    return _SRS_OVERRIDES.get(vrt_name)
+```
+
+In `build()`, right after the `vrt_ds.FlushCache()` / `del vrt_ds` block, apply the override:
+
+```python
+        vrt_ds.FlushCache()
+        del vrt_ds
+
+        epsg = _srs_override(vrt_name)
+        if epsg is not None:
+            from osgeo import osr
+            srs = osr.SpatialReference()
+            srs.SetFromUserInput(epsg)
+            ds = gdal.Open(str(vrt_path), gdal.GA_Update)
+            ds.SetProjection(srs.ExportToWkt())
+            ds.FlushCache()
+            del ds
+            logger.info("Stamped %s with %s", vrt_path, epsg)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pixi run -e dev pytest tests/test_build_vrt_srs.py -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/gfv2_params/shared_rasters/build_vrt.py tests/test_build_vrt_srs.py
+git commit -m "feat(shared): add twi_hydrodem VRT type with named EPSG:5070 (#94)
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+## Task A2: SLURM script to finish `twi.vrt` + build both TWI VRTs
+
+**Files:**
+- Create: `slurm_batch/submit_twi_completion.sh`
+
+This is operational (no unit test): run the already-registered `merge_rpu_by_vpu_twi` step for all VPUs (02–18 are empty; 01 exists), then `build_vrt` (now also builds `twi_hydrodem.vrt`).
+
+- [ ] **Step 1: Create the submit script**
+
+Create `slurm_batch/submit_twi_completion.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Finish twi.vrt (ArcPy Twi_merged for VPUs 02-18 were never merged) and build
+# both TWI VRTs (twi.vrt + twi_hydrodem.vrt). Inputs are all staged: per-RPU
+# TWI at input/twi/<rpu>/twi.tif (59 RPUs) and per-VPU land masks for all 18.
+# Pure on-cluster; no ArcPy. Run from a shell with ~/.pixi/bin on PATH.
+#
+#   bash slurm_batch/submit_twi_completion.sh
+set -euo pipefail
+cd "$(dirname "$0")/.."
+CFG=configs/shared_rasters/shared_rasters.yml
+
+# 1) merge ArcPy per-RPU TWI -> per-VPU Twi_merged for every VPU (idempotent;
+#    --force re-merges 01 too so all 18 are consistent).
+merge=$(sbatch --parsable --job-name=twi_merge \
+  --wrap="pixi run --as-is python scripts/build_shared_rasters.py \
+          --config $CFG --step merge_rpu_by_vpu_twi --force")
+echo "merge_rpu_by_vpu_twi: $merge"
+
+# 2) (re)build CONUS VRTs after the merge — builds twi.vrt AND twi_hydrodem.vrt.
+vrt=$(sbatch --parsable --dependency=afterok:$merge --job-name=twi_vrt \
+  --wrap="pixi run --as-is python scripts/build_shared_rasters.py \
+          --config $CFG --step build_vrt --force")
+echo "build_vrt: $vrt"
+echo "Submitted. When done, verify with: scripts/build_shared_rasters.py logs + gdalinfo on both VRTs."
+```
+
+- [ ] **Step 2: Make executable + commit**
+
+```bash
+chmod +x slurm_batch/submit_twi_completion.sh
+git add slurm_batch/submit_twi_completion.sh
+git commit -m "feat(slurm): submit_twi_completion.sh to finish twi.vrt + build twi_hydrodem.vrt (#94)
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+- [ ] **Step 3: Run it (operational) and verify**
+
+```bash
+bash slurm_batch/submit_twi_completion.sh
+# After both jobs finish (watch: squeue -u $USER):
+DR=$(awk '/^data_root:/ {print $2}' configs/base_config.yml)
+pixi run --as-is python - <<PY
+import rasterio, numpy as np
+DR="$DR"
+for name in ("twi.vrt", "twi_hydrodem.vrt"):
+    p=f"{DR}/shared/conus/vrt/{name}"
+    with rasterio.open(p) as ds:
+        w=ds.read(1, out_shape=(1, ds.height//50, ds.width//50))
+        nod=ds.nodata
+        valid=np.isfinite(w) & (w!=nod) if nod is not None else np.isfinite(w)
+        print(name, "crs=", ds.crs, "valid%=", round(100*valid.mean(),1))
+PY
+```
+
+Expected: both VRTs report `crs=EPSG:5070`; `twi.vrt` valid% now substantially > 0 across CONUS (not just VPU 01); `twi_hydrodem.vrt` valid% high.
+
+---
+
+# PHASE B — Reference-percentile pre-step
+
+Compute valid-land TWI percentile cutoffs (`T_P`) per VPU and CONUS for each source, with defaults derived by inverting 8.0/15.6 through VPU 01's ArcPy CDF.
+
+## Task B1: Pure percentile + CDF-inversion helpers
+
+**Files:**
+- Create: `src/gfv2_params/shared_rasters/twi_reference.py`
+- Test: `tests/test_twi_reference.py` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_twi_reference.py`:
+
+```python
+"""Unit tests for the pure percentile / CDF-inversion helpers used to derive
+TWI threshold cutoffs (issue #55 Stage 1)."""
+
+import numpy as np
+import pytest
+
+from gfv2_params.shared_rasters.twi_reference import (
+    percentile_of_values,
+    rank_of_value,
+)
+
+
+def test_percentile_of_values_basic():
+    vals = np.arange(1, 101, dtype="float64")  # 1..100
+    p = percentile_of_values(vals, [75.0, 95.0])
+    assert p[0] == pytest.approx(75.25, abs=0.5)
+    assert p[1] == pytest.approx(95.05, abs=0.5)
+
+
+def test_percentile_drops_nan_and_nodata():
+    vals = np.array([1.0, 2.0, 3.0, 4.0, np.nan, -9999.0], dtype="float64")
+    p = percentile_of_values(vals, [50.0], nodata=-9999.0)
+    # median of {1,2,3,4} == 2.5
+    assert p[0] == pytest.approx(2.5)
+
+
+def test_rank_of_value_is_inverse_of_percentile():
+    vals = np.arange(1, 101, dtype="float64")
+    # value 75 sits at ~the 75th percentile
+    assert rank_of_value(vals, 75.0) == pytest.approx(75.0, abs=1.0)
+
+
+def test_rank_of_value_handles_nodata():
+    vals = np.array([1.0, 2.0, 3.0, 4.0, -9999.0], dtype="float64")
+    # 3.0 is >= 3 of 4 valid values -> 75%
+    assert rank_of_value(vals, 3.0, nodata=-9999.0) == pytest.approx(75.0)
+
+
+def test_percentile_empty_raises():
+    with pytest.raises(ValueError, match="no valid"):
+        percentile_of_values(np.array([-9999.0, np.nan]), [50.0], nodata=-9999.0)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run -e dev pytest tests/test_twi_reference.py -v`
+Expected: FAIL (module/functions undefined).
+
+- [ ] **Step 3: Implement the helpers**
+
+Create `src/gfv2_params/shared_rasters/twi_reference.py` with the pure helpers (the builder is added in B2):
+
+```python
+"""Valid-land TWI percentile cutoffs for distribution-invariant carea_max /
+smidx_coef (issues #94 + #55 Stage 1).
+
+The cutoff that classifies a cell as "wet" used to be a hardcoded TWI value
+(8.0 / 15.6) calibrated to the ArcPy TWI distribution. Here we derive it from
+the data instead: the P-th percentile of valid-land TWI over a reference
+population (per-VPU or CONUS). Because it is recomputed from whatever TWI
+source is in play, swapping the source preserves each cell's rank, so the
+parameters become invariant to the source.
+
+This module holds the pure math (percentile / CDF-inversion) plus the
+`build_twi_reference` shared-raster builder that samples the staged TWI tiles.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def _valid(values: np.ndarray, nodata: float | None) -> np.ndarray:
+    """Return the finite, non-nodata subset as a 1-D float64 array."""
+    v = np.asarray(values, dtype="float64").ravel()
+    mask = np.isfinite(v)
+    if nodata is not None:
+        mask &= v != nodata
+    return v[mask]
+
+
+def percentile_of_values(values: np.ndarray, ps, nodata: float | None = None):
+    """The P-th percentile(s) of the valid values. `ps` is a list of [0,100]."""
+    valid = _valid(values, nodata)
+    if valid.size == 0:
+        raise ValueError("percentile_of_values: no valid (finite, non-nodata) values")
+    return [float(x) for x in np.percentile(valid, ps)]
+
+
+def rank_of_value(values: np.ndarray, value: float, nodata: float | None = None) -> float:
+    """Percentile rank (0-100) of `value` in the valid distribution: the
+    fraction of valid values <= `value`, x100. Inverse of percentile_of_values;
+    used to find what percentile the legacy 8.0 / 15.6 occupy."""
+    valid = _valid(values, nodata)
+    if valid.size == 0:
+        raise ValueError("rank_of_value: no valid values")
+    return float(100.0 * np.count_nonzero(valid <= value) / valid.size)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pixi run -e dev pytest tests/test_twi_reference.py -v`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/gfv2_params/shared_rasters/twi_reference.py tests/test_twi_reference.py
+git commit -m "feat(shared): TWI percentile + CDF-inversion helpers (#55)
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+## Task B2: `build_twi_reference` builder + sampling + table assembly
+
+**Files:**
+- Modify: `src/gfv2_params/shared_rasters/twi_reference.py`
+- Test: `tests/test_twi_reference.py` (extend)
+
+The builder samples land-masked TWI per VPU for a source, derives default percentiles by inverting 8.0/15.6 on ArcPy VPU 01, evaluates `T_P` per VPU + CONUS, and writes a CSV. We unit-test the *table assembly* with an injected sampler so no rasters are needed.
+
+- [ ] **Step 1: Write the failing test (extend the file)**
+
+Append to `tests/test_twi_reference.py`:
+
+```python
+from gfv2_params.shared_rasters.twi_reference import assemble_reference_table
+
+
+def test_assemble_reference_table_uses_inverted_defaults():
+    # Fake per-VPU valid-land TWI samples for two VPUs of one source.
+    samples = {
+        "01": np.arange(1, 101, dtype="float64"),       # 1..100
+        "17": np.arange(1, 201, dtype="float64") / 2.0,  # 0.5..100
+    }
+
+    def sampler(vpu):
+        return samples[vpu]
+
+    rows = assemble_reference_table(
+        source="hydrodem",
+        vpus=["01", "17"],
+        sampler=sampler,
+        # invert 8.0/15.6 against this ArcPy VPU01 sample to get the percentiles
+        arcpy_vpu01_sample=np.arange(1, 101, dtype="float64"),
+        legacy_carea=8.0,
+        legacy_smidx=15.6,
+    )
+    by = {(r["scope"], r["vpu"]): r for r in rows}
+    # Inversion: 8.0 -> ~8th pct, 15.6 -> ~16th pct of 1..100
+    assert by[("vpu", "01")]["p_carea"] == pytest.approx(8.0, abs=1.0)
+    assert by[("vpu", "01")]["p_smidx"] == pytest.approx(15.6, abs=1.0)
+    # CONUS row pools all VPUs and uses the same percentiles
+    assert ("conus", "CONUS") in by
+    # t_carea is the p_carea-th percentile of that scope's sample
+    assert by[("vpu", "17")]["t_carea"] < by[("vpu", "01")]["t_carea"]
+
+
+def test_assemble_reference_table_explicit_percentiles_skip_inversion():
+    samples = {"01": np.arange(1, 101, dtype="float64")}
+    rows = assemble_reference_table(
+        source="arcpy", vpus=["01"], sampler=lambda v: samples[v],
+        p_carea=75.0, p_smidx=95.0,
+    )
+    r = next(x for x in rows if x["scope"] == "vpu")
+    assert r["p_carea"] == 75.0 and r["p_smidx"] == 95.0
+    assert r["t_carea"] == pytest.approx(75.25, abs=0.5)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run -e dev pytest tests/test_twi_reference.py -v`
+Expected: FAIL (`assemble_reference_table` undefined).
+
+- [ ] **Step 3: Implement table assembly + the builder**
+
+Append to `twi_reference.py`:
+
+```python
+from pathlib import Path
+
+import csv
+
+import rasterio
+
+# Legacy ArcPy thresholds (docs/0b_TB_depr_stor.py); used to derive default
+# percentiles by inversion so percentile-mode reproduces VPU 01 by construction.
+LEGACY_CAREA_THRESHOLD = 8.0
+LEGACY_SMIDX_THRESHOLD = 15.6
+
+_TABLE_FIELDS = ["source", "scope", "vpu", "p_carea", "p_smidx", "t_carea", "t_smidx"]
+
+
+def assemble_reference_table(
+    source: str,
+    vpus: list[str],
+    sampler,
+    *,
+    arcpy_vpu01_sample=None,
+    legacy_carea: float = LEGACY_CAREA_THRESHOLD,
+    legacy_smidx: float = LEGACY_SMIDX_THRESHOLD,
+    p_carea: float | None = None,
+    p_smidx: float | None = None,
+    nodata: float | None = -9999.0,
+) -> list[dict]:
+    """Build the reference-percentile rows for one TWI source.
+
+    `sampler(vpu) -> 1-D array` supplies valid-land TWI samples per VPU. If
+    `p_carea`/`p_smidx` are not given, they are derived by inverting
+    legacy_carea/legacy_smidx through `arcpy_vpu01_sample` (the CDF-inversion
+    default). One `vpu`-scope row per VPU plus one pooled `conus` row.
+    """
+    if p_carea is None or p_smidx is None:
+        if arcpy_vpu01_sample is None:
+            raise ValueError(
+                "assemble_reference_table: provide p_carea/p_smidx or "
+                "arcpy_vpu01_sample to derive them by inversion"
+            )
+        p_carea = rank_of_value(arcpy_vpu01_sample, legacy_carea, nodata=nodata)
+        p_smidx = rank_of_value(arcpy_vpu01_sample, legacy_smidx, nodata=nodata)
+
+    rows: list[dict] = []
+    pooled = []
+    for vpu in vpus:
+        s = sampler(vpu)
+        valid = _valid(s, nodata)
+        if valid.size == 0:
+            continue
+        pooled.append(valid)
+        tc, ts = percentile_of_values(valid, [p_carea, p_smidx])
+        rows.append({
+            "source": source, "scope": "vpu", "vpu": vpu,
+            "p_carea": round(p_carea, 4), "p_smidx": round(p_smidx, 4),
+            "t_carea": tc, "t_smidx": ts,
+        })
+    if pooled:
+        allv = np.concatenate(pooled)
+        tc, ts = percentile_of_values(allv, [p_carea, p_smidx])
+        rows.append({
+            "source": source, "scope": "conus", "vpu": "CONUS",
+            "p_carea": round(p_carea, 4), "p_smidx": round(p_smidx, 4),
+            "t_carea": tc, "t_smidx": ts,
+        })
+    return rows
+
+
+def write_reference_table(rows: list[dict], out_path: Path) -> None:
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_path, "w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=_TABLE_FIELDS)
+        w.writeheader()
+        for r in rows:
+            w.writerow(r)
+
+
+def _sample_land_masked_twi(twi_path: Path, mask_path: Path, decimate: int, nodata):
+    """Decimated valid-land TWI sample (1-D). Reads both rasters at a coarse
+    overview to keep CONUS-scale sampling cheap; mask==1 marks land."""
+    with rasterio.open(twi_path) as t:
+        oh, ow = max(1, t.height // decimate), max(1, t.width // decimate)
+        twi = t.read(1, out_shape=(1, oh, ow))
+        tnod = t.nodata if nodata is None else nodata
+    with rasterio.open(mask_path) as m:
+        land = m.read(1, out_shape=(1, oh, ow)) == 1
+    sample = twi[land]
+    return _valid(sample, tnod)
+
+
+# Maps the depstor "twi family" to the per-VPU tile filename prefix.
+_SOURCE_PREFIX = {"arcpy": "Twi_merged", "hydrodem": "Twi_hydrodem"}
+
+
+def build(step_cfg: dict, ctx, logger) -> dict:
+    """shared-raster builder: write reference-percentile CSVs for each source.
+
+    step_cfg keys:
+      sources    list[str] subset of {"arcpy","hydrodem"} (default both)
+      percentiles {carea_max, smidx}  optional explicit percentiles; if absent,
+                  derived by inverting 8.0/15.6 on the ArcPy VPU 01 sample.
+      decimate   int overview factor for sampling (default 20)
+    """
+    sources = step_cfg.get("sources", ["arcpy", "hydrodem"])
+    pcfg = step_cfg.get("percentiles", {})
+    p_carea = pcfg.get("carea_max")
+    p_smidx = pcfg.get("smidx")
+    decimate = int(step_cfg.get("decimate", 20))
+    nodata = -9999.0
+    out_dir = ctx.conus_dir
+    produced = {}
+
+    def mask_path(vpu):
+        return ctx.per_vpu_dir / vpu / f"land_mask_{vpu}.tif"
+
+    # ArcPy VPU 01 sample drives the inverted default percentiles.
+    arcpy01 = None
+    if p_carea is None or p_smidx is None:
+        twi01 = ctx.per_vpu_dir / "01" / "Twi_merged_01.tif"
+        arcpy01 = _sample_land_masked_twi(twi01, mask_path("01"), decimate, nodata)
+        logger.info("build_twi_reference: derived default percentiles by "
+                    "inverting 8.0/15.6 on ArcPy VPU 01 (%d samples)", arcpy01.size)
+
+    for source in sources:
+        prefix = _SOURCE_PREFIX[source]
+
+        def sampler(vpu, _prefix=prefix):
+            twi = ctx.per_vpu_dir / vpu / f"{_prefix}_{vpu}.tif"
+            return _sample_land_masked_twi(twi, mask_path(vpu), decimate, nodata)
+
+        rows = assemble_reference_table(
+            source=source, vpus=list(ctx.vpus), sampler=sampler,
+            arcpy_vpu01_sample=arcpy01, p_carea=p_carea, p_smidx=p_smidx,
+            nodata=nodata,
+        )
+        out_path = out_dir / f"twi_reference_percentiles.{source}.csv"
+        write_reference_table(rows, out_path)
+        logger.info("build_twi_reference: wrote %d rows -> %s", len(rows), out_path)
+        produced[f"twi_reference_{source}"] = out_path
+
+    return produced
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pixi run -e dev pytest tests/test_twi_reference.py -v`
+Expected: PASS (7 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/gfv2_params/shared_rasters/twi_reference.py tests/test_twi_reference.py
+git commit -m "feat(shared): build_twi_reference builder + table assembly (#55)
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+## Task B3: Register `build_twi_reference` in the shared-raster DAG
+
+**Files:**
+- Modify: `src/gfv2_params/shared_rasters/__init__.py`
+- Modify: `configs/shared_rasters/shared_rasters.yml`
+
+- [ ] **Step 1: Register the builder**
+
+In `src/gfv2_params/shared_rasters/__init__.py`: add `twi_reference` to the imports, the `BUILDERS` dict, `STEP_ORDER`, and `PLANNED_STEPS`. It runs **after** `build_vrt` (needs per-VPU tiles; independent of derived rasters):
+
+```python
+from . import (
+    build_border_dem,
+    build_derived_rasters,
+    build_lulc_rasters,
+    build_vpu_landmask,
+    build_vrt,
+    compute_dem_derivatives,
+    merge_rpu_by_vpu,
+    twi_reference,
+)
+```
+
+```python
+    "build_vrt":               build_vrt.build,
+    "twi_reference":           twi_reference.build,
+    "build_derived_rasters":   build_derived_rasters.build,
+```
+
+```python
+    "build_vrt",
+    "twi_reference",
+    "build_derived_rasters",
+```
+
+Add `"twi_reference"` to `STEP_ORDER` in the same position; `PLANNED_STEPS = list(STEP_ORDER)` already mirrors it.
+
+- [ ] **Step 2: Add the config block**
+
+In `configs/shared_rasters/shared_rasters.yml`, add after the `build_vrt` step:
+
+```yaml
+  # Stage 2a': valid-land TWI percentile cutoffs per source (issue #55/#94).
+  # Defaults derived by inverting 8.0/15.6 on ArcPy VPU 01; override with
+  # `percentiles: {carea_max: <P>, smidx: <P>}`.
+  - name: twi_reference
+    sources: [arcpy, hydrodem]
+    decimate: 20
+```
+
+- [ ] **Step 3: Verify registration imports cleanly**
+
+Run: `pixi run --as-is python -c "from gfv2_params.shared_rasters import BUILDERS, STEP_ORDER; assert 'twi_reference' in BUILDERS and 'twi_reference' in STEP_ORDER; print('ok', STEP_ORDER)"`
+Expected: prints `ok [...]` with `twi_reference` after `build_vrt`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/gfv2_params/shared_rasters/__init__.py configs/shared_rasters/shared_rasters.yml
+git commit -m "feat(shared): register twi_reference step in the shared DAG (#55)
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+- [ ] **Step 5: Run the step (operational, after Phase A)**
+
+```bash
+pixi run --as-is python scripts/build_shared_rasters.py \
+  --config configs/shared_rasters/shared_rasters.yml --step twi_reference --force
+DR=$(awk '/^data_root:/ {print $2}' configs/base_config.yml)
+column -s, -t "$DR/shared/conus/twi_reference_percentiles.arcpy.csv" | head
+column -s, -t "$DR/shared/conus/twi_reference_percentiles.hydrodem.csv" | head
+```
+
+Expected: two CSVs; the ArcPy VPU 01 `t_carea`≈8.0 and `t_smidx`≈15.6 (inversion sanity); `p_carea`/`p_smidx` near 8/16 (the inverted percentiles).
+
+---
+
+# PHASE C — Percentile-mode `carea_map`
+
+## Task C1: `compute_carea_map_binary` accepts a per-cell-array threshold
+
+**Files:**
+- Modify: `src/gfv2_params/depstor.py`
+- Test: `tests/test_carea_map_threshold.py` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_carea_map_threshold.py`:
+
+```python
+"""compute_carea_map_binary must accept a per-cell-array threshold (percentile
+mode, per-VPU) and match the scalar path cell-for-cell when the array is
+constant (issue #55)."""
+
+import numpy as np
+
+from gfv2_params.depstor import compute_carea_map_binary
+
+
+def _inputs():
+    perv = np.array([[1, 1, 1], [1, 0, 1]], dtype="uint8")
+    onstream = np.array([[0, 0, 1], [0, 0, 0]], dtype="uint8")
+    twi = np.array([[5.0, 9.0, 5.0], [20.0, 9.0, -9999.0]], dtype="float32")
+    land = np.ones((2, 3), dtype=bool)
+    return perv, onstream, twi, land
+
+
+def test_scalar_threshold_unchanged():
+    perv, onstream, twi, land = _inputs()
+    out = compute_carea_map_binary(perv, onstream, twi, 8.0, -9999.0, land)
+    # keep where perv & land & (twi>8 or onstream); 255 elsewhere
+    expected = np.array([[255, 1, 1], [1, 255, 255]], dtype="uint8")
+    assert np.array_equal(out, expected)
+
+
+def test_constant_array_threshold_matches_scalar():
+    perv, onstream, twi, land = _inputs()
+    scalar = compute_carea_map_binary(perv, onstream, twi, 8.0, -9999.0, land)
+    arr = np.full(twi.shape, 8.0, dtype="float64")
+    out = compute_carea_map_binary(perv, onstream, twi, arr, -9999.0, land)
+    assert np.array_equal(out, scalar)
+
+
+def test_per_cell_array_threshold_varies():
+    perv, onstream, twi, land = _inputs()
+    # column 1 has twi=9; threshold 10 there -> excluded; threshold 8 -> included
+    arr = np.array([[8.0, 10.0, 8.0], [8.0, 10.0, 8.0]], dtype="float64")
+    out = compute_carea_map_binary(perv, onstream, twi, arr, -9999.0, land)
+    assert out[0, 1] == 255  # 9 !> 10
+    assert out[0, 2] == 1    # onstream rescues
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run -e dev pytest tests/test_carea_map_threshold.py -v`
+Expected: PASS for scalar tests; the array tests may already pass if `twi > threshold` broadcasts — run to confirm. If all pass, **still** add the docstring note in Step 3 (no behaviour change needed); if any fail, fix per Step 3.
+
+- [ ] **Step 3: Confirm/Update implementation**
+
+In `src/gfv2_params/depstor.py`, update `compute_carea_map_binary`'s signature type hint and docstring to make the array contract explicit (the numpy `twi > threshold` already broadcasts a scalar or same-shape array, so no logic change):
+
+```python
+def compute_carea_map_binary(
+    perv: np.ndarray,
+    onstream: np.ndarray,
+    twi: np.ndarray,
+    threshold,  # float scalar OR np.ndarray broadcastable to twi (per-cell T_P)
+    twi_nodata: Optional[float],
+    land_valid: np.ndarray,
+) -> np.ndarray:
+```
+
+Add to the docstring:
+
+```
+    `threshold` may be a scalar (absolute mode, or percentile-conus / single-VPU)
+    or a per-cell float array the same shape as `twi` (percentile per-VPU mode,
+    where each cell carries its HRU's home-VPU T_P). `twi > threshold` broadcasts
+    either way.
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pixi run -e dev pytest tests/test_carea_map_threshold.py -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/gfv2_params/depstor.py tests/test_carea_map_threshold.py
+git commit -m "feat(depstor): carea_map binary accepts per-cell array threshold (#55)
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+## Task C2: `vpu_id` builder — rasterise HRU→VPU code onto the template
+
+**Files:**
+- Create: `src/gfv2_params/depstor_builders/vpu_id.py`
+- Test: `tests/test_vpu_id.py` (create)
+- Modify: `src/gfv2_params/depstor_builders/context.py` (add `vpu` field)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_vpu_id.py`:
+
+```python
+"""Unit tests for vpu_id code mapping + resolution precedence (issue #55)."""
+
+import pytest
+
+from gfv2_params.depstor_builders.vpu_id import vpu_to_code, resolve_vpu_source
+
+
+def test_vpu_to_code_zero_padded():
+    assert vpu_to_code("01") == 1
+    assert vpu_to_code("17") == 17
+    assert vpu_to_code("18") == 18
+
+
+def test_vpu_to_code_rejects_garbage():
+    with pytest.raises(ValueError):
+        vpu_to_code("not-a-vpu")
+
+
+def test_resolve_prefers_profile_scalar():
+    # profile vpu scalar wins even if the fabric has an attribute
+    kind, value = resolve_vpu_source(profile_vpu="17", fabric_has_vpu_attr=True)
+    assert kind == "scalar" and value == "17"
+
+
+def test_resolve_falls_back_to_attribute():
+    kind, value = resolve_vpu_source(profile_vpu=None, fabric_has_vpu_attr=True)
+    assert kind == "attribute" and value == "vpu"
+
+
+def test_resolve_errors_when_neither():
+    with pytest.raises(ValueError, match="requires a profile `vpu`"):
+        resolve_vpu_source(profile_vpu=None, fabric_has_vpu_attr=False)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run -e dev pytest tests/test_vpu_id.py -v`
+Expected: FAIL (module undefined).
+
+- [ ] **Step 3: Implement the builder**
+
+Create `src/gfv2_params/depstor_builders/vpu_id.py`:
+
+```python
+"""Rasterise each HRU's home VPU code onto the template grid.
+
+Used by carea_map percentile-`vpu` mode on multi-VPU fabrics (gfv2): each cell
+gets the integer VPU code of the HRU that covers it, so the builder can map
+`vpu_code -> T_P` into a per-cell threshold array. Because the HRU polygon's
+`vpu` value is burned, every cell of an HRU carries that HRU's home VPU — the
+exact per-HRU home-VPU assignment the spec requires.
+
+For single-VPU fabrics the profile declares `vpu:` and the raster is a constant
+fill (or carea_map uses the scalar T_P directly and skips this step).
+"""
+
+from __future__ import annotations
+
+import geopandas as gpd
+import numpy as np
+import rasterio
+from rasterio.features import rasterize
+
+from ..depstor import RasterInfo
+from .context import BuildContext
+
+VPU_NODATA = 0  # 0 is not a valid VPU code (VPUs are 01..18 -> 1..18)
+
+
+def vpu_to_code(vpu: str) -> int:
+    """'01'..'18' -> 1..18. Raises on anything that isn't a VPU label."""
+    try:
+        code = int(str(vpu).lstrip("0") or "0")
+    except (TypeError, ValueError):
+        raise ValueError(f"Not a VPU label: {vpu!r}")
+    if not 1 <= code <= 21:  # NHDPlus VPUs run 01..18 (+ a few sub-regions)
+        raise ValueError(f"VPU code out of range: {vpu!r} -> {code}")
+    return code
+
+
+def resolve_vpu_source(profile_vpu, fabric_has_vpu_attr: bool):
+    """Resolution precedence: profile scalar > fabric attribute > error."""
+    if profile_vpu:
+        return "scalar", str(profile_vpu)
+    if fabric_has_vpu_attr:
+        return "attribute", "vpu"
+    raise ValueError(
+        "carea_map percentile `vpu` scope requires a profile `vpu` scalar "
+        "(single-VPU fabric) or a `vpu` attribute on the HRU layer."
+    )
+
+
+def build(step_cfg: dict, ctx: BuildContext, logger) -> dict:
+    out = ctx.resolve_output(step_cfg["output"])
+    if out.exists() and not ctx.force:
+        logger.info("  vpu_id exists — skipping (pass --force)")
+        return {"vpu_id": out}
+
+    info = RasterInfo.from_path(ctx.template_path)
+    profile = {
+        "driver": "GTiff", "height": info.height, "width": info.width, "count": 1,
+        "dtype": "uint8", "crs": info.crs, "transform": info.transform,
+        "nodata": VPU_NODATA, "compress": "LZW", "tiled": True,
+        "blockxsize": 256, "blockysize": 256, "BIGTIFF": "YES",
+    }
+
+    hru = gpd.read_file(ctx.hru_gpkg, layer=ctx.hru_layer)
+    kind, value = resolve_vpu_source(ctx.vpu, "vpu" in hru.columns)
+    logger.info("--- vpu_id (%s) ---", kind)
+
+    out.parent.mkdir(parents=True, exist_ok=True)
+    with rasterio.open(out, "w", **profile) as dst:
+        if kind == "scalar":
+            dst.write(np.full((info.height, info.width), vpu_to_code(value),
+                              dtype="uint8"), 1)
+        else:
+            if hru.crs != info.crs:
+                hru = hru.to_crs(info.crs)
+            shapes = ((geom, vpu_to_code(v)) for geom, v in zip(hru.geometry, hru[value]))
+            arr = rasterize(
+                shapes, out_shape=(info.height, info.width),
+                transform=info.transform, fill=VPU_NODATA, dtype="uint8",
+                all_touched=True,
+            )
+            dst.write(arr, 1)
+    logger.info("  Wrote vpu_id raster -> %s", out)
+    return {"vpu_id": out}
+```
+
+Add the `vpu` field to `BuildContext` in `context.py` (after `twi_raster`):
+
+```python
+    twi_raster: Path | None = None
+    vpu: str | None = None  # single-VPU fabric's VPU label (e.g. "17"); None = use fabric `vpu` attr
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pixi run -e dev pytest tests/test_vpu_id.py -v`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/gfv2_params/depstor_builders/vpu_id.py src/gfv2_params/depstor_builders/context.py tests/test_vpu_id.py
+git commit -m "feat(depstor): vpu_id builder rasterising HRU home-VPU codes (#55)
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+## Task C3: Threshold resolution in the `carea_map` builder
+
+**Files:**
+- Modify: `src/gfv2_params/depstor_builders/carea_map.py`
+- Test: `tests/test_carea_map_threshold.py` (extend)
+
+- [ ] **Step 1: Write the failing test (extend)**
+
+Append to `tests/test_carea_map_threshold.py`:
+
+```python
+import csv
+from pathlib import Path
+
+from gfv2_params.depstor_builders.carea_map import (
+    load_reference_table,
+    resolve_scalar_thresholds,
+)
+
+
+def _write_table(tmp_path) -> Path:
+    p = tmp_path / "twi_reference_percentiles.hydrodem.csv"
+    with open(p, "w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=["source", "scope", "vpu", "p_carea", "p_smidx", "t_carea", "t_smidx"])
+        w.writeheader()
+        w.writerow({"source": "hydrodem", "scope": "conus", "vpu": "CONUS", "p_carea": 8, "p_smidx": 16, "t_carea": 7.7, "t_smidx": 14.9})
+        w.writerow({"source": "hydrodem", "scope": "vpu", "vpu": "17", "p_carea": 8, "p_smidx": 16, "t_carea": 6.2, "t_smidx": 12.1})
+    return p
+
+
+def test_load_reference_table_indexes_by_scope_vpu(tmp_path):
+    table = load_reference_table(_write_table(tmp_path))
+    assert table[("conus", "CONUS")]["t_carea"] == 7.7
+    assert table[("vpu", "17")]["t_smidx"] == 12.1
+
+
+def test_resolve_scalar_conus(tmp_path):
+    table = load_reference_table(_write_table(tmp_path))
+    tc, ts = resolve_scalar_thresholds(table, scope="conus", vpu=None)
+    assert (tc, ts) == (7.7, 14.9)
+
+
+def test_resolve_scalar_single_vpu(tmp_path):
+    table = load_reference_table(_write_table(tmp_path))
+    tc, ts = resolve_scalar_thresholds(table, scope="vpu", vpu="17")
+    assert (tc, ts) == (6.2, 12.1)
+
+
+def test_resolve_scalar_missing_vpu_raises(tmp_path):
+    table = load_reference_table(_write_table(tmp_path))
+    import pytest
+    with pytest.raises(KeyError, match="no reference row"):
+        resolve_scalar_thresholds(table, scope="vpu", vpu="09")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run -e dev pytest tests/test_carea_map_threshold.py -v`
+Expected: FAIL (`load_reference_table` / `resolve_scalar_thresholds` undefined).
+
+- [ ] **Step 3: Implement the resolution helpers**
+
+In `carea_map.py`, add near the top (after imports):
+
+```python
+import csv
+
+
+def load_reference_table(path) -> dict:
+    """Load a twi_reference_percentiles.<source>.csv into {(scope, vpu): row}."""
+    table = {}
+    with open(path, newline="") as f:
+        for row in csv.DictReader(f):
+            for k in ("p_carea", "p_smidx", "t_carea", "t_smidx"):
+                row[k] = float(row[k])
+            table[(row["scope"], row["vpu"])] = row
+    return table
+
+
+def resolve_scalar_thresholds(table: dict, scope: str, vpu):
+    """Return (t_carea, t_smidx) scalars for conus scope or a single VPU."""
+    key = ("conus", "CONUS") if scope == "conus" else ("vpu", str(vpu))
+    if key not in table:
+        raise KeyError(f"no reference row for {key}; have {sorted(table)}")
+    row = table[key]
+    return row["t_carea"], row["t_smidx"]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pixi run -e dev pytest tests/test_carea_map_threshold.py -v`
+Expected: PASS (7 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/gfv2_params/depstor_builders/carea_map.py tests/test_carea_map_threshold.py
+git commit -m "feat(depstor): reference-table loaders for carea_map percentile mode (#55)
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+## Task C4: Wire `threshold_mode` through `carea_map.build`
+
+**Files:**
+- Modify: `src/gfv2_params/depstor_builders/carea_map.py`
+- Modify: `configs/depstor/depstor_rasters.yml`
+
+Drive the per-strip classify with a resolved threshold: scalar (`absolute`, `percentile`+conus, or `percentile`+vpu on a single-VPU fabric) or a per-cell array from the `vpu_id` raster (`percentile`+vpu on a multi-VPU fabric).
+
+- [ ] **Step 1: Update `carea_map.build`**
+
+Replace the `thresholds = step_cfg["thresholds"]` / `runs = [...]` block and the per-strip loop's threshold use. After computing `info = RasterInfo.from_path(ctx.template_path)` and before the `ExitStack`, resolve the threshold plan:
+
+```python
+    mode = step_cfg.get("threshold_mode", "absolute")
+    outputs = step_cfg["outputs"]
+
+    if mode == "absolute":
+        thr = step_cfg["thresholds"]
+        carea_t, smidx_t = float(thr["carea_max"]), float(thr["smidx"])
+        per_cell = False
+        # Guard: absolute thresholds are calibrated to ArcPy TWI only.
+        if ctx.twi_raster and "hydrodem" in ctx.twi_raster.name:
+            logger.warning(
+                "  threshold_mode=absolute paired with a non-ArcPy TWI source "
+                "(%s) — 8.0/15.6 are calibrated to ArcPy TWI; this is a "
+                "validation-only counterexample, not a shippable output.",
+                ctx.twi_raster.name,
+            )
+    elif mode == "percentile":
+        scope = step_cfg["reference_scope"]          # "conus" | "vpu"
+        table = load_reference_table(step_cfg["reference_table"])
+        if scope == "conus" or ctx.vpu:
+            # single threshold pair (CONUS, or a single-VPU fabric's VPU)
+            carea_t, smidx_t = resolve_scalar_thresholds(
+                table, scope, ctx.vpu if scope == "vpu" else None)
+            per_cell = False
+        else:
+            # multi-VPU fabric, per-VPU scope -> per-cell threshold via vpu_id
+            per_cell = True
+            vpu_id_path = ctx.require("vpu_id")
+            carea_lut = _threshold_lut(table, "t_carea")
+            smidx_lut = _threshold_lut(table, "t_smidx")
+    else:
+        raise ValueError(f"carea_map: unknown threshold_mode {mode!r}")
+
+    runs = [
+        (ctx.resolve_output(outputs["carea_max"]), "carea_max"),
+        (ctx.resolve_output(outputs["smidx"]),     "smidx_coef"),
+    ]
+```
+
+Add the LUT helper near `load_reference_table`:
+
+```python
+def _threshold_lut(table: dict, column: str):
+    """Build a code-indexed lookup array: lut[vpu_code] = threshold.
+
+    vpu_code is the integer from vpu_id.vpu_to_code ('17' -> 17). Index 0 is the
+    vpu_id nodata code; fill it with +inf so unmapped cells never pass twi>thr.
+    """
+    import numpy as np
+    from .vpu_id import vpu_to_code
+    rows = {vpu: row for (scope, vpu), row in table.items() if scope == "vpu"}
+    size = max((vpu_to_code(v) for v in rows), default=0) + 1
+    lut = np.full(size, np.inf, dtype="float64")
+    for vpu, row in rows.items():
+        lut[vpu_to_code(vpu)] = row[column]
+    return lut
+```
+
+In the per-strip loop, build the threshold(s) per strip and pass to `compute_carea_map_binary`. Replace the existing `for i, (thresh, _, _) in enumerate(runs):` body:
+
+```python
+        if per_cell:
+            vpu_id_src = stack.enter_context(rasterio.open(vpu_id_path))
+            _assert_aligned(vpu_id_src, info, "vpu_id")
+
+        for row_off in range(0, info.height, STRIP_ROWS):
+            h = min(STRIP_ROWS, info.height - row_off)
+            window = Window(0, row_off, info.width, h)
+            land_valid = landmask_src.read(1, window=window) == 1
+            perv = perv_src.read(1, window=window)
+            onstream = onstream_src.read(1, window=window)
+            twi = twi_vrt.read(1, window=window)
+            if per_cell:
+                codes = vpu_id_src.read(1, window=window)
+                thresholds = [carea_lut[codes], smidx_lut[codes]]
+            else:
+                thresholds = [carea_t, smidx_t]
+            for i, (out_path, _label) in enumerate(runs):
+                out = compute_carea_map_binary(
+                    perv, onstream, twi, thresholds[i], twi_nodata, land_valid
+                )
+                dsts[i].write(out, 1, window=window)
+                counts[i] += int((out == 1).sum())
+```
+
+Update the `dsts = [...]` and the `if not ctx.force and all(out.exists()...)` / logging lines to use `runs` as `(out_path, label)` pairs (drop the old 3-tuple threshold element). Keep the early-return dict keys `{"carea_max": ..., "smidx": ...}`.
+
+- [ ] **Step 2: Update the config block**
+
+In `configs/depstor/depstor_rasters.yml`, replace the `carea_map` block:
+
+```yaml
+  - name: carea_map
+    # threshold_mode: absolute (legacy 8.0/15.6, ArcPy TWI) | percentile (#55).
+    # Percentile reads the reference table for the matching twi_source; pick the
+    # source by pointing the profile's twi_raster at twi.vrt or twi_hydrodem.vrt.
+    threshold_mode: percentile
+    reference_scope: vpu          # vpu | conus
+    reference_table: "{data_root}/shared/conus/twi_reference_percentiles.hydrodem.csv"
+    # Used only when threshold_mode: absolute
+    thresholds:
+      carea_max: 8.0
+      smidx:     15.6
+    outputs:
+      carea_max: carea_map_t8_binary.tif
+      smidx:     carea_map_t156_binary.tif
+```
+
+Add a `vpu_id` step **before** `carea_map` (multi-VPU fabrics need it; single-VPU fabrics use the scalar path but the step is cheap and harmless):
+
+```yaml
+  - name: vpu_id
+    output: vpu_id.tif
+```
+
+- [ ] **Step 3: Run the existing carea_map tests + import check**
+
+Run: `pixi run -e dev pytest tests/test_carea_map_threshold.py -v`
+Run: `pixi run --as-is python -c "import gfv2_params.depstor_builders.carea_map as m; print('ok')"`
+Expected: PASS; `ok`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/gfv2_params/depstor_builders/carea_map.py configs/depstor/depstor_rasters.yml
+git commit -m "feat(depstor): threshold_mode (absolute|percentile) in carea_map (#55)
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+## Task C5: Register `vpu_id` in the depstor DAG + pass `vpu` into context
+
+**Files:**
+- Modify: `src/gfv2_params/depstor_builders/__init__.py`
+- Modify: `scripts/build_depstor_rasters.py`
+
+- [ ] **Step 1: Register the builder**
+
+In `src/gfv2_params/depstor_builders/__init__.py`: add `vpu_id` to the imports, `BUILDERS`, and `STEP_ORDER` (immediately before `carea_map`):
+
+```python
+from . import carea_map, dprst, imperv, intersect, landmask, perv, routing, streambuffer, vpu_id, waterbody
+```
+
+```python
+    "drains_imperv": intersect.build,
+    "vpu_id":        vpu_id.build,
+    "carea_map":     carea_map.build,
+```
+
+```python
+    "drains_imperv",
+    "vpu_id",
+    "carea_map",
+```
+
+- [ ] **Step 2: Map `vpu_id`'s output + pass `vpu` into BuildContext**
+
+In `scripts/build_depstor_rasters.py` `_expected_outputs`, add `vpu_id` to the single-output map:
+
+```python
+        single_key = {
+            "landmask": "landmask",
+            "imperv": "imperv",
+            "streambuffer": "stream_buffer",
+            "perv": "perv",
+            "routing": "drains_to_dprst",
+            "vpu_id": "vpu_id",
+        }
+```
+
+In `_build_context`, pass the profile's optional `vpu`:
+
+```python
+        twi_raster=Path(config["twi_raster"]) if config.get("twi_raster") else None,
+        vpu=config.get("vpu"),
+        imperv_source=Path(config["imperv_source"]) if config.get("imperv_source") else None,
+```
+
+- [ ] **Step 3: Import + DAG check**
+
+Run: `pixi run --as-is python -c "from gfv2_params.depstor_builders import STEP_ORDER; assert STEP_ORDER.index('vpu_id') < STEP_ORDER.index('carea_map'); print('ok', STEP_ORDER)"`
+Expected: `ok [...]` with `vpu_id` before `carea_map`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/gfv2_params/depstor_builders/__init__.py scripts/build_depstor_rasters.py
+git commit -m "feat(depstor): register vpu_id step + thread profile vpu into context (#55)
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+## Task C6: Profile wiring (oregon `vpu`, gfv2 attribute, twi sources)
+
+**Files:**
+- Modify: `configs/base_config.yml`
+
+- [ ] **Step 1: Edit the oregon + gfv2 profiles**
+
+In the **oregon** profile: add the single-VPU declaration and switch the depstor TWI source to the open-source VRT (percentile mode pairs with hydrodem). Replace the `twi_raster` line + #94 caveat block:
+
+```yaml
+    # Single-VPU fabric: declare the VPU so vpu_id is a constant fill and the
+    # per-VPU reference threshold resolves to VPU 17.
+    vpu: "17"
+    # Depstor TWI source for percentile mode: open-source Twi_hydrodem (CONUS-
+    # complete; #94). carea_map percentile mode reads
+    # twi_reference_percentiles.hydrodem.csv (set in depstor_rasters.yml).
+    twi_raster: "{data_root}/shared/conus/vrt/twi_hydrodem.vrt"
+```
+
+In the **gfv2** profile: do NOT set `vpu` (it must use the per-HRU `vpu` attribute). Switch its depstor `twi_raster` to `twi_hydrodem.vrt` as well, and update the existing TWI-coverage comment to note percentile mode + the per-HRU `vpu` attribute drives per-VPU thresholds.
+
+```yaml
+    twi_raster: "{data_root}/shared/conus/vrt/twi_hydrodem.vrt"
+```
+
+- [ ] **Step 2: Validate config loads for both fabrics**
+
+Run:
+```bash
+pixi run --as-is python -c "
+from gfv2_params.config import load_config
+from pathlib import Path
+for fab in ('oregon','gfv2'):
+    c=load_config(Path('configs/depstor/depstor_rasters.yml'), fabric=fab)
+    print(fab, 'twi_raster=', c.get('twi_raster'), 'vpu=', c.get('vpu'))
+"
+```
+Expected: oregon → `twi_hydrodem.vrt`, `vpu=17`; gfv2 → `twi_hydrodem.vrt`, `vpu=None`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add configs/base_config.yml
+git commit -m "feat(config): wire oregon/gfv2 to percentile mode + twi_hydrodem (#55/#94)
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+# PHASE D — Validation (operational)
+
+Run on the cluster after Phases A–C land. These produce the evidence in spec §5.
+
+## Task D1: Oregon non-degeneracy
+
+- [ ] **Step 1: Build vpu_id + carea_map for oregon (percentile)**
+
+```bash
+FABRIC=oregon pixi run --as-is python scripts/build_depstor_rasters.py \
+  --config configs/depstor/depstor_rasters.yml --from vpu_id --force
+```
+
+- [ ] **Step 2: Verify the two binaries are no longer identical**
+
+```bash
+DR=$(awk '/^data_root:/ {print $2}' configs/base_config.yml)
+pixi run --as-is python - <<PY
+import rasterio, numpy as np
+d="$DR/oregon/depstor_rasters"
+a=rasterio.open(f"{d}/carea_map_t8_binary.tif").read(1)
+b=rasterio.open(f"{d}/carea_map_t156_binary.tif").read(1)
+print("identical:", np.array_equal(a,b), "  t8 ones:", int((a==1).sum()), " t156 ones:", int((b==1).sum()))
+PY
+```
+Expected: `identical: False`, with `t8 ones > t156 ones` (smidx threshold is higher).
+
+## Task D2: VPU 01 calibration A/B
+
+- [ ] **Step 1: Run absolute (ArcPy) and percentile on gfv2_vpu01**
+
+Run depstor rasters twice on `gfv2_vpu01`, once with the carea_map config `threshold_mode: absolute` + a temporary `twi_raster` pointing at the ArcPy `twi.vrt`, once with `threshold_mode: percentile`. Then run the params stage (`derive_depstor_params.py --mode zonal/merge/ratios` for `carea_t8_frac`, `carea_t156_frac`, `perv_frac`) for each and compare the merged `nhm_carea_max_params.csv` / `nhm_smidx_coef_params.csv`.
+
+- [ ] **Step 2: Compare per-HRU**
+
+```bash
+pixi run --as-is python - <<'PY'
+import pandas as pd, numpy as np
+abs_ = pd.read_csv("ABSOLUTE/nhm_carea_max_params.csv")
+pct  = pd.read_csv("PERCENTILE/nhm_carea_max_params.csv")
+m = abs_.merge(pct, on="nat_hru_id", suffixes=("_abs","_pct"))
+d = m["carea_max_pct"] - m["carea_max_abs"]
+print("carea_max  mean|Δ|=", float(d.abs().mean()), " corr=", float(m["carea_max_abs"].corr(m["carea_max_pct"])))
+PY
+```
+Expected: with the inverted-default percentiles, `mean|Δ|` small and correlation high — percentile mode reproduces the calibrated absolute output on VPU 01.
+
+## Task D3: Source A/B (invariance proof)
+
+- [ ] **Step 1: Run percentile mode on VPU 01 against both sources**
+
+Build carea_map on `gfv2_vpu01` with `threshold_mode: percentile` twice — once with `twi_raster: twi.vrt` + `reference_table: ...arcpy.csv`, once with `twi_hydrodem.vrt` + `...hydrodem.csv` — and also `threshold_mode: absolute` against both sources.
+
+- [ ] **Step 2: Quantify movement**
+
+Compare the resulting `carea_max`/`smidx_coef` between sources for each mode (same per-HRU diff as D2).
+Expected: percentile-mode parameters barely move between ArcPy and hydrodem (small `mean|Δ|`); absolute-mode parameters move a lot — demonstrating the invariance claim (spec §5).
+
+---
+
+# PHASE E — Docs + issue housekeeping
+
+## Task E1: Documentation
+
+**Files:**
+- Modify: `README.md`, `slurm_batch/RUNME.md`, `configs/base_config.yml`, `src/gfv2_params/shared_rasters/build_vrt.py`
+
+- [ ] **Step 1: Update docs**
+
+- `slurm_batch/RUNME.md`: add a stage for `submit_twi_completion.sh` (finish `twi.vrt` + build `twi_hydrodem.vrt`), the `twi_reference` step, and percentile-mode carea_map (note the `vpu_id` step + mode↔source pairing). 
+- `README.md`: replace the line that says the calibration thresholds reference the canonical ArcPy TWI with a pointer to the percentile refactor + the spec; note `twi_hydrodem.vrt` is now a first-class source.
+- `build_vrt.py`: soften the "DO NOT SWAP" comment on the `twi` type to: absolute mode still requires ArcPy TWI, but percentile mode (`twi_reference` + carea_map `threshold_mode: percentile`) makes `twi_hydrodem` safe — cross-reference the spec.
+- `configs/base_config.yml`: replace the oregon `⚠️ #94` carea-degenerate caveat with a note that percentile mode + `twi_hydrodem.vrt` resolves it.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add README.md slurm_batch/RUNME.md configs/base_config.yml src/gfv2_params/shared_rasters/build_vrt.py
+git commit -m "docs(depstor): document TWI completion, twi_reference, percentile carea_map (#55/#94)
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+## Task E2: Issue housekeeping + PR
+
+- [ ] **Step 1: Open the combined umbrella issue + cross-link**
+
+```bash
+gh issue comment 94 --body "Folded into the percentile refactor on feat/twi-percentile-carea-smidx (see docs/superpowers/specs/2026-05-21-carea-smidx-twi-percentile-design.md). Resolved by building twi_hydrodem.vrt + finishing twi.vrt + data-derived percentile thresholds."
+gh issue comment 55 --body "Stage 1 implemented on feat/twi-percentile-carea-smidx (per-HRU/VPU + CONUS percentile cutoffs, valid-land reference, CDF-inverted defaults). Stage 2 (NWI/SSURGO/NLCD observational decoupling) remains open."
+```
+
+- [ ] **Step 2: Run pre-commit + open the PR**
+
+```bash
+pixi run -e dev pre-commit run --all-files
+git push -u origin feat/twi-percentile-carea-smidx
+gh pr create --fill --title "Distribution-invariant carea_max/smidx_coef: TWI percentile thresholds (#55/#94)"
+```
+
+Lead the PR body with a scope summary: TWI source completion (Phase A), reference-percentile pre-step (B), percentile-mode carea_map reusing the binary builder (C), validation evidence (D), docs (E). Note #55 Stage 2 is deferred. Let CI run `pytest` (the test gate).
+
+---
+
+## Self-review notes (for the implementer)
+
+- **Spec coverage:** §4.1 → A1/A2; §4.2 + §3.4 → B1/B2/B3; §4.3 → C1/C3/C4; §4.4 (pairing + guard) → C4 Step 1 guard + C6; §4.5 (per-VPU) → C2/C4/C5/C6; §5 → D1/D2/D3; §6 docs → E1; issue housekeeping → E2.
+- **Threshold contract:** `compute_carea_map_binary(threshold)` is scalar-or-array (C1); `_threshold_lut` fills nodata code 0 with `+inf` so unmapped cells never pass — keep that invariant.
+- **Single-VPU fast path:** when `ctx.vpu` is set, percentile-`vpu` uses `resolve_scalar_thresholds` (no vpu_id read needed), so oregon does not depend on the multi-VPU array path.

--- a/docs/superpowers/specs/2026-05-21-carea-smidx-twi-percentile-design.md
+++ b/docs/superpowers/specs/2026-05-21-carea-smidx-twi-percentile-design.md
@@ -208,6 +208,61 @@ The parameter contract is **unchanged**: same pervious denominator, same onstrea
 inclusion, same clamp to 1.0, same per-HRU [0, 1] float into the same PRMS slots.
 Only the source of the cutoff number changes.
 
+### 4.4 Mode ↔ source pairing
+
+`threshold_mode` and `twi_source` are **independent config axes**, but only one
+combination of each is a valid *production* output. The defaults wire up the
+correct pairing; the cross combinations exist solely for validation.
+
+**Production pairing (the "diagonal" — these are the only shippable outputs):**
+
+| `threshold_mode` | `twi_source` | Meaning |
+|---|---|---|
+| `absolute` (8.0 / 15.6) | `twi.vrt` (ArcPy `Twi_merged`) | The only source those constants were calibrated against. Valid only where ArcPy TWI exists (VPU 01, or anywhere once §4.1 finishes `twi.vrt`). |
+| `percentile` (data-derived) | `twi_hydrodem.vrt` | CONUS-complete open-source source; the path forward for every fabric outside VPU 01. |
+
+**Off-diagonal (validation-only, never shipped):**
+
+- `absolute` × `twi_hydrodem.vrt` — the *broken* case (absolute thresholds on a
+  distribution they were not calibrated to). Run **only** in the §5 invariance
+  proof as the counterexample that demonstrates absolute-mode fragility.
+- `percentile` × `twi.vrt` — used in the §3.4 CDF inversion (measure where
+  8.0/15.6 land in VPU 01's ArcPy distribution) and as the percentile-mode arm of
+  the VPU 01 calibration A/B.
+
+**Guard:** the config loader emits a warning (not a hard error — validation needs
+the off-diagonal) when `threshold_mode: absolute` is paired with any non-ArcPy
+`twi_source`, so a broken combination cannot be shipped by accident.
+
+### 4.5 Per-VPU threshold application (multi-VPU fabrics, e.g. gfv2)
+
+`reference_scope: vpu` resolves a different `T_P` per VPU, so a fabric spanning
+multiple VPUs (gfv2 = all 18) needs an HRU→VPU mapping. Because the percentile
+runner processes HRUs one at a time (Approach A, §4.3), this is a per-HRU lookup,
+not a spatial operation.
+
+**HRU→VPU resolution precedence:**
+
+1. **Profile `vpu:` scalar** — single-VPU fabrics (oregon → `vpu: "17"`) declare
+   their VPU in the profile; every HRU uses that `T_P`.
+2. **Fabric `vpu` attribute** — multi-VPU fabrics use the per-HRU column. Verified
+   present on gfv2 (`gfv2_nhru_merged.gpkg` layer `nhru`: fields include `vpu`,
+   `source_vpu`, `vpu_agg_id`; 361,471 HRUs). The runner loads an
+   `id_feature → vpu` map once from the fabric and looks up each HRU by id within
+   the batch (no dependency on batch files carrying the attribute).
+3. **Neither present** — `percentile` + `vpu` scope raises with a clear message
+   (require a profile `vpu:` or a fabric `vpu` column).
+
+**Border HRUs:** an HRU is assigned to its single home `vpu` (the attribute value),
+so it gets exactly one threshold even if its cells drape slightly across a VPU
+boundary — well-defined, no per-cell ambiguity. This matches how the parameter is
+already a single per-HRU value.
+
+**Reference-percentile coverage:** the §4.2 table must contain a per-VPU `T_P` for
+every VPU present in the fabric. The pre-step computes all 18 regardless, so gfv2
+is covered; the runner validates that each HRU's `vpu` has an entry and fails
+loudly otherwise.
+
 ---
 
 ## 5. Validation & success criteria
@@ -241,10 +296,9 @@ Only the source of the cutoff number changes.
 
 ## 7. Open questions / follow-ups
 
-- **Multi-VPU per-VPU application (gfv2):** per-VPU thresholds on a CONUS fabric
-  need an HRU→VPU mapping (HRU attribute or spatial join). Oregon is single-VPU
-  (profile scalar), so this is only exercised when gfv2 runs percentile-mode —
-  resolve in the implementation plan.
 - **`smidx_exp`** is still not produced by this pipeline (NHM default); unchanged
   by this work, noted for completeness.
 - **Stage 2** (observational decoupling) — separate spec.
+
+(The multi-VPU per-VPU application is resolved in §4.5: gfv2 carries a per-HRU
+`vpu` attribute, so it's a direct lookup, not a spatial join.)

--- a/docs/superpowers/specs/2026-05-21-carea-smidx-twi-percentile-design.md
+++ b/docs/superpowers/specs/2026-05-21-carea-smidx-twi-percentile-design.md
@@ -1,0 +1,250 @@
+# Design: distribution-invariant `carea_max` / `smidx_coef` (unify #94 + #55 Stage 1)
+
+**Date:** 2026-05-21
+**Status:** design — pending implementation plan
+**Issues folded in:** #94 (TWI staging gap), #55 Stage 1 (decouple from absolute TWI thresholds)
+**Deferred:** #55 Stage 2 (NWI/SSURGO/NLCD observational decoupling)
+
+---
+
+## 1. Problem & motivation
+
+Two PRMS depression-storage parameters, both per-HRU floats in [0, 1]:
+
+- **`carea_max`** — the *storm-event ceiling*: the maximum fraction of an HRU's
+  pervious area that can produce surface runoff at full saturation (upper bound
+  of the variable source area).
+- **`smidx_coef`** — the *soil-moisture-index coefficient*: scales how fast the
+  contributing area grows with wetting in PRMS's nonlinear runoff term
+  `ca_fraction = smidx_coef × smidx^smidx_exp`.
+
+They are physically distinct (a ceiling vs. a reactivity rate), but the legacy
+method derives **both from a single proxy — TWI — at two hardcoded thresholds.**
+
+Two open issues meet here:
+
+- **#94** — the canonical ArcPy TWI (`Twi_merged_<vpu>.tif` → `shared/conus/vrt/twi.vrt`)
+  is only populated for **VPU 01**. Everywhere else `twi.vrt` is nodata, so any
+  `carea_map` run outside VPU 01 is degenerate (`carea_map_t8 ≡ carea_map_t156`,
+  byte-identical). The populated alternative — open-source `Twi_hydrodem_<vpu>.tif`,
+  present and valid for all 18 VPUs — *cannot* be adopted because…
+- **#55** — …the `8.0`/`15.6` thresholds are calibrated to the *shape* of the
+  ArcPy TWI distribution. Any TWI pipeline change silently invalidates them
+  ([build_vrt.py](../../../src/gfv2_params/shared_rasters/build_vrt.py) literally
+  says "**DO NOT SWAP**" to `Twi_hydrodem`).
+
+**The link that unifies them:** if the cutoff is derived from the TWI data
+itself (a percentile) instead of being hardcoded, it *self-recalibrates* when the
+source changes — so adopting `Twi_hydrodem` becomes safe, which closes #94's
+coverage gap. #55 Stage 1 is the enabler for #94.
+
+---
+
+## 2. Background: the previous method (ArcPy) and how this repo reproduces it
+
+### 2.1 The legacy computation
+
+`getCarea(threshold)` in [docs/0b_TB_depr_stor.py:264-312](../../0b_TB_depr_stor.py#L264)
+does exactly:
+
+```
+careaMap = pervious AND ( TWI > threshold  OR  onStreamStorage )   # 0/1 mask
+carea    = count(careaMap cells per HRU) / count(pervious cells per HRU)
+carea    = min(carea, 1.0)
+```
+
+with two hardcoded thresholds:
+
+- `carea_max`  → **TWI > 8.0**  ([:244-261](../../0b_TB_depr_stor.py#L244))
+- `smidx_coef` → **TWI > 15.6** ([:219-239](../../0b_TB_depr_stor.py#L219))
+
+Each parameter is *"the fraction of this HRU's pervious cells whose TWI clears a
+fixed cutoff (or that sit on a stream)."* Because 15.6 > 8.0, `smidx_coef ≤ carea_max`
+by construction.
+
+### 2.2 Faithful reproduction in this repo
+
+The same math, split across the orchestrator/builder pattern:
+
+- [carea_map.py](../../../src/gfv2_params/depstor_builders/carea_map.py) +
+  `compute_carea_map_binary` build the two 0/1 rasters
+  (`carea_map_t8_binary.tif`, `carea_map_t156_binary.tif`) using the literal
+  `8.0`/`15.6` from
+  [depstor_rasters.yml](../../../configs/depstor/depstor_rasters.yml#L62-L68).
+- [depstor_params.yml](../../../configs/depstor/depstor_params.yml) zonal-counts
+  each binary per HRU (`carea_t8_frac`, `carea_t156_frac`), counts pervious cells
+  (`perv_frac`), and the `carea_max` / `smidx_coef` ratios divide-and-clamp —
+  byte-for-byte the legacy `careaCount / perviousCount` capped at 1.0.
+
+### 2.3 Provenance of 8.0 / 15.6 — *undocumented*
+
+Searched every reference doc. `8.0`/`15.6` appear as **bare constants with no
+derivation**: the legacy docstrings, [depstor_workflow.md:344,354](../../depstor_workflow.md#L344),
+and [README.md:294](../../../README.md#L294) all present them as given.
+README frames them as *"calibration thresholds [that] reference the canonical
+ArcPy-derived TWI"* — i.e. empirically calibrated to that specific TWI product,
+not analytically derived. **We do not know a priori what percentile they occupy.**
+
+### 2.4 The three structural problems (from #55)
+
+1. **One proxy, two thresholds, conflating two physics.** TWI is a steady-state
+   geomorphic wetness proxy; using it at 8.0 (storm ceiling) and 15.6 (reactivity)
+   entangles two quantities that should move independently.
+2. **Absolute cutoffs welded to one distribution.** Any TWI pipeline change shifts
+   the distribution and silently invalidates 8.0/15.6 — the root cause of #94's
+   deadlock.
+3. **Hard step at the threshold** — TWI 7.99 → 0, 8.01 → 1; no graduated response.
+
+---
+
+## 3. Proposed change (Stage 1)
+
+**Replace the hardcoded cutoff with a cutoff derived from the TWI data itself —
+a percentile `T_P`** — applied otherwise identically:
+
+```
+T_P      = the P-th percentile of TWI over a reference population
+careaMap = pervious AND ( TWI > T_P  OR  onStreamStorage )
+carea    = count(careaMap) / count(pervious)   ,  capped at 1.0
+```
+
+Changing the TWI source shifts the whole distribution, but `T_P` is recomputed
+from that same distribution, so it shifts with it: a cell's *rank* (is it in the
+wettest quartile?) is preserved. The parameters become **invariant to the TWI
+source** → `Twi_hydrodem` is safe → #94 closes. This fixes **problem 2 only**.
+
+### 3.1 What Stage 1 deliberately does NOT do
+
+It keeps the single-proxy / two-threshold / step-function structure. **Problems 1
+and 3** (decoupling the two parameters via observational data — stream buffer +
+NLCD wetlands for `carea_max`; NWI + hydric soils, *no TWI*, for `smidx_coef` —
+and a graduated response) are **#55 Stage 2**, deferred to a follow-up issue.
+
+### 3.2 Reference population (decided: valid-land TWI)
+
+A percentile needs a population. Per-HRU self-referential cutoffs are **degenerate**
+(taking each HRU's own top quartile drives `carea_max ≈ 1−P` everywhere, destroying
+cross-HRU contrast). A **reference population** yields one `T_P` applied across
+HRUs — structurally like today's 8.0, but auto-derived — and preserves cross-HRU
+dynamic range.
+
+**Decision:** the reference population is **valid-land TWI** (all land cells, via
+`land_mask`), *not* pervious-only. Rationale: the percentile's job is only to
+define "what TWI is high" for a given raster product — a clean, **source-intrinsic,
+fabric-independent** property computed once per TWI source and cached in `shared/`.
+The pervious restriction still governs the numerator/denominator of the actual
+parameter; the two concerns are separable.
+
+### 3.3 Reference scope (decided: compute both, switchable)
+
+Compute `T_P` at **two scopes** for **both TWI sources**, and select via config:
+
+- **CONUS-global** — one `T_P` nationwide; closest analog to today's fixed scalar,
+  auto-recalibrating per source.
+- **Per-VPU** — one `T_P` per VPU; preserves regional climate/terrain differences.
+
+### 3.4 Setting the percentile defaults (principled, not guessed)
+
+Rather than guessing P75/P95, **derive the defaults by inverting the legacy
+thresholds through the VPU 01 ArcPy-TWI CDF**: measure what percentile `8.0` and
+`15.6` occupy in VPU 01's valid-land TWI distribution. Those measured percentiles
+(`P_carea`, `P_smidx`) become the defaults — so percentile-mode reproduces the
+legacy parameters on VPU 01 *by construction*, then ports invariantly to other
+sources/regions. P75/P95 (#55's draft) is retained only as a sanity reference.
+Percentiles remain config-overridable.
+
+---
+
+## 4. Architecture
+
+### 4.1 Data staging (shared / Part-1)
+
+- **`twi_hydrodem.vrt`** — add a VRT entry in
+  [build_vrt.py](../../../src/gfv2_params/shared_rasters/build_vrt.py) sourced
+  from `Twi_hydrodem_*.tif` (all 18 present, multi-GB, valid). Apply
+  `-a_srs EPSG:5070` so the VRT carries a *named* CRS — the tiles report
+  `"unnamed"` Albers/GRS80 and carea_map does a strict `src.crs != template.crs`
+  check. Verified: `Twi_hydrodem_17` is whole-cell aligned with the fdr-clip
+  template (Δx/30 = 4297.0, Δy/30 = 0.0).
+- **Finish `twi.vrt`** — a SLURM step running `merge_rpu_by_vpu` (TWI manifest,
+  [merge_rpu_by_vpu_twi.yml](../../../configs/shared_rasters/merge_rpu_by_vpu_twi.yml))
+  for VPUs 02–18, then rebuilding the VRT. All inputs are present
+  (`input/twi/<rpu>/twi.tif`, 59 RPUs; per-VPU land masks for all 18 VPUs);
+  02–18 were simply never merged. Pure on-cluster — **no ArcPy needed.** This
+  enables the `twi.vrt` vs `twi_hydrodem.vrt` A/B.
+
+Both VRTs become selectable `twi_raster` sources in the fabric profiles.
+
+### 4.2 Reference-percentile pre-step (new)
+
+A new step computes the `T_P` table over valid-land TWI:
+
+- Output: a small cached artifact (CSV/YAML) keyed by
+  `(twi_source, scope, vpu?)` → `{p_carea: T_Pa, p_smidx: T_Ps}`, for both scopes
+  and both sources. Lives in `shared/`.
+- Includes the §3.4 inversion: report the percentile that 8.0 / 15.6 occupy in the
+  VPU 01 ArcPy distribution, used to seed `P_carea` / `P_smidx`.
+- Cheap (decimated/streamed percentile over land-masked TWI per VPU + CONUS).
+
+### 4.3 `carea_max` / `smidx_coef` refactor (Approach A — zonal stage)
+
+A `threshold_mode` switch:
+
+- **`absolute`** (default for now) — 8.0 / 15.6 via the **existing binary-raster
+  builder + count/ratio**, untouched. This is the calibrated A/B baseline.
+- **`percentile`** with `reference_scope: vpu | conus` and
+  `twi_source: arcpy | hydrodem` — a **new zonal runner** resolves each HRU's
+  threshold (`mode × scope × source`; per-VPU keyed by the HRU's VPU — a profile
+  scalar for single-VPU fabrics like oregon, an HRU attribute for multi-VPU gfv2)
+  and computes the parameter directly per HRU: same numpy classify as
+  `compute_carea_map_binary`, aggregated per HRU instead of rasterized.
+
+**Decision:** keep `absolute` on the existing builder (zero regression risk to the
+trusted baseline, exact byte-for-byte A/B reference) rather than unifying both modes
+into one runner. Accepts two code paths short-term; can collapse to one once
+percentile mode is validated.
+
+The parameter contract is **unchanged**: same pervious denominator, same onstream
+inclusion, same clamp to 1.0, same per-HRU [0, 1] float into the same PRMS slots.
+Only the source of the cutoff number changes.
+
+---
+
+## 5. Validation & success criteria
+
+- **Non-degeneracy:** on **oregon** (VPU 17), percentile-mode yields
+  `carea_max ≠ smidx_coef` (the t8 ≡ t156 byte-identical bug is gone).
+- **Calibration A/B on `gfv2_vpu01`** (the one fabric with valid ArcPy TWI):
+  compare `percentile`-mode vs `absolute`-mode parameters per HRU; with the §3.4
+  inverted defaults, percentile-mode should reproduce the absolute outputs closely.
+  Report per-HRU distribution stats / scatter.
+- **Source A/B:** `twi.vrt` (ArcPy) vs `twi_hydrodem.vrt` once both exist —
+  quantify how much the parameters move (should be small under percentile-mode,
+  large under absolute-mode — demonstrating the invariance claim).
+
+---
+
+## 6. Tests & docs
+
+- **Unit tests** (builder + test together, repo convention): percentile
+  computation over a masked array; threshold resolution (`mode × scope × source`,
+  per-VPU lookup); per-HRU classify + aggregate equivalence with
+  `compute_carea_map_binary` on a synthetic grid; CDF-inversion helper.
+- **Docs:** README, `slurm_batch/RUNME.md` (new Stage: TWI merge completion +
+  reference-percentile + percentile-mode params), update the #94 caveat in
+  [base_config.yml](../../../configs/base_config.yml), refresh the
+  `twi_canonical_source` memory and the "DO NOT SWAP" note in `build_vrt.py`.
+- **Issue housekeeping:** open one combined umbrella issue; mark #94 + #55-Stage-1
+  folded in; leave #55-Stage-2 as the remaining scope.
+
+---
+
+## 7. Open questions / follow-ups
+
+- **Multi-VPU per-VPU application (gfv2):** per-VPU thresholds on a CONUS fabric
+  need an HRU→VPU mapping (HRU attribute or spatial join). Oregon is single-VPU
+  (profile scalar), so this is only exercised when gfv2 runs percentile-mode —
+  resolve in the implementation plan.
+- **`smidx_exp`** is still not produced by this pipeline (NHM default); unchanged
+  by this work, noted for completeness.
+- **Stage 2** (observational decoupling) — separate spec.

--- a/docs/superpowers/specs/2026-05-21-carea-smidx-twi-percentile-design.md
+++ b/docs/superpowers/specs/2026-05-21-carea-smidx-twi-percentile-design.md
@@ -186,23 +186,28 @@ A new step computes the `T_P` table over valid-land TWI:
   VPU 01 ArcPy distribution, used to seed `P_carea` / `P_smidx`.
 - Cheap (decimated/streamed percentile over land-masked TWI per VPU + CONUS).
 
-### 4.3 `carea_max` / `smidx_coef` refactor (Approach A — zonal stage)
+### 4.3 `carea_max` / `smidx_coef` refactor (reuse the existing builder)
 
-A `threshold_mode` switch:
+Because the reference-population choice (§3.2–3.3) makes the cutoff a **per-region
+value applied per cell** — the same shape as today's `8.0` — there is **no new
+zonal runner.** The existing `carea_map` binary builder + count + ratio pipeline is
+reused end to end; only the *source of the threshold number* changes, fed via a
+`threshold_mode` switch in [depstor_rasters.yml](../../../configs/depstor/depstor_rasters.yml):
 
-- **`absolute`** (default for now) — 8.0 / 15.6 via the **existing binary-raster
-  builder + count/ratio**, untouched. This is the calibrated A/B baseline.
-- **`percentile`** with `reference_scope: vpu | conus` and
-  `twi_source: arcpy | hydrodem` — a **new zonal runner** resolves each HRU's
-  threshold (`mode × scope × source`; per-VPU keyed by the HRU's VPU — a profile
-  scalar for single-VPU fabrics like oregon, an HRU attribute for multi-VPU gfv2)
-  and computes the parameter directly per HRU: same numpy classify as
-  `compute_carea_map_binary`, aggregated per HRU instead of rasterized.
+- **`absolute`** (default) — scalar 8.0 / 15.6, exactly as today.
+- **`percentile`** with `reference_scope: vpu | conus` and `twi_source: arcpy |
+  hydrodem` — the builder reads the §4.2 reference table:
+  - **`conus` scope** (or any single-VPU fabric) → a **scalar** `T_P` per param;
+    drop-in for `8.0`/`15.6` in the existing per-strip classify.
+  - **`vpu` scope on a multi-VPU fabric** (gfv2) → a **per-cell threshold array**
+    built from a `vpu_id` raster (§4.5): each cell's `T_P = table[source][vpu_id]`.
 
-**Decision:** keep `absolute` on the existing builder (zero regression risk to the
-trusted baseline, exact byte-for-byte A/B reference) rather than unifying both modes
-into one runner. Accepts two code paths short-term; can collapse to one once
-percentile mode is validated.
+The classify itself (`compute_carea_map_binary`) is unchanged except that
+`threshold` may be a scalar **or** a per-cell array (`twi > threshold` broadcasts
+either way). The two `carea_map_t8/t156_binary.tif` artifacts are still produced —
+useful for the §5 source A/B byte-diff. The existing `carea_t8_frac` /
+`carea_t156_frac` zonal counts and the `carea_max` / `smidx_coef` ratios are
+**untouched.**
 
 The parameter contract is **unchanged**: same pervious denominator, same onstream
 inclusion, same clamp to 1.0, same per-HRU [0, 1] float into the same PRMS slots.
@@ -237,26 +242,27 @@ the off-diagonal) when `threshold_mode: absolute` is paired with any non-ArcPy
 ### 4.5 Per-VPU threshold application (multi-VPU fabrics, e.g. gfv2)
 
 `reference_scope: vpu` resolves a different `T_P` per VPU, so a fabric spanning
-multiple VPUs (gfv2 = all 18) needs an HRU→VPU mapping. Because the percentile
-runner processes HRUs one at a time (Approach A, §4.3), this is a per-HRU lookup,
-not a spatial operation.
+multiple VPUs (gfv2 = all 18) needs an HRU→VPU mapping. This is realized as a
+**`vpu_id` raster on the template grid** (a small new builder step): the fabric
+HRU polygons are rasterised burning an integer VPU code, so every cell of an HRU
+carries **that HRU's home VPU**. The `carea_map` builder maps `vpu_id → T_P` to
+form the per-cell threshold array (§4.3).
 
-**HRU→VPU resolution precedence:**
+**VPU-code resolution precedence (for building the `vpu_id` raster):**
 
 1. **Profile `vpu:` scalar** — single-VPU fabrics (oregon → `vpu: "17"`) declare
-   their VPU in the profile; every HRU uses that `T_P`.
-2. **Fabric `vpu` attribute** — multi-VPU fabrics use the per-HRU column. Verified
-   present on gfv2 (`gfv2_nhru_merged.gpkg` layer `nhru`: fields include `vpu`,
-   `source_vpu`, `vpu_agg_id`; 361,471 HRUs). The runner loads an
-   `id_feature → vpu` map once from the fabric and looks up each HRU by id within
-   the batch (no dependency on batch files carrying the attribute).
+   their VPU in the profile; the `vpu_id` raster is a constant fill (or the builder
+   uses the scalar `T_P` directly and skips the raster).
+2. **Fabric `vpu` attribute** — multi-VPU fabrics rasterise the per-HRU column.
+   Verified present on gfv2 (`gfv2_nhru_merged.gpkg` layer `nhru`: fields include
+   `vpu`, `source_vpu`, `vpu_agg_id`; 361,471 HRUs).
 3. **Neither present** — `percentile` + `vpu` scope raises with a clear message
    (require a profile `vpu:` or a fabric `vpu` column).
 
-**Border HRUs:** an HRU is assigned to its single home `vpu` (the attribute value),
-so it gets exactly one threshold even if its cells drape slightly across a VPU
-boundary — well-defined, no per-cell ambiguity. This matches how the parameter is
-already a single per-HRU value.
+**Border cells:** because the rasteriser burns the *HRU polygon's* `vpu` value,
+every cell of an HRU gets that HRU's home-VPU threshold even where the HRU drapes
+across a VPU divide — i.e. the raster realises exactly the per-HRU home-VPU
+assignment, with no per-cell ambiguity.
 
 **Reference-percentile coverage:** the §4.2 table must contain a per-VPU `T_P` for
 every VPU present in the fabric. The pre-step computes all 18 regardless, so gfv2
@@ -281,10 +287,11 @@ loudly otherwise.
 
 ## 6. Tests & docs
 
-- **Unit tests** (builder + test together, repo convention): percentile
-  computation over a masked array; threshold resolution (`mode × scope × source`,
-  per-VPU lookup); per-HRU classify + aggregate equivalence with
-  `compute_carea_map_binary` on a synthetic grid; CDF-inversion helper.
+- **Unit tests** (builder + test together, repo convention): valid-land
+  percentile computation over a masked array; CDF-inversion helper (percentile of
+  8.0/15.6); threshold resolution (`mode × scope × source`); `vpu_id → T_P` per-cell
+  threshold mapping; `compute_carea_map_binary` accepting a per-cell array threshold
+  (equivalence with the scalar path on a synthetic grid).
 - **Docs:** README, `slurm_batch/RUNME.md` (new Stage: TWI merge completion +
   reference-percentile + percentile-mode params), update the #94 caveat in
   [base_config.yml](../../../configs/base_config.yml), refresh the

--- a/scripts/build_depstor_rasters.py
+++ b/scripts/build_depstor_rasters.py
@@ -83,6 +83,7 @@ def _build_context(config: dict, force: bool) -> BuildContext:
         waterbody_layer=config.get("waterbody_layer"),
         fdr_raster=Path(config["fdr_raster"]) if config.get("fdr_raster") else None,
         twi_raster=Path(config["twi_raster"]) if config.get("twi_raster") else None,
+        vpu=config.get("vpu"),
         imperv_source=Path(config["imperv_source"]) if config.get("imperv_source") else None,
         force=force,
     )
@@ -122,6 +123,7 @@ def _expected_outputs(step: dict) -> dict:
             "streambuffer": "stream_buffer",
             "perv": "perv",
             "routing": "drains_to_dprst",
+            "vpu_id": "vpu_id",
         }
         return {single_key[name]: step["output"]}
     outputs = step["outputs"]

--- a/slurm_batch/RUNME.md
+++ b/slurm_batch/RUNME.md
@@ -291,6 +291,32 @@ downstream zonal aggregation. Depends on Stage 1c1.
 
 **Stage 2a — `build_vrt`:** Combine per-VPU rasters and optional Copernicus
 fill into CONUS-wide GDAL virtual rasters (elevation/slope/aspect/fdr/twi).
+Also builds `twi_hydrodem.vrt` (open-source WhiteboxTools TWI, CONUS-complete)
+if `Twi_hydrodem_*.tif` tiles are present in `per_vpu/`. If the ArcPy
+`Twi_merged_*.tif` tiles for VPUs 02-18 were never merged (issue #94),
+finish them first and then rebuild both VRTs in one shot:
+
+```bash
+bash slurm_batch/submit_twi_completion.sh
+```
+
+This submits two chained jobs: `merge_rpu_by_vpu_twi --force` (rebuilds all
+18 VPUs idempotently) → `build_vrt --force` (writes `twi.vrt` and
+`twi_hydrodem.vrt`). Verify afterwards with `gdalinfo` on both VRTs.
+
+**Stage 2a' — `twi_reference`:** Compute valid-land TWI percentile cutoffs
+per VPU (and CONUS) for each TWI source (`arcpy`, `hydrodem`). Outputs
+`shared/conus/twi_reference_percentiles.arcpy.csv` and
+`shared/conus/twi_reference_percentiles.hydrodem.csv`. These tables are the
+input to `carea_map threshold_mode: percentile` (Stage 2d). The default
+percentiles are derived by inverting the legacy 8.0/15.6 thresholds through
+VPU 01's ArcPy TWI CDF. Runs automatically after `build_vrt` in the
+orchestrator DAG; run on its own with:
+
+```bash
+pixi run python scripts/build_shared_rasters.py \
+    --config configs/shared_rasters/shared_rasters.yml --step twi_reference
+```
 
 **Stage 2b — `build_derived_rasters`:** Pre-compute `rd_250_raw.tif` and
 `soil_moist_max.tif`.
@@ -323,9 +349,27 @@ Inputs (per fabric, from `base_config.yml`):
 
 One sbatch builds the entire stack in dependency order
 (landmask → imperv/streambuffer/waterbody → dprst → perv/routing →
-drains_perv/drains_imperv → carea_map). The 10-step DAG is encoded in
-`src/gfv2_params/depstor_builders/__init__.py`; selective re-runs are supported
-via `--step <name>` or `--from <name>` passed through to the python script.
+drains_perv/drains_imperv → vpu_id → carea_map). The 11-step DAG is encoded
+in `src/gfv2_params/depstor_builders/__init__.py`; selective re-runs are
+supported via `--step <name>` or `--from <name>` passed through to the python
+script.
+
+**`vpu_id` step:** rasterises the HRU fabric's `vpu` attribute onto the
+template grid. Required by `carea_map` when `threshold_mode: percentile` and
+the fabric spans multiple VPUs (multi-VPU fabrics look up each cell's VPU in
+the reference table; single-VPU fabrics set `vpu: "17"` in their profile and
+skip this step).
+
+**`carea_map` threshold modes:** configured in `configs/depstor/depstor_rasters.yml`.
+- `threshold_mode: absolute` — legacy 8.0/15.6 thresholds. Requires ArcPy
+  `twi.vrt` as `twi_raster`; the builder warns if paired with a non-ArcPy
+  source.
+- `threshold_mode: percentile` — derives the TWI cutoff from the data by
+  reading the per-VPU reference table produced by Stage 2a'. Source-agnostic:
+  use with `twi.vrt` (ArcPy) or `twi_hydrodem.vrt` (open-source). Point the
+  profile's `twi_raster` at the chosen VRT and set `reference_table`
+  accordingly. The off-diagonal pairings (absolute + hydrodem, percentile +
+  arcpy) are valid for validation but the builder warns.
 
 ```bash
 sbatch slurm_batch/build_depstor_rasters.batch
@@ -619,6 +663,7 @@ orchestrators cover them — the library code they delegated to lives under
 | Batch / shell | Config | Script |
 |---|---|---|
 | `stage_twi.batch` | `base_config.yml` (indirectly) | `scripts/stage_twi.sh` |
+| `submit_twi_completion.sh` | `shared_rasters/shared_rasters.yml` | `build_shared_rasters.py --step merge_rpu_by_vpu_twi --force` then `--step build_vrt --force` (finishes `twi.vrt` + builds `twi_hydrodem.vrt`) |
 | `download_rpu_rasters.batch` | `base_config.yml` | `gfv2_params.download.rpu_rasters` |
 | `download_nalcms.batch` | `base_config.yml` | `gfv2_params.download.nalcms_lulc` |
 | `download_nhm_v11.batch` | `base_config.yml` | `gfv2_params.download.nhm_v11_lulc` |

--- a/slurm_batch/RUNME.md
+++ b/slurm_batch/RUNME.md
@@ -300,9 +300,11 @@ finish them first and then rebuild both VRTs in one shot:
 bash slurm_batch/submit_twi_completion.sh
 ```
 
-This submits two chained jobs: `merge_rpu_by_vpu_twi --force` (rebuilds all
+This submits three chained jobs: `merge_rpu_by_vpu_twi --force` (rebuilds all
 18 VPUs idempotently) → `build_vrt --force` (writes `twi.vrt` and
-`twi_hydrodem.vrt`). Verify afterwards with `gdalinfo` on both VRTs.
+`twi_hydrodem.vrt`) → `twi_reference --force` (writes the per-VPU percentile
+CSVs used by `carea_map threshold_mode: percentile`). Verify afterwards with
+`gdalinfo` on both VRTs.
 
 **Stage 2a' — `twi_reference`:** Compute valid-land TWI percentile cutoffs
 per VPU (and CONUS) for each TWI source (`arcpy`, `hydrodem`). Outputs
@@ -363,13 +365,13 @@ skip this step).
 **`carea_map` threshold modes:** configured in `configs/depstor/depstor_rasters.yml`.
 - `threshold_mode: absolute` — legacy 8.0/15.6 thresholds. Requires ArcPy
   `twi.vrt` as `twi_raster`; the builder warns if paired with a non-ArcPy
-  source.
+  (hydrodem) source.
 - `threshold_mode: percentile` — derives the TWI cutoff from the data by
   reading the per-VPU reference table produced by Stage 2a'. Source-agnostic:
-  use with `twi.vrt` (ArcPy) or `twi_hydrodem.vrt` (open-source). Point the
-  profile's `twi_raster` at the chosen VRT and set `reference_table`
-  accordingly. The off-diagonal pairings (absolute + hydrodem, percentile +
-  arcpy) are valid for validation but the builder warns.
+  use with `twi.vrt` (ArcPy) or `twi_hydrodem.vrt` (open-source). The
+  `reference_table` key (here in `depstor_rasters.yml`) and the profile's
+  `twi_raster` must be set to the same source together — there is no
+  auto-selection or guard for the pairing.
 
 ```bash
 sbatch slurm_batch/build_depstor_rasters.batch
@@ -663,7 +665,7 @@ orchestrators cover them — the library code they delegated to lives under
 | Batch / shell | Config | Script |
 |---|---|---|
 | `stage_twi.batch` | `base_config.yml` (indirectly) | `scripts/stage_twi.sh` |
-| `submit_twi_completion.sh` | `shared_rasters/shared_rasters.yml` | `build_shared_rasters.py --step merge_rpu_by_vpu_twi --force` then `--step build_vrt --force` (finishes `twi.vrt` + builds `twi_hydrodem.vrt`) |
+| `submit_twi_completion.sh` | `shared_rasters/shared_rasters.yml` | `build_shared_rasters.py --step merge_rpu_by_vpu_twi --force` → `--step build_vrt --force` → `--step twi_reference --force` (three chained jobs: finishes `twi.vrt` + `twi_hydrodem.vrt` + writes percentile CSVs) |
 | `download_rpu_rasters.batch` | `base_config.yml` | `gfv2_params.download.rpu_rasters` |
 | `download_nalcms.batch` | `base_config.yml` | `gfv2_params.download.nalcms_lulc` |
 | `download_nhm_v11.batch` | `base_config.yml` | `gfv2_params.download.nhm_v11_lulc` |

--- a/slurm_batch/submit_twi_completion.sh
+++ b/slurm_batch/submit_twi_completion.sh
@@ -1,24 +1,44 @@
 #!/usr/bin/env bash
-# Finish twi.vrt (ArcPy Twi_merged for VPUs 02-18 were never merged) and build
-# both TWI VRTs (twi.vrt + twi_hydrodem.vrt). Inputs are all staged: per-RPU
-# TWI at input/twi/<rpu>/twi.tif (59 RPUs) and per-VPU land masks for all 18.
-# Pure on-cluster; no ArcPy. Run from a shell with ~/.pixi/bin on PATH.
+# Finish twi.vrt (ArcPy Twi_merged for VPUs 02-18 were never merged), build both
+# TWI VRTs (twi.vrt + twi_hydrodem.vrt), and compute the TWI reference percentiles
+# — the three shared-raster steps the percentile carea_map pipeline depends on.
+# Inputs are all staged: per-RPU TWI at input/twi/<rpu>/twi.tif (59 RPUs) and
+# per-VPU land masks for all 18. Pure on-cluster; no ArcPy.
+#
+# Submits three afterok-chained jobs (merge -> build_vrt -> twi_reference) with
+# the cluster's required directives (-p cpu -A impd + time/mem), mirroring
+# slurm_batch/build_shared_rasters.batch. Run from a shell with ~/.pixi/bin on
+# PATH (sbatch inherits it):
 #
 #   bash slurm_batch/submit_twi_completion.sh
 set -euo pipefail
 cd "$(dirname "$0")/.."
+mkdir -p logs
 CFG=configs/shared_rasters/shared_rasters.yml
+# Common directives every job needs (partition/account/logs); the QOS rejects
+# jobs that omit partition/account/time/mem.
+SB=(sbatch --parsable -p cpu -A impd --ntasks=1
+    --output=logs/job_%j.out --error=logs/job_%j.err)
 
-# 1) merge ArcPy per-RPU TWI -> per-VPU Twi_merged for every VPU (idempotent;
-#    --force re-merges 01 too so all 18 are consistent).
-merge=$(sbatch --parsable --job-name=twi_merge \
+# 1) merge ArcPy per-RPU TWI -> per-VPU Twi_merged for every VPU in the manifest
+#    (idempotent; --force re-merges 01 too so all 18 are consistent).
+merge=$("${SB[@]}" --job-name=twi_merge --time=12:00:00 --cpus-per-task=16 --mem=96G \
   --wrap="pixi run --as-is python scripts/build_shared_rasters.py \
           --config $CFG --step merge_rpu_by_vpu_twi --force")
 echo "merge_rpu_by_vpu_twi: $merge"
 
 # 2) (re)build CONUS VRTs after the merge — builds twi.vrt AND twi_hydrodem.vrt.
-vrt=$(sbatch --parsable --dependency=afterok:$merge --job-name=twi_vrt \
+vrt=$("${SB[@]}" --dependency=afterok:"$merge" --job-name=twi_vrt \
+  --time=02:00:00 --cpus-per-task=8 --mem=48G \
   --wrap="pixi run --as-is python scripts/build_shared_rasters.py \
           --config $CFG --step build_vrt --force")
 echo "build_vrt: $vrt"
-echo "Submitted. When done, verify with: scripts/build_shared_rasters.py logs + gdalinfo on both VRTs."
+
+# 3) valid-land TWI percentile cutoffs per VPU + CONUS, both sources.
+ref=$("${SB[@]}" --dependency=afterok:"$vrt" --job-name=twi_ref \
+  --time=04:00:00 --cpus-per-task=8 --mem=64G \
+  --wrap="pixi run --as-is python scripts/build_shared_rasters.py \
+          --config $CFG --step twi_reference --force")
+echo "twi_reference: $ref"
+
+echo "Chained merge($merge) -> vrt($vrt) -> twi_reference($ref). Watch: squeue -u \$USER"

--- a/slurm_batch/submit_twi_completion.sh
+++ b/slurm_batch/submit_twi_completion.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Finish twi.vrt (ArcPy Twi_merged for VPUs 02-18 were never merged) and build
+# both TWI VRTs (twi.vrt + twi_hydrodem.vrt). Inputs are all staged: per-RPU
+# TWI at input/twi/<rpu>/twi.tif (59 RPUs) and per-VPU land masks for all 18.
+# Pure on-cluster; no ArcPy. Run from a shell with ~/.pixi/bin on PATH.
+#
+#   bash slurm_batch/submit_twi_completion.sh
+set -euo pipefail
+cd "$(dirname "$0")/.."
+CFG=configs/shared_rasters/shared_rasters.yml
+
+# 1) merge ArcPy per-RPU TWI -> per-VPU Twi_merged for every VPU (idempotent;
+#    --force re-merges 01 too so all 18 are consistent).
+merge=$(sbatch --parsable --job-name=twi_merge \
+  --wrap="pixi run --as-is python scripts/build_shared_rasters.py \
+          --config $CFG --step merge_rpu_by_vpu_twi --force")
+echo "merge_rpu_by_vpu_twi: $merge"
+
+# 2) (re)build CONUS VRTs after the merge — builds twi.vrt AND twi_hydrodem.vrt.
+vrt=$(sbatch --parsable --dependency=afterok:$merge --job-name=twi_vrt \
+  --wrap="pixi run --as-is python scripts/build_shared_rasters.py \
+          --config $CFG --step build_vrt --force")
+echo "build_vrt: $vrt"
+echo "Submitted. When done, verify with: scripts/build_shared_rasters.py logs + gdalinfo on both VRTs."

--- a/slurm_batch/submit_twi_completion.sh
+++ b/slurm_batch/submit_twi_completion.sh
@@ -26,8 +26,14 @@ SB=(sbatch --parsable -p cpu -A impd --ntasks=1
     --output=logs/job_%j.out --error=logs/job_%j.err)
 
 # 1) merge ArcPy per-RPU TWI -> per-VPU Twi_merged for every raster VPU in the
-#    manifest (idempotent; --force re-merges 01 too so all 18 are consistent).
-merge=$("${SB[@]}" --job-name=twi_merge --time=12:00:00 --cpus-per-task=16 --mem=96G \
+#    manifest. --force is REQUIRED here: the builder's skip-if-output-exists is
+#    idempotent on file existence, but VPUs 02..18 already exist as empty ~stubs
+#    from the #94 gap, so a non-forced run would skip them and never fill the
+#    gap. --force overwrites the stubs. (To resume after a partial failure, scope
+#    it: --vpus 10,11,...,18 --force leaves the already-good 01..09 untouched.)
+#    384G: VPU 10 (largest, 9 RPUs) holds several full-extent float32 copies in
+#    the merge+mask+write path and OOMs at 96G; the cpu partition has 503G nodes.
+merge=$("${SB[@]}" --job-name=twi_merge --time=12:00:00 --cpus-per-task=8 --mem=384G \
   --wrap="pixi run --as-is python scripts/build_shared_rasters.py \
           --config $CFG --step merge_rpu_by_vpu_twi --vpus $RASTER_VPUS --force")
 echo "merge_rpu_by_vpu_twi: $merge"

--- a/slurm_batch/submit_twi_completion.sh
+++ b/slurm_batch/submit_twi_completion.sh
@@ -15,16 +15,21 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 mkdir -p logs
 CFG=configs/shared_rasters/shared_rasters.yml
+# The TWI manifest (merge_rpu_by_vpu_twi.yml) is keyed by RASTER VPUs (01..18),
+# but shared_rasters.yml's `vpus:` is the DETAILED list (03N/03S/03W, 10L/10U).
+# Iterating the detailed list makes the merge skip VPU 03 and 10 ("not in
+# manifest"), leaving twi.vrt incomplete. Drive the merge with the raster VPUs.
+RASTER_VPUS=01,02,03,04,05,06,07,08,09,10,11,12,13,14,15,16,17,18
 # Common directives every job needs (partition/account/logs); the QOS rejects
 # jobs that omit partition/account/time/mem.
 SB=(sbatch --parsable -p cpu -A impd --ntasks=1
     --output=logs/job_%j.out --error=logs/job_%j.err)
 
-# 1) merge ArcPy per-RPU TWI -> per-VPU Twi_merged for every VPU in the manifest
-#    (idempotent; --force re-merges 01 too so all 18 are consistent).
+# 1) merge ArcPy per-RPU TWI -> per-VPU Twi_merged for every raster VPU in the
+#    manifest (idempotent; --force re-merges 01 too so all 18 are consistent).
 merge=$("${SB[@]}" --job-name=twi_merge --time=12:00:00 --cpus-per-task=16 --mem=96G \
   --wrap="pixi run --as-is python scripts/build_shared_rasters.py \
-          --config $CFG --step merge_rpu_by_vpu_twi --force")
+          --config $CFG --step merge_rpu_by_vpu_twi --vpus $RASTER_VPUS --force")
 echo "merge_rpu_by_vpu_twi: $merge"
 
 # 2) (re)build CONUS VRTs after the merge — builds twi.vrt AND twi_hydrodem.vrt.

--- a/src/gfv2_params/depstor.py
+++ b/src/gfv2_params/depstor.py
@@ -18,8 +18,8 @@ from typing import Optional
 
 import numpy as np
 import rasterio
-from rasterio.crs import CRS
 from rasterio.coords import BoundingBox
+from rasterio.crs import CRS
 from rasterio.features import rasterize as rio_rasterize
 from rasterio.transform import Affine
 from scipy import ndimage

--- a/src/gfv2_params/depstor.py
+++ b/src/gfv2_params/depstor.py
@@ -168,7 +168,7 @@ def compute_carea_map_binary(
     perv: np.ndarray,
     onstream: np.ndarray,
     twi: np.ndarray,
-    threshold: float,
+    threshold,  # float scalar OR np.ndarray broadcastable to twi (per-cell T_P)
     twi_nodata: Optional[float],
     land_valid: np.ndarray,
 ) -> np.ndarray:
@@ -188,6 +188,11 @@ def compute_carea_map_binary(
     Short-circuits on the perv test first so NaN / sentinel TWI values in
     non-perv cells do not pollute the result. Handles both NaN and the
     -9999-style sentinel nodata that the merged TWI rasters carry.
+
+    `threshold` may be a scalar (absolute mode, or percentile-conus / single-VPU)
+    or a per-cell float array the same shape as `twi` (percentile per-VPU mode,
+    where each cell carries its HRU's home-VPU T_P). `twi > threshold` broadcasts
+    either way.
     """
     is_perv = perv == 1
     is_onstream = onstream == 1

--- a/src/gfv2_params/depstor_builders/__init__.py
+++ b/src/gfv2_params/depstor_builders/__init__.py
@@ -14,9 +14,8 @@ These modules are thin orchestration wrappers around those helpers.
 
 from __future__ import annotations
 
-from .context import BuildContext
-
 from . import carea_map, dprst, imperv, intersect, landmask, perv, routing, streambuffer, vpu_id, waterbody
+from .context import BuildContext
 
 BUILDERS = {
     "landmask":      landmask.build,

--- a/src/gfv2_params/depstor_builders/__init__.py
+++ b/src/gfv2_params/depstor_builders/__init__.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from .context import BuildContext
 
-from . import carea_map, dprst, imperv, intersect, landmask, perv, routing, streambuffer, waterbody
+from . import carea_map, dprst, imperv, intersect, landmask, perv, routing, streambuffer, vpu_id, waterbody
 
 BUILDERS = {
     "landmask":      landmask.build,
@@ -28,6 +28,7 @@ BUILDERS = {
     "routing":       routing.build,
     "drains_perv":   intersect.build,
     "drains_imperv": intersect.build,
+    "vpu_id":        vpu_id.build,
     "carea_map":     carea_map.build,
 }
 
@@ -41,6 +42,7 @@ STEP_ORDER = [
     "routing",
     "drains_perv",
     "drains_imperv",
+    "vpu_id",
     "carea_map",
 ]
 

--- a/src/gfv2_params/depstor_builders/carea_map.py
+++ b/src/gfv2_params/depstor_builders/carea_map.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import csv
 from contextlib import ExitStack
 
+import numpy as np
 import rasterio
 from rasterio.enums import Resampling
 from rasterio.vrt import WarpedVRT
@@ -12,6 +13,7 @@ from rasterio.windows import Window
 
 from ..depstor import RasterInfo, compute_carea_map_binary
 from .context import BuildContext
+from .vpu_id import MAX_VPU_CODE, vpu_to_code
 
 # TWI is float32 — ~4x the per-strip memory of the uint8 inputs.
 STRIP_ROWS = 1024
@@ -71,14 +73,11 @@ def _threshold_lut(table: dict, column: str):
     """Build a code-indexed lookup array: lut[vpu_code] = threshold.
 
     vpu_code is the integer from vpu_id.vpu_to_code ('17' -> 17). Index 0 is the
-    vpu_id nodata code; fill it with +inf so unmapped cells never pass twi>thr.
+    vpu_id nodata code and any unmapped code stays +inf so those cells never pass
+    twi>thr. Sized to MAX_VPU_CODE+1 so any valid raster-VPU code indexes safely.
     """
-    import numpy as np  # noqa: PLC0415
-
-    from .vpu_id import vpu_to_code  # noqa: PLC0415
     rows = {vpu: row for (scope, vpu), row in table.items() if scope == "vpu"}
-    size = max((vpu_to_code(v) for v in rows), default=0) + 1
-    lut = np.full(size, np.inf, dtype="float64")
+    lut = np.full(MAX_VPU_CODE + 1, np.inf, dtype="float64")
     for vpu, row in rows.items():
         lut[vpu_to_code(vpu)] = row[column]
     return lut
@@ -117,6 +116,8 @@ def build(step_cfg: dict, ctx: BuildContext, logger) -> dict:
             carea_t, smidx_t = resolve_scalar_thresholds(
                 table, scope, ctx.vpu if scope == "vpu" else None)
             per_cell = False
+            logger.info("  percentile thresholds (scope=%s, vpu=%s): carea=%.4f smidx=%.4f",
+                        scope, ctx.vpu if scope == "vpu" else "CONUS", carea_t, smidx_t)
         else:
             # multi-VPU fabric, per-VPU scope -> per-cell threshold via vpu_id
             per_cell = True

--- a/src/gfv2_params/depstor_builders/carea_map.py
+++ b/src/gfv2_params/depstor_builders/carea_map.py
@@ -74,6 +74,7 @@ def _threshold_lut(table: dict, column: str):
     vpu_id nodata code; fill it with +inf so unmapped cells never pass twi>thr.
     """
     import numpy as np  # noqa: PLC0415
+
     from .vpu_id import vpu_to_code  # noqa: PLC0415
     rows = {vpu: row for (scope, vpu), row in table.items() if scope == "vpu"}
     size = max((vpu_to_code(v) for v in rows), default=0) + 1

--- a/src/gfv2_params/depstor_builders/carea_map.py
+++ b/src/gfv2_params/depstor_builders/carea_map.py
@@ -67,6 +67,22 @@ def resolve_scalar_thresholds(table: dict, scope: str, vpu) -> tuple:
     return row["t_carea"], row["t_smidx"]
 
 
+def _threshold_lut(table: dict, column: str):
+    """Build a code-indexed lookup array: lut[vpu_code] = threshold.
+
+    vpu_code is the integer from vpu_id.vpu_to_code ('17' -> 17). Index 0 is the
+    vpu_id nodata code; fill it with +inf so unmapped cells never pass twi>thr.
+    """
+    import numpy as np  # noqa: PLC0415
+    from .vpu_id import vpu_to_code  # noqa: PLC0415
+    rows = {vpu: row for (scope, vpu), row in table.items() if scope == "vpu"}
+    size = max((vpu_to_code(v) for v in rows), default=0) + 1
+    lut = np.full(size, np.inf, dtype="float64")
+    for vpu, row in rows.items():
+        lut[vpu_to_code(vpu)] = row[column]
+    return lut
+
+
 def build(step_cfg: dict, ctx: BuildContext, logger) -> dict:
     if ctx.twi_raster is None:
         raise KeyError("carea_map step needs `twi_raster` in fabric profile.")
@@ -77,24 +93,54 @@ def build(step_cfg: dict, ctx: BuildContext, logger) -> dict:
     perv_path = ctx.require("perv")
     onstream_path = ctx.require("onstream")
 
-    thresholds = step_cfg["thresholds"]
+    mode = step_cfg.get("threshold_mode", "absolute")
     outputs = step_cfg["outputs"]
+
+    if mode == "absolute":
+        thr = step_cfg["thresholds"]
+        carea_t, smidx_t = float(thr["carea_max"]), float(thr["smidx"])
+        per_cell = False
+        # Guard: absolute thresholds are calibrated to ArcPy TWI only.
+        if ctx.twi_raster and "hydrodem" in ctx.twi_raster.name:
+            logger.warning(
+                "  threshold_mode=absolute paired with a non-ArcPy TWI source "
+                "(%s) — 8.0/15.6 are calibrated to ArcPy TWI; this is a "
+                "validation-only counterexample, not a shippable output.",
+                ctx.twi_raster.name,
+            )
+    elif mode == "percentile":
+        scope = step_cfg["reference_scope"]          # "conus" | "vpu"
+        table = load_reference_table(step_cfg["reference_table"])
+        if scope == "conus" or ctx.vpu:
+            # single threshold pair (CONUS, or a single-VPU fabric's VPU)
+            carea_t, smidx_t = resolve_scalar_thresholds(
+                table, scope, ctx.vpu if scope == "vpu" else None)
+            per_cell = False
+        else:
+            # multi-VPU fabric, per-VPU scope -> per-cell threshold via vpu_id
+            per_cell = True
+            vpu_id_path = ctx.require("vpu_id")
+            carea_lut = _threshold_lut(table, "t_carea")
+            smidx_lut = _threshold_lut(table, "t_smidx")
+    else:
+        raise ValueError(f"carea_map: unknown threshold_mode {mode!r}")
+
     runs = [
-        (float(thresholds["carea_max"]), ctx.resolve_output(outputs["carea_max"]), "carea_max"),
-        (float(thresholds["smidx"]),     ctx.resolve_output(outputs["smidx"]),     "smidx_coef"),
+        (ctx.resolve_output(outputs["carea_max"]), "carea_max"),
+        (ctx.resolve_output(outputs["smidx"]),     "smidx_coef"),
     ]
 
     logger.info("--- carea_map ---")
     logger.info("  TWI     : %s", ctx.twi_raster)
-    for _, out, label in runs:
+    for out, label in runs:
         logger.info("  Output (%s): %s", label, out)
 
-    if not ctx.force and all(out.exists() for _, out, _ in runs):
+    if not ctx.force and all(out.exists() for out, _ in runs):
         logger.info("  All outputs exist — skipping (pass --force to rebuild)")
-        return {"carea_max": runs[0][1], "smidx": runs[1][1]}
+        return {"carea_max": runs[0][0], "smidx": runs[1][0]}
 
     info = RasterInfo.from_path(ctx.template_path)
-    for _, out, _ in runs:
+    for out, _ in runs:
         out.parent.mkdir(parents=True, exist_ok=True)
 
     counts = [0 for _ in runs]
@@ -138,7 +184,11 @@ def build(step_cfg: dict, ctx: BuildContext, logger) -> dict:
         twi_nodata = twi_src.nodata
 
         twi_vrt = stack.enter_context(WarpedVRT(twi_src, **vrt_options))
-        dsts = [stack.enter_context(rasterio.open(out, "w", **profile)) for _, out, _ in runs]
+        dsts = [stack.enter_context(rasterio.open(out, "w", **profile)) for out, _ in runs]
+
+        if per_cell:
+            vpu_id_src = stack.enter_context(rasterio.open(vpu_id_path))
+            _assert_aligned(vpu_id_src, info, "vpu_id")
 
         for row_off in range(0, info.height, STRIP_ROWS):
             h = min(STRIP_ROWS, info.height - row_off)
@@ -147,18 +197,23 @@ def build(step_cfg: dict, ctx: BuildContext, logger) -> dict:
             perv = perv_src.read(1, window=window)
             onstream = onstream_src.read(1, window=window)
             twi = twi_vrt.read(1, window=window)
-            for i, (thresh, _, _) in enumerate(runs):
+            if per_cell:
+                codes = vpu_id_src.read(1, window=window)
+                thresholds = [carea_lut[codes], smidx_lut[codes]]
+            else:
+                thresholds = [carea_t, smidx_t]
+            for i, (out_path, _label) in enumerate(runs):
                 out = compute_carea_map_binary(
-                    perv, onstream, twi, thresh, twi_nodata, land_valid
+                    perv, onstream, twi, thresholds[i], twi_nodata, land_valid
                 )
                 dsts[i].write(out, 1, window=window)
                 counts[i] += int((out == 1).sum())
 
     total = info.height * info.width
-    for (thresh, out, label), n in zip(runs, counts):
+    for (out, label), n in zip(runs, counts):
         logger.info(
             "  %s: %d cells (%.4f%% of grid) -> %s",
             label, n, 100 * n / total, out,
         )
 
-    return {"carea_max": runs[0][1], "smidx": runs[1][1]}
+    return {"carea_max": runs[0][0], "smidx": runs[1][0]}

--- a/src/gfv2_params/depstor_builders/carea_map.py
+++ b/src/gfv2_params/depstor_builders/carea_map.py
@@ -13,7 +13,7 @@ from rasterio.windows import Window
 
 from ..depstor import RasterInfo, compute_carea_map_binary
 from .context import BuildContext
-from .vpu_id import MAX_VPU_CODE, vpu_to_code
+from .vpu_id import MAX_VPU_CODE, VPU_NODATA, vpu_to_code
 
 # TWI is float32 — ~4x the per-strip memory of the uint8 inputs.
 STRIP_ROWS = 1024
@@ -83,6 +83,22 @@ def _threshold_lut(table: dict, column: str):
     return lut
 
 
+def uncovered_vpu_codes(present_codes, *luts) -> list:
+    """VPU codes present in the vpu_id raster but lacking a finite threshold.
+
+    A code maps to +inf in a LUT when its VPU has no row in the reference table
+    (e.g. twi_reference skipped an empty-sample VPU). Such cells would be silently
+    classified never-wet, so the caller raises on a non-empty result.
+    """
+    out = []
+    for c in sorted({int(x) for x in present_codes}):
+        if c == VPU_NODATA:
+            continue
+        if any(c >= len(lut) or not np.isfinite(lut[c]) for lut in luts):
+            out.append(c)
+    return out
+
+
 def build(step_cfg: dict, ctx: BuildContext, logger) -> dict:
     if ctx.twi_raster is None:
         raise KeyError("carea_map step needs `twi_raster` in fabric profile.")
@@ -121,6 +137,7 @@ def build(step_cfg: dict, ctx: BuildContext, logger) -> dict:
         else:
             # multi-VPU fabric, per-VPU scope -> per-cell threshold via vpu_id
             per_cell = True
+            present_codes: set = set()
             vpu_id_path = ctx.require("vpu_id")
             carea_lut = _threshold_lut(table, "t_carea")
             smidx_lut = _threshold_lut(table, "t_smidx")
@@ -201,6 +218,7 @@ def build(step_cfg: dict, ctx: BuildContext, logger) -> dict:
             twi = twi_vrt.read(1, window=window)
             if per_cell:
                 codes = vpu_id_src.read(1, window=window)
+                present_codes.update(np.unique(codes).tolist())
                 thresholds = [carea_lut[codes], smidx_lut[codes]]
             else:
                 thresholds = [carea_t, smidx_t]
@@ -210,6 +228,15 @@ def build(step_cfg: dict, ctx: BuildContext, logger) -> dict:
                 )
                 dsts[i].write(out, 1, window=window)
                 counts[i] += int((out == 1).sum())
+
+    if per_cell:
+        bad = uncovered_vpu_codes(present_codes, carea_lut, smidx_lut)
+        if bad:
+            raise ValueError(
+                f"carea_map percentile vpu mode: VPU code(s) {bad} present in the "
+                f"vpu_id raster but absent from {step_cfg['reference_table']}; re-run "
+                f"twi_reference so every fabric VPU has a row."
+            )
 
     total = info.height * info.width
     for (out, label), n in zip(runs, counts):

--- a/src/gfv2_params/depstor_builders/carea_map.py
+++ b/src/gfv2_params/depstor_builders/carea_map.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import csv
 from contextlib import ExitStack
 
 import rasterio
@@ -44,6 +45,26 @@ def _assert_aligned(src, info: RasterInfo, name: str) -> None:
         raise ValueError(f"{name} CRS {src.crs} != template CRS {info.crs}")
     if src.transform != info.transform:
         raise ValueError(f"{name} transform mismatch with template")
+
+
+def load_reference_table(path) -> dict:
+    """Load a twi_reference_percentiles.<source>.csv into {(scope, vpu): row}."""
+    table = {}
+    with open(path, newline="") as f:
+        for row in csv.DictReader(f):
+            for k in ("p_carea", "p_smidx", "t_carea", "t_smidx"):
+                row[k] = float(row[k])
+            table[(row["scope"], row["vpu"])] = row
+    return table
+
+
+def resolve_scalar_thresholds(table: dict, scope: str, vpu) -> tuple:
+    """Return (t_carea, t_smidx) scalars for conus scope or a single VPU."""
+    key = ("conus", "CONUS") if scope == "conus" else ("vpu", str(vpu))
+    if key not in table:
+        raise KeyError(f"no reference row for {key}; have {sorted(table)}")
+    row = table[key]
+    return row["t_carea"], row["t_smidx"]
 
 
 def build(step_cfg: dict, ctx: BuildContext, logger) -> dict:

--- a/src/gfv2_params/depstor_builders/context.py
+++ b/src/gfv2_params/depstor_builders/context.py
@@ -27,6 +27,7 @@ class BuildContext:
     waterbody_layer: str | None = None
     fdr_raster: Path | None = None
     twi_raster: Path | None = None
+    vpu: str | None = None  # single-VPU fabric's VPU label (e.g. "17"); None = use fabric `vpu` attr
     imperv_source: Path | None = None
     paths: dict[str, Path] = field(default_factory=dict)
     force: bool = False

--- a/src/gfv2_params/depstor_builders/vpu_id.py
+++ b/src/gfv2_params/depstor_builders/vpu_id.py
@@ -1,0 +1,83 @@
+"""Rasterise each HRU's home VPU code onto the template grid.
+
+Used by carea_map percentile-`vpu` mode on multi-VPU fabrics (gfv2): each cell
+gets the integer VPU code of the HRU that covers it, so the builder can map
+`vpu_code -> T_P` into a per-cell threshold array. Because the HRU polygon's
+`vpu` value is burned, every cell of an HRU carries that HRU's home VPU — the
+exact per-HRU home-VPU assignment the spec requires.
+
+For single-VPU fabrics the profile declares `vpu:` and the raster is a constant
+fill (or carea_map uses the scalar T_P directly and skips this step).
+"""
+
+from __future__ import annotations
+
+import geopandas as gpd
+import numpy as np
+import rasterio
+from rasterio.features import rasterize
+
+from ..depstor import RasterInfo
+from .context import BuildContext
+
+VPU_NODATA = 0  # 0 is not a valid VPU code (VPUs are 01..18 -> 1..18)
+
+
+def vpu_to_code(vpu: str) -> int:
+    """'01'..'18' -> 1..18. Raises on anything that isn't a VPU label."""
+    try:
+        code = int(str(vpu).lstrip("0") or "0")
+    except (TypeError, ValueError):
+        raise ValueError(f"Not a VPU label: {vpu!r}")
+    if not 1 <= code <= 21:  # NHDPlus VPUs run 01..18 (+ a few sub-regions)
+        raise ValueError(f"VPU code out of range: {vpu!r} -> {code}")
+    return code
+
+
+def resolve_vpu_source(profile_vpu, fabric_has_vpu_attr: bool):
+    """Resolution precedence: profile scalar > fabric attribute > error."""
+    if profile_vpu:
+        return "scalar", str(profile_vpu)
+    if fabric_has_vpu_attr:
+        return "attribute", "vpu"
+    raise ValueError(
+        "carea_map percentile `vpu` scope requires a profile `vpu` scalar "
+        "(single-VPU fabric) or a `vpu` attribute on the HRU layer."
+    )
+
+
+def build(step_cfg: dict, ctx: BuildContext, logger) -> dict:
+    out = ctx.resolve_output(step_cfg["output"])
+    if out.exists() and not ctx.force:
+        logger.info("  vpu_id exists — skipping (pass --force)")
+        return {"vpu_id": out}
+
+    info = RasterInfo.from_path(ctx.template_path)
+    profile = {
+        "driver": "GTiff", "height": info.height, "width": info.width, "count": 1,
+        "dtype": "uint8", "crs": info.crs, "transform": info.transform,
+        "nodata": VPU_NODATA, "compress": "LZW", "tiled": True,
+        "blockxsize": 256, "blockysize": 256, "BIGTIFF": "YES",
+    }
+
+    hru = gpd.read_file(ctx.hru_gpkg, layer=ctx.hru_layer)
+    kind, value = resolve_vpu_source(ctx.vpu, "vpu" in hru.columns)
+    logger.info("--- vpu_id (%s) ---", kind)
+
+    out.parent.mkdir(parents=True, exist_ok=True)
+    with rasterio.open(out, "w", **profile) as dst:
+        if kind == "scalar":
+            dst.write(np.full((info.height, info.width), vpu_to_code(value),
+                              dtype="uint8"), 1)
+        else:
+            if hru.crs != info.crs:
+                hru = hru.to_crs(info.crs)
+            shapes = ((geom, vpu_to_code(v)) for geom, v in zip(hru.geometry, hru[value]))
+            arr = rasterize(
+                shapes, out_shape=(info.height, info.width),
+                transform=info.transform, fill=VPU_NODATA, dtype="uint8",
+                all_touched=True,
+            )
+            dst.write(arr, 1)
+    logger.info("  Wrote vpu_id raster -> %s", out)
+    return {"vpu_id": out}

--- a/src/gfv2_params/depstor_builders/vpu_id.py
+++ b/src/gfv2_params/depstor_builders/vpu_id.py
@@ -17,19 +17,28 @@ import numpy as np
 import rasterio
 from rasterio.features import rasterize
 
+from gfv2_params.config import VPU_RASTER_MAP
+
 from ..depstor import RasterInfo
 from .context import BuildContext
 
 VPU_NODATA = 0  # 0 is not a valid VPU code (VPUs are 01..18 -> 1..18)
+MAX_VPU_CODE = 18  # NHDPlus raster VPUs 01..18 (sub-regions map to parent)
 
 
 def vpu_to_code(vpu: str) -> int:
-    """'01'..'18' -> 1..18. Raises on anything that isn't a VPU label."""
+    """Detailed or raster VPU label -> integer raster-VPU code (1..18).
+
+    Sub-region labels (03N/03S/03W, 10L/10U) map to their parent raster VPU via
+    VPU_RASTER_MAP (03->3, 10->10), so they share one code/threshold — matching
+    the per-raster-VPU TWI tiles and the reference table. '01'..'18' -> 1..18.
+    """
+    raster = VPU_RASTER_MAP.get(str(vpu), str(vpu))
     try:
-        code = int(str(vpu).lstrip("0") or "0")
+        code = int(raster.lstrip("0") or "0")
     except (TypeError, ValueError):
         raise ValueError(f"Not a VPU label: {vpu!r}")
-    if not 1 <= code <= 21:  # NHDPlus VPUs run 01..18 (+ a few sub-regions)
+    if not 1 <= code <= MAX_VPU_CODE:
         raise ValueError(f"VPU code out of range: {vpu!r} -> {code}")
     return code
 

--- a/src/gfv2_params/shared_rasters/__init__.py
+++ b/src/gfv2_params/shared_rasters/__init__.py
@@ -24,6 +24,7 @@ from . import (
     compute_dem_derivatives,
     compute_slope_aspect,
     merge_rpu_by_vpu,
+    twi_reference,
 )
 from .context import SharedRastersContext
 
@@ -42,6 +43,7 @@ BUILDERS: dict = {
     "compute_dem_derivatives": compute_dem_derivatives.build,
     "merge_rpu_by_vpu_twi":    merge_rpu_by_vpu.build,  # post-landmask invocation
     "build_vrt":               build_vrt.build,
+    "twi_reference":           twi_reference.build,
     "build_derived_rasters":   build_derived_rasters.build,
     "build_lulc_rasters":      build_lulc_rasters.build,
 }
@@ -54,6 +56,7 @@ STEP_ORDER: list[str] = [
     "compute_dem_derivatives",  # optional / parallel
     "merge_rpu_by_vpu_twi",
     "build_vrt",
+    "twi_reference",
     "build_derived_rasters",
     "build_lulc_rasters",
 ]

--- a/src/gfv2_params/shared_rasters/build_vrt.py
+++ b/src/gfv2_params/shared_rasters/build_vrt.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from osgeo import gdal
+from osgeo import gdal, osr
 
 from .context import SharedRastersContext
 
@@ -113,11 +113,13 @@ def build(step_cfg: dict, ctx: SharedRastersContext, logger) -> dict:
 
         epsg = _srs_override(vrt_name)
         if epsg is not None:
-            from osgeo import osr
             srs = osr.SpatialReference()
             srs.SetFromUserInput(epsg)
             ds = gdal.Open(str(vrt_path), gdal.GA_Update)
-            ds.SetProjection(srs.ExportToWkt())
+            if ds is None:
+                raise RuntimeError(f"could not reopen {vrt_path} to stamp {epsg}")
+            if ds.SetProjection(srs.ExportToWkt()) != gdal.CE_None:
+                raise RuntimeError(f"SetProjection({epsg}) failed for {vrt_path}")
             ds.FlushCache()
             del ds
             logger.info("Stamped %s with %s", vrt_path, epsg)

--- a/src/gfv2_params/shared_rasters/build_vrt.py
+++ b/src/gfv2_params/shared_rasters/build_vrt.py
@@ -32,12 +32,15 @@ from .context import SharedRastersContext
 #   slope/aspect: RichDEM SaveGDAL always writes -9999 (NED-based, raw DEM).
 #   fdr: NHDPlus FDR tiles are Byte rasters with nodata=255 (D8 codes are 1-128).
 #   twi: merge_rpu_by_vpu's TWI case writes float32 and remaps the source
-#        -FLT_MAX sentinel to -9999. **DO NOT SWAP** this to the open-source
-#        Twi_hydrodem_*.tif produced by compute_dem_derivatives: PRMS
-#        parameter extraction (carea_max, smidx_coef) thresholds TWI at
-#        calibrated values (8.0, 15.6) that depend on the original ArcPy TWI
-#        distribution shape. Swapping the source would invalidate those
-#        thresholds. See PR #54 discussion.
+#        -FLT_MAX sentinel to -9999. The absolute thresholds (8.0, 15.6) in
+#        carea_map are calibrated to the ArcPy TWI distribution, so
+#        ``threshold_mode: absolute`` still requires twi.vrt as the source.
+#        However, ``threshold_mode: percentile`` (the ``twi_reference`` shared-
+#        raster step + ``carea_map threshold_mode: percentile`` in
+#        depstor_rasters.yml) derives the cutoff from the data and makes the
+#        open-source ``twi_hydrodem.vrt`` a fully supported first-class source —
+#        see the entry below and
+#        docs/superpowers/specs/2026-05-21-carea-smidx-twi-percentile-design.md.
 RASTER_TYPES = {
     "elevation": ("NEDSnapshot_merged_fixed_*.tif", "-9999"),
     "slope":     ("NEDSnapshot_merged_slope_*.tif", "-9999"),

--- a/src/gfv2_params/shared_rasters/build_vrt.py
+++ b/src/gfv2_params/shared_rasters/build_vrt.py
@@ -44,7 +44,21 @@ RASTER_TYPES = {
     "aspect":    ("NEDSnapshot_merged_aspect_*.tif", "-9999"),
     "fdr":       ("Fdr_merged_*.tif", "255"),
     "twi":       ("Twi_merged_*.tif", "-9999"),
+    # Open-source WhiteboxTools TWI (issue #94): CONUS-complete, drop-in grid
+    # with fdr.vrt. Tiles report an "unnamed" Albers CRS, so the VRT must be
+    # stamped with a named EPSG:5070 to satisfy carea_map's CRS-equality check.
+    "twi_hydrodem": ("Twi_hydrodem_*.tif", "-9999"),
 }
+
+# VRT types whose source tiles carry an unnamed/implicit CRS and must be
+# stamped with an explicit EPSG so strict CRS-equality checks downstream pass.
+_SRS_OVERRIDES = {"twi_hydrodem": "EPSG:5070"}
+
+
+def _srs_override(vrt_name: str) -> str | None:
+    """EPSG string to force onto the built VRT, or None to keep source CRS."""
+    return _SRS_OVERRIDES.get(vrt_name)
+
 
 def build(step_cfg: dict, ctx: SharedRastersContext, logger) -> dict:
     """Build CONUS-wide VRTs for elevation, slope, aspect, fdr, twi.
@@ -93,6 +107,17 @@ def build(step_cfg: dict, ctx: SharedRastersContext, logger) -> dict:
             raise RuntimeError(f"gdal.BuildVRT failed for {vrt_name}")
         vrt_ds.FlushCache()
         del vrt_ds
+
+        epsg = _srs_override(vrt_name)
+        if epsg is not None:
+            from osgeo import osr
+            srs = osr.SpatialReference()
+            srs.SetFromUserInput(epsg)
+            ds = gdal.Open(str(vrt_path), gdal.GA_Update)
+            ds.SetProjection(srs.ExportToWkt())
+            ds.FlushCache()
+            del ds
+            logger.info("Stamped %s with %s", vrt_path, epsg)
 
         built_count += 1
         produced[f"{vrt_name}_vrt"] = vrt_path

--- a/src/gfv2_params/shared_rasters/twi_reference.py
+++ b/src/gfv2_params/shared_rasters/twi_reference.py
@@ -87,6 +87,7 @@ def assemble_reference_table(
     p_carea: float | None = None,
     p_smidx: float | None = None,
     nodata: float | None = -9999.0,
+    logger=None,
 ) -> list[dict]:
     """Build the reference-percentile rows for one TWI source.
 
@@ -110,6 +111,11 @@ def assemble_reference_table(
         s = sampler(vpu)
         valid = _valid(s, nodata)
         if valid.size == 0:
+            if logger is not None:
+                logger.warning(
+                    "twi_reference[%s]: VPU %s has no valid-land TWI; skipping (no row written)",
+                    source, vpu,
+                )
             continue
         pooled.append(valid)
         tc, ts = percentile_of_values(valid, [p_carea, p_smidx])
@@ -203,7 +209,7 @@ def build(step_cfg: dict, ctx, logger) -> dict:
         rows = assemble_reference_table(
             source=source, vpus=raster_vpus(ctx.vpus), sampler=sampler,
             arcpy_vpu01_sample=arcpy01, p_carea=p_carea, p_smidx=p_smidx,
-            nodata=nodata,
+            nodata=nodata, logger=logger,
         )
         out_path = out_dir / f"twi_reference_percentiles.{source}.csv"
         write_reference_table(rows, out_path)

--- a/src/gfv2_params/shared_rasters/twi_reference.py
+++ b/src/gfv2_params/shared_rasters/twi_reference.py
@@ -1,0 +1,44 @@
+"""Valid-land TWI percentile cutoffs for distribution-invariant carea_max /
+smidx_coef (issues #94 + #55 Stage 1).
+
+The cutoff that classifies a cell as "wet" used to be a hardcoded TWI value
+(8.0 / 15.6) calibrated to the ArcPy TWI distribution. Here we derive it from
+the data instead: the P-th percentile of valid-land TWI over a reference
+population (per-VPU or CONUS). Because it is recomputed from whatever TWI
+source is in play, swapping the source preserves each cell's rank, so the
+parameters become invariant to the source.
+
+This module holds the pure math (percentile / CDF-inversion) plus the
+`build_twi_reference` shared-raster builder that samples the staged TWI tiles.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def _valid(values: np.ndarray, nodata: float | None) -> np.ndarray:
+    """Return the finite, non-nodata subset as a 1-D float64 array."""
+    v = np.asarray(values, dtype="float64").ravel()
+    mask = np.isfinite(v)
+    if nodata is not None:
+        mask &= v != nodata
+    return v[mask]
+
+
+def percentile_of_values(values: np.ndarray, ps, nodata: float | None = None):
+    """The P-th percentile(s) of the valid values. `ps` is a list of [0,100]."""
+    valid = _valid(values, nodata)
+    if valid.size == 0:
+        raise ValueError("percentile_of_values: no valid (finite, non-nodata) values")
+    return [float(x) for x in np.percentile(valid, ps)]
+
+
+def rank_of_value(values: np.ndarray, value: float, nodata: float | None = None) -> float:
+    """Percentile rank (0-100) of `value` in the valid distribution: the
+    fraction of valid values <= `value`, x100. Inverse of percentile_of_values;
+    used to find what percentile the legacy 8.0 / 15.6 occupy."""
+    valid = _valid(values, nodata)
+    if valid.size == 0:
+        raise ValueError("rank_of_value: no valid values")
+    return float(100.0 * np.count_nonzero(valid <= value) / valid.size)

--- a/src/gfv2_params/shared_rasters/twi_reference.py
+++ b/src/gfv2_params/shared_rasters/twi_reference.py
@@ -44,9 +44,8 @@ def rank_of_value(values: np.ndarray, value: float, nodata: float | None = None)
     return float(100.0 * np.count_nonzero(valid <= value) / valid.size)
 
 
-from pathlib import Path
-
 import csv
+from pathlib import Path
 
 import rasterio
 

--- a/src/gfv2_params/shared_rasters/twi_reference.py
+++ b/src/gfv2_params/shared_rasters/twi_reference.py
@@ -42,3 +42,145 @@ def rank_of_value(values: np.ndarray, value: float, nodata: float | None = None)
     if valid.size == 0:
         raise ValueError("rank_of_value: no valid values")
     return float(100.0 * np.count_nonzero(valid <= value) / valid.size)
+
+
+from pathlib import Path
+
+import csv
+
+import rasterio
+
+# Legacy ArcPy thresholds (docs/0b_TB_depr_stor.py); used to derive default
+# percentiles by inversion so percentile-mode reproduces VPU 01 by construction.
+LEGACY_CAREA_THRESHOLD = 8.0
+LEGACY_SMIDX_THRESHOLD = 15.6
+
+_TABLE_FIELDS = ["source", "scope", "vpu", "p_carea", "p_smidx", "t_carea", "t_smidx"]
+
+
+def assemble_reference_table(
+    source: str,
+    vpus: list[str],
+    sampler,
+    *,
+    arcpy_vpu01_sample=None,
+    legacy_carea: float = LEGACY_CAREA_THRESHOLD,
+    legacy_smidx: float = LEGACY_SMIDX_THRESHOLD,
+    p_carea: float | None = None,
+    p_smidx: float | None = None,
+    nodata: float | None = -9999.0,
+) -> list[dict]:
+    """Build the reference-percentile rows for one TWI source.
+
+    `sampler(vpu) -> 1-D array` supplies valid-land TWI samples per VPU. If
+    `p_carea`/`p_smidx` are not given, they are derived by inverting
+    legacy_carea/legacy_smidx through `arcpy_vpu01_sample` (the CDF-inversion
+    default). One `vpu`-scope row per VPU plus one pooled `conus` row.
+    """
+    if p_carea is None or p_smidx is None:
+        if arcpy_vpu01_sample is None:
+            raise ValueError(
+                "assemble_reference_table: provide p_carea/p_smidx or "
+                "arcpy_vpu01_sample to derive them by inversion"
+            )
+        p_carea = rank_of_value(arcpy_vpu01_sample, legacy_carea, nodata=nodata)
+        p_smidx = rank_of_value(arcpy_vpu01_sample, legacy_smidx, nodata=nodata)
+
+    rows: list[dict] = []
+    pooled = []
+    for vpu in vpus:
+        s = sampler(vpu)
+        valid = _valid(s, nodata)
+        if valid.size == 0:
+            continue
+        pooled.append(valid)
+        tc, ts = percentile_of_values(valid, [p_carea, p_smidx])
+        rows.append({
+            "source": source, "scope": "vpu", "vpu": vpu,
+            "p_carea": round(p_carea, 4), "p_smidx": round(p_smidx, 4),
+            "t_carea": tc, "t_smidx": ts,
+        })
+    if pooled:
+        allv = np.concatenate(pooled)
+        tc, ts = percentile_of_values(allv, [p_carea, p_smidx])
+        rows.append({
+            "source": source, "scope": "conus", "vpu": "CONUS",
+            "p_carea": round(p_carea, 4), "p_smidx": round(p_smidx, 4),
+            "t_carea": tc, "t_smidx": ts,
+        })
+    return rows
+
+
+def write_reference_table(rows: list[dict], out_path: Path) -> None:
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_path, "w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=_TABLE_FIELDS)
+        w.writeheader()
+        for r in rows:
+            w.writerow(r)
+
+
+def _sample_land_masked_twi(twi_path: Path, mask_path: Path, decimate: int, nodata):
+    """Decimated valid-land TWI sample (1-D). Reads both rasters at a coarse
+    overview to keep CONUS-scale sampling cheap; mask==1 marks land."""
+    with rasterio.open(twi_path) as t:
+        oh, ow = max(1, t.height // decimate), max(1, t.width // decimate)
+        twi = t.read(1, out_shape=(1, oh, ow))
+        tnod = t.nodata if nodata is None else nodata
+    with rasterio.open(mask_path) as m:
+        land = m.read(1, out_shape=(1, oh, ow)) == 1
+    sample = twi[land]
+    return _valid(sample, tnod)
+
+
+# Maps the depstor "twi family" to the per-VPU tile filename prefix.
+_SOURCE_PREFIX = {"arcpy": "Twi_merged", "hydrodem": "Twi_hydrodem"}
+
+
+def build(step_cfg: dict, ctx, logger) -> dict:
+    """shared-raster builder: write reference-percentile CSVs for each source.
+
+    step_cfg keys:
+      sources    list[str] subset of {"arcpy","hydrodem"} (default both)
+      percentiles {carea_max, smidx}  optional explicit percentiles; if absent,
+                  derived by inverting 8.0/15.6 on the ArcPy VPU 01 sample.
+      decimate   int overview factor for sampling (default 20)
+    """
+    sources = step_cfg.get("sources", ["arcpy", "hydrodem"])
+    pcfg = step_cfg.get("percentiles", {})
+    p_carea = pcfg.get("carea_max")
+    p_smidx = pcfg.get("smidx")
+    decimate = int(step_cfg.get("decimate", 20))
+    nodata = -9999.0
+    out_dir = ctx.conus_dir
+    produced = {}
+
+    def mask_path(vpu):
+        return ctx.per_vpu_dir / vpu / f"land_mask_{vpu}.tif"
+
+    # ArcPy VPU 01 sample drives the inverted default percentiles.
+    arcpy01 = None
+    if p_carea is None or p_smidx is None:
+        twi01 = ctx.per_vpu_dir / "01" / "Twi_merged_01.tif"
+        arcpy01 = _sample_land_masked_twi(twi01, mask_path("01"), decimate, nodata)
+        logger.info("build_twi_reference: derived default percentiles by "
+                    "inverting 8.0/15.6 on ArcPy VPU 01 (%d samples)", arcpy01.size)
+
+    for source in sources:
+        prefix = _SOURCE_PREFIX[source]
+
+        def sampler(vpu, _prefix=prefix):
+            twi = ctx.per_vpu_dir / vpu / f"{_prefix}_{vpu}.tif"
+            return _sample_land_masked_twi(twi, mask_path(vpu), decimate, nodata)
+
+        rows = assemble_reference_table(
+            source=source, vpus=list(ctx.vpus), sampler=sampler,
+            arcpy_vpu01_sample=arcpy01, p_carea=p_carea, p_smidx=p_smidx,
+            nodata=nodata,
+        )
+        out_path = out_dir / f"twi_reference_percentiles.{source}.csv"
+        write_reference_table(rows, out_path)
+        logger.info("build_twi_reference: wrote %d rows -> %s", len(rows), out_path)
+        produced[f"twi_reference_{source}"] = out_path
+
+    return produced

--- a/src/gfv2_params/shared_rasters/twi_reference.py
+++ b/src/gfv2_params/shared_rasters/twi_reference.py
@@ -20,6 +20,8 @@ from pathlib import Path
 import numpy as np
 import rasterio
 
+from gfv2_params.config import VPU_RASTER_MAP
+
 
 def _valid(values: np.ndarray, nodata: float | None) -> np.ndarray:
     """Return the finite, non-nodata subset as a 1-D float64 array."""
@@ -54,6 +56,21 @@ LEGACY_CAREA_THRESHOLD = 8.0
 LEGACY_SMIDX_THRESHOLD = 15.6
 
 _TABLE_FIELDS = ["source", "scope", "vpu", "p_carea", "p_smidx", "t_carea", "t_smidx"]
+
+
+def raster_vpus(vpus):
+    """Dedup detailed VPU labels to ordered-unique raster VPUs.
+
+    03N/03S/03W -> 03, 10L/10U -> 10 (via VPU_RASTER_MAP); pass-through otherwise.
+    The per-VPU TWI tiles and land masks live in the raster-VPU namespace, so the
+    reference table is keyed by raster VPU to match.
+    """
+    out = []
+    for v in vpus:
+        rv = VPU_RASTER_MAP.get(str(v), str(v))
+        if rv not in out:
+            out.append(rv)
+    return out
 
 
 def assemble_reference_table(
@@ -125,7 +142,14 @@ def _sample_land_masked_twi(twi_path: Path, mask_path: Path, decimate: int, noda
         oh, ow = max(1, t.height // decimate), max(1, t.width // decimate)
         twi = t.read(1, out_shape=(1, oh, ow))
         tnod = t.nodata if nodata is None else nodata
+        t_hw = (t.height, t.width)
     with rasterio.open(mask_path) as m:
+        if (m.height, m.width) != t_hw:
+            raise ValueError(
+                f"TWI/mask grid mismatch for percentile sampling: "
+                f"TWI {twi_path.name}={t_hw}, mask {mask_path.name}="
+                f"({m.height},{m.width}); they must share a grid."
+            )
         land = m.read(1, out_shape=(1, oh, ow)) == 1
     sample = twi[land]
     return _valid(sample, tnod)
@@ -172,7 +196,7 @@ def build(step_cfg: dict, ctx, logger) -> dict:
             return _sample_land_masked_twi(twi, mask_path(vpu), decimate, nodata)
 
         rows = assemble_reference_table(
-            source=source, vpus=list(ctx.vpus), sampler=sampler,
+            source=source, vpus=raster_vpus(ctx.vpus), sampler=sampler,
             arcpy_vpu01_sample=arcpy01, p_carea=p_carea, p_smidx=p_smidx,
             nodata=nodata,
         )

--- a/src/gfv2_params/shared_rasters/twi_reference.py
+++ b/src/gfv2_params/shared_rasters/twi_reference.py
@@ -19,6 +19,9 @@ from pathlib import Path
 
 import numpy as np
 import rasterio
+from rasterio.enums import Resampling
+from rasterio.transform import Affine
+from rasterio.vrt import WarpedVRT
 
 from gfv2_params.config import VPU_RASTER_MAP
 
@@ -136,21 +139,23 @@ def write_reference_table(rows: list[dict], out_path: Path) -> None:
 
 
 def _sample_land_masked_twi(twi_path: Path, mask_path: Path, decimate: int, nodata):
-    """Decimated valid-land TWI sample (1-D). Reads both rasters at a coarse
-    overview to keep CONUS-scale sampling cheap; mask==1 marks land."""
+    """Decimated valid-land TWI sample (1-D).
+
+    Reads TWI at a coarse overview, then resamples the per-VPU land mask (nearest)
+    onto that SAME decimated TWI grid via a WarpedVRT. The ArcPy Twi_merged tiles
+    and the Hydrodem-grid land mask do NOT share a grid, so the mask must be
+    regridded, not index-aligned (a plain same-shape read silently misaligns).
+    Cells outside the mask coverage read as nodata (255) -> not land.
+    """
     with rasterio.open(twi_path) as t:
         oh, ow = max(1, t.height // decimate), max(1, t.width // decimate)
         twi = t.read(1, out_shape=(1, oh, ow))
         tnod = t.nodata if nodata is None else nodata
-        t_hw = (t.height, t.width)
-    with rasterio.open(mask_path) as m:
-        if (m.height, m.width) != t_hw:
-            raise ValueError(
-                f"TWI/mask grid mismatch for percentile sampling: "
-                f"TWI {twi_path.name}={t_hw}, mask {mask_path.name}="
-                f"({m.height},{m.width}); they must share a grid."
-            )
-        land = m.read(1, out_shape=(1, oh, ow)) == 1
+        dec_transform = t.transform * Affine.scale(t.width / ow, t.height / oh)
+        with rasterio.open(mask_path) as m:
+            with WarpedVRT(m, crs=t.crs, transform=dec_transform,
+                           width=ow, height=oh, resampling=Resampling.nearest) as vrt:
+                land = vrt.read(1) == 1
     sample = twi[land]
     return _valid(sample, tnod)
 

--- a/src/gfv2_params/shared_rasters/twi_reference.py
+++ b/src/gfv2_params/shared_rasters/twi_reference.py
@@ -14,7 +14,11 @@ This module holds the pure math (percentile / CDF-inversion) plus the
 
 from __future__ import annotations
 
+import csv
+from pathlib import Path
+
 import numpy as np
+import rasterio
 
 
 def _valid(values: np.ndarray, nodata: float | None) -> np.ndarray:
@@ -43,11 +47,6 @@ def rank_of_value(values: np.ndarray, value: float, nodata: float | None = None)
         raise ValueError("rank_of_value: no valid values")
     return float(100.0 * np.count_nonzero(valid <= value) / valid.size)
 
-
-import csv
-from pathlib import Path
-
-import rasterio
 
 # Legacy ArcPy thresholds (docs/0b_TB_depr_stor.py); used to derive default
 # percentiles by inversion so percentile-mode reproduces VPU 01 by construction.

--- a/tests/test_build_vrt_srs.py
+++ b/tests/test_build_vrt_srs.py
@@ -1,0 +1,19 @@
+"""Unit tests for build_vrt's per-type SRS override (twi_hydrodem needs a
+named EPSG:5070 because the source tiles report an 'unnamed' Albers CRS)."""
+
+import importlib
+
+build_vrt = importlib.import_module("gfv2_params.shared_rasters.build_vrt")
+
+
+def test_twi_hydrodem_registered_with_nodata():
+    assert "twi_hydrodem" in build_vrt.RASTER_TYPES
+    pattern, src_nodata = build_vrt.RASTER_TYPES["twi_hydrodem"][:2]
+    assert pattern == "Twi_hydrodem_*.tif"
+    assert src_nodata == "-9999"
+
+
+def test_srs_override_only_for_twi_hydrodem():
+    assert build_vrt._srs_override("twi_hydrodem") == "EPSG:5070"
+    assert build_vrt._srs_override("twi") is None
+    assert build_vrt._srs_override("fdr") is None

--- a/tests/test_carea_map_threshold.py
+++ b/tests/test_carea_map_threshold.py
@@ -2,9 +2,17 @@
 mode, per-VPU) and match the scalar path cell-for-cell when the array is
 constant (issue #55)."""
 
+import csv
+from pathlib import Path
+
 import numpy as np
+import pytest
 
 from gfv2_params.depstor import compute_carea_map_binary
+from gfv2_params.depstor_builders.carea_map import (
+    load_reference_table,
+    resolve_scalar_thresholds,
+)
 
 
 def _inputs():
@@ -38,3 +46,37 @@ def test_per_cell_array_threshold_varies():
     out = compute_carea_map_binary(perv, onstream, twi, arr, -9999.0, land)
     assert out[0, 1] == 255  # 9 !> 10
     assert out[0, 2] == 1    # onstream rescues
+
+
+def _write_table(tmp_path) -> Path:
+    p = tmp_path / "twi_reference_percentiles.hydrodem.csv"
+    with open(p, "w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=["source", "scope", "vpu", "p_carea", "p_smidx", "t_carea", "t_smidx"])
+        w.writeheader()
+        w.writerow({"source": "hydrodem", "scope": "conus", "vpu": "CONUS", "p_carea": 8, "p_smidx": 16, "t_carea": 7.7, "t_smidx": 14.9})
+        w.writerow({"source": "hydrodem", "scope": "vpu", "vpu": "17", "p_carea": 8, "p_smidx": 16, "t_carea": 6.2, "t_smidx": 12.1})
+    return p
+
+
+def test_load_reference_table_indexes_by_scope_vpu(tmp_path):
+    table = load_reference_table(_write_table(tmp_path))
+    assert table[("conus", "CONUS")]["t_carea"] == 7.7
+    assert table[("vpu", "17")]["t_smidx"] == 12.1
+
+
+def test_resolve_scalar_conus(tmp_path):
+    table = load_reference_table(_write_table(tmp_path))
+    tc, ts = resolve_scalar_thresholds(table, scope="conus", vpu=None)
+    assert (tc, ts) == (7.7, 14.9)
+
+
+def test_resolve_scalar_single_vpu(tmp_path):
+    table = load_reference_table(_write_table(tmp_path))
+    tc, ts = resolve_scalar_thresholds(table, scope="vpu", vpu="17")
+    assert (tc, ts) == (6.2, 12.1)
+
+
+def test_resolve_scalar_missing_vpu_raises(tmp_path):
+    table = load_reference_table(_write_table(tmp_path))
+    with pytest.raises(KeyError, match="no reference row"):
+        resolve_scalar_thresholds(table, scope="vpu", vpu="09")

--- a/tests/test_carea_map_threshold.py
+++ b/tests/test_carea_map_threshold.py
@@ -10,9 +10,12 @@ import pytest
 
 from gfv2_params.depstor import compute_carea_map_binary
 from gfv2_params.depstor_builders.carea_map import (
+    _threshold_lut,
     load_reference_table,
     resolve_scalar_thresholds,
+    uncovered_vpu_codes,
 )
+from gfv2_params.depstor_builders.vpu_id import VPU_NODATA, vpu_to_code
 
 
 def _inputs():
@@ -80,3 +83,27 @@ def test_resolve_scalar_missing_vpu_raises(tmp_path):
     table = load_reference_table(_write_table(tmp_path))
     with pytest.raises(KeyError, match="no reference row"):
         resolve_scalar_thresholds(table, scope="vpu", vpu="09")
+
+
+def _vpu_ref_table():
+    return {
+        ("vpu", "17"): {"t_carea": 8.94, "t_smidx": 15.15},
+        ("vpu", "01"): {"t_carea": 8.0, "t_smidx": 15.6},
+        ("conus", "CONUS"): {"t_carea": 7.7, "t_smidx": 14.9},
+    }
+
+
+def test_threshold_lut_fills_and_maps():
+    lut = _threshold_lut(_vpu_ref_table(), "t_carea")
+    assert lut[vpu_to_code("17")] == 8.94
+    assert lut[vpu_to_code("01")] == 8.0
+    assert not np.isfinite(lut[VPU_NODATA])   # index 0 nodata stays +inf
+    assert not np.isfinite(lut[9])            # VPU 09 absent -> +inf
+
+
+def test_uncovered_vpu_codes_detects_missing():
+    t = _vpu_ref_table()
+    ca = _threshold_lut(t, "t_carea")
+    sm = _threshold_lut(t, "t_smidx")
+    assert uncovered_vpu_codes({0, 1, 9}, ca, sm) == [9]   # 0 ignored, 9 missing
+    assert uncovered_vpu_codes({0, 1, 17}, ca, sm) == []   # all covered

--- a/tests/test_carea_map_threshold.py
+++ b/tests/test_carea_map_threshold.py
@@ -1,0 +1,40 @@
+"""compute_carea_map_binary must accept a per-cell-array threshold (percentile
+mode, per-VPU) and match the scalar path cell-for-cell when the array is
+constant (issue #55)."""
+
+import numpy as np
+
+from gfv2_params.depstor import compute_carea_map_binary
+
+
+def _inputs():
+    perv = np.array([[1, 1, 1], [1, 0, 1]], dtype="uint8")
+    onstream = np.array([[0, 0, 1], [0, 0, 0]], dtype="uint8")
+    twi = np.array([[5.0, 9.0, 5.0], [20.0, 9.0, -9999.0]], dtype="float32")
+    land = np.ones((2, 3), dtype=bool)
+    return perv, onstream, twi, land
+
+
+def test_scalar_threshold_unchanged():
+    perv, onstream, twi, land = _inputs()
+    out = compute_carea_map_binary(perv, onstream, twi, 8.0, -9999.0, land)
+    # keep where perv & land & (twi>8 or onstream); 255 elsewhere
+    expected = np.array([[255, 1, 1], [1, 255, 255]], dtype="uint8")
+    assert np.array_equal(out, expected)
+
+
+def test_constant_array_threshold_matches_scalar():
+    perv, onstream, twi, land = _inputs()
+    scalar = compute_carea_map_binary(perv, onstream, twi, 8.0, -9999.0, land)
+    arr = np.full(twi.shape, 8.0, dtype="float64")
+    out = compute_carea_map_binary(perv, onstream, twi, arr, -9999.0, land)
+    assert np.array_equal(out, scalar)
+
+
+def test_per_cell_array_threshold_varies():
+    perv, onstream, twi, land = _inputs()
+    # column 1 has twi=9; threshold 10 there -> excluded; threshold 8 -> included
+    arr = np.array([[8.0, 10.0, 8.0], [8.0, 10.0, 8.0]], dtype="float64")
+    out = compute_carea_map_binary(perv, onstream, twi, arr, -9999.0, land)
+    assert out[0, 1] == 255  # 9 !> 10
+    assert out[0, 2] == 1    # onstream rescues

--- a/tests/test_twi_reference.py
+++ b/tests/test_twi_reference.py
@@ -39,3 +39,46 @@ def test_rank_of_value_handles_nodata():
 def test_percentile_empty_raises():
     with pytest.raises(ValueError, match="no valid"):
         percentile_of_values(np.array([-9999.0, np.nan]), [50.0], nodata=-9999.0)
+
+
+from gfv2_params.shared_rasters.twi_reference import assemble_reference_table
+
+
+def test_assemble_reference_table_uses_inverted_defaults():
+    # Fake per-VPU valid-land TWI samples for two VPUs of one source.
+    samples = {
+        "01": np.arange(1, 101, dtype="float64"),       # 1..100
+        "17": np.arange(1, 201, dtype="float64") / 2.0,  # 0.5..100
+    }
+
+    def sampler(vpu):
+        return samples[vpu]
+
+    rows = assemble_reference_table(
+        source="hydrodem",
+        vpus=["01", "17"],
+        sampler=sampler,
+        # invert 8.0/15.6 against this ArcPy VPU01 sample to get the percentiles
+        arcpy_vpu01_sample=np.arange(1, 101, dtype="float64"),
+        legacy_carea=8.0,
+        legacy_smidx=15.6,
+    )
+    by = {(r["scope"], r["vpu"]): r for r in rows}
+    # Inversion: 8.0 -> ~8th pct, 15.6 -> ~16th pct of 1..100
+    assert by[("vpu", "01")]["p_carea"] == pytest.approx(8.0, abs=1.0)
+    assert by[("vpu", "01")]["p_smidx"] == pytest.approx(15.6, abs=1.0)
+    # CONUS row pools all VPUs and uses the same percentiles
+    assert ("conus", "CONUS") in by
+    # t_carea is the p_carea-th percentile of that scope's sample
+    assert by[("vpu", "17")]["t_carea"] < by[("vpu", "01")]["t_carea"]
+
+
+def test_assemble_reference_table_explicit_percentiles_skip_inversion():
+    samples = {"01": np.arange(1, 101, dtype="float64")}
+    rows = assemble_reference_table(
+        source="arcpy", vpus=["01"], sampler=lambda v: samples[v],
+        p_carea=75.0, p_smidx=95.0,
+    )
+    r = next(x for x in rows if x["scope"] == "vpu")
+    assert r["p_carea"] == 75.0 and r["p_smidx"] == 95.0
+    assert r["t_carea"] == pytest.approx(75.25, abs=0.5)

--- a/tests/test_twi_reference.py
+++ b/tests/test_twi_reference.py
@@ -88,3 +88,7 @@ def test_raster_vpus_dedup_subregions():
         "01", "02", "03", "10", "17",
     ]
     assert raster_vpus(["01", "01", "18"]) == ["01", "18"]
+
+
+def test_raster_vpus_maps_oregon_alias():
+    assert raster_vpus(["OR", "17"]) == ["17"]

--- a/tests/test_twi_reference.py
+++ b/tests/test_twi_reference.py
@@ -8,6 +8,7 @@ from gfv2_params.shared_rasters.twi_reference import (
     assemble_reference_table,
     percentile_of_values,
     rank_of_value,
+    raster_vpus,
 )
 
 
@@ -80,3 +81,10 @@ def test_assemble_reference_table_explicit_percentiles_skip_inversion():
     r = next(x for x in rows if x["scope"] == "vpu")
     assert r["p_carea"] == 75.0 and r["p_smidx"] == 95.0
     assert r["t_carea"] == pytest.approx(75.25, abs=0.5)
+
+
+def test_raster_vpus_dedup_subregions():
+    assert raster_vpus(["01", "02", "03N", "03S", "03W", "10L", "10U", "17"]) == [
+        "01", "02", "03", "10", "17",
+    ]
+    assert raster_vpus(["01", "01", "18"]) == ["01", "18"]

--- a/tests/test_twi_reference.py
+++ b/tests/test_twi_reference.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest
 
 from gfv2_params.shared_rasters.twi_reference import (
+    assemble_reference_table,
     percentile_of_values,
     rank_of_value,
 )
@@ -39,9 +40,6 @@ def test_rank_of_value_handles_nodata():
 def test_percentile_empty_raises():
     with pytest.raises(ValueError, match="no valid"):
         percentile_of_values(np.array([-9999.0, np.nan]), [50.0], nodata=-9999.0)
-
-
-from gfv2_params.shared_rasters.twi_reference import assemble_reference_table
 
 
 def test_assemble_reference_table_uses_inverted_defaults():

--- a/tests/test_twi_reference.py
+++ b/tests/test_twi_reference.py
@@ -1,0 +1,41 @@
+"""Unit tests for the pure percentile / CDF-inversion helpers used to derive
+TWI threshold cutoffs (issue #55 Stage 1)."""
+
+import numpy as np
+import pytest
+
+from gfv2_params.shared_rasters.twi_reference import (
+    percentile_of_values,
+    rank_of_value,
+)
+
+
+def test_percentile_of_values_basic():
+    vals = np.arange(1, 101, dtype="float64")  # 1..100
+    p = percentile_of_values(vals, [75.0, 95.0])
+    assert p[0] == pytest.approx(75.25, abs=0.5)
+    assert p[1] == pytest.approx(95.05, abs=0.5)
+
+
+def test_percentile_drops_nan_and_nodata():
+    vals = np.array([1.0, 2.0, 3.0, 4.0, np.nan, -9999.0], dtype="float64")
+    p = percentile_of_values(vals, [50.0], nodata=-9999.0)
+    # median of {1,2,3,4} == 2.5
+    assert p[0] == pytest.approx(2.5)
+
+
+def test_rank_of_value_is_inverse_of_percentile():
+    vals = np.arange(1, 101, dtype="float64")
+    # value 75 sits at ~the 75th percentile
+    assert rank_of_value(vals, 75.0) == pytest.approx(75.0, abs=1.0)
+
+
+def test_rank_of_value_handles_nodata():
+    vals = np.array([1.0, 2.0, 3.0, 4.0, -9999.0], dtype="float64")
+    # 3.0 is >= 3 of 4 valid values -> 75%
+    assert rank_of_value(vals, 3.0, nodata=-9999.0) == pytest.approx(75.0)
+
+
+def test_percentile_empty_raises():
+    with pytest.raises(ValueError, match="no valid"):
+        percentile_of_values(np.array([-9999.0, np.nan]), [50.0], nodata=-9999.0)

--- a/tests/test_vpu_id.py
+++ b/tests/test_vpu_id.py
@@ -38,3 +38,14 @@ def test_vpu_to_code_subregions_map_to_parent():
     assert vpu_to_code("03W") == 3
     assert vpu_to_code("10L") == 10
     assert vpu_to_code("10U") == 10
+
+
+def test_vpu_to_code_out_of_range_raises():
+    with pytest.raises(ValueError, match="out of range"):
+        vpu_to_code("19")
+    with pytest.raises(ValueError):
+        vpu_to_code("00")
+
+
+def test_vpu_to_code_oregon_alias():
+    assert vpu_to_code("OR") == 17

--- a/tests/test_vpu_id.py
+++ b/tests/test_vpu_id.py
@@ -1,0 +1,32 @@
+"""Unit tests for vpu_id code mapping + resolution precedence (issue #55)."""
+
+import pytest
+
+from gfv2_params.depstor_builders.vpu_id import vpu_to_code, resolve_vpu_source
+
+
+def test_vpu_to_code_zero_padded():
+    assert vpu_to_code("01") == 1
+    assert vpu_to_code("17") == 17
+    assert vpu_to_code("18") == 18
+
+
+def test_vpu_to_code_rejects_garbage():
+    with pytest.raises(ValueError):
+        vpu_to_code("not-a-vpu")
+
+
+def test_resolve_prefers_profile_scalar():
+    # profile vpu scalar wins even if the fabric has an attribute
+    kind, value = resolve_vpu_source(profile_vpu="17", fabric_has_vpu_attr=True)
+    assert kind == "scalar" and value == "17"
+
+
+def test_resolve_falls_back_to_attribute():
+    kind, value = resolve_vpu_source(profile_vpu=None, fabric_has_vpu_attr=True)
+    assert kind == "attribute" and value == "vpu"
+
+
+def test_resolve_errors_when_neither():
+    with pytest.raises(ValueError, match="requires a profile `vpu`"):
+        resolve_vpu_source(profile_vpu=None, fabric_has_vpu_attr=False)

--- a/tests/test_vpu_id.py
+++ b/tests/test_vpu_id.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from gfv2_params.depstor_builders.vpu_id import vpu_to_code, resolve_vpu_source
+from gfv2_params.depstor_builders.vpu_id import resolve_vpu_source, vpu_to_code
 
 
 def test_vpu_to_code_zero_padded():

--- a/tests/test_vpu_id.py
+++ b/tests/test_vpu_id.py
@@ -30,3 +30,11 @@ def test_resolve_falls_back_to_attribute():
 def test_resolve_errors_when_neither():
     with pytest.raises(ValueError, match="requires a profile `vpu`"):
         resolve_vpu_source(profile_vpu=None, fabric_has_vpu_attr=False)
+
+
+def test_vpu_to_code_subregions_map_to_parent():
+    assert vpu_to_code("03N") == 3
+    assert vpu_to_code("03S") == 3
+    assert vpu_to_code("03W") == 3
+    assert vpu_to_code("10L") == 10
+    assert vpu_to_code("10U") == 10


### PR DESCRIPTION
## Scope

Unifies **#94** (TWI staging gap → degenerate `carea_map` outside VPU 01) and **#55 Stage 1** (decouple `carea_max`/`smidx_coef` from absolute TWI thresholds) into one branch. **#55 Stage 2** (NWI/SSURGO/NLCD observational decoupling) is deferred to a follow-up.

Design spec: `docs/superpowers/specs/2026-05-21-carea-smidx-twi-percentile-design.md`
Plan: `docs/superpowers/plans/2026-05-21-twi-percentile-carea-smidx.md`

## What changed

The TWI cutoff for `carea_max`/`smidx_coef` is now **derived from the data** (a percentile) instead of the hardcoded `8.0`/`15.6`, so it self-recalibrates per TWI source — which makes the CONUS-complete open-source `Twi_hydrodem` safe to adopt and closes the #94 coverage gap. The existing `carea_map` binary builder + zonal-count + ratio pipeline is **reused unchanged**; only the threshold number changes.

- **Phase A — TWI source completion**
  - `build_vrt`: new `twi_hydrodem` VRT type, stamped `EPSG:5070` (tiles report an unnamed Albers CRS).
  - `slurm_batch/submit_twi_completion.sh`: finishes the ArcPy `twi.vrt` for VPUs 02–18 (never merged) + builds both VRTs — pure on-cluster, no ArcPy.
- **Phase B — reference percentiles**
  - New `twi_reference` shared-raster step → `shared/conus/twi_reference_percentiles.{arcpy,hydrodem}.csv` (valid-land TWI percentile cutoffs per VPU + CONUS). Default percentiles **derived by inverting 8.0/15.6 through VPU 01's ArcPy CDF**, so percentile-mode reproduces VPU 01 by construction.
- **Phase C — percentile-mode `carea_map`**
  - `compute_carea_map_binary` accepts a scalar **or** per-cell-array threshold.
  - New `vpu_id` builder rasterises each HRU's home-VPU code; `carea_map` gains `threshold_mode: absolute|percentile` (`reference_scope: vpu|conus`). Scalar threshold for conus/single-VPU; per-cell array via the `vpu_id` lookup for multi-VPU.
  - Mode↔source pairing: production = `absolute↔twi.vrt` / `percentile↔twi_hydrodem.vrt`; off-diagonal is validation-only and the builder **warns** on `absolute × non-ArcPy`.
  - Profiles: oregon declares `vpu: "17"`; gfv2 uses its per-HRU `vpu` attribute. Both depstor `twi_raster` → `twi_hydrodem.vrt`.

The parameter contract is unchanged: same pervious denominator, onstream term, clamp-to-1, per-HRU `[0,1]` floats into the same PRMS slots.

## Review-caught fix (worth a look)

A multi-agent review caught that gfv2's `vpu` column uses **detailed sub-region labels** (`03N/03S/03W`, `10L/10U`) while tiles/masks are per **raster VPU** (`01`–`18`). The initial `vpu_to_code` would have crashed on `"03N"`, breaking the gfv2 per-VPU path. Fixed by normalizing through the existing `VPU_RASTER_MAP` everywhere (`03N/03S/03W→3`, `10L/10U→10`), plus robust LUT sizing and a TWI/land-mask grid-alignment guard.

## Tests

21 new unit tests (`test_twi_reference`, `test_vpu_id`, `test_carea_map_threshold`, `test_build_vrt_srs`) — all passing; pre-commit clean. CI is the test gate.

## Validation (run after merge prerequisites are staged)

`submit_twi_completion.sh` → `twi_reference` step → oregon non-degeneracy (`carea_map_t8 ≠ t156`) → VPU 01 calibration A/B → `twi.vrt` vs `twi_hydrodem.vrt` source A/B. See plan Phase D.

🤖 Generated with [Claude Code](https://claude.com/claude-code)