### PR TITLE
Fabric parameterization results-viewer notebooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,6 +183,11 @@ cython_debug/
 output/
 logs/
 
+# Fabric results-viewer figures: the PNGs under docs/figures/<fabric>/ are
+# committed (regenerate with `scripts/render_figures.py`); only the executed
+# notebook copies in the .cache/ subdir are ignored.
+docs/figures/.cache/
+
 # abock's stray working copies, renamed out of the way so they don't shadow
 # imports from the repo root (canonical homes are scripts/ and src/)
 /_gfv2_params_legacy/

--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ gfv2-params/
 │   ├── submit_jobs.sh        # SLURM array job submission wrapper
 │   └── RUNME.md              # HPC workflow documentation (authoritative)
 ├── docs/                     # Pipeline reference docs (depstor workflow, validation, port summary)
-├── notebooks/                # Marimo interactive notebooks (incl. VPU01 QA/QC)
+├── notebooks/                # Interactive notebooks (marimo + Jupyter QA/QC)
+│   └── fabric_results/        # Fabric results viewers (01 inputs, 02 depstor, 03 params)
 ├── tests/                    # Unit tests
 ├── pyproject.toml            # Package + pixi config
 ├── pixi.lock                 # Pinned pixi environment
@@ -371,6 +372,36 @@ The orchestrator's per-step library functions live under
 [src/gfv2_params/zonal_runners.py](src/gfv2_params/zonal_runners.py).
 For per-step debugging, invoke the orchestrator directly with
 `--mode zonal --param <name> --batch_id <N>` (see "Single-batch run" above).
+
+## Viewing fabric results
+
+Once a fabric is processed, the three Jupyter notebooks in
+[notebooks/fabric_results/](notebooks/fabric_results/) give a complete picture of
+a fabric's parameterization — the inputs that fed it and the per-HRU results:
+
+| Notebook | Shows |
+|---|---|
+| `01_input_rasters.ipynb` | Every shared/zonal source raster clipped to the fabric bounds, HRU outline overlaid. |
+| `02_depstor_rasters.ipynb` | The 14 per-fabric depression-storage binary/label rasters + coverage stats. |
+| `03_param_results.ipynb` | Choropleth + distribution of all 16 merged per-HRU params, plus a depstor-ratio summary. |
+
+All three are **parameterized by the `FABRIC` env var** (default `oregon`) and read
+the active profile via `load_base_config`; they share the tested helpers in
+[src/gfv2_params/viz.py](src/gfv2_params/viz.py). Run them **inside JupyterHub on a
+compute node with enough `--mem`** — a full CONUS `gfv2` render loads ~361k HRU
+polygons and is too large for the login node. Per-fabric launch notes live in
+`notebooks/<fabric>/README.md` (e.g. [notebooks/oregon/README.md](notebooks/oregon/README.md)).
+
+**Saving figures for a report.** Set `SAVE_FIGURES=1` (or `viz.SAVE_FIGURES = True`
+in the first cell) to write each plot to `docs/figures/<fabric>/` with a
+`{section}_{item}.png` name. To regenerate the whole set headlessly:
+
+```bash
+pixi run -e notebooks python scripts/render_figures.py --fabric oregon
+```
+
+The PNGs under `docs/figures/<fabric>/` are committed; the executed notebook copies
+in `docs/figures/.cache/` are gitignored.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -169,11 +169,11 @@ orchestrator over [configs/shared_rasters/shared_rasters.yml](configs/shared_ras
 pixi run python scripts/build_shared_rasters.py --config configs/shared_rasters/shared_rasters.yml
 ```
 
-This walks 7 production steps in dependency order (merge_rpu_by_vpu →
+This walks 9 production steps in dependency order (merge_rpu_by_vpu →
 compute_slope_aspect → build_border_dem → build_vpu_landmask →
-merge_rpu_by_vpu_twi → build_vrt → build_derived_rasters → build_lulc_rasters)
-and writes everything into the shared `work/` store consumed by every
-fabric. Add `--step <name>` to run one step or `--from <name>` to resume.
+merge_rpu_by_vpu_twi → build_vrt → twi_reference → build_derived_rasters →
+build_lulc_rasters) and writes everything into the shared `shared/` store
+consumed by every fabric. Add `--step <name>` to run one step or `--from <name>` to resume.
 `--vpus 01,02` scopes per-VPU steps to a subset; `--force` rebuilds
 existing outputs. See [Shared rasters pipeline](#shared-rasters-pipeline)
 below for the design notes.

--- a/notebooks/fabric_results/01_input_rasters.ipynb
+++ b/notebooks/fabric_results/01_input_rasters.ipynb
@@ -1,0 +1,158 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "fa8e4169",
+   "metadata": {},
+   "source": [
+    "# 01 — Input rasters (fabric-bounded)\n",
+    "\n",
+    "Snapshots of every CONUS/shared and zonal-source raster that feeds the parameterization, clipped to the active fabric's bounds with the HRU outline overlaid. Missing sources (e.g. an unused LULC source) are skipped with a warning.\n",
+    "\n",
+    "> **Run this in JupyterHub on a compute node with enough `--mem`.** Rendering a\n",
+    "> full fabric (especially CONUS `gfv2`, ~361k HRUs) loads large geometries and\n",
+    "> rasters; the login node will run out of memory. Pick the fabric with the\n",
+    "> `FABRIC` env var (or edit the first code cell). Set `SAVE_FIGURES=1` (or\n",
+    "> `viz.SAVE_FIGURES = True`) to write PNGs into `docs/figures/{FABRIC}/`, or\n",
+    "> batch-generate them with `python scripts/render_figures.py --fabric {FABRIC}`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "31a91d9d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from gfv2_params import viz\n",
+    "from gfv2_params.config import load_base_config\n",
+    "\n",
+    "# Fabric is selected by the FABRIC env var (set it in your JupyterHub session),\n",
+    "# or edit the default here. SAVE_FIGURES=1 writes PNGs to docs/figures/{FABRIC}/.\n",
+    "FABRIC = os.environ.get(\"FABRIC\", \"oregon\")\n",
+    "viz.FABRIC = FABRIC\n",
+    "viz.SAVE_FIGURES = os.environ.get(\"SAVE_FIGURES\", \"0\") == \"1\"\n",
+    "\n",
+    "cfg = load_base_config(fabric=FABRIC)\n",
+    "DATA_ROOT = Path(cfg[\"data_root\"])\n",
+    "HRU_GPKG = Path(cfg[\"hru_gpkg\"])\n",
+    "HRU_LAYER = cfg[\"hru_layer\"]\n",
+    "ID_FEATURE = cfg[\"id_feature\"]\n",
+    "\n",
+    "print(f\"FABRIC       = {FABRIC}\")\n",
+    "print(f\"SAVE_FIGURES = {viz.SAVE_FIGURES}  ->  docs/figures/{FABRIC}/\")\n",
+    "print(f\"data_root    = {DATA_ROOT}\")\n",
+    "print(f\"hru_gpkg     = {HRU_GPKG} (layer={HRU_LAYER}, id={ID_FEATURE})\")\n",
+    "\n",
+    "from gfv2_params.config import load_config\n",
+    "import gfv2_params.config as _cfgmod\n",
+    "ZONAL_YML = Path(_cfgmod.__file__).resolve().parents[2] / \"configs\" / \"zonal\" / \"zonal_params.yml\"\n",
+    "zonal_cfg = load_config(ZONAL_YML, fabric=FABRIC)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "998611d2",
+   "metadata": {},
+   "source": [
+    "## Build the raster inventory\n",
+    "\n",
+    "Shared hydrology/DEM VRTs (from the fabric profile + `shared/conus/vrt`) plus the zonal `source_raster` entries from `zonal_params.yml`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "31741797",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "inventory = viz.shared_raster_inventory(cfg) + viz.zonal_source_inventory(zonal_cfg)\n",
+    "for e in inventory:\n",
+    "    print(f\"{e.name:16} {e.kind:11} {e.path}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "504c0856",
+   "metadata": {},
+   "source": [
+    "## Read the fabric outline once\n",
+    "\n",
+    "Dissolved boundary, reused (reprojected per raster CRS) as an overlay. Fabric bounds are cached per CRS so the geometry is read only once."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f4a7144d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import geopandas as gpd\n",
+    "\n",
+    "fabric_geom = gpd.read_file(HRU_GPKG, layer=HRU_LAYER)\n",
+    "fabric_geom = fabric_geom[fabric_geom.geometry.notna() & ~fabric_geom.geometry.is_empty]\n",
+    "outline = fabric_geom.dissolve().boundary\n",
+    "\n",
+    "_bounds_cache = {}\n",
+    "def bounds_for(crs):\n",
+    "    key = crs.to_string() if crs is not None else None\n",
+    "    if key not in _bounds_cache:\n",
+    "        _bounds_cache[key] = tuple(fabric_geom.to_crs(crs).total_bounds)\n",
+    "    return _bounds_cache[key]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ae3205a7",
+   "metadata": {},
+   "source": [
+    "## Plot each raster clipped to the fabric"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "52a4ab7b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import rasterio\n",
+    "\n",
+    "for entry in inventory:\n",
+    "    with rasterio.open(entry.path) as src:\n",
+    "        rcrs = src.crs\n",
+    "    b = bounds_for(rcrs)\n",
+    "    arr, extent = viz.clip_overview(entry.path, b)\n",
+    "    fig, ax = plt.subplots(figsize=(8, 8))\n",
+    "    viz.plot_raster(ax, arr, extent=extent, cmap=entry.cmap,\n",
+    "                    categorical=(entry.kind == \"categorical\"),\n",
+    "                    title=f\"{entry.name}  [{FABRIC}]\", label=entry.units)\n",
+    "    try:\n",
+    "        outline.to_crs(rcrs).plot(ax=ax, color=\"red\", linewidth=0.6)\n",
+    "    except Exception as exc:\n",
+    "        print(f\"  (outline overlay skipped for {entry.name}: {exc})\")\n",
+    "    viz.save_figure(fig, f\"input_raster_{entry.name}\")\n",
+    "    plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/fabric_results/02_depstor_rasters.ipynb
+++ b/notebooks/fabric_results/02_depstor_rasters.ipynb
@@ -1,0 +1,119 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e8e80458",
+   "metadata": {},
+   "source": [
+    "# 02 — Depression-storage rasters\n",
+    "\n",
+    "The 14 per-fabric depstor binary/label rasters under `{data_root}/{FABRIC}/depstor_rasters/`. These are already at fabric extent, so they are shown as decimated thumbnails (no clipping) with a coverage statistic. Missing rasters are skipped with a warning.\n",
+    "\n",
+    "> **Run this in JupyterHub on a compute node with enough `--mem`.** Rendering a\n",
+    "> full fabric (especially CONUS `gfv2`, ~361k HRUs) loads large geometries and\n",
+    "> rasters; the login node will run out of memory. Pick the fabric with the\n",
+    "> `FABRIC` env var (or edit the first code cell). Set `SAVE_FIGURES=1` (or\n",
+    "> `viz.SAVE_FIGURES = True`) to write PNGs into `docs/figures/{FABRIC}/`, or\n",
+    "> batch-generate them with `python scripts/render_figures.py --fabric {FABRIC}`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2ba4050b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from gfv2_params import viz\n",
+    "from gfv2_params.config import load_base_config\n",
+    "\n",
+    "# Fabric is selected by the FABRIC env var (set it in your JupyterHub session),\n",
+    "# or edit the default here. SAVE_FIGURES=1 writes PNGs to docs/figures/{FABRIC}/.\n",
+    "FABRIC = os.environ.get(\"FABRIC\", \"oregon\")\n",
+    "viz.FABRIC = FABRIC\n",
+    "viz.SAVE_FIGURES = os.environ.get(\"SAVE_FIGURES\", \"0\") == \"1\"\n",
+    "\n",
+    "cfg = load_base_config(fabric=FABRIC)\n",
+    "DATA_ROOT = Path(cfg[\"data_root\"])\n",
+    "HRU_GPKG = Path(cfg[\"hru_gpkg\"])\n",
+    "HRU_LAYER = cfg[\"hru_layer\"]\n",
+    "ID_FEATURE = cfg[\"id_feature\"]\n",
+    "\n",
+    "print(f\"FABRIC       = {FABRIC}\")\n",
+    "print(f\"SAVE_FIGURES = {viz.SAVE_FIGURES}  ->  docs/figures/{FABRIC}/\")\n",
+    "print(f\"data_root    = {DATA_ROOT}\")\n",
+    "print(f\"hru_gpkg     = {HRU_GPKG} (layer={HRU_LAYER}, id={ID_FEATURE})\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0123291d",
+   "metadata": {},
+   "source": [
+    "## Inventory"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0ff9cfd9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "inventory = viz.depstor_raster_inventory(cfg)\n",
+    "for e in inventory:\n",
+    "    print(f\"{e.name:24} {e.path.name}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7df881c3",
+   "metadata": {},
+   "source": [
+    "## Thumbnails + coverage\n",
+    "\n",
+    "`frac>0` is the fraction of valid (non-nodata) cells with a value above zero — e.g. the share of the land mask flagged as a depression, pervious cell, etc. For label rasters (`vpu_id`, `wbody_regions`) it is just the non-zero share."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e8aed15c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "for entry in inventory:\n",
+    "    arr = viz.read_overview(entry.path)\n",
+    "    valid = np.ma.compressed(arr)\n",
+    "    n_valid = int(valid.size)\n",
+    "    frac_set = float((valid > 0).mean()) if n_valid else 0.0\n",
+    "    fig, ax = plt.subplots(figsize=(8, 8))\n",
+    "    viz.plot_raster(ax, arr, cmap=entry.cmap, categorical=True,\n",
+    "                    title=f\"{entry.name}  [{FABRIC}]\\n\"\n",
+    "                          f\"valid cells = {n_valid:,}   frac>0 = {frac_set:.3f}\",\n",
+    "                    label=\"class\")\n",
+    "    viz.save_figure(fig, f\"depstor_{entry.name}\")\n",
+    "    plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/fabric_results/03_param_results.ipynb
+++ b/notebooks/fabric_results/03_param_results.ipynb
@@ -1,0 +1,153 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7bc38e84",
+   "metadata": {},
+   "source": [
+    "# 03 — Parameterization results (per-HRU)\n",
+    "\n",
+    "Choropleths + distributions of every merged per-HRU parameter in `{data_root}/{FABRIC}/params/merged/`, joined to the fabric geometry by `id_feature`. Continuous params get a map + histogram; categorical params (`soils`, `cov_type`) get a map + class legend. Missing CSVs are skipped.\n",
+    "\n",
+    "> **Run this in JupyterHub on a compute node with enough `--mem`.** Rendering a\n",
+    "> full fabric (especially CONUS `gfv2`, ~361k HRUs) loads large geometries and\n",
+    "> rasters; the login node will run out of memory. Pick the fabric with the\n",
+    "> `FABRIC` env var (or edit the first code cell). Set `SAVE_FIGURES=1` (or\n",
+    "> `viz.SAVE_FIGURES = True`) to write PNGs into `docs/figures/{FABRIC}/`, or\n",
+    "> batch-generate them with `python scripts/render_figures.py --fabric {FABRIC}`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5c131c73",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from gfv2_params import viz\n",
+    "from gfv2_params.config import load_base_config\n",
+    "\n",
+    "# Fabric is selected by the FABRIC env var (set it in your JupyterHub session),\n",
+    "# or edit the default here. SAVE_FIGURES=1 writes PNGs to docs/figures/{FABRIC}/.\n",
+    "FABRIC = os.environ.get(\"FABRIC\", \"oregon\")\n",
+    "viz.FABRIC = FABRIC\n",
+    "viz.SAVE_FIGURES = os.environ.get(\"SAVE_FIGURES\", \"0\") == \"1\"\n",
+    "\n",
+    "cfg = load_base_config(fabric=FABRIC)\n",
+    "DATA_ROOT = Path(cfg[\"data_root\"])\n",
+    "HRU_GPKG = Path(cfg[\"hru_gpkg\"])\n",
+    "HRU_LAYER = cfg[\"hru_layer\"]\n",
+    "ID_FEATURE = cfg[\"id_feature\"]\n",
+    "\n",
+    "print(f\"FABRIC       = {FABRIC}\")\n",
+    "print(f\"SAVE_FIGURES = {viz.SAVE_FIGURES}  ->  docs/figures/{FABRIC}/\")\n",
+    "print(f\"data_root    = {DATA_ROOT}\")\n",
+    "print(f\"hru_gpkg     = {HRU_GPKG} (layer={HRU_LAYER}, id={ID_FEATURE})\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8ff4f3a4",
+   "metadata": {},
+   "source": [
+    "## Load fabric geometry once + locate the merged params"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4f2b4143",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import geopandas as gpd\n",
+    "import pandas as pd\n",
+    "\n",
+    "fabric_gdf = gpd.read_file(HRU_GPKG, layer=HRU_LAYER)[[ID_FEATURE, \"geometry\"]]\n",
+    "PARAMS_DIR = DATA_ROOT / FABRIC / \"params\" / \"merged\"\n",
+    "print(f\"{len(fabric_gdf):,} HRUs;  params dir = {PARAMS_DIR}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6ee855df",
+   "metadata": {},
+   "source": [
+    "## Per-parameter maps"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b90f53f8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for p in viz.param_inventory():\n",
+    "    csv_path = PARAMS_DIR / p.csv_name\n",
+    "    if not csv_path.exists():\n",
+    "        print(f\"skip {p.name}: missing {p.csv_name}\")\n",
+    "        continue\n",
+    "    gdf = viz.load_param(PARAMS_DIR, p.csv_name, fabric_gdf, ID_FEATURE)\n",
+    "    title = f\"{p.name}  [{FABRIC}]\"\n",
+    "    if p.kind == \"categorical\":\n",
+    "        fig = viz.map_categorical(gdf, p.column, title)\n",
+    "    else:\n",
+    "        fig = viz.map_continuous(gdf, p.column, title, units=p.units, cmap=p.cmap)\n",
+    "    viz.save_figure(fig, f\"param_{p.column}\")\n",
+    "    plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7918869b",
+   "metadata": {},
+   "source": [
+    "## Depression-storage ratio summary\n",
+    "\n",
+    "Quick distribution table for the clamped `[0, 1]` depstor ratios (`carea_max`, `smidx_coef`, `sro_to_dprst_perv/imperv`, `hru_percent_imperv`, `dprst_frac`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9f402fb3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ratio_cols = {\"carea_max\", \"smidx_coef\", \"sro_to_dprst_perv\",\n",
+    "              \"sro_to_dprst_imperv\", \"hru_percent_imperv\", \"dprst_frac\"}\n",
+    "rows = []\n",
+    "for p in viz.param_inventory():\n",
+    "    if p.column not in ratio_cols:\n",
+    "        continue\n",
+    "    csv_path = PARAMS_DIR / p.csv_name\n",
+    "    if not csv_path.exists():\n",
+    "        continue\n",
+    "    s = pd.read_csv(csv_path)[p.column].dropna()\n",
+    "    rows.append({\"param\": p.column, \"n\": len(s), \"mean\": s.mean(),\n",
+    "                 \"median\": s.median(), \"min\": s.min(), \"max\": s.max(),\n",
+    "                 \"frac_zero\": float((s == 0).mean()),\n",
+    "                 \"frac_one\": float((s >= 1).mean())})\n",
+    "pd.DataFrame(rows).set_index(\"param\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/oregon/README.md
+++ b/notebooks/oregon/README.md
@@ -1,0 +1,37 @@
+# oregon — results viewer
+
+This directory is a thin per-fabric launcher stub. The actual notebooks live once
+in [`../fabric_results/`](../fabric_results/) and are parameterized by the `FABRIC`
+env var — there is no per-fabric copy to maintain.
+
+## View the results
+
+Spawn a **JupyterHub** session on a compute node with enough memory (`oregon` is
+small; CONUS `gfv2` needs much more `--mem`), then open the three notebooks with
+`FABRIC=oregon`:
+
+```bash
+# in the JupyterHub session environment
+export FABRIC=oregon
+# then open, top-to-bottom:
+#   ../fabric_results/01_input_rasters.ipynb   (source rasters, fabric-clipped)
+#   ../fabric_results/02_depstor_rasters.ipynb (depstor binary masks)
+#   ../fabric_results/03_param_results.ipynb   (per-HRU param maps + summary)
+```
+
+If you can't set the env var in your Hub spawner, just edit the first code cell
+(`FABRIC = os.environ.get("FABRIC", "oregon")`) — `oregon` is already the default.
+
+## Save figures for a report
+
+Set `SAVE_FIGURES=1` (or `viz.SAVE_FIGURES = True` in the first cell) to write each
+plot to `docs/figures/oregon/` as `input_raster_*`, `depstor_*`, `param_*` PNGs.
+To regenerate the whole set headlessly:
+
+```bash
+pixi run -e notebooks python scripts/render_figures.py --fabric oregon
+```
+
+Any other fabric reuses the same three notebooks + render script — just change
+`FABRIC` (and add a `notebooks/<fabric>/` stub like this one if you want a
+fabric-specific landing page).

--- a/pixi.lock
+++ b/pixi.lock
@@ -40,7 +40,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-common-cpp-12.12.0-ha7a2c86_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-files-datalake-cpp-12.14.0-h52c5a47_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/backports.zstd-1.4.0-py312h90b7ffd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.14.3-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.3.0-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-with-css-6.3.0-hbca2aae_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.6-he440d0b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.43.0-pyhd8ed1ab_0.conda
@@ -82,6 +84,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.19.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.20-py312h8285ef7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/deprecated-1.3.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/distlib-0.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2026.3.0-pyhc364b38_0.conda
@@ -150,6 +153,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2025.9.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.8.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/kealib-1.6.2-h63db1d0_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.5.0-py312h0a2e395_0.conda
@@ -266,6 +270,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/minizip-4.2.1-hb71707f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.2.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.1.2-py312hd9148b4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/msgspec-0.21.1-py312h4c3975b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/multidict-6.7.1-py312h8a5da7c_0.conda
@@ -274,6 +279,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/muparser-2.3.5-h5888daf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.20.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-7.17.1-hb502eef_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.17.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-pandoc-7.17.1-h08b4883_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
@@ -292,6 +301,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/orc-2.3.0-h21090e2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-3.0.2-py312h8ecdadd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pandoc-3.9.0.2-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.8.10-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/param-2.3.3-pyhc455866_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.7-pyhcf101f3_0.conda
@@ -369,6 +380,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.2-h03e3b7b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.8.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/spatialpandas-0.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/spdlog-1.17.0-hab81395_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.53.1-hbc0de68_0.conda
@@ -379,6 +391,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/texttable-1.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.6.0-pyhecae5ae_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tiledb-2.30.1-h8789cd1_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.14.0-pyha770c72_0.conda
@@ -1165,7 +1178,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-common-cpp-12.12.0-ha7a2c86_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-files-datalake-cpp-12.14.0-h52c5a47_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/backports.zstd-1.4.0-py312h90b7ffd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.14.3-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.3.0-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-with-css-6.3.0-hbca2aae_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.6-he440d0b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.43.0-pyhd8ed1ab_0.conda
@@ -1205,6 +1220,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.19.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.20-py312h8285ef7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/deprecated-1.3.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2026.3.0-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/docutils-0.22.4-pyhd8ed1ab_0.conda
@@ -1269,6 +1285,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2025.9.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.8.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/kealib-1.6.2-h63db1d0_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.5.0-py312h0a2e395_0.conda
@@ -1385,6 +1402,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/minizip-4.2.1-hb71707f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.2.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.1.2-py312hd9148b4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/msgspec-0.21.1-py312h4c3975b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/multidict-6.7.1-py312h8a5da7c_0.conda
@@ -1393,6 +1411,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/muparser-2.3.5-h5888daf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.20.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-7.17.1-hb502eef_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.17.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-pandoc-7.17.1-h08b4883_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
@@ -1410,6 +1432,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/orc-2.3.0-h21090e2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-3.0.2-py312h8ecdadd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pandoc-3.9.0.2-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.8.10-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/param-2.3.3-pyhc455866_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.7-pyhcf101f3_0.conda
@@ -1482,6 +1506,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.2-h03e3b7b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.8.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/spatialpandas-0.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/spdlog-1.17.0-hab81395_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.53.1-hbc0de68_0.conda
@@ -1492,6 +1517,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/texttable-1.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.6.0-pyhecae5ae_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tiledb-2.30.1-h8789cd1_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.14.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.1.0-pyhd8ed1ab_1.conda
@@ -1984,6 +2010,19 @@ packages:
   - pkg:pypi/backports-zstd?source=compressed-mapping
   size: 238360
   timestamp: 1777848717715
+- conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.14.3-pyha770c72_0.conda
+  sha256: bf1e71c3c0a5b024e44ff928225a0874fc3c3356ec1a0b6fe719108e6d1288f6
+  md5: 5267bef8efea4127aacd1f4e1f149b6e
+  depends:
+  - python >=3.10
+  - soupsieve >=1.2
+  - typing-extensions
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/beautifulsoup4?source=hash-mapping
+  size: 90399
+  timestamp: 1764520638652
 - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.3.0-pyhcf101f3_1.conda
   sha256: f8ff1f98423674278964a46c93a1766f9e91960d44efd91c6c3ed56a33813f46
   md5: 7c5ebdc286220e8021bf55e6384acd67
@@ -1998,6 +2037,16 @@ packages:
   - pkg:pypi/bleach?source=hash-mapping
   size: 142008
   timestamp: 1770719370680
+- conda: https://conda.anaconda.org/conda-forge/noarch/bleach-with-css-6.3.0-hbca2aae_1.conda
+  sha256: 7c07a865e5e4cca233cc4e0eb3f0f5ff6c90776461687b4fb0b1764133e1fd61
+  md5: f11a319b9700b203aa14c295858782b6
+  depends:
+  - bleach ==6.3.0 pyhcf101f3_1
+  - tinycss2
+  license: Apache-2.0 AND MIT
+  purls: []
+  size: 4409
+  timestamp: 1770719370682
 - conda: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.6-he440d0b_1.conda
   sha256: e7af5d1183b06a206192ff440e08db1c4e8b2ca1f8376ee45fb2f3a85d4ee45d
   md5: 2c2fae981fd2afd00812c92ac47d023d
@@ -2601,6 +2650,17 @@ packages:
   - pkg:pypi/decorator?source=hash-mapping
   size: 14129
   timestamp: 1740385067843
+- conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+  sha256: 9717a059677553562a8f38ff07f3b9f61727bd614f505658b0a5ecbcf8df89be
+  md5: 961b3a227b437d82ad7054484cfa71b2
+  depends:
+  - python >=3.6
+  license: PSF-2.0
+  license_family: PSF
+  purls:
+  - pkg:pypi/defusedxml?source=hash-mapping
+  size: 24062
+  timestamp: 1615232388757
 - conda: https://conda.anaconda.org/conda-forge/noarch/deprecated-1.3.1-pyhd8ed1ab_1.conda
   sha256: 7d57a7b8266043ffb99d092ebc25e89a0a2490bed4146b9432c83c2c476fa94d
   md5: 5498feb783ab29db6ca8845f68fa0f03
@@ -3085,7 +3145,7 @@ packages:
 - pypi: ./
   name: gfv2-params
   version: 0.1.0
-  sha256: c8cfedd527220c15d31c270df9d4583e2d8f139a3f9854c3ff60c4aa96117504
+  sha256: beb3c0443aaea24234bab031f1de0ea722527517ffb4ceb57e2b7cdf781a6541
   requires_dist:
   - gdptools>=0.3.13
   - pandas
@@ -3624,6 +3684,20 @@ packages:
   - pkg:pypi/jupyter-core?source=hash-mapping
   size: 65503
   timestamp: 1760643864586
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_2.conda
+  sha256: dc24b900742fdaf1e077d9a3458fd865711de80bca95fe3c6d46610c532c6ef0
+  md5: fd312693df06da3578383232528c468d
+  depends:
+  - pygments >=2.4.1,<3
+  - python >=3.9
+  constrains:
+  - jupyterlab >=4.0.8,<5.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/jupyterlab-pygments?source=hash-mapping
+  size: 18711
+  timestamp: 1733328194037
 - conda: https://conda.anaconda.org/conda-forge/linux-64/kealib-1.6.2-h63db1d0_3.conda
   sha256: c84098c12517ae21810e83420950833e83289460292436f5ca9908fd66e747bc
   md5: e54b7a33dd3405ba1a9d3d95917ea32b
@@ -5315,6 +5389,19 @@ packages:
   purls: []
   size: 520570
   timestamp: 1778002506337
+- conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.2.1-pyhcf101f3_0.conda
+  sha256: b52dc6c78fbbe7a3008535cb8bfd87d70d8053e9250bbe16e387470a9df07070
+  md5: b97e84d1553b4a1c765b87fff83453ad
+  depends:
+  - python >=3.10
+  - typing_extensions
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/mistune?source=hash-mapping
+  size: 74567
+  timestamp: 1777824616382
 - conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.1.2-py312hd9148b4_1.conda
   sha256: 94068fd39d1a672f8799e3146a18ba4ef553f0fcccefddb3c07fbdabfd73667a
   md5: 2e489969e38f0b428c39492619b5e6e5
@@ -5415,6 +5502,73 @@ packages:
   - pkg:pypi/narwhals?source=compressed-mapping
   size: 283664
   timestamp: 1776691974709
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.4-pyhd8ed1ab_0.conda
+  sha256: 1b66960ee06874ddceeebe375d5f17fb5f393d025a09e15b830ad0c4fffb585b
+  md5: 00f5b8dafa842e0c27c1cd7296aa4875
+  depends:
+  - jupyter_client >=6.1.12
+  - jupyter_core >=4.12,!=5.0.*
+  - nbformat >=5.1
+  - python >=3.8
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/nbclient?source=hash-mapping
+  size: 28473
+  timestamp: 1766485646962
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-7.17.1-hb502eef_0.conda
+  sha256: 6b6d96cca8e9dd34e0735b59534831e1f8206b7366c79c71e08da6ee55c50683
+  md5: 02669c36935d23e5258c5dd1a5e601ab
+  depends:
+  - nbconvert-core ==7.17.1 pyhcf101f3_0
+  - nbconvert-pandoc ==7.17.1 h08b4883_0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 5364
+  timestamp: 1775615493260
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.17.1-pyhcf101f3_0.conda
+  sha256: ab2ac79c5892c5434d50b3542d96645bdaa06d025b6e03734be29200de248ac2
+  md5: 2bce0d047658a91b99441390b9b27045
+  depends:
+  - beautifulsoup4
+  - bleach-with-css !=5.0.0
+  - defusedxml
+  - importlib-metadata >=3.6
+  - jinja2 >=3.0
+  - jupyter_core >=4.7
+  - jupyterlab_pygments
+  - markupsafe >=2.0
+  - mistune >=2.0.3,<4
+  - nbclient >=0.5.0
+  - nbformat >=5.7
+  - packaging
+  - pandocfilters >=1.4.1
+  - pygments >=2.4.1
+  - python >=3.10
+  - traitlets >=5.1
+  - python
+  constrains:
+  - pandoc >=2.9.2,<4.0.0
+  - nbconvert ==7.17.1 *_0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/nbconvert?source=hash-mapping
+  size: 202229
+  timestamp: 1775615493260
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-pandoc-7.17.1-h08b4883_0.conda
+  sha256: b576268b5b3da13b703a15d28d218fd1b552511726253575025930091e6206ae
+  md5: f635af333701d2ed89d70ba9adb8e2ee
+  depends:
+  - nbconvert-core ==7.17.1 pyhcf101f3_0
+  - pandoc
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 5840
+  timestamp: 1775615493260
 - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
   sha256: 7a5bd30a2e7ddd7b85031a5e2e14f290898098dc85bea5b3a5bf147c25122838
   md5: bbe1963f1e47f594070ffe87cdf612ea
@@ -5740,6 +5894,25 @@ packages:
   - pkg:pypi/pandas?source=compressed-mapping
   size: 14849233
   timestamp: 1774916580467
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pandoc-3.9.0.2-ha770c72_0.conda
+  sha256: d46f76ed09396e3bd1dc11030b3d0d222c25ba8d92f3cde08bc6fbd1eec4f9e0
+  md5: de8ccf9ffba55bd20ee56301cfc7e6db
+  license: GPL-2.0-or-later
+  license_family: GPL
+  purls: []
+  size: 22364689
+  timestamp: 1773933354952
+- conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+  sha256: 2bb9ba9857f4774b85900c2562f7e711d08dd48e2add9bee4e1612fbee27e16f
+  md5: 457c2c8c08e54905d6954e79cb5b5db9
+  depends:
+  - python !=3.0,!=3.1,!=3.2,!=3.3
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/pandocfilters?source=hash-mapping
+  size: 11627
+  timestamp: 1631603397334
 - conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.8.10-pyhd8ed1ab_0.conda
   sha256: 81e26bd12f9b1244d3ce249765aeefacda63e7a2e37c4f740491352ac4355bfc
   md5: d44afaf70929d526f3eb4f8a25cf2953
@@ -6908,6 +7081,17 @@ packages:
   - pkg:pypi/sortedcontainers?source=hash-mapping
   size: 28657
   timestamp: 1738440459037
+- conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.8.3-pyhd8ed1ab_0.conda
+  sha256: 23b71ecf089967d2900126920e7f9ff18cdcef82dbff3e2f54ffa360243a17ac
+  md5: 18de09b20462742fe093ba39185d9bac
+  depends:
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/soupsieve?source=hash-mapping
+  size: 38187
+  timestamp: 1769034509657
 - conda: https://conda.anaconda.org/conda-forge/noarch/spatialpandas-0.5.0-pyhd8ed1ab_0.conda
   sha256: 81e0aa7d3ca621694ba8facbbf9ba0dc72d2753b4149a0d5453498b809029a1e
   md5: e371879bca521d38ad57e88a705bcda4
@@ -7068,6 +7252,18 @@ packages:
   purls: []
   size: 4423071
   timestamp: 1778170901236
+- conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+  sha256: cad582d6f978276522f84bd209a5ddac824742fe2d452af6acf900f8650a73a2
+  md5: f1acf5fdefa8300de697982bcb1761c9
+  depends:
+  - python >=3.5
+  - webencodings >=0.4
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/tinycss2?source=hash-mapping
+  size: 28285
+  timestamp: 1729802975370
 - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
   sha256: cafeec44494f842ffeca27e9c8b0c27ed714f93ac77ddadc6aaf726b5554ebac
   md5: cffd3bdd58090148f4cfcd831f4b26ab

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,7 @@ intake-parquet = "*"
 s3fs = "*"
 ipykernel = "*"
 nbformat = "*"  # for `marimo export ipynb` round-trip
+nbconvert = "*"  # headless notebook execution (scripts/render_figures.py)
 
 [tool.pixi.feature.dev.dependencies]
 pytest = "*"

--- a/scripts/clip_shared_to_fabric.py
+++ b/scripts/clip_shared_to_fabric.py
@@ -27,7 +27,6 @@ Usage:
 """
 
 import argparse
-import math
 from pathlib import Path
 
 import geopandas as gpd
@@ -36,55 +35,15 @@ from osgeo import gdal
 
 from gfv2_params.config import load_base_config, require_config_key
 from gfv2_params.log import configure_logging
+from gfv2_params.viz import snap_bounds_to_grid, whole_cell_offset
 
 gdal.UseExceptions()
 
-
-def _snap_bounds_to_grid(bounds, transform, buffer_cells: int):
-    """Expand HRU bounds by `buffer_cells` then snap OUTWARD to the source grid.
-
-    Returns (ulx, uly, lrx, lry) on the source pixel lattice, guaranteed to
-    fully contain the (buffered) input bounds. Works for a north-up raster
-    (transform.a > 0, transform.e < 0).
-    """
-    minx, miny, maxx, maxy = bounds
-    px = transform.a          # +cellsize
-    py = transform.e          # -cellsize
-    ox = transform.c          # left edge of column 0
-    oy = transform.f          # top edge of row 0
-    # The floor/ceil snapping below is only correct for an axis-aligned, north-up
-    # raster. Fail loudly on a rotated/flipped --source rather than emitting a
-    # silently-wrong window.
-    if transform.b != 0 or transform.d != 0 or px <= 0 or py >= 0:
-        raise ValueError(
-            f"Source raster is not axis-aligned north-up (a={px}, e={py}, "
-            f"b={transform.b}, d={transform.d}); _snap_bounds_to_grid assumes it."
-        )
-    cell_x = abs(px)
-    cell_y = abs(py)
-
-    minx -= buffer_cells * cell_x
-    maxx += buffer_cells * cell_x
-    miny -= buffer_cells * cell_y
-    maxy += buffer_cells * cell_y
-
-    c_left = math.floor((minx - ox) / cell_x)
-    c_right = math.ceil((maxx - ox) / cell_x)
-    r_top = math.floor((oy - maxy) / cell_y)
-    r_bot = math.ceil((oy - miny) / cell_y)
-
-    ulx = ox + c_left * cell_x
-    lrx = ox + c_right * cell_x
-    uly = oy - r_top * cell_y
-    lry = oy - r_bot * cell_y
-    return ulx, uly, lrx, lry
-
-
-def _whole_cell_offset(t_a, ref_transform):
-    """Fractional-cell offset of transform origin vs a reference lattice."""
-    col = (t_a.c - ref_transform.c) / ref_transform.a
-    row = (t_a.f - ref_transform.f) / ref_transform.e
-    return col - round(col), row - round(row)
+# The grid-snap helpers now live in gfv2_params.viz (shared with the results-viewer
+# notebooks). Keep the underscore-prefixed names as thin aliases so the call sites
+# below — and any external importers — stay unchanged.
+_snap_bounds_to_grid = snap_bounds_to_grid
+_whole_cell_offset = whole_cell_offset
 
 
 def main() -> int:

--- a/scripts/render_figures.py
+++ b/scripts/render_figures.py
@@ -52,6 +52,7 @@ def main() -> int:
 
     env = dict(os.environ, FABRIC=args.fabric, SAVE_FIGURES="1", MPLBACKEND="Agg")
 
+    executed = 0
     for nb in args.notebooks:
         src = NB_DIR / nb
         if not src.exists():
@@ -64,13 +65,32 @@ def main() -> int:
             f"--ExecutePreprocessor.kernel_name={args.kernel}",
             "--output-dir", str(cache), "--output", nb, str(src),
         ]
-        result = subprocess.run(cmd, env=env)
+        try:
+            result = subprocess.run(cmd, env=env)
+        except FileNotFoundError:
+            logger.error(
+                "`jupyter` not found on PATH. Run inside a JupyterHub session or "
+                "the notebooks env, e.g. `pixi run -e notebooks python %s`.",
+                " ".join(["scripts/render_figures.py", "--fabric", args.fabric]),
+            )
+            return 1
         if result.returncode != 0:
             logger.error("nbconvert failed for %s (exit %d)", nb, result.returncode)
             return result.returncode
+        executed += 1
+
+    if executed == 0:
+        logger.error("no notebooks executed (all missing) — check --notebooks; "
+                     "nothing was rendered.")
+        return 1
 
     pngs = sorted(figdir.glob("*.png")) if figdir.exists() else []
-    logger.info("done: %d figure(s) in %s", len(pngs), figdir)
+    if not pngs:
+        logger.error("ran %d notebook(s) but found no figures in %s — "
+                     "check that SAVE_FIGURES took effect.", executed, figdir)
+        return 1
+    logger.info("done: ran %d notebook(s), %d figure(s) in %s",
+                executed, len(pngs), figdir)
     for p in pngs:
         logger.info("  %s", p.name)
     return 0

--- a/scripts/render_figures.py
+++ b/scripts/render_figures.py
@@ -1,0 +1,80 @@
+"""Headlessly (re)generate the fabric_results figures for a fabric.
+
+Executes each ``notebooks/fabric_results/*.ipynb`` via ``jupyter nbconvert
+--execute`` with ``FABRIC`` and ``SAVE_FIGURES=1`` set in the environment, so
+``gfv2_params.viz.save_figure`` writes PNGs into ``docs/figures/{fabric}/``.
+The executed notebook copies land in the gitignored
+``docs/figures/.cache/{fabric}/`` (only the PNGs are committed).
+
+``MPLBACKEND=Agg`` is forced here because this path is non-interactive — the
+viewer library deliberately does NOT pin a backend so that the same notebooks
+display inline under JupyterHub's ``%matplotlib inline``.
+
+Run where ``jupyter`` is available (a JupyterHub session or the ``notebooks``
+pixi env) on a compute node with enough ``--mem`` (CONUS ``gfv2`` is large):
+
+  pixi run -e notebooks python scripts/render_figures.py --fabric oregon
+"""
+
+import argparse
+import os
+import subprocess
+from pathlib import Path
+
+from gfv2_params.log import configure_logging
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+NB_DIR = REPO_ROOT / "notebooks" / "fabric_results"
+DEFAULT_NOTEBOOKS = [
+    "01_input_rasters.ipynb",
+    "02_depstor_rasters.ipynb",
+    "03_param_results.ipynb",
+]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("--fabric", default="oregon", help="Fabric to render (default: oregon).")
+    ap.add_argument("--notebooks", nargs="*", default=DEFAULT_NOTEBOOKS,
+                    help="Subset of notebook filenames to run (default: all three).")
+    ap.add_argument("--kernel", default="python3",
+                    help="Jupyter kernel name to execute with (default: python3).")
+    ap.add_argument("--timeout", type=int, default=1800,
+                    help="Per-cell execution timeout in seconds (default: 1800).")
+    args = ap.parse_args()
+
+    logger = configure_logging("render_figures")
+    cache = REPO_ROOT / "docs" / "figures" / ".cache" / args.fabric
+    cache.mkdir(parents=True, exist_ok=True)
+    figdir = REPO_ROOT / "docs" / "figures" / args.fabric
+
+    env = dict(os.environ, FABRIC=args.fabric, SAVE_FIGURES="1", MPLBACKEND="Agg")
+
+    for nb in args.notebooks:
+        src = NB_DIR / nb
+        if not src.exists():
+            logger.warning("skip missing notebook: %s", src)
+            continue
+        logger.info("executing %s (FABRIC=%s)", nb, args.fabric)
+        cmd = [
+            "jupyter", "nbconvert", "--to", "notebook", "--execute",
+            f"--ExecutePreprocessor.timeout={args.timeout}",
+            f"--ExecutePreprocessor.kernel_name={args.kernel}",
+            "--output-dir", str(cache), "--output", nb, str(src),
+        ]
+        result = subprocess.run(cmd, env=env)
+        if result.returncode != 0:
+            logger.error("nbconvert failed for %s (exit %d)", nb, result.returncode)
+            return result.returncode
+
+    pngs = sorted(figdir.glob("*.png")) if figdir.exists() else []
+    logger.info("done: %d figure(s) in %s", len(pngs), figdir)
+    for p in pngs:
+        logger.info("  %s", p.name)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/slurm_batch/RUNME.md
+++ b/slurm_batch/RUNME.md
@@ -521,6 +521,21 @@ pixi run python scripts/merge_and_fill_params.py --base_config configs/base_conf
 pixi run python scripts/merge_default_params.py --base_config configs/base_config.yml
 ```
 
+### Stage 9: View results (notebooks)
+
+The three notebooks in `notebooks/fabric_results/` view a fabric's full
+parameterization — input rasters (clipped to the fabric), depstor rasters, and
+per-HRU param maps. They are parameterized by the `FABRIC` env var. **Run them in
+JupyterHub on a compute node with enough `--mem`** (not the login node — a full
+CONUS `gfv2` render loads ~361k HRU polygons). See
+`notebooks/<fabric>/README.md` for the launch recipe. To regenerate the figure
+set for a report headlessly:
+
+```bash
+pixi run -e notebooks python scripts/render_figures.py --fabric <name>
+# -> docs/figures/<name>/{input_raster_*,depstor_*,param_*}.png  (committed)
+```
+
 ## Adding a new fabric (e.g., Oregon)
 
 A new fabric is added by appending a profile to `configs/base_config.yml` —

--- a/slurm_batch/RUNME.md
+++ b/slurm_batch/RUNME.md
@@ -250,7 +250,7 @@ Note: `--check` only validates manually-staged inputs (soils, litho, lulc_veg, t
 
 **All of these are now driven by `sbatch slurm_batch/build_shared_rasters.batch`** (or the
 `pixi run python scripts/build_shared_rasters.py --config configs/shared_rasters/shared_rasters.yml`
-interactive equivalent). The orchestrator walks the canonical 8-step DAG in
+interactive equivalent). The orchestrator walks the canonical 9-step DAG in
 dependency order — there is no longer a per-step batch surface; all the
 per-step CLIs/sbatches were retired now that the orchestrator covers them.
 

--- a/src/gfv2_params/viz.py
+++ b/src/gfv2_params/viz.py
@@ -279,7 +279,7 @@ def map_categorical(gdf, col, title, *, labels=None):
     cats = sorted(gdf[col].dropna().unique())
     if not cats:
         cats = [0]
-    cmap_base = plt.cm.get_cmap("tab20", max(len(cats), 1))
+    cmap_base = plt.get_cmap("tab20", max(len(cats), 1))
     colors = [cmap_base(i) for i in range(len(cats))]
     cmap = mcolors.ListedColormap(colors)
     norm = mcolors.BoundaryNorm([c - 0.5 for c in cats] + [cats[-1] + 0.5], len(cats))

--- a/src/gfv2_params/viz.py
+++ b/src/gfv2_params/viz.py
@@ -1,0 +1,487 @@
+"""Shared, tested helpers for the fabric results-viewer notebooks.
+
+The notebooks under ``notebooks/`` import this module for everything that is
+worth unit-testing: grid-snapping, decimated/windowed raster reads, raster
+thumbnails + parameter choropleths, config-driven raster/param inventories, and
+a save-figures workflow. Keeping that logic here (rather than inline in each
+notebook) lets CI exercise it on synthetic data.
+
+Conventions mirrored from the rest of the repo:
+- ``snap_bounds_to_grid`` / ``whole_cell_offset`` are lifted verbatim from
+  ``scripts/clip_shared_to_fabric.py`` (made public here).
+- ``read_overview`` follows the decimated ``out_shape`` pattern in
+  ``notebooks/check_vrts.ipynb``; ``clip_overview`` follows the windowed
+  ``rasterio.windows.from_bounds(..., boundless=True)`` pattern in
+  ``src/gfv2_params/depstor.py:read_land_mask_for_grid``.
+- ``map_continuous`` / ``map_categorical`` follow ``notebooks/check_params.ipynb``
+  but **return** the Figure so the notebook can save it.
+- Inventory builders read paths from a resolved config (``require_config_key`` /
+  ``cfg["data_root"]``) — never hardcoded — and skip missing entries with a
+  warning so the viewer is best-effort.
+"""
+
+from __future__ import annotations
+
+import math
+import warnings
+from dataclasses import dataclass
+from pathlib import Path
+
+import matplotlib.colors as mcolors
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import rasterio
+from matplotlib.patches import Patch
+from rasterio.enums import Resampling
+from rasterio.windows import from_bounds as window_from_bounds
+
+# ----------------------------------------------------------------------------- #
+# Grid snapping (verbatim from scripts/clip_shared_to_fabric.py, made public)
+# ----------------------------------------------------------------------------- #
+
+
+def snap_bounds_to_grid(bounds, transform, buffer_cells: int = 8):
+    """Expand HRU bounds by `buffer_cells` then snap OUTWARD to the source grid.
+
+    Returns (ulx, uly, lrx, lry) on the source pixel lattice, guaranteed to
+    fully contain the (buffered) input bounds. Works for a north-up raster
+    (transform.a > 0, transform.e < 0).
+    """
+    minx, miny, maxx, maxy = bounds
+    px = transform.a          # +cellsize
+    py = transform.e          # -cellsize
+    ox = transform.c          # left edge of column 0
+    oy = transform.f          # top edge of row 0
+    # The floor/ceil snapping below is only correct for an axis-aligned, north-up
+    # raster. Fail loudly on a rotated/flipped source rather than emitting a
+    # silently-wrong window.
+    if transform.b != 0 or transform.d != 0 or px <= 0 or py >= 0:
+        raise ValueError(
+            f"Source raster is not axis-aligned north-up (a={px}, e={py}, "
+            f"b={transform.b}, d={transform.d}); snap_bounds_to_grid assumes it."
+        )
+    cell_x = abs(px)
+    cell_y = abs(py)
+
+    minx -= buffer_cells * cell_x
+    maxx += buffer_cells * cell_x
+    miny -= buffer_cells * cell_y
+    maxy += buffer_cells * cell_y
+
+    c_left = math.floor((minx - ox) / cell_x)
+    c_right = math.ceil((maxx - ox) / cell_x)
+    r_top = math.floor((oy - maxy) / cell_y)
+    r_bot = math.ceil((oy - miny) / cell_y)
+
+    ulx = ox + c_left * cell_x
+    lrx = ox + c_right * cell_x
+    uly = oy - r_top * cell_y
+    lry = oy - r_bot * cell_y
+    return ulx, uly, lrx, lry
+
+
+def whole_cell_offset(t_a, ref_transform):
+    """Fractional-cell offset of transform origin vs a reference lattice."""
+    col = (t_a.c - ref_transform.c) / ref_transform.a
+    row = (t_a.f - ref_transform.f) / ref_transform.e
+    return col - round(col), row - round(row)
+
+
+# ----------------------------------------------------------------------------- #
+# Fabric bounds
+# ----------------------------------------------------------------------------- #
+
+
+def fabric_bounds(hru_gpkg, hru_layer, dst_crs=None):
+    """Total bounds of an HRU fabric (minx, miny, maxx, maxy).
+
+    Drops null/empty geometries (mirrors clip_shared_to_fabric.py) and
+    optionally reprojects to `dst_crs` (e.g. a raster's CRS) before computing
+    the bounds.
+    """
+    import geopandas as gpd
+
+    hru = gpd.read_file(hru_gpkg, layer=hru_layer)
+    hru = hru[hru.geometry.notna() & ~hru.geometry.is_empty]
+    if len(hru) == 0:
+        raise ValueError(
+            f"HRU layer '{hru_layer}' in {hru_gpkg} has no valid geometries."
+        )
+    if dst_crs is not None and hru.crs != dst_crs:
+        hru = hru.to_crs(dst_crs)
+    return tuple(hru.total_bounds)
+
+
+# ----------------------------------------------------------------------------- #
+# Raster reads
+# ----------------------------------------------------------------------------- #
+
+
+def read_overview(path, target_px: int = 800) -> np.ma.MaskedArray:
+    """Return a masked 2-D float32 thumbnail of the full raster at `path`.
+
+    Decimated read via rasterio `out_shape`, so the full raster is never loaded.
+    nodata and non-finite values are masked.
+    """
+    with rasterio.open(path) as src:
+        factor = max(1, max(src.width, src.height) // target_px)
+        out_h = max(1, src.height // factor)
+        out_w = max(1, src.width // factor)
+        data = src.read(
+            1,
+            out_shape=(out_h, out_w),
+            resampling=Resampling.nearest,
+        ).astype(np.float32)
+        nd = src.nodata
+    mask = ~np.isfinite(data)
+    if nd is not None:
+        mask |= data == nd
+    return np.ma.array(data, mask=mask)
+
+
+def clip_overview(path, bounds, target_px: int = 800):
+    """Windowed, decimated read of `path` over `bounds` (in the raster's CRS).
+
+    Returns ``(masked_array, extent)`` where ``extent = (minx, maxx, miny, maxy)``
+    suitable for ``ax.imshow(arr, extent=extent)``. The window is read
+    `boundless=True` so a request partly outside the raster is padded with
+    nodata rather than clipped. nodata / non-finite values are masked.
+    """
+    with rasterio.open(path) as src:
+        window = window_from_bounds(*bounds, transform=src.transform)
+        win_w = max(1, int(round(window.width)))
+        win_h = max(1, int(round(window.height)))
+        factor = max(1, max(win_w, win_h) // target_px)
+        out_h = max(1, win_h // factor)
+        out_w = max(1, win_w // factor)
+        data = src.read(
+            1,
+            window=window,
+            out_shape=(out_h, out_w),
+            resampling=Resampling.nearest,
+            boundless=True,
+            fill_value=src.nodata if src.nodata is not None else 0,
+        ).astype(np.float32)
+        nd = src.nodata
+        # extent is the window's true bounds on the raster lattice
+        win_transform = src.window_transform(window)
+        minx = win_transform.c
+        maxy = win_transform.f
+        maxx = minx + win_w * src.transform.a
+        miny = maxy + win_h * src.transform.e  # transform.e is negative
+
+    mask = ~np.isfinite(data)
+    if nd is not None:
+        mask |= data == nd
+    arr = np.ma.array(data, mask=mask)
+    extent = (minx, maxx, miny, maxy)
+    return arr, extent
+
+
+# ----------------------------------------------------------------------------- #
+# Raster thumbnail plotting
+# ----------------------------------------------------------------------------- #
+
+
+def plot_raster(ax, arr, extent=None, *, cmap="viridis", pct=(2, 98),
+                categorical=False, title=None, label=""):
+    """Render a masked raster thumbnail onto `ax`.
+
+    Continuous: percentile-stretch (`pct`) + colorbar. Categorical: discrete
+    classes via a BoundaryNorm + colorbar. Returns the matplotlib image.
+    """
+    imshow_kwargs = {"interpolation": "nearest", "rasterized": True}
+    if extent is not None:
+        imshow_kwargs["extent"] = extent
+
+    valid = np.ma.compressed(arr)
+    if categorical:
+        cats = np.unique(valid)
+        if len(cats) == 0:
+            cats = np.array([0])
+        listed = mcolors.ListedColormap(
+            plt.cm.tab20(np.linspace(0, 1, max(len(cats), 1)))
+        )
+        bounds = list(cats - 0.5) + [cats[-1] + 0.5]
+        norm = mcolors.BoundaryNorm(bounds, listed.N)
+        im = ax.imshow(arr, cmap=listed, norm=norm, **imshow_kwargs)
+    else:
+        if len(valid):
+            vmin, vmax = np.percentile(valid, pct)
+        else:
+            vmin, vmax = 0, 1
+        im = ax.imshow(arr, cmap=cmap, vmin=vmin, vmax=vmax, **imshow_kwargs)
+
+    if title:
+        ax.set_title(title, fontsize=10)
+    ax.axis("off")
+    ax.figure.colorbar(im, ax=ax, fraction=0.03, pad=0.02, label=label)
+    return im
+
+
+# ----------------------------------------------------------------------------- #
+# Param load + choropleths
+# ----------------------------------------------------------------------------- #
+
+
+def load_param(params_dir, csv_name, fabric_gdf, id_feature):
+    """Read a merged param CSV and left-merge it onto the fabric geometry.
+
+    Left join preserves every HRU (missing HRUs in the CSV become NaN). Returns
+    a GeoDataFrame indexed like `fabric_gdf`.
+    """
+    df = pd.read_csv(Path(params_dir) / csv_name)
+    gdf = fabric_gdf[[id_feature, "geometry"]].merge(df, on=id_feature, how="left")
+    return gdf
+
+
+def map_continuous(gdf, col, title, *, units="", cmap="viridis",
+                   pct_lo=2, pct_hi=98):
+    """Choropleth + side histogram for a continuous parameter. Returns the Figure."""
+    vals = gdf[col].dropna()
+    if len(vals):
+        vmin, vmax = np.percentile(vals, [pct_lo, pct_hi])
+    else:
+        vmin, vmax = 0, 1
+
+    fig, (ax_map, ax_hist) = plt.subplots(
+        1, 2, figsize=(14, 7), gridspec_kw={"width_ratios": [3, 1]}
+    )
+    gdf.plot(column=col, cmap=cmap, vmin=vmin, vmax=vmax,
+             linewidth=0, ax=ax_map, legend=True,
+             legend_kwds={"label": units, "shrink": 0.6, "pad": 0.01},
+             missing_kwds={"color": "lightgrey", "label": "No data"})
+    ax_map.set_title(title, fontsize=11)
+    ax_map.axis("off")
+
+    if len(vals):
+        ax_hist.hist(vals, bins=100, color="steelblue", edgecolor="none", density=True)
+        p25, p50, p75 = np.percentile(vals, [25, 50, 75])
+        ax_hist.axvline(p25, color="cornflowerblue", ls="--", lw=1.2, label=f"p25 = {p25:.3g}")
+        ax_hist.axvline(p50, color="navy", ls="-", lw=1.8, label=f"p50 = {p50:.3g}")
+        ax_hist.axvline(p75, color="cornflowerblue", ls="--", lw=1.2, label=f"p75 = {p75:.3g}")
+        ax_hist.axvline(vmin, color="orange", ls=":", lw=1.2, label=f"stretch lo = {vmin:.3g}")
+        ax_hist.axvline(vmax, color="red", ls=":", lw=1.2, label=f"stretch hi = {vmax:.3g}")
+        ax_hist.set_title(
+            f"n = {len(vals):,}  mean = {vals.mean():.4g}\nstd = {vals.std():.4g}",
+            fontsize=8, loc="left", family="monospace",
+        )
+        ax_hist.legend(fontsize=8)
+    ax_hist.set_xlabel(units or col)
+    ax_hist.set_ylabel("density")
+    fig.tight_layout()
+    return fig
+
+
+def map_categorical(gdf, col, title, *, labels=None):
+    """Categorical choropleth + legend. Returns the Figure."""
+    cats = sorted(gdf[col].dropna().unique())
+    if not cats:
+        cats = [0]
+    colors = list(plt.cm.Set2.colors[:len(cats)])
+    cmap = mcolors.ListedColormap(colors[:len(cats)])
+    norm = mcolors.BoundaryNorm([c - 0.5 for c in cats] + [cats[-1] + 0.5], len(cats))
+
+    fig, (ax_map, ax_leg) = plt.subplots(
+        1, 2, figsize=(14, 7), gridspec_kw={"width_ratios": [4, 1]}
+    )
+    gdf.plot(column=col, cmap=cmap, norm=norm,
+             linewidth=0, ax=ax_map,
+             missing_kwds={"color": "lightgrey"})
+    ax_map.set_title(title, fontsize=11)
+    ax_map.axis("off")
+
+    counts = gdf[col].value_counts().sort_index()
+    total = counts.sum() or 1
+    patches = []
+    for cat, color in zip(cats, colors[:len(cats)]):
+        lbl = labels.get(cat, str(cat)) if labels else str(cat)
+        n = counts.get(cat, 0)
+        patches.append(Patch(color=color, label=f"{lbl}\n({n:,}, {100 * n / total:.1f}%)"))
+    ax_leg.legend(handles=patches, loc="center", frameon=False, fontsize=9)
+    ax_leg.axis("off")
+    fig.tight_layout()
+    return fig
+
+
+# ----------------------------------------------------------------------------- #
+# Inventories
+# ----------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class RasterEntry:
+    name: str
+    path: Path
+    kind: str  # "continuous" | "categorical"
+    cmap: str = "viridis"
+    units: str = ""
+
+
+@dataclass(frozen=True)
+class ParamEntry:
+    name: str
+    csv_name: str
+    column: str
+    kind: str  # "continuous" | "categorical"
+    units: str = ""
+    cmap: str = "viridis"
+
+
+def _existing_raster_entries(entries: list[RasterEntry]) -> list[RasterEntry]:
+    """Drop entries whose path does not exist, warning for each."""
+    kept = []
+    for e in entries:
+        if Path(e.path).exists():
+            kept.append(e)
+        else:
+            warnings.warn(f"Skipping raster '{e.name}': path not found: {e.path}")
+    return kept
+
+
+def shared_raster_inventory(cfg) -> list[RasterEntry]:
+    """Fabric profile hydrology rasters + the shared DEM-derivative VRTs.
+
+    Pulls twi_raster / fdr_raster / template_raster from the resolved fabric
+    profile (when present) and adds the CONUS elevation/slope/aspect VRTs under
+    ``{data_root}/shared/conus/vrt``. Missing files are skipped with a warning.
+    """
+    vrt_dir = Path(cfg["data_root"]) / "shared" / "conus" / "vrt"
+    entries: list[RasterEntry] = []
+    if cfg.get("twi_raster"):
+        entries.append(RasterEntry("twi", Path(cfg["twi_raster"]), "continuous",
+                                   cmap="viridis", units="unitless"))
+    if cfg.get("fdr_raster"):
+        entries.append(RasterEntry("fdr", Path(cfg["fdr_raster"]), "categorical",
+                                   cmap="nipy_spectral", units="D8 code"))
+    if cfg.get("template_raster"):
+        entries.append(RasterEntry("template", Path(cfg["template_raster"]),
+                                   "categorical", cmap="nipy_spectral", units="D8 code"))
+    entries.append(RasterEntry("elevation", vrt_dir / "elevation.vrt", "continuous",
+                               cmap="terrain", units="m"))
+    entries.append(RasterEntry("slope", vrt_dir / "slope.vrt", "continuous",
+                               cmap="YlOrRd", units="degrees"))
+    entries.append(RasterEntry("aspect", vrt_dir / "aspect.vrt", "continuous",
+                               cmap="twilight", units="degrees"))
+    return _existing_raster_entries(entries)
+
+
+# Heuristic: zonal sources that are class rasters render best as categorical.
+_ZONAL_CATEGORICAL = {"soils", "lulc_nhm_v11", "lulc_nalcms", "lulc_nlcd", "lulc_foresce"}
+
+
+def zonal_source_inventory(zonal_cfg) -> list[RasterEntry]:
+    """One RasterEntry per `params:` item in zonal_params.yml with a source_raster.
+
+    `zonal_cfg` is the result of ``load_config("configs/zonal/zonal_params.yml",
+    fabric=...)``. Soils and LULC sources are categorical; the rest continuous.
+    Missing files are skipped with a warning.
+    """
+    entries: list[RasterEntry] = []
+    for item in zonal_cfg.get("params", []):
+        src = item.get("source_raster")
+        if not src:
+            continue
+        name = item["name"]
+        kind = "categorical" if name in _ZONAL_CATEGORICAL else "continuous"
+        cmap = "tab20" if kind == "categorical" else "viridis"
+        entries.append(RasterEntry(name, Path(src), kind, cmap=cmap))
+    return _existing_raster_entries(entries)
+
+
+# Fixed depstor binary raster outputs (configs/depstor/depstor_rasters.yml +
+# depstor_builders/__init__.py). Binary masks / region labels -> categorical.
+_DEPSTOR_RASTERS = [
+    "land_mask.tif",
+    "imperv_binary.tif",
+    "perv_binary.tif",
+    "dprst_binary.tif",
+    "onstream_binary.tif",
+    "stream_buffer.tif",
+    "wbody_binary.tif",
+    "wbody_regions.tif",
+    "carea_map_t8_binary.tif",
+    "carea_map_t156_binary.tif",
+    "drains_imperv_binary.tif",
+    "drains_perv_binary.tif",
+    "drains_to_dprst.tif",
+    "vpu_id.tif",
+]
+
+
+def depstor_raster_inventory(cfg) -> list[RasterEntry]:
+    """The fixed 14 depstor binary rasters under {data_root}/{fabric}/depstor_rasters.
+
+    All are discrete (binary masks / region or VPU labels), so kind is
+    "categorical". Missing files are skipped with a warning.
+    """
+    base = Path(cfg["data_root"]) / cfg["fabric"] / "depstor_rasters"
+    entries = [
+        RasterEntry(fname.replace(".tif", ""), base / fname, "categorical",
+                    cmap="tab20")
+        for fname in _DEPSTOR_RASTERS
+    ]
+    return _existing_raster_entries(entries)
+
+
+# Curated display metadata for the merged param CSVs (display-only; not pipeline
+# logic). CSV names + columns confirmed against {fabric}/params/merged/.
+_PARAM_ENTRIES = [
+    ParamEntry("elevation", "nhm_elevation_params.csv", "mean", "continuous", "m", "terrain"),
+    ParamEntry("slope", "nhm_slope_params.csv", "mean", "continuous", "degrees", "YlOrRd"),
+    ParamEntry("aspect", "nhm_aspect_params.csv", "mean", "continuous", "degrees", "twilight"),
+    ParamEntry("soils", "nhm_soils_params.csv", "soils", "categorical"),
+    ParamEntry("soil_moist_max", "nhm_soil_moist_max_params.csv", "soil_moist_max", "continuous", "cm", "Blues"),
+    ParamEntry("cov_type", "nhm_lulc_nhm_v11_params.csv", "cov_type", "categorical"),
+    ParamEntry("covden_sum", "nhm_lulc_nhm_v11_params.csv", "covden_sum", "continuous", "fraction", "Greens"),
+    ParamEntry("covden_win", "nhm_lulc_nhm_v11_params.csv", "covden_win", "continuous", "fraction", "YlGn"),
+    ParamEntry("retention", "nhm_lulc_nhm_v11_params.csv", "retention", "continuous", "fraction", "PuBuGn"),
+    ParamEntry("snow_intcp", "nhm_lulc_nhm_v11_params.csv", "snow_intcp", "continuous", "in", "PuBu"),
+    ParamEntry("carea_max", "nhm_carea_max_params.csv", "carea_max", "continuous", "fraction", "magma"),
+    ParamEntry("smidx_coef", "nhm_smidx_coef_params.csv", "smidx_coef", "continuous", "fraction", "magma"),
+    ParamEntry("sro_to_dprst_perv", "nhm_sro_to_dprst_perv_params.csv", "sro_to_dprst_perv", "continuous", "fraction", "cividis"),
+    ParamEntry("sro_to_dprst_imperv", "nhm_sro_to_dprst_imperv_params.csv", "sro_to_dprst_imperv", "continuous", "fraction", "cividis"),
+    ParamEntry("hru_percent_imperv", "nhm_hru_percent_imperv_params.csv", "hru_percent_imperv", "continuous", "fraction", "OrRd"),
+    ParamEntry("dprst_frac", "nhm_dprst_frac_params.csv", "dprst_frac", "continuous", "fraction", "GnBu"),
+]
+
+
+def param_inventory() -> list[ParamEntry]:
+    """Curated list of the merged param CSVs (display metadata, not pipeline logic).
+
+    Returns the full list regardless of disk — existence is checked by the
+    notebook/loader, not here.
+    """
+    return list(_PARAM_ENTRIES)
+
+
+# ----------------------------------------------------------------------------- #
+# Save-figures workflow (module-level state; mirrors notebooks/_helpers patterns)
+# ----------------------------------------------------------------------------- #
+
+SAVE_FIGURES: bool = False
+FABRIC: str | None = None
+FIGURES_DIR: Path = Path("docs/figures")
+
+
+def save_figure(fig, name, *, dpi: int = 150) -> None:
+    """Save `fig` to ``FIGURES_DIR[/FABRIC]/<name>.png`` when SAVE_FIGURES is set.
+
+    No-op unless ``SAVE_FIGURES``. If saving is enabled but no ``FABRIC`` is set,
+    warns (figures land in the un-namespaced base dir). A relative ``FIGURES_DIR``
+    is resolved against the repo root.
+    """
+    if not SAVE_FIGURES:
+        return
+    if not FABRIC:
+        warnings.warn("save_figure: SAVE_FIGURES is set but FABRIC is None; "
+                      "figures will not be namespaced by fabric.")
+
+    base = Path(FIGURES_DIR)
+    if not base.is_absolute():
+        repo_root = Path(__file__).resolve().parents[2]
+        base = repo_root / base
+    target = base / FABRIC if FABRIC else base
+    target.mkdir(parents=True, exist_ok=True)
+    fig.savefig(target / f"{name}.png", dpi=dpi, bbox_inches="tight")

--- a/src/gfv2_params/viz.py
+++ b/src/gfv2_params/viz.py
@@ -7,17 +7,18 @@ a save-figures workflow. Keeping that logic here (rather than inline in each
 notebook) lets CI exercise it on synthetic data.
 
 Conventions mirrored from the rest of the repo:
-- ``snap_bounds_to_grid`` / ``whole_cell_offset`` are lifted verbatim from
-  ``scripts/clip_shared_to_fabric.py`` (made public here).
+- ``snap_bounds_to_grid`` / ``whole_cell_offset`` are the canonical grid-snap
+  helpers (``scripts/clip_shared_to_fabric.py`` imports them from here).
 - ``read_overview`` follows the decimated ``out_shape`` pattern in
   ``notebooks/check_vrts.ipynb``; ``clip_overview`` follows the windowed
   ``rasterio.windows.from_bounds(..., boundless=True)`` pattern in
   ``src/gfv2_params/depstor.py:read_land_mask_for_grid``.
 - ``map_continuous`` / ``map_categorical`` follow ``notebooks/check_params.ipynb``
   but **return** the Figure so the notebook can save it.
-- Inventory builders read paths from a resolved config (``require_config_key`` /
-  ``cfg["data_root"]``) — never hardcoded — and skip missing entries with a
-  warning so the viewer is best-effort.
+- Inventory builders read paths from a resolved config (``cfg["data_root"]`` /
+  ``cfg.get(...)`` / fabric-profile keys) — never hardcoded — and skip missing
+  entries with a warning so the viewer is best-effort (intentionally lenient,
+  not fail-loud).
 """
 
 from __future__ import annotations
@@ -26,6 +27,7 @@ import math
 import warnings
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Literal
 
 import matplotlib.colors as mcolors
 import matplotlib.pyplot as plt
@@ -35,6 +37,8 @@ import rasterio
 from matplotlib.patches import Patch
 from rasterio.enums import Resampling
 from rasterio.windows import from_bounds as window_from_bounds
+
+Kind = Literal["continuous", "categorical"]
 
 # ----------------------------------------------------------------------------- #
 # Grid snapping (verbatim from scripts/clip_shared_to_fabric.py, made public)
@@ -311,13 +315,23 @@ def map_categorical(gdf, col, title, *, labels=None):
 # ----------------------------------------------------------------------------- #
 
 
+def _validate_kind(kind: str) -> None:
+    if kind not in ("continuous", "categorical"):
+        raise ValueError(
+            f"kind must be 'continuous' or 'categorical', got {kind!r}"
+        )
+
+
 @dataclass(frozen=True)
 class RasterEntry:
     name: str
     path: Path
-    kind: str  # "continuous" | "categorical"
+    kind: Kind
     cmap: str = "viridis"
     units: str = ""
+
+    def __post_init__(self) -> None:
+        _validate_kind(self.kind)
 
 
 @dataclass(frozen=True)
@@ -325,9 +339,12 @@ class ParamEntry:
     name: str
     csv_name: str
     column: str
-    kind: str  # "continuous" | "categorical"
-    units: str = ""
+    kind: Kind
     cmap: str = "viridis"
+    units: str = ""
+
+    def __post_init__(self) -> None:
+        _validate_kind(self.kind)
 
 
 def _existing_raster_entries(entries: list[RasterEntry]) -> list[RasterEntry]:
@@ -436,23 +453,25 @@ def depstor_raster_inventory(cfg) -> list[RasterEntry]:
 
 # Curated display metadata for the merged param CSVs (display-only; not pipeline
 # logic). CSV names + columns confirmed against {fabric}/params/merged/.
+# Keyword args throughout: RasterEntry/ParamEntry share a (kind, cmap, units)
+# tail, so positional construction is an easy place to swap cmap/units.
 _PARAM_ENTRIES = [
-    ParamEntry("elevation", "nhm_elevation_params.csv", "mean", "continuous", "m", "terrain"),
-    ParamEntry("slope", "nhm_slope_params.csv", "mean", "continuous", "degrees", "YlOrRd"),
-    ParamEntry("aspect", "nhm_aspect_params.csv", "mean", "continuous", "degrees", "twilight"),
-    ParamEntry("soils", "nhm_soils_params.csv", "soils", "categorical"),
-    ParamEntry("soil_moist_max", "nhm_soil_moist_max_params.csv", "soil_moist_max", "continuous", "cm", "Blues"),
-    ParamEntry("cov_type", "nhm_lulc_nhm_v11_params.csv", "cov_type", "categorical"),
-    ParamEntry("covden_sum", "nhm_lulc_nhm_v11_params.csv", "covden_sum", "continuous", "fraction", "Greens"),
-    ParamEntry("covden_win", "nhm_lulc_nhm_v11_params.csv", "covden_win", "continuous", "fraction", "YlGn"),
-    ParamEntry("retention", "nhm_lulc_nhm_v11_params.csv", "retention", "continuous", "fraction", "PuBuGn"),
-    ParamEntry("snow_intcp", "nhm_lulc_nhm_v11_params.csv", "snow_intcp", "continuous", "in", "PuBu"),
-    ParamEntry("carea_max", "nhm_carea_max_params.csv", "carea_max", "continuous", "fraction", "magma"),
-    ParamEntry("smidx_coef", "nhm_smidx_coef_params.csv", "smidx_coef", "continuous", "fraction", "magma"),
-    ParamEntry("sro_to_dprst_perv", "nhm_sro_to_dprst_perv_params.csv", "sro_to_dprst_perv", "continuous", "fraction", "cividis"),
-    ParamEntry("sro_to_dprst_imperv", "nhm_sro_to_dprst_imperv_params.csv", "sro_to_dprst_imperv", "continuous", "fraction", "cividis"),
-    ParamEntry("hru_percent_imperv", "nhm_hru_percent_imperv_params.csv", "hru_percent_imperv", "continuous", "fraction", "OrRd"),
-    ParamEntry("dprst_frac", "nhm_dprst_frac_params.csv", "dprst_frac", "continuous", "fraction", "GnBu"),
+    ParamEntry(name="elevation", csv_name="nhm_elevation_params.csv", column="mean", kind="continuous", units="m", cmap="terrain"),
+    ParamEntry(name="slope", csv_name="nhm_slope_params.csv", column="mean", kind="continuous", units="degrees", cmap="YlOrRd"),
+    ParamEntry(name="aspect", csv_name="nhm_aspect_params.csv", column="mean", kind="continuous", units="degrees", cmap="twilight"),
+    ParamEntry(name="soils", csv_name="nhm_soils_params.csv", column="soils", kind="categorical"),
+    ParamEntry(name="soil_moist_max", csv_name="nhm_soil_moist_max_params.csv", column="soil_moist_max", kind="continuous", units="cm", cmap="Blues"),
+    ParamEntry(name="cov_type", csv_name="nhm_lulc_nhm_v11_params.csv", column="cov_type", kind="categorical"),
+    ParamEntry(name="covden_sum", csv_name="nhm_lulc_nhm_v11_params.csv", column="covden_sum", kind="continuous", units="fraction", cmap="Greens"),
+    ParamEntry(name="covden_win", csv_name="nhm_lulc_nhm_v11_params.csv", column="covden_win", kind="continuous", units="fraction", cmap="YlGn"),
+    ParamEntry(name="retention", csv_name="nhm_lulc_nhm_v11_params.csv", column="retention", kind="continuous", units="fraction", cmap="PuBuGn"),
+    ParamEntry(name="snow_intcp", csv_name="nhm_lulc_nhm_v11_params.csv", column="snow_intcp", kind="continuous", units="in", cmap="PuBu"),
+    ParamEntry(name="carea_max", csv_name="nhm_carea_max_params.csv", column="carea_max", kind="continuous", units="fraction", cmap="magma"),
+    ParamEntry(name="smidx_coef", csv_name="nhm_smidx_coef_params.csv", column="smidx_coef", kind="continuous", units="fraction", cmap="magma"),
+    ParamEntry(name="sro_to_dprst_perv", csv_name="nhm_sro_to_dprst_perv_params.csv", column="sro_to_dprst_perv", kind="continuous", units="fraction", cmap="cividis"),
+    ParamEntry(name="sro_to_dprst_imperv", csv_name="nhm_sro_to_dprst_imperv_params.csv", column="sro_to_dprst_imperv", kind="continuous", units="fraction", cmap="cividis"),
+    ParamEntry(name="hru_percent_imperv", csv_name="nhm_hru_percent_imperv_params.csv", column="hru_percent_imperv", kind="continuous", units="fraction", cmap="OrRd"),
+    ParamEntry(name="dprst_frac", csv_name="nhm_dprst_frac_params.csv", column="dprst_frac", kind="continuous", units="fraction", cmap="GnBu"),
 ]
 
 

--- a/src/gfv2_params/viz.py
+++ b/src/gfv2_params/viz.py
@@ -279,8 +279,9 @@ def map_categorical(gdf, col, title, *, labels=None):
     cats = sorted(gdf[col].dropna().unique())
     if not cats:
         cats = [0]
-    colors = list(plt.cm.Set2.colors[:len(cats)])
-    cmap = mcolors.ListedColormap(colors[:len(cats)])
+    cmap_base = plt.cm.get_cmap("tab20", max(len(cats), 1))
+    colors = [cmap_base(i) for i in range(len(cats))]
+    cmap = mcolors.ListedColormap(colors)
     norm = mcolors.BoundaryNorm([c - 0.5 for c in cats] + [cats[-1] + 0.5], len(cats))
 
     fig, (ax_map, ax_leg) = plt.subplots(
@@ -295,7 +296,7 @@ def map_categorical(gdf, col, title, *, labels=None):
     counts = gdf[col].value_counts().sort_index()
     total = counts.sum() or 1
     patches = []
-    for cat, color in zip(cats, colors[:len(cats)]):
+    for cat, color in zip(cats, colors):
         lbl = labels.get(cat, str(cat)) if labels else str(cat)
         n = counts.get(cat, 0)
         patches.append(Patch(color=color, label=f"{lbl}\n({n:,}, {100 * n / total:.1f}%)"))

--- a/src/gfv2_params/viz.py
+++ b/src/gfv2_params/viz.py
@@ -378,12 +378,20 @@ def zonal_source_inventory(zonal_cfg) -> list[RasterEntry]:
     `zonal_cfg` is the result of ``load_config("configs/zonal/zonal_params.yml",
     fabric=...)``. Soils and LULC sources are categorical; the rest continuous.
     Missing files are skipped with a warning.
+
+    Note: ``load_config`` resolves ``{data_root}``/``{fabric}`` only in top-level
+    string values, not inside the nested ``params:`` list (the real orchestrator,
+    ``scripts/derive_zonal_params.py``, resolves those per-param). So we resolve
+    the same two placeholders here against the merged-in top-level keys.
     """
+    data_root = str(zonal_cfg.get("data_root", ""))
+    fabric = str(zonal_cfg.get("fabric", ""))
     entries: list[RasterEntry] = []
     for item in zonal_cfg.get("params", []):
         src = item.get("source_raster")
         if not src:
             continue
+        src = src.replace("{data_root}", data_root).replace("{fabric}", fabric)
         name = item["name"]
         kind = "categorical" if name in _ZONAL_CATEGORICAL else "continuous"
         cmap = "tab20" if kind == "categorical" else "viridis"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+import matplotlib
+
+matplotlib.use("Agg")

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -1,13 +1,8 @@
 """Tests for the results-viewer helper library `gfv2_params.viz`.
 
 Synthetic data only — no real fabric files, so these run in CI. Plotting uses
-the non-interactive Agg backend.
+the non-interactive Agg backend (selected globally in tests/conftest.py).
 """
-
-
-import matplotlib
-
-matplotlib.use("Agg")
 
 import geopandas as gpd
 import matplotlib.pyplot as plt

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -1,0 +1,190 @@
+"""Tests for the results-viewer helper library `gfv2_params.viz`.
+
+Synthetic data only — no real fabric files, so these run in CI. Plotting uses
+the non-interactive Agg backend.
+"""
+
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import geopandas as gpd
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import rasterio
+from affine import Affine
+from rasterio.crs import CRS
+from shapely.geometry import box
+
+from gfv2_params import viz
+
+# --------------------------------------------------------------------------- #
+# grid-snapping helpers (mirrored verbatim from clip_shared_to_fabric.py)
+# --------------------------------------------------------------------------- #
+
+def test_snap_bounds_to_grid_contains_input():
+    # north-up: 30 m cells, origin (0, 1000)
+    transform = Affine(30, 0, 0, 0, -30, 1000)
+    bounds = (115.0, 217.0, 403.0, 661.0)
+    snapped = viz.snap_bounds_to_grid(bounds, transform, buffer_cells=8)
+    ulx, uly, lrx, lry = snapped
+    # snapped window fully contains the (unbuffered) input bounds
+    assert ulx <= bounds[0]
+    assert lry <= bounds[1]
+    assert lrx >= bounds[2]
+    assert uly >= bounds[3]
+    # corners lie on the pixel lattice
+    for x in (ulx, lrx):
+        assert abs(((x - transform.c) / transform.a) - round((x - transform.c) / transform.a)) < 1e-9
+    for y in (uly, lry):
+        assert abs(((transform.f - y) / -transform.e) - round((transform.f - y) / -transform.e)) < 1e-9
+
+
+def test_whole_cell_offset_aligned_is_zero():
+    ref = Affine(30, 0, 0, 0, -30, 1000)
+    col_frac, row_frac = viz.whole_cell_offset(ref, ref)
+    assert abs(col_frac) < 1e-9
+    assert abs(row_frac) < 1e-9
+
+
+# --------------------------------------------------------------------------- #
+# raster reads
+# --------------------------------------------------------------------------- #
+
+def _write_tif(path, arr, nodata, transform=None, crs="EPSG:5070"):
+    if transform is None:
+        transform = Affine(30, 0, 0, 0, -30, 100 * 30)
+    with rasterio.open(
+        path,
+        "w",
+        driver="GTiff",
+        height=arr.shape[0],
+        width=arr.shape[1],
+        count=1,
+        dtype=arr.dtype,
+        crs=CRS.from_string(crs),
+        transform=transform,
+        nodata=nodata,
+    ) as dst:
+        dst.write(arr, 1)
+
+
+def test_read_overview_masks_nodata(tmp_path):
+    arr = np.arange(100 * 100, dtype="float32").reshape(100, 100)
+    arr[:10, :10] = -9999.0
+    path = tmp_path / "ov.tif"
+    _write_tif(path, arr, nodata=-9999.0)
+
+    out = viz.read_overview(path, target_px=50)
+    assert isinstance(out, np.ma.MaskedArray)
+    assert out.shape[0] <= 50 and out.shape[1] <= 50
+    # the nodata corner must be masked
+    assert out.mask.any()
+    assert -9999.0 not in out.compressed()
+
+
+def test_clip_overview_shape_and_extent(tmp_path):
+    arr = np.arange(100 * 100, dtype="float32").reshape(100, 100)
+    transform = Affine(30, 0, 0, 0, -30, 3000)  # origin (0, 3000)
+    path = tmp_path / "clip.tif"
+    _write_tif(path, arr, nodata=None, transform=transform)
+
+    full, full_extent = viz.clip_overview(path, (0, 0, 3000, 3000), target_px=200)
+    # extent ordering is (minx, maxx, miny, maxy)
+    assert full_extent[0] < full_extent[1]
+    assert full_extent[2] < full_extent[3]
+
+    # a sub-window returns fewer cells than the full read
+    sub, sub_extent = viz.clip_overview(path, (0, 1500, 1500, 3000), target_px=200)
+    assert isinstance(sub, np.ma.MaskedArray)
+    assert sub.size < full.size
+    assert sub_extent[1] <= full_extent[1] + 1e-6
+    assert sub_extent[2] >= full_extent[2] - 1e-6
+
+
+# --------------------------------------------------------------------------- #
+# param load / join
+# --------------------------------------------------------------------------- #
+
+def _synthetic_fabric(id_feature="nat_hru_id"):
+    geoms = [box(i, 0, i + 1, 1) for i in range(3)]
+    return gpd.GeoDataFrame(
+        {id_feature: [1, 2, 3], "geometry": geoms},
+        crs="EPSG:5070",
+    )
+
+
+def test_load_param_left_join_preserves_all_hrus(tmp_path):
+    fabric = _synthetic_fabric()
+    # CSV covers only HRUs 1 and 2
+    df = pd.DataFrame({"nat_hru_id": [1, 2], "mean": [10.0, 20.0]})
+    csv = tmp_path / "p.csv"
+    df.to_csv(csv, index=False)
+
+    gdf = viz.load_param(tmp_path, "p.csv", fabric, "nat_hru_id")
+    assert len(gdf) == 3
+    by_id = gdf.set_index("nat_hru_id")["mean"]
+    assert by_id[1] == 10.0
+    assert by_id[2] == 20.0
+    assert pd.isna(by_id[3])
+
+
+# --------------------------------------------------------------------------- #
+# inventories
+# --------------------------------------------------------------------------- #
+
+def test_param_inventory_kinds():
+    entries = viz.param_inventory()
+    assert len(entries) == 16
+    assert all(isinstance(e, viz.ParamEntry) for e in entries)
+    by_name = {e.name: e for e in entries}
+    assert by_name["soils"].kind == "categorical"
+    assert by_name["cov_type"].kind == "categorical"
+    # a representative continuous one
+    assert by_name["elevation"].kind == "continuous"
+
+
+# --------------------------------------------------------------------------- #
+# plotting helpers return Figures
+# --------------------------------------------------------------------------- #
+
+def test_map_continuous_returns_figure():
+    fabric = _synthetic_fabric()
+    fabric["mean"] = [1.0, 2.0, 3.0]
+    fig = viz.map_continuous(fabric, "mean", "T", units="m")
+    assert isinstance(fig, plt.Figure)
+    plt.close(fig)
+
+
+def test_map_categorical_returns_figure():
+    fabric = _synthetic_fabric()
+    fabric["soils"] = [1, 2, 1]
+    fig = viz.map_categorical(fabric, "soils", "S")
+    assert isinstance(fig, plt.Figure)
+    plt.close(fig)
+
+
+# --------------------------------------------------------------------------- #
+# save-figures workflow
+# --------------------------------------------------------------------------- #
+
+def test_save_figure_writes_when_enabled(tmp_path, monkeypatch):
+    monkeypatch.setattr(viz, "FIGURES_DIR", tmp_path)
+    monkeypatch.setattr(viz, "FABRIC", "testfab")
+    monkeypatch.setattr(viz, "SAVE_FIGURES", True)
+    fig, ax = plt.subplots()
+    viz.save_figure(fig, "x")
+    plt.close(fig)
+    assert (tmp_path / "testfab" / "x.png").exists()
+
+
+def test_save_figure_noop_when_disabled(tmp_path, monkeypatch):
+    monkeypatch.setattr(viz, "FIGURES_DIR", tmp_path)
+    monkeypatch.setattr(viz, "FABRIC", "testfab")
+    monkeypatch.setattr(viz, "SAVE_FIGURES", False)
+    fig, ax = plt.subplots()
+    viz.save_figure(fig, "x")
+    plt.close(fig)
+    assert not (tmp_path / "testfab" / "x.png").exists()

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -8,10 +8,11 @@ import geopandas as gpd
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
+import pytest
 import rasterio
 from affine import Affine
 from rasterio.crs import CRS
-from shapely.geometry import box
+from shapely.geometry import Polygon, box
 
 from gfv2_params import viz
 
@@ -99,6 +100,40 @@ def test_clip_overview_shape_and_extent(tmp_path):
     assert sub_extent[2] >= full_extent[2] - 1e-6
 
 
+def test_clip_overview_pads_out_of_bounds(tmp_path):
+    # raster covers (0,0)-(3000,3000); request a window extending past its
+    # left/top edges. boundless=True must pad with nodata, and the pad masked.
+    arr = np.ones((100, 100), dtype="float32")
+    transform = Affine(30, 0, 0, 0, -30, 3000)
+    path = tmp_path / "oob.tif"
+    _write_tif(path, arr, nodata=-9999.0, transform=transform)
+
+    out, _ = viz.clip_overview(path, (-1500, 1500, 1500, 4500), target_px=300)
+    assert isinstance(out, np.ma.MaskedArray)
+    assert out.mask.any()            # the out-of-raster pad is masked
+    assert 1.0 in out.compressed()   # the in-raster cells survive
+
+
+# --------------------------------------------------------------------------- #
+# fabric bounds
+# --------------------------------------------------------------------------- #
+
+def test_fabric_bounds_reprojects(tmp_path):
+    gpkg = tmp_path / "f.gpkg"
+    _synthetic_fabric("hru_id").to_file(gpkg, layer="nhru", driver="GPKG")
+    native = viz.fabric_bounds(gpkg, "nhru")
+    reproj = viz.fabric_bounds(gpkg, "nhru", dst_crs="EPSG:4326")
+    assert native != reproj  # reprojection actually changed the bounds
+
+
+def test_fabric_bounds_raises_on_empty(tmp_path):
+    gdf = gpd.GeoDataFrame({"hru_id": [1], "geometry": [Polygon()]}, crs="EPSG:5070")
+    gpkg = tmp_path / "empty.gpkg"
+    gdf.to_file(gpkg, layer="nhru", driver="GPKG")
+    with pytest.raises(ValueError):
+        viz.fabric_bounds(gpkg, "nhru")
+
+
 # --------------------------------------------------------------------------- #
 # param load / join
 # --------------------------------------------------------------------------- #
@@ -139,6 +174,66 @@ def test_param_inventory_kinds():
     assert by_name["cov_type"].kind == "categorical"
     # a representative continuous one
     assert by_name["elevation"].kind == "continuous"
+
+
+def test_shared_raster_inventory_skips_missing(tmp_path):
+    vrt_dir = tmp_path / "shared" / "conus" / "vrt"
+    vrt_dir.mkdir(parents=True)
+    for name in ("elevation.vrt", "slope.vrt", "aspect.vrt"):
+        (vrt_dir / name).write_text("")  # existence-only
+    twi = tmp_path / "twi.vrt"
+    twi.write_text("")
+    cfg = {
+        "data_root": str(tmp_path),
+        "twi_raster": str(twi),
+        "fdr_raster": str(tmp_path / "missing_fdr.vrt"),  # absent -> skipped
+    }
+    with pytest.warns(UserWarning, match="fdr"):
+        entries = viz.shared_raster_inventory(cfg)
+    names = {e.name for e in entries}
+    assert {"twi", "elevation", "slope", "aspect"} <= names
+    assert "fdr" not in names  # skipped because the path is missing
+    assert all(e.kind in ("continuous", "categorical") for e in entries)
+
+
+def test_zonal_source_inventory_resolves_placeholders(tmp_path):
+    # load_config leaves {data_root}/{fabric} unresolved inside the params list;
+    # the inventory builder must resolve them itself.
+    (tmp_path / "e.tif").write_text("")
+    (tmp_path / "s.tif").write_text("")
+    zonal_cfg = {
+        "data_root": str(tmp_path),
+        "fabric": "oregon",
+        "params": [
+            {"name": "elevation", "source_raster": "{data_root}/e.tif"},
+            {"name": "soils", "source_raster": "{data_root}/s.tif"},
+            {"name": "ssflux", "source_shapefile": "{data_root}/x.shp"},  # no raster
+        ],
+    }
+    entries = viz.zonal_source_inventory(zonal_cfg)
+    by_name = {e.name: e for e in entries}
+    assert set(by_name) == {"elevation", "soils"}  # ssflux excluded (no source_raster)
+    assert "{data_root}" not in str(by_name["elevation"].path)  # placeholder resolved
+    assert by_name["soils"].kind == "categorical"
+    assert by_name["elevation"].kind == "continuous"
+
+
+def test_depstor_raster_inventory_skips_missing(tmp_path):
+    base = tmp_path / "fab" / "depstor_rasters"
+    base.mkdir(parents=True)
+    (base / "land_mask.tif").write_text("")  # only one of the 14 present
+    cfg = {"data_root": str(tmp_path), "fabric": "fab"}
+    with pytest.warns(UserWarning):
+        entries = viz.depstor_raster_inventory(cfg)
+    assert [e.name for e in entries] == ["land_mask"]
+    assert entries[0].kind == "categorical"
+
+
+def test_entry_kind_validation():
+    with pytest.raises(ValueError):
+        viz.ParamEntry(name="x", csv_name="y.csv", column="z", kind="bogus")
+    with pytest.raises(ValueError):
+        viz.RasterEntry("x", "p.tif", "bogus")
 
 
 # --------------------------------------------------------------------------- #
@@ -183,3 +278,15 @@ def test_save_figure_noop_when_disabled(tmp_path, monkeypatch):
     viz.save_figure(fig, "x")
     plt.close(fig)
     assert not (tmp_path / "testfab" / "x.png").exists()
+
+
+def test_save_figure_warns_without_fabric(tmp_path, monkeypatch):
+    monkeypatch.setattr(viz, "FIGURES_DIR", tmp_path)
+    monkeypatch.setattr(viz, "FABRIC", None)
+    monkeypatch.setattr(viz, "SAVE_FIGURES", True)
+    fig, ax = plt.subplots()
+    with pytest.warns(UserWarning):
+        viz.save_figure(fig, "y")
+    plt.close(fig)
+    # un-namespaced: lands directly in the base dir, not a fabric subdir
+    assert (tmp_path / "y.png").exists()


### PR DESCRIPTION
## Summary

Adds a reusable, `FABRIC`-parameterized way to view a fabric's full parameterization — the input rasters that fed it and the per-HRU results that came out. Built around a small tested library so the notebooks stay thin.

- **`src/gfv2_params/viz.py`** (+ `tests/test_viz.py`, `tests/conftest.py`) — tested viewer helpers: grid-snap (now shared with the clip script), decimated `read_overview`/`clip_overview`, `plot_raster`, `load_param`, `map_continuous`/`map_categorical`, config-driven raster/param inventories, and a `save_figure` workflow.
- **`notebooks/fabric_results/0{1,2,3}_*.ipynb`** — three Jupyter viewers selected by the `FABRIC` env var:
  - `01_input_rasters` — shared + zonal source rasters clipped to fabric bounds, HRU outline overlaid.
  - `02_depstor_rasters` — the 14 per-fabric depstor binary/label rasters + coverage stats.
  - `03_param_results` — choropleth + distribution of all 16 merged per-HRU params, plus a depstor-ratio summary table.
- **`scripts/render_figures.py`** + `.gitignore` — headless `nbconvert --execute` (with `FABRIC`/`SAVE_FIGURES=1`, `MPLBACKEND=Agg`) to regenerate `docs/figures/{fabric}/` for a report. PNGs are committed; executed copies in `docs/figures/.cache/` are ignored.
- **`scripts/clip_shared_to_fabric.py`** — refactored to import the grid-snap helpers from `viz` (no behavior change).
- **Docs** — README "Viewing fabric results" section, RUNME Stage 9, and `notebooks/oregon/README.md` launcher stub.

## Design decisions

- **Jupyter `.ipynb` on JupyterHub** (not marimo): `gfv2` (~361k HRUs) is memory-heavy regardless of notebook tech, and JupyterHub already gives per-session `--mem` control. The login node can't render a full fabric.
- **One parameterized set + thin per-fabric stub**: notebook source lives once in `fabric_results/`; `notebooks/{fabric}/` holds a launcher README.
- **Agg backend in `tests/conftest.py`, not in `viz.py`**: so the notebooks display inline under `%matplotlib inline`; the headless render path sets `MPLBACKEND=Agg` itself.
- Save-figures workflow mirrors the `nhf-spatial-targets` convention (`SAVE_FIGURES` toggle, `docs/figures/{fabric}/`, committed PNGs).

## Verification

- All four inventories resolve against the on-disk **oregon** fabric; all 16 param CSV columns + `id_feature` match; core render paths smoke-tested (`carea_max` mean 0.157). Notebooks are nbformat-valid and all code cells compile. `py_compile`/import/pre-commit clean.
- Full `pytest` is the CI gate (not run on the HPC head node).
- **Not yet exercised:** CONUS `gfv2` rendering (needs a high-`--mem` JupyterHub session); no figures committed yet (generated on demand via `render_figures.py`).

## ⚠️ Scope expansion

The branch doc audit (CLAUDE.md doc-check rule) caught a **pre-existing, unrelated** staleness in the README/RUNME Part-1 blurb: the default shared-raster DAG is **9 steps** (incl. `twi_reference`, added in #95), not 7 (README) / 8 (RUNME), and the store is `shared/`, not `work/`. Corrected in its own commit (`docs: correct stale Part-1 shared-raster step count + store path`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)