### PR TITLE
Fix VPU-17 FDR/FAC merge: add missing RPU 17d (W Oregon coast + Willamette)

### DIFF
--- a/configs/shared_rasters/merge_rpu_by_vpu.yml
+++ b/configs/shared_rasters/merge_rpu_by_vpu.yml
@@ -15,16 +15,12 @@
 
   FdrFac_Fdr:
     rpus:
-      [
-        "shared/source/01/01a/FdrFac/NHDPlusNE/NHDPlus01/NHDPlusFdrFac01a/fdr",
-      ]
+      ["shared/source/01/01a/FdrFac/NHDPlusNE/NHDPlus01/NHDPlusFdrFac01a/fdr"]
     output: "shared/per_vpu/01/Fdr_merged_01.tif"
 
   FdrFac_Fac:
     rpus:
-      [
-        "shared/source/01/01a/FdrFac/NHDPlusNE/NHDPlus01/NHDPlusFdrFac01a/fac",
-      ]
+      ["shared/source/01/01a/FdrFac/NHDPlusNE/NHDPlus01/NHDPlusFdrFac01a/fac"]
     output: "shared/per_vpu/01/Fac_merged_01.tif"
 
 "02":
@@ -208,16 +204,12 @@
 
   FdrFac_Fdr:
     rpus:
-      [
-        "shared/source/06/06a/FdrFac/NHDPlusMS/NHDPlus06/NHDPlusFdrFac06a/fdr",
-      ]
+      ["shared/source/06/06a/FdrFac/NHDPlusMS/NHDPlus06/NHDPlusFdrFac06a/fdr"]
     output: "shared/per_vpu/06/Fdr_merged_06.tif"
 
   FdrFac_Fac:
     rpus:
-      [
-        "shared/source/06/06a/FdrFac/NHDPlusMS/NHDPlus06/NHDPlusFdrFac06a/fac",
-      ]
+      ["shared/source/06/06a/FdrFac/NHDPlusMS/NHDPlus06/NHDPlusFdrFac06a/fac"]
     output: "shared/per_vpu/06/Fac_merged_06.tif"
 
 "07":
@@ -311,16 +303,12 @@
 
   FdrFac_Fdr:
     rpus:
-      [
-        "shared/source/09/09a/FdrFac/NHDPlusSR/NHDPlus09/NHDPlusFdrFac09a/fdr",
-      ]
+      ["shared/source/09/09a/FdrFac/NHDPlusSR/NHDPlus09/NHDPlusFdrFac09a/fdr"]
     output: "shared/per_vpu/09/Fdr_merged_09.tif"
 
   FdrFac_Fac:
     rpus:
-      [
-        "shared/source/09/09a/FdrFac/NHDPlusSR/NHDPlus09/NHDPlusFdrFac09a/fac",
-      ]
+      ["shared/source/09/09a/FdrFac/NHDPlusSR/NHDPlus09/NHDPlusFdrFac09a/fac"]
     output: "shared/per_vpu/09/Fac_merged_09.tif"
 
 "10":
@@ -633,6 +621,7 @@
         "shared/source/17/17a/FdrFac/NHDPlusPN/NHDPlus17/NHDPlusFdrFac17a/fdr",
         "shared/source/17/17b/FdrFac/NHDPlusPN/NHDPlus17/NHDPlusFdrFac17b/fdr",
         "shared/source/17/17c/FdrFac/NHDPlusPN/NHDPlus17/NHDPlusFdrFac17c/fdr",
+        "shared/source/17/17d/FdrFac/NHDPlusPN/NHDPlus17/NHDPlusFdrFac17d/fdr",
       ]
     output: "shared/per_vpu/17/Fdr_merged_17.tif"
 
@@ -642,6 +631,7 @@
         "shared/source/17/17a/FdrFac/NHDPlusPN/NHDPlus17/NHDPlusFdrFac17a/fac",
         "shared/source/17/17b/FdrFac/NHDPlusPN/NHDPlus17/NHDPlusFdrFac17b/fac",
         "shared/source/17/17c/FdrFac/NHDPlusPN/NHDPlus17/NHDPlusFdrFac17c/fac",
+        "shared/source/17/17d/FdrFac/NHDPlusPN/NHDPlus17/NHDPlusFdrFac17d/fac",
       ]
     output: "shared/per_vpu/17/Fac_merged_17.tif"
 

--- a/scripts/build_shared_rasters.py
+++ b/scripts/build_shared_rasters.py
@@ -83,9 +83,17 @@ def _load_data_root(base_config_path: Path) -> str:
 def _select_steps(all_steps, only_step, from_step):
     names = [s["name"] for s in all_steps]
     if only_step:
-        if only_step not in names:
-            raise ValueError(f"--step '{only_step}' not in config; available: {names}")
-        return [s for s in all_steps if s["name"] == only_step]
+        if only_step in names:
+            return [s for s in all_steps if s["name"] == only_step]
+        # Allow --step to invoke a registered builder that isn't in the default
+        # DAG (e.g. `compute_dem_derivatives`, the optional/parallel hydro-DEM
+        # step). Its build() uses ctx defaults when step_cfg keys are absent.
+        if only_step in BUILDERS:
+            return [{"name": only_step}]
+        raise ValueError(
+            f"--step '{only_step}' not in config and not a registered builder. "
+            f"In config: {names}; registered: {sorted(BUILDERS)}"
+        )
     if from_step:
         if from_step not in names:
             raise ValueError(f"--from '{from_step}' not in config; available: {names}")

--- a/slurm_batch/RUNME.md
+++ b/slurm_batch/RUNME.md
@@ -704,6 +704,45 @@ sbatch --array=37 --export=ALL,PARAM=elevation,FABRIC=gfv2,BASE_CONFIG=configs/b
 `--step` flag: `pixi run python scripts/build_shared_rasters.py
 --config configs/shared_rasters/shared_rasters.yml --step <name>`.)
 
+### Recovery: refill a VPU after a merge-manifest / source fix
+
+When a per-VPU source gap is fixed (e.g. an RPU added to a VPU's merge entry in
+`configs/shared_rasters/merge_rpu_by_vpu.yml`, or a stale merge that predates a
+staged RPU), re-merge **just that VPU** and rebuild the products that depend on
+it, then re-run the affected fabric's depstor stage. Run the steps in order,
+waiting for each to finish (they aren't auto-chained). Example for **VPU 17**
+(the W Oregon 17d FDR gap); the per-VPU merge is memory-heavy, so bump `--mem`:
+
+```bash
+V=17
+# 1. re-merge NED / Hydrodem / Fdr / Fac for the VPU (now incl. the added RPU)
+VPUS=$V FORCE=1 sbatch --mem=384G slurm_batch/build_shared_rasters.batch --step merge_rpu_by_vpu
+# 2. regenerate the open-source hydrology derivatives (Fdr_hydrodem, Twi_hydrodem)
+#    from the refreshed Hydrodem — NOT in the default DAG, so name it explicitly
+VPUS=$V FORCE=1 sbatch --mem=192G slurm_batch/build_shared_rasters.batch --step compute_dem_derivatives
+# 3. re-merge the ArcPy TWI (masked) for the VPU
+VPUS=$V FORCE=1 sbatch --mem=384G slurm_batch/build_shared_rasters.batch --step merge_rpu_by_vpu_twi
+# 4. rebuild the CONUS VRTs (fdr.vrt, twi.vrt, twi_hydrodem.vrt, elevation/slope/aspect)
+FORCE=1 sbatch slurm_batch/build_shared_rasters.batch --step build_vrt
+# 5. recompute the TWI percentile reference tables
+FORCE=1 sbatch slurm_batch/build_shared_rasters.batch --step twi_reference
+```
+
+Then refresh the affected fabric and re-run **only its depstor stage** (the
+zonal params — elevation/slope/aspect/soils/LULC/ssflux — are on the gap-free
+DEM lattice and do not need re-running):
+
+```bash
+# re-clip the fabric template/fdr from the rebuilt fdr.vrt
+pixi run python scripts/clip_shared_to_fabric.py --fabric oregon
+# re-derive depstor rasters (routing + carea_map) and params
+FABRIC=oregon sbatch slurm_batch/build_depstor_rasters.batch --force
+slurm_batch/submit_depstor_params.sh {data_root}/oregon/batches oregon configs/base_config.yml
+```
+
+Verify with `notebooks/fabric_results/01_input_rasters.ipynb` (the `fdr` /
+`twi_hydrodem` panels should no longer have a nodata void inside the fabric).
+
 ## Monitoring
 
 ```bash

--- a/slurm_batch/RUNME.md
+++ b/slurm_batch/RUNME.md
@@ -733,11 +733,15 @@ zonal params — elevation/slope/aspect/soils/LULC/ssflux — are on the gap-fre
 DEM lattice and do not need re-running):
 
 ```bash
+# resolve data_root from the base config (the submit script needs a real path,
+# not the {data_root} placeholder)
+DR=$(grep '^data_root:' configs/base_config.yml | awk '{print $2}' | tr -d '"')
+
 # re-clip the fabric template/fdr from the rebuilt fdr.vrt
 pixi run python scripts/clip_shared_to_fabric.py --fabric oregon
 # re-derive depstor rasters (routing + carea_map) and params
 FABRIC=oregon sbatch slurm_batch/build_depstor_rasters.batch --force
-slurm_batch/submit_depstor_params.sh {data_root}/oregon/batches oregon configs/base_config.yml
+slurm_batch/submit_depstor_params.sh "$DR/oregon/batches" oregon configs/base_config.yml
 ```
 
 Verify with `notebooks/fabric_results/01_input_rasters.ipynb` (the `fdr` /

--- a/slurm_batch/build_shared_rasters.batch
+++ b/slurm_batch/build_shared_rasters.batch
@@ -24,9 +24,13 @@
 #   FORCE=1            rebuild outputs that already exist
 #   VPUS=01,10         restrict per-VPU steps to a comma-separated subset
 #
-# Per-step debugging: the individual slurm_batch/*.batch files remain as thin
-# shells around the same library builders — use them when you want per-step
-# granularity or per-VPU parallelism via SLURM arrays.
+# Extra args after the batch name are forwarded to the orchestrator, so you can
+# run a single step (or resume) incrementally, e.g. to refill one VPU after a
+# merge-manifest fix (see RUNME.md "Recovery: refill a VPU"):
+#   VPUS=17 sbatch slurm_batch/build_shared_rasters.batch --step merge_rpu_by_vpu --force
+#   VPUS=17 sbatch slurm_batch/build_shared_rasters.batch --step compute_dem_derivatives --force
+# Note compute_dem_derivatives is registered but NOT in the default step list,
+# so it only runs when named explicitly with --step.
 
 set -euo pipefail
 
@@ -37,4 +41,4 @@ VPUS_OVERRIDE=${VPUS:+--vpus $VPUS}
 
 pixi run --as-is python scripts/build_shared_rasters.py \
     --config configs/shared_rasters/shared_rasters.yml \
-    $VPUS_OVERRIDE $FORCE
+    $VPUS_OVERRIDE $FORCE "$@"


### PR DESCRIPTION
## What & why

The `notebooks/fabric_results/01_input_rasters.ipynb` viewer surfaced a large nodata void in `fdr` / `template` over W Oregon (Coast Range + Willamette Valley) — *inside* the oregon HRU polygons, not just ocean. Measured strictly inside the fabric:

| raster | nodata inside fabric |
|---|---|
| `elevation.vrt` | 0.0% ✓ |
| `fdr.vrt` | **17.9%** ✗ |
| `twi_hydrodem.vrt` | **14.4%** ✗ |
| `NEDSnapshot_merged_17` | 12.8% |
| `Hydrodem_merged_17` | 12.8% |
| `Fdr_merged_17` (ArcPy) | 17.9% |

That means oregon's depstor routing (`drains_to_dprst`, `sro_to_dprst_*`) and `carea_max` / `smidx_coef` are degenerate for ~18% of HRUs — the "oregon fully processed" status is wrong for that region.

## Root cause (confirmed)

`configs/shared_rasters/merge_rpu_by_vpu.yml` listed only RPUs **17a/17b/17c** for VPU 17's `FdrFac_Fdr` / `FdrFac_Fac` — **17d was omitted**, even though its FdrFac source is staged on disk (248 MB) and `NEDSnapshot`/`Hydrodem` list all four. A scan of all 18 VPUs shows **17 is the only mismatch**. The 17d RPU geographically covers lon −124.58…−122.11 (the W Oregon coastal/Willamette strip) — exactly the hole.

The NED/Hydrodem tiles are *also* holed despite listing 17d → **stale outputs** that predate 17d staging; a `--force` re-merge refreshes them.

## Changes

- **`cde146c` `fix(merge)`** — add 17d to VPU-17 `FdrFac_Fdr` + `FdrFac_Fac`. (Prettier compacted some unrelated single-RPU arrays — formatting only; total `FdrFac_Fdr` entries 59, 18 VPUs, all other VPUs verified content-identical.)
- **`0d0270d` `feat(slurm)`** — `build_shared_rasters.batch` now forwards `--step`/`--vpus`/`--force` (`\"$@\"`, mirroring `build_depstor_rasters.batch`), and RUNME gains a **"Recovery: refill a VPU after a merge-manifest / source fix"** section with the exact ordered re-run.
- **`859e0d0` `fix(build_shared_rasters)`** — `--step` now accepts builders registered in `BUILDERS` even if not in the default `steps:` block (with a minimal `step_cfg={\"name\": X}`). This makes `--step compute_dem_derivatives` (the optional/parallel hydro-DEM step that regenerates `Fdr_hydrodem` / `Twi_hydrodem`) usable for the recovery — previously it raised `ValueError` at the selection stage. In-DAG behavior + unknown-name errors are unchanged; verified inline.

## Verification (this PR)

- Manifest parses, VPU 17 now has `{17a, 17b, 17c, 17d}` for both Fdr and Fac; 0 cross-VPU mismatches; yamllint clean.
- `_select_steps` smoke-tested: in-DAG step → returned correctly; `compute_dem_derivatives` → resolves to one-off `step_cfg`; unknown → still raises.
- `bash -n` on the edited batch; `py_compile` on the orchestrator.

## Operational follow-up (separate from this PR)

The fix is the config + tooling change; the actual data fix is the re-merge sequence documented in RUNME's new "Recovery" section. For VPU 17:

```bash
V=17
VPUS=$V FORCE=1 sbatch --mem=384G slurm_batch/build_shared_rasters.batch --step merge_rpu_by_vpu
VPUS=$V FORCE=1 sbatch --mem=192G slurm_batch/build_shared_rasters.batch --step compute_dem_derivatives
VPUS=$V FORCE=1 sbatch --mem=384G slurm_batch/build_shared_rasters.batch --step merge_rpu_by_vpu_twi
FORCE=1 sbatch slurm_batch/build_shared_rasters.batch --step build_vrt
FORCE=1 sbatch slurm_batch/build_shared_rasters.batch --step twi_reference
pixi run python scripts/clip_shared_to_fabric.py --fabric oregon
FABRIC=oregon sbatch slurm_batch/build_depstor_rasters.batch --force
slurm_batch/submit_depstor_params.sh {data_root}/oregon/batches oregon configs/base_config.yml
```

Zonal params (DEM-lattice — elevation/slope/aspect/soils/LULC/ssflux) are unaffected and do not need re-running. Verify with `notebooks/fabric_results/01_input_rasters.ipynb` (the fdr / twi_hydrodem panels should no longer have an inland nodata void).

🤖 Generated with [Claude Code](https://claude.com/claude-code)