### PR TITLE
viz: dedupe inventory + categorical class legends + nodata grey (notebook 01 fixes)

### DIFF
--- a/notebooks/fabric_results/01_input_rasters.ipynb
+++ b/notebooks/fabric_results/01_input_rasters.ipynb
@@ -71,11 +71,7 @@
    "id": "31741797",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "inventory = viz.shared_raster_inventory(cfg) + viz.zonal_source_inventory(zonal_cfg)\n",
-    "for e in inventory:\n",
-    "    print(f\"{e.name:16} {e.kind:11} {e.path}\")"
-   ]
+   "source": "inventory = viz.dedupe_raster_entries(\n    viz.shared_raster_inventory(cfg) + viz.zonal_source_inventory(zonal_cfg)\n)\nfor e in inventory:\n    print(f\"{e.name:16} {e.kind:11} {e.path}\")"
   },
   {
    "cell_type": "markdown",

--- a/src/gfv2_params/viz.py
+++ b/src/gfv2_params/viz.py
@@ -188,12 +188,22 @@ def clip_overview(path, bounds, target_px: int = 800):
 # ----------------------------------------------------------------------------- #
 
 
+def _format_category(value):
+    """Render a category value as a compact label (1.0 -> '1')."""
+    f = float(value)
+    return str(int(f)) if f.is_integer() else f"{f:g}"
+
+
 def plot_raster(ax, arr, extent=None, *, cmap="viridis", pct=(2, 98),
-                categorical=False, title=None, label=""):
+                categorical=False, title=None, label="", max_legend=20):
     """Render a masked raster thumbnail onto `ax`.
 
     Continuous: percentile-stretch (`pct`) + colorbar. Categorical: discrete
-    classes via a BoundaryNorm + colorbar. Returns the matplotlib image.
+    classes with a per-class **legend** when there are <= `max_legend` distinct
+    classes (so soils/LULC/FDR codes are labelled), else a discrete colorbar
+    (e.g. region-label rasters with many values). Masked/nodata cells render as
+    light grey so gaps (ocean, off-fabric) read as intentional. Returns the
+    matplotlib image.
     """
     imshow_kwargs = {"interpolation": "nearest", "rasterized": True}
     if extent is not None:
@@ -207,20 +217,31 @@ def plot_raster(ax, arr, extent=None, *, cmap="viridis", pct=(2, 98),
         listed = mcolors.ListedColormap(
             plt.cm.tab20(np.linspace(0, 1, max(len(cats), 1)))
         )
+        listed.set_bad("lightgrey")
         bounds = list(cats - 0.5) + [cats[-1] + 0.5]
         norm = mcolors.BoundaryNorm(bounds, listed.N)
         im = ax.imshow(arr, cmap=listed, norm=norm, **imshow_kwargs)
+        if len(cats) <= max_legend:
+            handles = [Patch(color=listed(norm(cat)), label=_format_category(cat))
+                       for cat in cats]
+            ax.legend(handles=handles, title=label or None, loc="center left",
+                      bbox_to_anchor=(1.0, 0.5), fontsize=7, frameon=False,
+                      title_fontsize=8)
+        else:
+            ax.figure.colorbar(im, ax=ax, fraction=0.03, pad=0.02, label=label)
     else:
+        cmap_obj = plt.get_cmap(cmap).copy()
+        cmap_obj.set_bad("lightgrey")
         if len(valid):
             vmin, vmax = np.percentile(valid, pct)
         else:
             vmin, vmax = 0, 1
-        im = ax.imshow(arr, cmap=cmap, vmin=vmin, vmax=vmax, **imshow_kwargs)
+        im = ax.imshow(arr, cmap=cmap_obj, vmin=vmin, vmax=vmax, **imshow_kwargs)
+        ax.figure.colorbar(im, ax=ax, fraction=0.03, pad=0.02, label=label)
 
     if title:
         ax.set_title(title, fontsize=10)
     ax.axis("off")
-    ax.figure.colorbar(im, ax=ax, fraction=0.03, pad=0.02, label=label)
     return im
 
 
@@ -356,6 +377,25 @@ def _existing_raster_entries(entries: list[RasterEntry]) -> list[RasterEntry]:
         else:
             warnings.warn(f"Skipping raster '{e.name}': path not found: {e.path}")
     return kept
+
+
+def dedupe_raster_entries(entries: list[RasterEntry]) -> list[RasterEntry]:
+    """Drop entries whose resolved path repeats (first occurrence wins, order kept).
+
+    The input-raster view concatenates the shared and zonal-source inventories,
+    which both list the DEM VRTs (elevation/slope/aspect) and — for single-VPU
+    fabrics — the same fdr/template clip. Dedupe by path so each file is shown
+    once.
+    """
+    seen: set[str] = set()
+    out: list[RasterEntry] = []
+    for e in entries:
+        key = str(e.path)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(e)
+    return out
 
 
 def shared_raster_inventory(cfg) -> list[RasterEntry]:

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -236,6 +236,55 @@ def test_entry_kind_validation():
         viz.RasterEntry("x", "p.tif", "bogus")
 
 
+def test_dedupe_raster_entries_preserves_first_and_order():
+    e1 = viz.RasterEntry("twi", "/x/twi.vrt", "continuous")
+    e2 = viz.RasterEntry("fdr", "/x/oregon_fdr.vrt", "categorical")
+    e3 = viz.RasterEntry("template", "/x/oregon_fdr.vrt", "categorical")  # dup path
+    e4 = viz.RasterEntry("elevation", "/x/elev.vrt", "continuous")
+    e5 = viz.RasterEntry("elevation", "/x/elev.vrt", "continuous")        # dup path
+    out = viz.dedupe_raster_entries([e1, e2, e3, e4, e5])
+    assert [e.name for e in out] == ["twi", "fdr", "elevation"]  # first wins, order kept
+
+
+# --------------------------------------------------------------------------- #
+# plot_raster: categorical class legend (vs colorbar) + nodata grey
+# --------------------------------------------------------------------------- #
+
+def test_plot_raster_categorical_builds_class_legend():
+    # 3 classes (1, 2, 3) — should render one legend handle per class
+    data = np.array([[1, 2, 3], [3, 2, 1]], dtype="float32")
+    arr = np.ma.array(data, mask=np.zeros_like(data, dtype=bool))
+    fig, ax = plt.subplots()
+    viz.plot_raster(ax, arr, categorical=True, title="soils", label="class")
+    leg = ax.get_legend()
+    assert leg is not None
+    assert [t.get_text() for t in leg.get_texts()] == ["1", "2", "3"]
+    plt.close(fig)
+
+
+def test_plot_raster_categorical_falls_back_to_colorbar_above_max_legend():
+    # 5 classes with max_legend=4 -> falls back to colorbar (no legend)
+    data = np.array([[1, 2, 3, 4, 5]], dtype="float32")
+    arr = np.ma.array(data, mask=np.zeros_like(data, dtype=bool))
+    fig, ax = plt.subplots()
+    viz.plot_raster(ax, arr, categorical=True, label="vpu", max_legend=4)
+    assert ax.get_legend() is None
+    plt.close(fig)
+
+
+def test_plot_raster_masks_nodata_with_grey():
+    # Continuous: cmap.set_bad("lightgrey") should be applied so masked cells
+    # render distinguishably from valid data.
+    data = np.array([[1.0, 2.0], [3.0, 4.0]], dtype="float32")
+    arr = np.ma.array(data, mask=[[True, False], [False, False]])
+    fig, ax = plt.subplots()
+    im = viz.plot_raster(ax, arr, categorical=False, cmap="viridis")
+    bad_rgba = im.get_cmap().get_bad()
+    # matplotlib "lightgrey" == (0.827, 0.827, 0.827, 1.0)
+    assert bad_rgba[:3] == pytest.approx((0.8274509803921568,) * 3, abs=1e-3)
+    plt.close(fig)
+
+
 # --------------------------------------------------------------------------- #
 # plotting helpers return Figures
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## What & why

Three rendering issues in `notebooks/fabric_results/01_input_rasters.ipynb` that surfaced once the FDR data gap (#99) was fixed:

1. **Duplicate panels** — `elevation`/`slope`/`aspect` plotted twice (once from `shared_raster_inventory`, once from `zonal_source_inventory`), and `fdr`/`template` are the same `oregon_fdr.vrt` clip plotted twice.
2. **Categorical rasters had only a colorbar**, no labelled legend — soils/LULC/FDR codes need to be readable as classes.
3. **Nodata cells rendered as blank white**, making genuine gaps (ocean, off-fabric) look like a plotting glitch.

## Changes

- **`src/gfv2_params/viz.py`**:
  - `dedupe_raster_entries(entries)` — drop entries whose resolved path repeats, first wins, order preserved. Doc'd that it collapses the shared/zonal DEM-VRT overlap and the per-fabric fdr/template duplicate.
  - `plot_raster` categorical branch now builds a discrete per-class **legend** (one `Patch` per class) when there are ≤ `max_legend=20` distinct values; falls back to a colorbar above that. So soils / LULC / FDR / `vpu_id` / depstor binaries get labelled legends; `wbody_regions` and similar large-cardinality rasters keep the colorbar.
  - `cmap.set_bad("lightgrey")` on both continuous and categorical paths so masked/nodata cells read clearly.
- **`notebooks/fabric_results/01_input_rasters.ipynb`** — wraps the shared+zonal inventory concatenation in `viz.dedupe_raster_entries(...)`.
- **`tests/test_viz.py`** — 4 new tests (dedupe order-preservation, categorical class legend, max_legend colorbar fallback, nodata-grey `set_bad`) on top of the existing 18 → **22/22 pass**.

## Verification (oregon, post-FDR-re-merge)

End-to-end smoke test on oregon (now-clean fabric):

| | before | after |
|---|---|---|
| inventory entries | 13 (3 dups) | **9** |
| fdr nodata over bbox | 24.7% (inland + ocean) | **6.3%** (ocean only) |
| fdr categorical | colorbar | **8-class legend** (D8 codes) |
| soils / lulc_nhm_v11 / lulc_nalcms | colorbar | **3 / 5 / 12-class legends** |
| twi / elevation (continuous) | colorbar | colorbar ✓ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)