### PR TITLE
feat(viz): interactive folium overlay for the depstor output-binary rasters (notebook 04)

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ For per-step debugging, invoke the orchestrator directly with
 
 ## Viewing fabric results
 
-Once a fabric is processed, the three Jupyter notebooks in
+Once a fabric is processed, the Jupyter notebooks in
 [notebooks/fabric_results/](notebooks/fabric_results/) give a complete picture of
 a fabric's parameterization — the inputs that fed it and the per-HRU results:
 
@@ -391,8 +391,9 @@ a fabric's parameterization — the inputs that fed it and the per-HRU results:
 | `01_input_rasters.ipynb` | Every shared/zonal source raster clipped to the fabric bounds, HRU outline overlaid. |
 | `02_depstor_rasters.ipynb` | The 14 per-fabric depression-storage binary/label rasters + coverage stats. |
 | `03_param_results.ipynb` | Choropleth + distribution of all 16 merged per-HRU params, plus a depstor-ratio summary. |
+| `04_depstor_overlay.ipynb` | Interactive folium map: the 7 depstor binaries that directly feed a PRMS ratio (`carea_max`, `smidx_coef`, `sro_to_dprst_perv/imperv`, `hru_percent_imperv`, `dprst_frac`), each as a toggleable color overlay on OpenStreetMap / CartoDB / Esri imagery basemaps. |
 
-All three are **parameterized by the `FABRIC` env var** (default `oregon`) and read
+All are **parameterized by the `FABRIC` env var** (default `oregon`) and read
 the active profile via `load_base_config`; they share the tested helpers in
 [src/gfv2_params/viz.py](src/gfv2_params/viz.py). Run them **inside JupyterHub on a
 compute node with enough `--mem`** — a full CONUS `gfv2` render loads ~361k HRU

--- a/notebooks/fabric_results/04_depstor_overlay.ipynb
+++ b/notebooks/fabric_results/04_depstor_overlay.ipynb
@@ -1,0 +1,159 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "58679656",
+   "metadata": {},
+   "source": [
+    "# 04 — Depstor output binaries (interactive overlay)\n",
+    "\n",
+    "Stacks the 7 depstor binary rasters that **directly feed a PRMS ratio CSV** (`carea_max`, `smidx_coef`, `sro_to_dprst_perv/imperv`, `hru_percent_imperv`, `dprst_frac`) on an interactive OpenStreetMap basemap. Each layer is toggleable via the layer control (top right); colors are baked at 55% alpha so stacks of layers stay readable.\n",
+    "\n",
+    "Excluded: `land_mask`, `wbody_regions`, `vpu_id`, and the intermediates that don't appear as a numerator or denominator of any output ratio (`stream_buffer`, `wbody_binary`, `onstream_binary`, `drains_to_dprst`).\n",
+    "\n",
+    "> **Run this in JupyterHub on a compute node with enough `--mem`.** Folium\n",
+    "> reprojects each depstor raster to EPSG:4326 once and embeds an RGBA PNG into\n",
+    "> the notebook HTML; for CONUS `gfv2` (~361k HRUs) start with a higher `--mem`\n",
+    "> session. Pick the fabric via the `FABRIC` env var (or edit the first code cell)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ee4d4cb4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import geopandas as gpd\n",
+    "\n",
+    "from gfv2_params import viz\n",
+    "from gfv2_params.config import load_base_config\n",
+    "\n",
+    "# Fabric is selected by the FABRIC env var (set it in your JupyterHub session),\n",
+    "# or edit the default here.\n",
+    "FABRIC = os.environ.get(\"FABRIC\", \"oregon\")\n",
+    "viz.FABRIC = FABRIC\n",
+    "\n",
+    "cfg = load_base_config(fabric=FABRIC)\n",
+    "DATA_ROOT = Path(cfg[\"data_root\"])\n",
+    "HRU_GPKG = Path(cfg[\"hru_gpkg\"])\n",
+    "HRU_LAYER = cfg[\"hru_layer\"]\n",
+    "ID_FEATURE = cfg[\"id_feature\"]\n",
+    "\n",
+    "print(f\"FABRIC    = {FABRIC}\")\n",
+    "print(f\"data_root = {DATA_ROOT}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "36724f33",
+   "metadata": {},
+   "source": [
+    "## Inventory: the 7 output-binary rasters + the ratio each feeds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aaf332aa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "inventory = viz.depstor_output_binary_inventory(cfg)\n",
+    "for e in inventory:\n",
+    "    print(f\"  {e.name:24} color={e.color}  feeds {e.feeds}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8fe7b4fa",
+   "metadata": {},
+   "source": [
+    "## Build the interactive map\n",
+    "\n",
+    "Centers on the fabric centroid in lat/lon; the HRU outline is added as a thin red GeoJson layer (also toggleable). Use the layer control (top right) to show/hide individual rasters and switch basemaps."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "01535551",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import folium\n",
+    "\n",
+    "# Fabric outline once -> lat/lon\n",
+    "fabric_geom = gpd.read_file(HRU_GPKG, layer=HRU_LAYER)\n",
+    "fabric_geom = fabric_geom[fabric_geom.geometry.notna() & ~fabric_geom.geometry.is_empty]\n",
+    "outline_4326 = fabric_geom.dissolve().to_crs(\"EPSG:4326\")\n",
+    "minx, miny, maxx, maxy = outline_4326.total_bounds\n",
+    "center = [(miny + maxy) / 2, (minx + maxx) / 2]\n",
+    "\n",
+    "# Basemap + reasonable starting zoom (Leaflet zoom 6 ~ multi-state)\n",
+    "m = folium.Map(location=center, zoom_start=7, tiles=\"OpenStreetMap\",\n",
+    "               control_scale=True)\n",
+    "# Extra basemaps under the layer control\n",
+    "folium.TileLayer(\"CartoDB positron\", name=\"CartoDB positron\").add_to(m)\n",
+    "folium.TileLayer(\"Esri.WorldImagery\", attr=\"Tiles \\u00a9 Esri\",\n",
+    "                 name=\"Esri imagery\").add_to(m)\n",
+    "\n",
+    "# Add each depstor overlay (each one is reprojected + decimated lazily here)\n",
+    "for entry in inventory:\n",
+    "    viz.raster_to_image_overlay(\n",
+    "        entry.path, name=f\"{entry.name}  ({entry.color})\",\n",
+    "        color=entry.color, alpha=0.55, target_px=1200,\n",
+    "    ).add_to(m)\n",
+    "\n",
+    "# HRU outline as a toggleable overlay\n",
+    "folium.GeoJson(\n",
+    "    outline_4326.__geo_interface__,\n",
+    "    name=\"HRU fabric outline\",\n",
+    "    style_function=lambda _: {\"color\": \"#000000\", \"weight\": 1.5,\n",
+    "                              \"fill\": False},\n",
+    ").add_to(m)\n",
+    "\n",
+    "folium.LayerControl(collapsed=False).add_to(m)\n",
+    "m  # render inline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3a9260bc",
+   "metadata": {},
+   "source": [
+    "### Optional: save the map to a standalone HTML file\n",
+    "\n",
+    "Useful for sharing in a report (the HTML carries the rasters embedded as\n",
+    "base64 PNGs, so it's self-contained but bigger than a PNG)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0ddc8c27",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Uncomment to save:\n",
+    "# out = DATA_ROOT.parent / f\"depstor_overlay_{FABRIC}.html\"\n",
+    "# m.save(str(out)); print(f\"wrote {out}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/gfv2_params/viz.py
+++ b/src/gfv2_params/viz.py
@@ -553,3 +553,116 @@ def save_figure(fig, name, *, dpi: int = 150) -> None:
     target = base / FABRIC if FABRIC else base
     target.mkdir(parents=True, exist_ok=True)
     fig.savefig(target / f"{name}.png", dpi=dpi, bbox_inches="tight")
+
+
+# ----------------------------------------------------------------------------- #
+# Interactive folium overlays for the depstor "output-binary" rasters
+# ----------------------------------------------------------------------------- #
+
+# Curated list of depstor binaries that directly feed a PRMS ratio CSV (i.e.
+# appear as a numerator or denominator of one of the 6 ratios in
+# configs/depstor/depstor_params.yml). Intentionally excludes intermediates
+# (stream_buffer, wbody_binary, onstream_binary, drains_to_dprst) and the
+# non-ratio rasters (land_mask, wbody_regions, vpu_id). Each entry carries a
+# distinct hex color so layers stay visually distinguishable when stacked on
+# an interactive map. Maintained alongside _DEPSTOR_RASTERS above.
+_DEPSTOR_OUTPUT_BINARIES = [
+    # (file_stem, color, what it feeds)
+    ("perv_binary",          "#2ca02c", "denominator: carea_max, smidx_coef, sro_to_dprst_perv"),
+    ("imperv_binary",        "#d62728", "hru_percent_imperv (num); sro_to_dprst_imperv (denom)"),
+    ("dprst_binary",         "#1f77b4", "dprst_frac (numerator)"),
+    ("drains_perv_binary",   "#ff7f0e", "sro_to_dprst_perv (numerator)"),
+    ("drains_imperv_binary", "#9467bd", "sro_to_dprst_imperv (numerator)"),
+    ("carea_map_t8_binary",  "#e377c2", "carea_max (numerator)"),
+    ("carea_map_t156_binary","#17becf", "smidx_coef (numerator)"),
+]
+
+
+@dataclass(frozen=True)
+class OverlayEntry:
+    name: str
+    path: Path
+    color: str          # hex like "#2ca02c"; on-cells render as this color
+    feeds: str          # human-readable description of the output param it feeds
+
+
+def depstor_output_binary_inventory(cfg) -> list[OverlayEntry]:
+    """Curated depstor binaries that directly feed a PRMS output ratio.
+
+    Filters ``_DEPSTOR_OUTPUT_BINARIES`` against on-disk paths under
+    ``{data_root}/{fabric}/depstor_rasters/``; missing files are skipped with
+    a warning (mirrors the other inventory builders). Used by the interactive
+    folium-overlay notebook.
+    """
+    base = Path(cfg["data_root"]) / cfg["fabric"] / "depstor_rasters"
+    kept: list[OverlayEntry] = []
+    for name, color, feeds in _DEPSTOR_OUTPUT_BINARIES:
+        p = base / f"{name}.tif"
+        if p.exists():
+            kept.append(OverlayEntry(name=name, path=p, color=color, feeds=feeds))
+        else:
+            warnings.warn(f"Skipping overlay '{name}': path not found: {p}")
+    return kept
+
+
+def build_overlay_image(path, *, color: str, alpha: float = 0.55,
+                        target_px: int = 1000, threshold: float = 0.5):
+    """Reproject a binary-ish raster to EPSG:4326 and build an RGBA image.
+
+    Returns ``(rgba_uint8, (west, south, east, north))`` where ``rgba_uint8``
+    is an ``(H, W, 4)`` ``uint8`` ndarray. Cells where the raster value is
+    finite, not nodata, and strictly greater than ``threshold`` render as
+    ``color`` at ``alpha``; everything else is fully transparent.
+
+    Decimated so the long side is roughly ``target_px``. No folium dep — the
+    caller wraps this into ``folium.raster_layers.ImageOverlay``; see
+    ``raster_to_image_overlay`` for the wrapped version.
+    """
+    from rasterio.vrt import WarpedVRT
+
+    r, g, b = mcolors.to_rgb(color)
+    rgba = (int(r * 255), int(g * 255), int(b * 255), int(alpha * 255))
+
+    with rasterio.open(path) as src:
+        nd = src.nodata
+        with WarpedVRT(src, crs="EPSG:4326", resampling=Resampling.nearest) as vrt:
+            factor = max(1, max(vrt.width, vrt.height) // target_px)
+            oh = max(1, vrt.height // factor)
+            ow = max(1, vrt.width // factor)
+            data = vrt.read(1, out_shape=(oh, ow),
+                            resampling=Resampling.nearest).astype("float32")
+            bounds = vrt.bounds   # (left, bottom, right, top) in lat/lon
+
+    on = np.isfinite(data)
+    if nd is not None:
+        on &= (data != nd)
+    on &= (data > threshold)
+
+    img = np.zeros((data.shape[0], data.shape[1], 4), dtype="uint8")
+    img[on] = rgba
+    return img, (bounds.left, bounds.bottom, bounds.right, bounds.top)
+
+
+def raster_to_image_overlay(path, *, name: str, color: str,
+                            alpha: float = 0.55, target_px: int = 1000,
+                            threshold: float = 0.5):
+    """Build a folium ImageOverlay ready to ``.add_to(map)`` + LayerControl.
+
+    Thin wrapper around ``build_overlay_image`` that imports ``folium``
+    lazily (folium is only in the ``notebooks`` pixi env). ``mercator_project``
+    is enabled so the EPSG:4326 image is reprojected to Web Mercator
+    client-side instead of being stretched.
+    """
+    import folium  # noqa: PLC0415 — optional notebook dep
+
+    img, (w, s, e, n) = build_overlay_image(
+        path, color=color, alpha=alpha, target_px=target_px, threshold=threshold,
+    )
+    return folium.raster_layers.ImageOverlay(
+        image=img,
+        bounds=[[s, w], [n, e]],
+        opacity=1.0,            # alpha is baked into the RGBA
+        mercator_project=True,  # client-side warp to web mercator
+        name=name,
+        interactive=False,
+    )

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -339,3 +339,71 @@ def test_save_figure_warns_without_fabric(tmp_path, monkeypatch):
     plt.close(fig)
     # un-namespaced: lands directly in the base dir, not a fabric subdir
     assert (tmp_path / "y.png").exists()
+
+
+# --------------------------------------------------------------------------- #
+# Interactive folium overlays (depstor "output-binary" rasters)
+# --------------------------------------------------------------------------- #
+
+def test_depstor_output_binary_inventory_filters_and_warns(tmp_path):
+    # Stage 2 of the 7 curated binaries; the other 5 should be skipped+warned.
+    base = tmp_path / "fab" / "depstor_rasters"
+    base.mkdir(parents=True)
+    (base / "perv_binary.tif").write_text("")
+    (base / "carea_map_t8_binary.tif").write_text("")
+    cfg = {"data_root": str(tmp_path), "fabric": "fab"}
+    with pytest.warns(UserWarning):
+        entries = viz.depstor_output_binary_inventory(cfg)
+    names = [e.name for e in entries]
+    assert names == ["perv_binary", "carea_map_t8_binary"]  # first-occurrence order
+    assert all(isinstance(e, viz.OverlayEntry) for e in entries)
+    assert all(e.color.startswith("#") for e in entries)
+    assert "carea_max" in entries[1].feeds  # human-readable provenance
+
+
+def test_build_overlay_image_reprojects_to_latlon_and_marks_on_cells(tmp_path):
+    # Synthetic binary raster in EPSG:5070 over a small Albers window. The
+    # function should reproject to EPSG:4326, return an (H,W,4) uint8 array,
+    # paint on-cells (value > threshold) in the requested color, and leave
+    # off-cells fully transparent.
+    arr = np.array([[0, 0, 1, 1], [0, 1, 1, 1]], dtype="uint8")  # 6 on-cells out of 8
+    transform = Affine(30, 0, 1_000_000.0, 0, -30, 2_000_000.0)  # arbitrary Albers
+    path = tmp_path / "binary.tif"
+    _write_tif(path, arr, nodata=255, transform=transform, crs="EPSG:5070")
+
+    rgba, bounds = viz.build_overlay_image(
+        path, color="#ff0000", alpha=0.5, target_px=8, threshold=0.5,
+    )
+    assert rgba.ndim == 3 and rgba.shape[-1] == 4
+    assert rgba.dtype == np.uint8
+
+    # On-cells: red @ 50% alpha = (255, 0, 0, 127)
+    on_mask = rgba[..., 3] > 0
+    assert on_mask.any()
+    on_rgba = rgba[on_mask]
+    assert (on_rgba[:, 0] == 255).all() and (on_rgba[:, 1] == 0).all() and (on_rgba[:, 2] == 0).all()
+    assert (on_rgba[:, 3] == 127).all()
+    # Off-cells fully transparent
+    assert (rgba[~on_mask, 3] == 0).all()
+
+    # Bounds are in lat/lon (CONUS Albers origin reprojects to roughly N hemisphere)
+    w, s, e, n = bounds
+    assert -180 <= w < e <= 180
+    assert -90 <= s < n <= 90
+
+
+def test_raster_to_image_overlay_returns_folium_overlay(tmp_path):
+    folium = pytest.importorskip("folium")  # only in notebooks env
+    arr = np.array([[0, 1], [1, 1]], dtype="uint8")
+    transform = Affine(30, 0, 1_000_000.0, 0, -30, 2_000_000.0)
+    path = tmp_path / "binary.tif"
+    _write_tif(path, arr, nodata=255, transform=transform, crs="EPSG:5070")
+
+    ov = viz.raster_to_image_overlay(path, name="perv", color="#00ff00", target_px=4)
+    assert isinstance(ov, folium.raster_layers.ImageOverlay)
+    assert ov.layer_name == "perv"
+    # bounds shape: [[south, west], [north, east]]
+    b = ov.bounds
+    assert len(b) == 2 and len(b[0]) == 2 and len(b[1]) == 2
+    assert b[0][0] < b[1][0]  # south < north
+    assert b[0][1] < b[1][1]  # west < east


### PR DESCRIPTION
## What

Adds **`notebooks/fabric_results/04_depstor_overlay.ipynb`**: stacks the 7 depstor binary rasters that **directly feed a PRMS output ratio** on an interactive OpenStreetMap basemap as toggleable color overlays (folium `LayerControl`). Excludes — per spec — `land_mask`, `wbody_regions`, `vpu_id`, and the intermediates (`stream_buffer`, `wbody_binary`, `onstream_binary`, `drains_to_dprst`) that don't appear as a numerator or denominator of any ratio in `configs/depstor/depstor_params.yml`.

| layer | color | feeds |
|---|---|---|
| `perv_binary` | green | denom: carea_max, smidx_coef, sro_to_dprst_perv |
| `imperv_binary` | red | num: hru_percent_imperv · denom: sro_to_dprst_imperv |
| `dprst_binary` | blue | num: dprst_frac |
| `drains_perv_binary` | orange | num: sro_to_dprst_perv |
| `drains_imperv_binary` | purple | num: sro_to_dprst_imperv |
| `carea_map_t8_binary` | magenta | num: carea_max |
| `carea_map_t156_binary` | cyan | num: smidx_coef |

Each layer renders at 55% alpha; nodata/off-cells are fully transparent. Basemap selectable: OpenStreetMap (default), CartoDB Positron, Esri imagery. HRU outline added as a toggleable GeoJson layer.

## Changes

- **`src/gfv2_params/viz.py`**:
  - `OverlayEntry` dataclass + `depstor_output_binary_inventory(cfg)` — the curated 7-layer list with per-layer color + ratio-provenance text. Filters against on-disk paths; skips missing with a warning.
  - `build_overlay_image(path, *, color, alpha, target_px, threshold)` — reprojects to EPSG:4326 via `WarpedVRT`, decimates, returns `(rgba_uint8, (west,south,east,north))`. **No folium dep — testable in CI.**
  - `raster_to_image_overlay(path, *, name, color, ...)` — thin wrapper returning a folium `ImageOverlay` with `mercator_project=True` (so the EPSG:4326 image is reprojected to Web Mercator client-side, no north-south stretch). Lazy folium import.
- **`notebooks/fabric_results/04_depstor_overlay.ipynb`** — new viewer; FABRIC-parameterized like 01-03.
- **`README.md`** — 4th row in the viewer table.
- **`tests/test_viz.py`** — 3 new tests (inventory filter+warn, overlay RGBA + lat/lon round-trip on synthetic EPSG:5070 raster, folium wrapper via `pytest.importorskip`) → **25/25 pass**.

## Verification

End-to-end on oregon: 7 layers in the inventory, all 7 reprojected + rendered as `ImageOverlay`s, map saved to a 1.5 MB self-contained HTML (rasters embedded as base64 PNGs). Notebook is `nbformat`-valid and all code cells compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)