### PR TITLE
feat(viz): notebook 03 now covers the 9 missing PRMS params (intcp + ssflux)

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ a fabric's parameterization — the inputs that fed it and the per-HRU results:
 |---|---|
 | `01_input_rasters.ipynb` | Every shared/zonal source raster clipped to the fabric bounds, HRU outline overlaid. |
 | `02_depstor_rasters.ipynb` | The 14 per-fabric depression-storage binary/label rasters + coverage stats. |
-| `03_param_results.ipynb` | Choropleth + distribution of all 16 merged per-HRU params, plus a depstor-ratio summary. |
+| `03_param_results.ipynb` | Choropleth + distribution of all 25 merged per-HRU params (DEM stats, soils, LULC incl. rain/snow interception, depstor ratios, ssflux), plus a depstor-ratio summary. |
 | `04_depstor_overlay.ipynb` | Interactive folium map: the 7 depstor binaries that directly feed a PRMS ratio (`carea_max`, `smidx_coef`, `sro_to_dprst_perv/imperv`, `hru_percent_imperv`, `dprst_frac`), each as a toggleable color overlay on OpenStreetMap / CartoDB / Esri imagery basemaps. |
 
 All are **parameterized by the `FABRIC` env var** (default `oregon`) and read

--- a/src/gfv2_params/viz.py
+++ b/src/gfv2_params/viz.py
@@ -506,12 +506,22 @@ _PARAM_ENTRIES = [
     ParamEntry(name="covden_win", csv_name="nhm_lulc_nhm_v11_params.csv", column="covden_win", kind="continuous", units="fraction", cmap="YlGn"),
     ParamEntry(name="retention", csv_name="nhm_lulc_nhm_v11_params.csv", column="retention", kind="continuous", units="fraction", cmap="PuBuGn"),
     ParamEntry(name="snow_intcp", csv_name="nhm_lulc_nhm_v11_params.csv", column="snow_intcp", kind="continuous", units="in", cmap="PuBu"),
+    ParamEntry(name="srain_intcp", csv_name="nhm_lulc_nhm_v11_params.csv", column="srain_intcp", kind="continuous", units="in", cmap="PuBu"),
+    ParamEntry(name="wrain_intcp", csv_name="nhm_lulc_nhm_v11_params.csv", column="wrain_intcp", kind="continuous", units="in", cmap="PuBu"),
     ParamEntry(name="carea_max", csv_name="nhm_carea_max_params.csv", column="carea_max", kind="continuous", units="fraction", cmap="magma"),
     ParamEntry(name="smidx_coef", csv_name="nhm_smidx_coef_params.csv", column="smidx_coef", kind="continuous", units="fraction", cmap="magma"),
     ParamEntry(name="sro_to_dprst_perv", csv_name="nhm_sro_to_dprst_perv_params.csv", column="sro_to_dprst_perv", kind="continuous", units="fraction", cmap="cividis"),
     ParamEntry(name="sro_to_dprst_imperv", csv_name="nhm_sro_to_dprst_imperv_params.csv", column="sro_to_dprst_imperv", kind="continuous", units="fraction", cmap="cividis"),
     ParamEntry(name="hru_percent_imperv", csv_name="nhm_hru_percent_imperv_params.csv", column="hru_percent_imperv", kind="continuous", units="fraction", cmap="OrRd"),
     ParamEntry(name="dprst_frac", csv_name="nhm_dprst_frac_params.csv", column="dprst_frac", kind="continuous", units="fraction", cmap="GnBu"),
+    # ssflux PRMS params (from the gap-filled Stage 7 CSV — PRMS-ready values).
+    ParamEntry(name="soil2gw_max", csv_name="filled_nhm_ssflux_params.csv", column="soil2gw_max", kind="continuous", units="in/day", cmap="Blues"),
+    ParamEntry(name="ssr2gw_rate", csv_name="filled_nhm_ssflux_params.csv", column="ssr2gw_rate", kind="continuous", units="1/day", cmap="BuPu"),
+    ParamEntry(name="fastcoef_lin", csv_name="filled_nhm_ssflux_params.csv", column="fastcoef_lin", kind="continuous", units="1/day", cmap="YlOrRd"),
+    ParamEntry(name="slowcoef_lin", csv_name="filled_nhm_ssflux_params.csv", column="slowcoef_lin", kind="continuous", units="1/day", cmap="YlGn"),
+    ParamEntry(name="gwflow_coef", csv_name="filled_nhm_ssflux_params.csv", column="gwflow_coef", kind="continuous", units="1/day", cmap="Purples"),
+    ParamEntry(name="dprst_seep_rate_open", csv_name="filled_nhm_ssflux_params.csv", column="dprst_seep_rate_open", kind="continuous", units="1/day", cmap="PuBu"),
+    ParamEntry(name="dprst_flow_coef", csv_name="filled_nhm_ssflux_params.csv", column="dprst_flow_coef", kind="continuous", units="1/day", cmap="GnBu"),
 ]
 
 

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -167,13 +167,20 @@ def test_load_param_left_join_preserves_all_hrus(tmp_path):
 
 def test_param_inventory_kinds():
     entries = viz.param_inventory()
-    assert len(entries) == 16
+    assert len(entries) == 25
     assert all(isinstance(e, viz.ParamEntry) for e in entries)
     by_name = {e.name: e for e in entries}
     assert by_name["soils"].kind == "categorical"
     assert by_name["cov_type"].kind == "categorical"
-    # a representative continuous one
+    # representative continuous params from each pipeline section
     assert by_name["elevation"].kind == "continuous"
+    assert by_name["srain_intcp"].csv_name == "nhm_lulc_nhm_v11_params.csv"
+    assert by_name["wrain_intcp"].csv_name == "nhm_lulc_nhm_v11_params.csv"
+    # ssflux PRMS params read from the gap-filled Stage 7 CSV
+    for n in ("soil2gw_max", "ssr2gw_rate", "fastcoef_lin", "slowcoef_lin",
+              "gwflow_coef", "dprst_seep_rate_open", "dprst_flow_coef"):
+        assert by_name[n].csv_name == "filled_nhm_ssflux_params.csv"
+        assert by_name[n].kind == "continuous"
 
 
 def test_shared_raster_inventory_skips_missing(tmp_path):


### PR DESCRIPTION
## What & why

Audit of `oregon/params/merged/` vs the curated `param_inventory()` showed **9 PRMS output params on disk that notebook 03 wasn't plotting**. Adds them so the viewer covers every param the pipeline produces.

| added | from | kind |
|---|---|---|
| `srain_intcp` | `nhm_lulc_nhm_v11_params.csv` | summer rain interception (in) |
| `wrain_intcp` | `nhm_lulc_nhm_v11_params.csv` | winter rain interception (in) |
| `soil2gw_max` | `filled_nhm_ssflux_params.csv` | soil→GW max rate (in/day) |
| `ssr2gw_rate` | `filled_nhm_ssflux_params.csv` | subsurface→GW rate (1/day) |
| `fastcoef_lin` | `filled_nhm_ssflux_params.csv` | fast interflow coef (1/day) |
| `slowcoef_lin` | `filled_nhm_ssflux_params.csv` | slow interflow coef (1/day) |
| `gwflow_coef` | `filled_nhm_ssflux_params.csv` | GW outflow coef (1/day) |
| `dprst_seep_rate_open` | `filled_nhm_ssflux_params.csv` | depstor seepage (1/day) |
| `dprst_flow_coef` | `filled_nhm_ssflux_params.csv` | depstor outflow (1/day) |

The ssflux 7 are read from **`filled_nhm_ssflux_params.csv`** (post-Stage-7 KNN gap-fill, the PRMS-ready values) per the user's choice; the un-filled CSV remains on disk if you want to swap it back.

Inventory grows **16 → 25**; the notebook needs no change (it already loops over `viz.param_inventory()`).

## Deliberately skipped (curation, not technical limits)

- **Alternate LULC sources** (`nhm_lulc_nalcms_params.csv`, NLCD/FORE-SCE if present) — NHM v1.1 is canonical; alternates are scenario inputs, not "the params."
- **ssflux diagnostic columns** (`k_perm_wtd`, `mean_slope_fraction`, `hru_area`) — derivation inputs, not PRMS params.
- **Zonal-stat siblings** of `mean` (median/std/min/max from elevation/slope/aspect CSVs) — `mean` is the PRMS param.

Easy to add later if you change your mind.

## Verification

- All 9 (csv, column) tuples resolve against on-disk `oregon` CSVs.
- `test_param_inventory_kinds` updated: asserts `len == 25` + spot-checks the new entries route to `filled_nhm_ssflux_params.csv`. **25/25 pass.**
- README 'Viewing fabric results' table updated to mention the 25 + new categories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)