### PR TITLE
fix(init_data_root): validate shapefile sidecars (closes #47)

### DIFF
--- a/scripts/init_data_root.py
+++ b/scripts/init_data_root.py
@@ -203,9 +203,17 @@ def _shapefile_companions(shp_path: Path) -> list[Path]:
     table); `.prj` (projection) is required for any CRS-aware read. All three
     must be staged alongside the `.shp` or pyogrio/fiona reads fail with a
     confusing error.
+
+    The sidecar extensions mirror the case of the input `.shp` extension so
+    the existence check works on case-sensitive filesystems regardless of
+    whether the shapefile was staged lowercase (`.shp`) or uppercase (`.SHP`).
     """
     stem = shp_path.with_suffix("")
-    return [stem.with_suffix(ext) for ext in (".shx", ".dbf", ".prj")]
+    # Mirror the case of the input extension. `.suffix` returns the original
+    # case (e.g. ".SHP" stays ".SHP"); the sidecars match that case.
+    upper = shp_path.suffix.isupper()
+    exts = (".SHX", ".DBF", ".PRJ") if upper else (".shx", ".dbf", ".prj")
+    return [stem.with_suffix(ext) for ext in exts]
 
 
 def validate_inputs(data_root: Path, fabric: str, logger) -> None:

--- a/scripts/init_data_root.py
+++ b/scripts/init_data_root.py
@@ -196,8 +196,25 @@ def init_data_root(data_root: Path, fabric: str, logger) -> None:
             logger.debug("  %s", d)
 
 
+def _shapefile_companions(shp_path: Path) -> list[Path]:
+    """Return the required ESRI sidecar paths for a shapefile.
+
+    Shapefiles cannot be opened without `.shx` (index) and `.dbf` (attribute
+    table); `.prj` (projection) is required for any CRS-aware read. All three
+    must be staged alongside the `.shp` or pyogrio/fiona reads fail with a
+    confusing error.
+    """
+    stem = shp_path.with_suffix("")
+    return [stem.with_suffix(ext) for ext in (".shx", ".dbf", ".prj")]
+
+
 def validate_inputs(data_root: Path, fabric: str, logger) -> None:
-    """Warn about missing staged inputs that cannot be auto-downloaded."""
+    """Warn about missing staged inputs that cannot be auto-downloaded.
+
+    For required `.shp` paths, also validates the `.shx` / `.dbf` / `.prj`
+    sidecars — each is reported separately so the user knows exactly what
+    to stage.
+    """
     required = [
         data_root / "input" / "soils_litho" / "TEXT_PRMS.tif",
         data_root / "input" / "soils_litho" / "AWC.tif",
@@ -208,7 +225,15 @@ def validate_inputs(data_root: Path, fabric: str, logger) -> None:
         # if missing.
         data_root / "input" / "twi" / "01a" / "twi.tif",
     ]
-    missing = [p for p in required if not p.exists()]
+    # Expand each .shp into the .shp itself + its 3 required sidecars so
+    # the user sees exactly which files are missing (not just "the shapefile").
+    to_check: list[Path] = []
+    for p in required:
+        to_check.append(p)
+        if p.suffix.lower() == ".shp":
+            to_check.extend(_shapefile_companions(p))
+
+    missing = [p for p in to_check if not p.exists()]
     if missing:
         logger.warning(
             "%d required input file(s) are not yet staged:", len(missing)

--- a/tests/test_validate_inputs.py
+++ b/tests/test_validate_inputs.py
@@ -1,0 +1,108 @@
+"""Tests for scripts/init_data_root.validate_inputs shapefile-sidecar check.
+
+Closes issue #47: validate_inputs must report `.shx`/`.dbf`/`.prj` sidecar
+files missing alongside `.shp` paths, instead of silently passing and
+letting pyogrio/fiona fail with a confusing error later.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+import sys
+from pathlib import Path
+
+
+# scripts/init_data_root.py is not a package import; load it by path.
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_INIT_DATA_ROOT_PATH = _REPO_ROOT / "scripts" / "init_data_root.py"
+_spec = importlib.util.spec_from_file_location("init_data_root", _INIT_DATA_ROOT_PATH)
+init_data_root = importlib.util.module_from_spec(_spec)
+sys.modules["init_data_root"] = init_data_root
+_spec.loader.exec_module(init_data_root)
+
+
+def _stage_all_non_shp(data_root: Path, fabric: str) -> None:
+    """Touch every required non-shapefile path so only the .shp check varies."""
+    paths = [
+        data_root / "input" / "soils_litho" / "TEXT_PRMS.tif",
+        data_root / "input" / "soils_litho" / "AWC.tif",
+        data_root / "input" / "lulc_veg" / "RootDepth.tif",
+        data_root / "input" / "depstor" / f"{fabric}_segments_wbodies.gpkg",
+        data_root / "input" / "twi" / "01a" / "twi.tif",
+    ]
+    for p in paths:
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.touch()
+
+
+def _stage_shapefile(data_root: Path, with_sidecars: tuple[str, ...]) -> Path:
+    """Touch Lithology_exp_Konly_Project.shp + the named sidecars."""
+    shp_dir = data_root / "input" / "soils_litho"
+    shp_dir.mkdir(parents=True, exist_ok=True)
+    shp = shp_dir / "Lithology_exp_Konly_Project.shp"
+    shp.touch()
+    for ext in with_sidecars:
+        (shp.with_suffix(ext)).touch()
+    return shp
+
+
+def test_all_required_present_emits_info(tmp_path, caplog):
+    """Happy path: every required file + every sidecar present → INFO 'All ... present'."""
+    _stage_all_non_shp(tmp_path, "gfv2")
+    _stage_shapefile(tmp_path, with_sidecars=(".shx", ".dbf", ".prj"))
+    caplog.set_level(logging.INFO)
+    logger = logging.getLogger("test_validate_inputs_happy")
+    init_data_root.validate_inputs(tmp_path, "gfv2", logger)
+    assert any("All required staged inputs are present" in r.message for r in caplog.records)
+    assert not any("MISSING" in r.message for r in caplog.records)
+
+
+def test_missing_sidecars_reported_individually(tmp_path, caplog):
+    """When only .shp is staged, all 3 sidecars (.shx/.dbf/.prj) must be reported."""
+    _stage_all_non_shp(tmp_path, "gfv2")
+    _stage_shapefile(tmp_path, with_sidecars=())  # bare .shp, no sidecars
+    caplog.set_level(logging.WARNING)
+    logger = logging.getLogger("test_validate_inputs_missing_sidecars")
+    init_data_root.validate_inputs(tmp_path, "gfv2", logger)
+    missing_msgs = [r.message for r in caplog.records if "MISSING" in r.message]
+    assert any(".shx" in m for m in missing_msgs), missing_msgs
+    assert any(".dbf" in m for m in missing_msgs), missing_msgs
+    assert any(".prj" in m for m in missing_msgs), missing_msgs
+    # .shp itself was staged, so it should NOT be in the missing list
+    assert not any(m.endswith(".shp") for m in missing_msgs)
+
+
+def test_missing_shp_does_not_duplicate_as_sidecars(tmp_path, caplog):
+    """When the .shp itself is missing, report it (don't also pretend sidecars are missing)."""
+    _stage_all_non_shp(tmp_path, "gfv2")
+    # Do NOT stage the shapefile at all
+    caplog.set_level(logging.WARNING)
+    logger = logging.getLogger("test_validate_inputs_missing_shp")
+    init_data_root.validate_inputs(tmp_path, "gfv2", logger)
+    missing_msgs = [r.message for r in caplog.records if "MISSING" in r.message]
+    # The .shp is reported as missing
+    assert any("Lithology_exp_Konly_Project.shp" in m for m in missing_msgs)
+    # Sidecars are also reported (they're missing too, since the .shp is missing)
+    # — this is correct + helpful: the user sees the full list of files to stage.
+    assert any(".shx" in m for m in missing_msgs)
+
+
+def test_non_shp_path_missing_still_reported(tmp_path, caplog):
+    """A non-.shp required path (e.g. TEXT_PRMS.tif) missing still triggers a warning."""
+    # Only stage some of the required files; intentionally omit TEXT_PRMS.tif
+    paths = [
+        tmp_path / "input" / "soils_litho" / "AWC.tif",
+        tmp_path / "input" / "lulc_veg" / "RootDepth.tif",
+        tmp_path / "input" / "depstor" / "gfv2_segments_wbodies.gpkg",
+        tmp_path / "input" / "twi" / "01a" / "twi.tif",
+    ]
+    for p in paths:
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.touch()
+    _stage_shapefile(tmp_path, with_sidecars=(".shx", ".dbf", ".prj"))
+    caplog.set_level(logging.WARNING)
+    logger = logging.getLogger("test_validate_inputs_missing_tif")
+    init_data_root.validate_inputs(tmp_path, "gfv2", logger)
+    missing_msgs = [r.message for r in caplog.records if "MISSING" in r.message]
+    assert any("TEXT_PRMS.tif" in m for m in missing_msgs)

--- a/tests/test_validate_inputs.py
+++ b/tests/test_validate_inputs.py
@@ -12,7 +12,6 @@ import logging
 import sys
 from pathlib import Path
 
-
 # scripts/init_data_root.py is not a package import; load it by path.
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _INIT_DATA_ROOT_PATH = _REPO_ROOT / "scripts" / "init_data_root.py"
@@ -73,19 +72,23 @@ def test_missing_sidecars_reported_individually(tmp_path, caplog):
     assert not any(m.endswith(".shp") for m in missing_msgs)
 
 
-def test_missing_shp_does_not_duplicate_as_sidecars(tmp_path, caplog):
-    """When the .shp itself is missing, report it (don't also pretend sidecars are missing)."""
+def test_missing_shp_reports_shp_and_all_sidecars(tmp_path, caplog):
+    """When the .shp itself is absent, all 4 paths (.shp + .shx/.dbf/.prj) are reported.
+
+    The user needs the full list of files to stage; reporting only the .shp
+    would leave them guessing about the sidecars they still need to provide.
+    """
     _stage_all_non_shp(tmp_path, "gfv2")
     # Do NOT stage the shapefile at all
     caplog.set_level(logging.WARNING)
     logger = logging.getLogger("test_validate_inputs_missing_shp")
     init_data_root.validate_inputs(tmp_path, "gfv2", logger)
     missing_msgs = [r.message for r in caplog.records if "MISSING" in r.message]
-    # The .shp is reported as missing
+    # All 4 of the shapefile-related paths must appear
     assert any("Lithology_exp_Konly_Project.shp" in m for m in missing_msgs)
-    # Sidecars are also reported (they're missing too, since the .shp is missing)
-    # — this is correct + helpful: the user sees the full list of files to stage.
     assert any(".shx" in m for m in missing_msgs)
+    assert any(".dbf" in m for m in missing_msgs)
+    assert any(".prj" in m for m in missing_msgs)
 
 
 def test_non_shp_path_missing_still_reported(tmp_path, caplog):


### PR DESCRIPTION
Closes #47.

## Why

`validate_inputs()` in [`scripts/init_data_root.py`](scripts/init_data_root.py) only checked that required `.shp` paths existed, not their `.shx`/`.dbf`/`.prj` sidecars. Users staging just the `.shp` got `"All required staged inputs are present"` then ran into a confusing pyogrio/fiona error later in the pipeline.

[`README.md:91`](README.md#L91) and [`slurm_batch/RUNME.md:191`](slurm_batch/RUNME.md#L191) already document the sidecar requirement — this fix brings the runtime check into compliance with what the docs promise.

## What

- New `_shapefile_companions(shp_path) -> list[Path]` helper returning the 3 sidecar paths (`.shx`, `.dbf`, `.prj`).
- `validate_inputs()` expands each required `.shp` into the `.shp` + its 3 sidecars in the `to_check` list, so each missing file is reported separately.
- Non-`.shp` paths (`.tif`, `.gpkg`) pass through unchanged — no behaviour regression for existing callers.

## Tests

New `tests/test_validate_inputs.py` with 4 tests:

1. **Happy path** — all required files + sidecars present → INFO `"All required staged inputs are present"`.
2. **Sidecars missing** — only `.shp` staged → 3 individual `MISSING` warnings (one per `.shx`/`.dbf`/`.prj`).
3. **`.shp` itself missing** — reported as missing (plus sidecars, also missing — correct + helpful).
4. **Non-`.shp` missing** — `TEXT_PRMS.tif` missing still triggers the warning (existing behaviour preserved).

`4 passed in 0.10s` locally; CI will re-run.

## Test plan

- [ ] CI green (pytest gate)
- [x] `4 passed in 0.10s` locally
- [x] Pre-commit clean (isort, ruff, eof-fixer)
- [x] Docs already correct (`README.md:91`, `RUNME.md:191` mention sidecars) — no doc updates needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)