### PR TITLE
fix(zonal_runners): gate startup heartbeat on SLURM_ARRAY_TASK_ID (#118)

### DIFF
--- a/src/gfv2_params/zonal_runners/__init__.py
+++ b/src/gfv2_params/zonal_runners/__init__.py
@@ -34,14 +34,18 @@ import time
 # Pre-import heartbeats so a future hang in the geo-library import chain
 # (rasterio/GDAL/PROJ/pyogrio init under shared-FS metadata contention,
 # observed once on VPU01 issue-#61 array run with zero stdout from one task)
-# can be localised. Printed unconditionally with flush=True so SLURM's
-# stdout/stderr line buffering doesn't swallow them.
-print(
-    f"[startup pid={os.getpid()} host={os.uname().nodename} "
-    f"task={os.environ.get('SLURM_ARRAY_TASK_ID', '-')}] "
-    f"python {sys.version.split()[0]} interpreter up, importing geo libs...",
-    flush=True,
-)
+# can be localised. Printed with flush=True so SLURM's stdout/stderr line
+# buffering doesn't swallow them. Gated on SLURM_ARRAY_TASK_ID so notebook /
+# interactive imports stay silent (a geoscientist importing run_zonal_batch
+# from Jupyter shouldn't see startup chatter and mistake it for an error).
+_in_slurm_array = os.environ.get("SLURM_ARRAY_TASK_ID") is not None
+if _in_slurm_array:
+    print(
+        f"[startup pid={os.getpid()} host={os.uname().nodename} "
+        f"task={os.environ['SLURM_ARRAY_TASK_ID']}] "
+        f"python {sys.version.split()[0]} interpreter up, importing geo libs...",
+        flush=True,
+    )
 _t_imports = time.time()
 
 import geopandas as gpd  # noqa: F401  (re-imported by submodules; cached)
@@ -51,7 +55,8 @@ import rioxarray  # noqa: F401
 from gdptools import UserTiffData, WeightGenP2P, ZonalGen  # noqa: F401
 from osgeo import gdal, osr
 
-print(f"[startup] geo-library imports complete in {time.time() - _t_imports:.1f}s", flush=True)
+if _in_slurm_array:
+    print(f"[startup] geo-library imports complete in {time.time() - _t_imports:.1f}s", flush=True)
 
 # Opt into the GDAL 4.0 default of raising Python exceptions instead of C-style
 # error codes. Silences the FutureWarning that osgeo emits when neither

--- a/tests/test_zonal_runners_startup.py
+++ b/tests/test_zonal_runners_startup.py
@@ -43,7 +43,12 @@ def test_heartbeat_silent_without_slurm():
 
 
 def test_heartbeat_fires_under_slurm():
-    """With SLURM_ARRAY_TASK_ID set, the heartbeat prints and includes the task id."""
+    """With SLURM_ARRAY_TASK_ID set, both pre- and post-import heartbeats fire.
+
+    Pins the diagnostic contract: a hang between the two prints localises
+    *where* the geo-library import died. A future regression that silences only
+    one of the two prints would defeat that, so assert on both lines.
+    """
     env = {**os.environ, "SLURM_ARRAY_TASK_ID": "42"}
     result = _run_import(env)
     assert "[startup " in result.stdout, (
@@ -51,4 +56,10 @@ def test_heartbeat_fires_under_slurm():
     )
     assert "task=42" in result.stdout, (
         f"expected task=42 in heartbeat output, got:\n{result.stdout!r}"
+    )
+    assert "interpreter up" in result.stdout, (
+        f"expected pre-import heartbeat ('interpreter up') in stdout, got:\n{result.stdout!r}"
+    )
+    assert "geo-library imports complete" in result.stdout, (
+        f"expected post-import heartbeat ('geo-library imports complete') in stdout, got:\n{result.stdout!r}"
     )

--- a/tests/test_zonal_runners_startup.py
+++ b/tests/test_zonal_runners_startup.py
@@ -1,0 +1,54 @@
+"""Tests for the startup-heartbeat gating in gfv2_params.zonal_runners.
+
+The package __init__ prints a `[startup ...]` line so a SLURM array task that
+hangs on geo-library import can be localised. Interactive imports (Jupyter,
+plain scripts) should stay silent so a geoscientist doesn't mistake the
+heartbeat for an error.
+
+Each test runs the import in a subprocess so the side-effect fires fresh (the
+print only happens at first import; re-importing in-process is a no-op).
+This also keeps the parent test-collector process geo-lib-free.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+_IMPORT_SNIPPET = "import gfv2_params.zonal_runners  # noqa: F401"
+
+
+def _run_import(env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    """Run a fresh subprocess that imports zonal_runners under the given env."""
+    return subprocess.run(
+        [sys.executable, "-c", _IMPORT_SNIPPET],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+def test_heartbeat_silent_without_slurm():
+    """Without SLURM_ARRAY_TASK_ID, importing the package prints nothing."""
+    env = {k: v for k, v in os.environ.items() if k != "SLURM_ARRAY_TASK_ID"}
+    result = _run_import(env)
+    assert "[startup" not in result.stdout, (
+        f"expected no [startup ...] line in stdout, got:\n{result.stdout!r}"
+    )
+    assert result.stdout == "", (
+        f"expected empty stdout outside SLURM, got:\n{result.stdout!r}"
+    )
+
+
+def test_heartbeat_fires_under_slurm():
+    """With SLURM_ARRAY_TASK_ID set, the heartbeat prints and includes the task id."""
+    env = {**os.environ, "SLURM_ARRAY_TASK_ID": "42"}
+    result = _run_import(env)
+    assert "[startup " in result.stdout, (
+        f"expected [startup ...] line in stdout, got:\n{result.stdout!r}"
+    )
+    assert "task=42" in result.stdout, (
+        f"expected task=42 in heartbeat output, got:\n{result.stdout!r}"
+    )


### PR DESCRIPTION
## Summary

- Gate the `[startup pid=... host=... task=...]` heartbeat in
  `src/gfv2_params/zonal_runners/__init__.py` on `SLURM_ARRAY_TASK_ID` being
  set in the environment. Notebook / interactive imports of
  `gfv2_params.zonal_runners` now stay silent — a geoscientist importing
  `run_zonal_batch` from Jupyter no longer sees startup chatter and mistakes
  it for an error.
- The GDAL/OSR `UseExceptions()` toggle stays unguarded — it's a library
  config, not a side-effect message.
- Both heartbeat prints are gated (the pre-import "interpreter up" line and
  the post-import "geo-library imports complete in Xs" line) so we don't
  emit half of a pair.

## Test plan

- [x] `pixi run -e dev pre-commit run --files src/gfv2_params/zonal_runners/__init__.py tests/test_zonal_runners_startup.py` — passes
- [x] `pixi run -e dev pytest tests/test_zonal_runners_startup.py -v` — 2 passed in ~40s (subprocess geo-import dominates; the gate logic itself is fast)
- [ ] CI runs full `pytest tests/` on push

`tests/test_zonal_runners_startup.py` covers:
1. `test_heartbeat_silent_without_slurm` — subprocess with `SLURM_ARRAY_TASK_ID` removed; stdout must be empty (no `[startup ...]`).
2. `test_heartbeat_fires_under_slurm` — subprocess with `SLURM_ARRAY_TASK_ID=42`; stdout must contain `[startup ` and `task=42`.

Each test runs the import in a subprocess so the side-effect fires fresh
(re-importing in-process is a no-op) and keeps the parent test-collector
process geo-lib-free.

Closes #118