### PR TITLE
docs(comment): document ctx.paths key inventory next to STEP_ORDER (#119)

### DIFF
--- a/src/gfv2_params/depstor_builders/__init__.py
+++ b/src/gfv2_params/depstor_builders/__init__.py
@@ -31,6 +31,27 @@ BUILDERS = {
     "carea_map":     carea_map.build,
 }
 
+# Outputs registered into ctx.paths by each builder (consumable downstream via
+# `ctx.require(<key>)`). Each builder's `build()` returns a dict that the
+# orchestrator merges into ctx.paths after the step runs (see
+# scripts/build_depstor_rasters.py). Keys are stable string handles — change
+# them only with a coordinated update of every downstream consumer.
+#
+#   step              -> registered key(s)        on-disk artifact (default name)
+#   landmask          -> "landmask"               land_mask.tif (uint8, 1=land)
+#   imperv            -> "imperv"                 imperv_binary.tif
+#   streambuffer      -> "stream_buffer"          stream_buffer.tif
+#   waterbody         -> "wbody_binary",          wbody_binary.tif,
+#                        "wbody_regions"          wbody_regions.tif
+#   dprst             -> "dprst",                 dprst_binary.tif,
+#                        "onstream"               onstream_binary.tif
+#   perv              -> "perv"                   perv_binary.tif
+#   routing           -> "drains_to_dprst"        drains_to_dprst.tif (WBT watershed)
+#   drains_perv       -> "drains_perv"            drains_perv_binary.tif (output_key from config)
+#   drains_imperv     -> "drains_imperv"          drains_imperv_binary.tif (output_key from config)
+#   vpu_id            -> "vpu_id"                 vpu_id.tif (per-cell VPU code, multi-VPU only)
+#   carea_map         -> "carea_max",             carea_max_*.tif,
+#                        "smidx"                  smidx_*.tif
 STEP_ORDER = [
     "landmask",
     "imperv",

--- a/src/gfv2_params/shared_rasters/__init__.py
+++ b/src/gfv2_params/shared_rasters/__init__.py
@@ -48,6 +48,31 @@ BUILDERS: dict = {
     "build_lulc_rasters":      build_lulc_rasters.build,
 }
 
+# What each step produces (consumable downstream via `ctx.require(<key>)` for
+# CONUS-scale outputs, or by re-templating off conventional per-VPU patterns).
+# Each builder's `build()` returns a dict that the orchestrator merges into
+# ctx.paths after the step runs (see scripts/build_shared_rasters.py).
+# Per-VPU steps return {} on purpose — their outputs are discovered by
+# globbing ctx.per_vpu_dir, not by key lookup.
+#
+#   step                     -> registered key(s)              on-disk artifact
+#   merge_rpu_by_vpu         -> (none; per-VPU)                shared/per_vpu/{vpu}/NEDSnapshot_merged_*.tif, Fdr_merged_*.tif, Twi_merged_*.tif
+#   compute_slope_aspect     -> (none; per-VPU)                shared/per_vpu/{vpu}/NEDSnapshot_merged_{fixed,slope,aspect}_*.tif
+#   build_border_dem         -> "border_elevation",            shared/conus/borders/border_elevation.tif
+#                               "border_slope",                shared/conus/borders/border_slope.tif
+#                               "border_aspect"                shared/conus/borders/border_aspect.tif
+#   build_vpu_landmask       -> (none; per-VPU)                shared/per_vpu/{vpu}/land_mask_{vpu}.tif
+#   compute_dem_derivatives  -> (none; per-VPU, optional)      shared/per_vpu/{vpu}/Twi_hydrodem_*.tif (open-source TWI)
+#   merge_rpu_by_vpu_twi     -> (none; per-VPU)                shared/per_vpu/{vpu}/Twi_*_{vpu}.tif (post-landmask invocation)
+#   build_vrt                -> "elevation_vrt", "slope_vrt",  shared/conus/vrt/{elevation,slope,aspect,fdr,twi,twi_hydrodem}.vrt
+#                               "aspect_vrt", "fdr_vrt",
+#                               "twi_vrt", "twi_hydrodem_vrt"
+#   twi_reference            -> "twi_reference_arcpy",         shared/conus/twi_reference_percentiles.arcpy.csv
+#                               "twi_reference_hydrodem"       shared/conus/twi_reference_percentiles.hydrodem.csv
+#   build_derived_rasters    -> "soil_moist_max"               shared/conus/derived/soil_moist_max.tif
+#   build_lulc_rasters       -> "cnpy_resampled_<source>",     shared/conus/derived/cnpy_resampled_<source>.tif,
+#                               "keep_resampled_<source>",     keep_resampled_<source>.tif,
+#                               "radtrn_<source>"              radtrn_<source>.tif (one set per LULC source)
 STEP_ORDER: list[str] = [
     "merge_rpu_by_vpu",
     "compute_slope_aspect",


### PR DESCRIPTION
## Summary

- Add a key-inventory comment block next to `STEP_ORDER` in `src/gfv2_params/depstor_builders/__init__.py` and `src/gfv2_params/shared_rasters/__init__.py`.
- For each step, lists the registered `ctx.paths` key(s) and the on-disk artifact name a builder author needs to know about. Verified against each module's actual `build()` return dict — not the issue body's sketch.
- Shared-raster per-VPU steps (`merge_rpu_by_vpu`, `compute_slope_aspect`, `build_vpu_landmask`, `compute_dem_derivatives`, `merge_rpu_by_vpu_twi`) are noted as registering nothing — they produce files discovered by globbing `ctx.per_vpu_dir`, matching their existing module docstrings.

Closes #119

## Test plan

- [x] `pixi run -e dev pre-commit run --files <changed files>` — passed
- [x] `py_compile` on both edited files — passed
- [ ] CI (`pytest`) passes on the PR

Geoscientist-readability follow-up #5 of 6 from the 2026-05-26 audit.

Generated with [Claude Code](https://claude.com/claude-code)