### PR TITLE
docs(comment): document the 5 origins of config dict in _build_param_cfg (#117)

### DIFF
--- a/scripts/derive_depstor_params.py
+++ b/scripts/derive_depstor_params.py
@@ -62,6 +62,24 @@ def _resolve_nested(value, replacements: dict):
 
 
 def _load_resolved_config(args) -> dict:
+    """Load + resolve the depstor config dict that every `run_*` mode reads.
+
+    Sources merged into the returned dict (later wins on conflict):
+      1. yaml at `args.config` — the depstor_params.yml top-level keys
+         (`defaults`, `fractions`, `ratios`, ...).
+      2. base_config.yml fabric profile — merged in by `load_config(...)`;
+         contributes `data_root`, `fabric`, `id_feature`, `hru_gpkg`,
+         `expected_max_hru_id`, etc. at the top level of `raw`.
+      3. `_resolve_nested` — expands `{data_root}`/`{fabric}`/`{vpu}` placeholders
+         in every string value (nested too) up front, so downstream code never
+         sees a `{...}` token.
+      4. `config["defaults"]["id_feature"]` — injected from the fabric profile,
+         because `defaults` is the dict every depstor `run_*` function actually
+         reads keys off (mirrors the zonal-side `_build_param_cfg` injection).
+
+    Unlike the zonal side, depstor does not flatten `defaults` + the per-fraction
+    `spec` into a single dict — each `run_*` function reads them separately.
+    """
     raw = load_config(
         Path(args.config),
         base_config_path=Path(args.base_config) if args.base_config else None,

--- a/scripts/derive_zonal_params.py
+++ b/scripts/derive_zonal_params.py
@@ -81,6 +81,23 @@ def _build_param_cfg(config: dict, entry: dict) -> dict:
     `source_type` is set from `entry["name"]` so per-batch CSV subdirs +
     file prefixes namespace cleanly when multiple LULC sources run in
     parallel.
+
+    Sources merged into the returned flat dict (later wins on conflict):
+      1. config["defaults"] — common settings from configs/zonal/zonal_params.yml
+         (batch_size, output_dir, batch_dir, ...).
+      2. entry — the per-param block from yaml `params:` (one of the dicts
+         returned by `_find_param`, e.g. the `elevation:` entry).
+      3. {"source_type": entry["name"]} — injected so runners namespace per-batch
+         CSV subdirs + file prefixes by param name.
+      4. config["fabric"] — active fabric name (from base_config.yml profile via
+         `_load_resolved_config`).
+      5. base_config.yml fabric profile fields: `expected_max_hru_id` (optional),
+         `id_feature` and `hru_gpkg` (required via `require_config_key`),
+         `hru_layer` (defaults to "nhru").
+
+    Note: `{data_root}`/`{fabric}`/`{vpu}` placeholder expansion happens
+    upstream in `_load_resolved_config` (via `_resolve_nested`), so values
+    arrive here already-resolved.
     """
     defaults = config.get("defaults", {})
     param_cfg = {**defaults, **entry}


### PR DESCRIPTION
Closes #117.

## Summary

From the 2026-05-26 geoscientist-readability audit (PR #114, HIGH #3):
`_build_param_cfg` flattens several sources into one config dict with no schema.
A new-param author won't discover that `id_feature` / `hru_gpkg` are injected
by the orchestrator until they hit a `KeyError` mid-batch. This PR adds
explicit "Sources merged" docstrings.

- `scripts/derive_zonal_params.py::_build_param_cfg` — 5-source merge order
  (defaults, per-param entry, injected `source_type`, fabric name, fabric
  profile fields). Notes that `{data_root}`/`{fabric}`/`{vpu}` placeholder
  expansion happens upstream in `_load_resolved_config`, so values arrive
  here already-resolved.
- `scripts/derive_depstor_params.py::_load_resolved_config` — mirror docstring
  on the depstor side (the analogous flattening is the `id_feature` injection
  into `config["defaults"]`; depstor doesn't have a `_build_param_cfg`-style
  full-flatten — each `run_*` reads `defaults` + `spec` separately, which the
  docstring now calls out).

Note: I expanded the zonal docstring from the 5 sources listed in the issue
body to reflect what the code actually does — `source_type` is an explicit
injection (item 3), and placeholder resolution happens upstream rather than
inside `_build_param_cfg` (so it's a Note, not an item).

## Test plan

- [x] `python -m py_compile` on both changed files
- [x] `pixi run -e dev pre-commit run --files scripts/derive_zonal_params.py` — passes
- [ ] CI green on push

Out-of-scope finding: `scripts/derive_depstor_params.py` has 4 pre-existing
E402 (module-level import not at top of file) ruff errors at lines 37/39/40/41,
caused by the intentional heartbeat `print(...)` between imports. Not from
this PR — visible on `main`. Worth a separate `# noqa: E402` or
`per-file-ignores` follow-up.