### PR TITLE
docs(slurm): split RUNME into a runbook + HPC reference; add SLURM wrappers (#131)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ Part 2 split, the **orchestrator + builder + unified-config pattern** for the
 4 pipeline stages, fabric profiles as the single source of truth (with the
 per-key required-field table), and how to add a new pipeline step.
 
-`slurm_batch/RUNME.md` is the authoritative step-by-step HPC workflow;
+`slurm_batch/RUNME.md` is the step-by-step runbook (the CONUS-gfv2 happy path); `slurm_batch/HPC_REFERENCE.md` holds the per-stage detail, alternate paths, and recovery;
 `README.md` covers user-facing setup and usage.
 
 ## Non-obvious conventions & gotchas
@@ -93,7 +93,7 @@ These are hard-won; violating them silently corrupts outputs.
 ## Working in this repo
 
 - **Every code change needs a docs check.** Audit `docs/`, `README.md`, and
-  `slurm_batch/RUNME.md`; update them on the same branch and surface findings
+  `slurm_batch/RUNME.md` (and `HPC_REFERENCE.md`); update them on the same branch and surface findings
   before merge.
 - **Atomic commits.** Split combined fixes into separate commits before pushing.
   If source changes exceed the original plan, lead the PR description with a

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ The following externally-provided files must be placed in the scaffolded directo
 
 ### 3. Run fabric-independent tasks
 
-These stages do not require a watershed fabric and can run while fabric preparation proceeds in parallel. This includes downloading and merging NHD rasters, building VRTs, and computing derived rasters. See `slurm_batch/HPC_REFERENCE.md` **Part 1** for the full sequence.
+These stages do not require a watershed fabric and can run while fabric preparation proceeds in parallel. This includes downloading and merging NHD rasters, building VRTs, and computing derived rasters. See `slurm_batch/HPC_REFERENCE.md` **Part 1 stage detail** for the full sequence.
 
 **Download NHDPlus RPU rasters** from S3 (~112 GB):
 
@@ -176,7 +176,7 @@ ways to run Part 2 (they produce identical outputs):
   ```
 
 See [Zonal-pass parameter pipeline](#zonal-pass-parameter-pipeline) below
-for the design notes, and `slurm_batch/HPC_REFERENCE.md` **Part 2 / Stage 4** for the
+for the design notes, and `slurm_batch/HPC_REFERENCE.md` **Stage 4A/4B** for the
 full sequence (both paths) including the depstor pipeline and gap-fill.
 
 ### Single-batch run (debugging one param + batch)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ pixi run -e dev pytest tests/test_wbt.py -v           # example: run a small tes
 Install pixi once per user (see https://pixi.sh/latest/installation/) and ensure
 `~/.pixi/bin` is on your `PATH`. For the full HPC workflow (downloads → shared
 rasters → fabric → zonal + depstor params), see
-[`slurm_batch/RUNME.md`](slurm_batch/RUNME.md).
+[`slurm_batch/RUNME.md`](slurm_batch/RUNME.md) (runbook) and
+[`slurm_batch/HPC_REFERENCE.md`](slurm_batch/HPC_REFERENCE.md) (per-stage detail).
 
 <details>
 <summary>Why <code>pixi run --as-is</code> and other SLURM gotchas</summary>
@@ -63,7 +64,7 @@ gfv2-params/
 │   └── download/             # Data download utilities
 ├── scripts/                  # CLI orchestrators + standalone helpers
 ├── configs/                  # Per-stage YAML configs (base + shared_rasters/ + depstor/ + zonal/)
-├── slurm_batch/              # HPC SLURM batch scripts (RUNME.md is the workflow walkthrough)
+├── slurm_batch/              # HPC SLURM batch scripts (RUNME.md = runbook; HPC_REFERENCE.md = detail)
 ├── docs/                     # ARCHITECTURE.md, depstor docs, superpowers/ design tree
 ├── notebooks/                # Interactive notebooks (fabric_results/, oregon/, _archive/)
 ├── tests/                    # Unit tests
@@ -116,7 +117,7 @@ The following externally-provided files must be placed in the scaffolded directo
 
 ### 3. Run fabric-independent tasks
 
-These stages do not require a watershed fabric and can run while fabric preparation proceeds in parallel. This includes downloading and merging NHD rasters, building VRTs, and computing derived rasters. See `slurm_batch/RUNME.md` **Part 1** for the full sequence.
+These stages do not require a watershed fabric and can run while fabric preparation proceeds in parallel. This includes downloading and merging NHD rasters, building VRTs, and computing derived rasters. See `slurm_batch/HPC_REFERENCE.md` **Part 1** for the full sequence.
 
 **Download NHDPlus RPU rasters** from S3 (~112 GB):
 
@@ -163,7 +164,7 @@ ways to run Part 2 (they produce identical outputs):
 
 - **Run by parameter** — submit each param/fraction as a small array + merge
   unit, in sequence, so you can follow the workflow and inspect one parameter
-  at a time. See `slurm_batch/RUNME.md` **Stage 4A** for the per-parameter
+  at a time. See `slurm_batch/HPC_REFERENCE.md` **Stage 4A** for the per-parameter
   commands and order.
 - **Run wholesale** — one command per stage; each wrapper just loops the
   by-parameter steps and chains them via `afterok`:
@@ -175,7 +176,7 @@ ways to run Part 2 (they produce identical outputs):
   ```
 
 See [Zonal-pass parameter pipeline](#zonal-pass-parameter-pipeline) below
-for the design notes, and `slurm_batch/RUNME.md` **Part 2 / Stage 4** for the
+for the design notes, and `slurm_batch/HPC_REFERENCE.md` **Part 2 / Stage 4** for the
 full sequence (both paths) including the depstor pipeline and gap-fill.
 
 ### Single-batch run (debugging one param + batch)
@@ -213,7 +214,7 @@ via (highest precedence first):
    For non-VPU-01 fabrics with depstor, use `threshold_mode: percentile` in
    `configs/depstor/depstor_rasters.yml` with `twi_raster` pointing at
    `twi_hydrodem.vrt`, and run the `twi_reference` step first (Stage 2a' in
-   `slurm_batch/RUNME.md`).
+   `slurm_batch/HPC_REFERENCE.md`).
 2. Place the fabric gpkg at the `hru_gpkg` path you set, under
    `{data_root}/oregon/fabric/` (NOT in `input/fabric/`)
 3. Run `prepare_fabric.py --fabric oregon` (reads `hru_gpkg` from the profile —
@@ -238,7 +239,7 @@ via (highest precedence first):
 2. Merge with `pixi run -e notebooks marimo run notebooks/merge_vpu_targets.py`, then run
    `prepare_fabric.py` and all stages with `--fabric <name>` (or `FABRIC=<name>`).
 
-See `slurm_batch/RUNME.md` for the full step-by-step workflow.
+See `slurm_batch/RUNME.md` for the runbook; `slurm_batch/HPC_REFERENCE.md` for per-stage detail.
 
 ## Shared rasters pipeline
 
@@ -276,7 +277,7 @@ unified configs:
 
 See [`docs/depstor_workflow.md`](docs/depstor_workflow.md) and
 [`docs/depstor_port_summary.md`](docs/depstor_port_summary.md) for the
-historical port reference. Stage 2d in `slurm_batch/RUNME.md` lists the
+historical port reference. Stage 2d in `slurm_batch/HPC_REFERENCE.md` lists the
 build order.
 
 ## Zonal-pass parameter pipeline

--- a/docs/ADDING_A_PARAMETER.md
+++ b/docs/ADDING_A_PARAMETER.md
@@ -236,7 +236,7 @@ For `elevation` that is
 - [`docs/ARCHITECTURE.md`](ARCHITECTURE.md) — the high-level
   orchestrator + builder + unified-config pattern this walkthrough
   illustrates, plus the "How to add a new pipeline step" recipe.
-- [`slurm_batch/RUNME.md`](../slurm_batch/RUNME.md) — Stage 4A walks the
+- [`slurm_batch/HPC_REFERENCE.md`](../slurm_batch/HPC_REFERENCE.md) — Stage 4A walks the
   per-parameter submit + inspect path manually.
 - Issue history: [#115](https://github.com/rmcd-mscb/gfv2-params/issues/115)
   — request for this walkthrough, from the 2026-05-26

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -212,6 +212,7 @@ dict at each step.
 
 - [`README.md`](../README.md) — user-facing setup + usage
 - [`CLAUDE.md`](../CLAUDE.md) — project rules for Claude (atomic commits, doc audit, etc.)
-- [`slurm_batch/RUNME.md`](../slurm_batch/RUNME.md) — authoritative HPC workflow walkthrough
+- [`slurm_batch/RUNME.md`](../slurm_batch/RUNME.md) — the step-by-step runbook (CONUS-gfv2 happy path)
+- [`slurm_batch/HPC_REFERENCE.md`](../slurm_batch/HPC_REFERENCE.md) — per-stage detail, alternate paths, recovery, script→config map
 - [`docs/superpowers/INDEX.md`](superpowers/INDEX.md) — index of design specs, implementation plans, and reviews
 - [`docs/depstor_workflow.md`](depstor_workflow.md), [`docs/depstor_port_summary.md`](depstor_port_summary.md), [`docs/depstor_vpu01_validation_results.md`](depstor_vpu01_validation_results.md) — depstor pipeline reference (historical and current)

--- a/docs/depstor_workflow.md
+++ b/docs/depstor_workflow.md
@@ -119,7 +119,7 @@ consumes this per-VPU mask via
 `Twi_merged_<vpu>.tif` and `Twi_hydrodem_<vpu>.tif` to the per-VPU HRU
 boundary. Without it, per-RPU TWI bulges (coastal ocean, adjacent-VPU
 drape on per-RPU Hydrodem tiles) leak into downstream zonal aggregation.
-Runs as **RUNME Stage 1c1**, before the TWI merge.
+Runs as **Stage 1c1** (see `slurm_batch/HPC_REFERENCE.md`), before the TWI merge.
 
 ---
 

--- a/docs/hpc-workflow.md
+++ b/docs/hpc-workflow.md
@@ -1,9 +1,16 @@
 # HPC workflow
 
-The content below is rendered from [`slurm_batch/RUNME.md`](https://github.com/rmcd-mscb/gfv2-params/blob/main/slurm_batch/RUNME.md);
-the canonical source stays alongside the SLURM batch scripts.
+The content below is rendered from [`slurm_batch/RUNME.md`](https://github.com/rmcd-mscb/gfv2-params/blob/main/slurm_batch/RUNME.md) (the CONUS-gfv2 happy-path runbook) and [`slurm_batch/HPC_REFERENCE.md`](https://github.com/rmcd-mscb/gfv2-params/blob/main/slurm_batch/HPC_REFERENCE.md) (per-stage detail, alternate paths, recovery);
+the canonical sources stay alongside the SLURM batch scripts.
 
 {%
   include-markdown "../slurm_batch/RUNME.md"
+  heading-offset=1
+%}
+
+## Reference
+
+{%
+  include-markdown "../slurm_batch/HPC_REFERENCE.md"
   heading-offset=1
 %}

--- a/docs/superpowers/plans/2026-05-29-runme-split-slurm-coverage.md
+++ b/docs/superpowers/plans/2026-05-29-runme-split-slurm-coverage.md
@@ -1,0 +1,559 @@
+# RUNME runbook/reference split + SLURM coverage Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Split `slurm_batch/RUNME.md` into a lean hydrologist runbook + a co-located HPC reference, and add SLURM wrappers for the compute/memory-intensive steps currently run on the login node.
+
+**Architecture:** Four new `.batch` wrappers around existing scripts (no script edits); a new `slurm_batch/HPC_REFERENCE.md` that retains the detailed stage taxonomy and relocated (trimmed) rationale; a rewritten `RUNME.md` that is a single linear CONUS-gfv2 command sequence; and cross-reference updates in the live docs that point at RUNME.
+
+**Tech Stack:** Bash/SLURM batch scripts, Markdown, pixi. No Python changes. Verification is `bash -n`, `sbatch --test-only`, `--help` arg checks, and `grep` audits — there are no unit tests for batch/doc files.
+
+**Spec:** [`docs/superpowers/specs/2026-05-29-runme-split-and-slurm-coverage-design.md`](../specs/2026-05-29-runme-split-and-slurm-coverage-design.md) (issue #131)
+
+## File structure
+
+- Create: `slurm_batch/prepare_fabric.batch`, `slurm_batch/merge_and_fill_params.batch`, `slurm_batch/merge_vpu_segments.batch`, `slurm_batch/render_figures.batch`
+- Create: `slurm_batch/HPC_REFERENCE.md`
+- Rewrite: `slurm_batch/RUNME.md`
+- Modify (cross-refs): `CLAUDE.md`, `README.md`, `docs/ARCHITECTURE.md`, `docs/depstor_workflow.md`, `docs/ADDING_A_PARAMETER.md`, `docs/hpc-workflow.md`
+- Leave untouched (archival point-in-time records): everything under `docs/superpowers/specs/` and `docs/superpowers/plans/`.
+
+---
+
+## Task 1: Add the four SLURM wrappers
+
+**Files:**
+- Create: `slurm_batch/prepare_fabric.batch`
+- Create: `slurm_batch/merge_and_fill_params.batch`
+- Create: `slurm_batch/merge_vpu_segments.batch`
+- Create: `slurm_batch/render_figures.batch`
+
+These wrap existing scripts unchanged, mirroring the convention in
+`slurm_batch/build_depstor_rasters.batch` (`cd "$SLURM_SUBMIT_DIR"`,
+`BASE_CONFIG`/`FABRIC` env defaults, `pixi run --as-is`, forward `"$@"`).
+
+- [ ] **Step 1: Create `slurm_batch/prepare_fabric.batch`**
+
+```bash
+#!/bin/bash
+#SBATCH -p cpu
+#SBATCH -A impd
+#SBATCH --job-name=prepare_fabric
+#SBATCH --output=logs/job_%j.out
+#SBATCH --error=logs/job_%j.err
+#SBATCH --time=02:00:00
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=64G
+#
+# Spatially batch a merged fabric into per-batch geopackages (KD-tree recursive
+# bisection) + a manifest. Loads the whole CONUS fabric into memory, so it runs
+# as a SLURM job rather than on the login node. Override FABRIC for other
+# fabrics:  FABRIC=oregon sbatch slurm_batch/prepare_fabric.batch
+# --mem/--time are starting points; right-size from `sacct -j <id> -o MaxRSS`.
+cd "$SLURM_SUBMIT_DIR"
+BASE_CONFIG=${BASE_CONFIG:-configs/base_config.yml}
+FABRIC=${FABRIC:-gfv2}
+
+pixi run --as-is python scripts/prepare_fabric.py \
+    --fabric "$FABRIC" \
+    --base_config "$BASE_CONFIG" \
+    "$@"
+```
+
+- [ ] **Step 2: Create `slurm_batch/merge_and_fill_params.batch`**
+
+```bash
+#!/bin/bash
+#SBATCH -p cpu
+#SBATCH -A impd
+#SBATCH --job-name=merge_and_fill_params
+#SBATCH --output=logs/job_%j.out
+#SBATCH --error=logs/job_%j.err
+#SBATCH --time=02:00:00
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=64G
+#
+# KNN gap-fill of missing parameter values against the fabric (Stage 7). Fits
+# sklearn NearestNeighbors over every HRU and fills all param columns, so it
+# runs as a SLURM job rather than on the login node. The fabric is read from
+# base_config's default_fabric (the script takes no --fabric).
+# --mem/--time are starting points; right-size from `sacct -j <id> -o MaxRSS`.
+cd "$SLURM_SUBMIT_DIR"
+BASE_CONFIG=${BASE_CONFIG:-configs/base_config.yml}
+
+pixi run --as-is python scripts/merge_and_fill_params.py \
+    --base_config "$BASE_CONFIG" \
+    "$@"
+```
+
+- [ ] **Step 3: Create `slurm_batch/merge_vpu_segments.batch`**
+
+```bash
+#!/bin/bash
+#SBATCH -p cpu
+#SBATCH -A impd
+#SBATCH --job-name=merge_vpu_segments
+#SBATCH --output=logs/job_%j.out
+#SBATCH --error=logs/job_%j.err
+#SBATCH --time=01:00:00
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=32G
+#
+# Merge the per-VPU `nsegment` layers into one CONUS stream-segments gpkg for the
+# depstor `streambuffer` step (VPU-based fabrics only). Concatenates 21 VPU
+# geometry layers in memory, so it runs as a SLURM job rather than on the login
+# node.  FABRIC=gfv2 sbatch slurm_batch/merge_vpu_segments.batch
+cd "$SLURM_SUBMIT_DIR"
+BASE_CONFIG=${BASE_CONFIG:-configs/base_config.yml}
+FABRIC=${FABRIC:-gfv2}
+
+pixi run --as-is python scripts/merge_vpu_segments.py \
+    --fabric "$FABRIC" \
+    --base_config "$BASE_CONFIG" \
+    "$@"
+```
+
+- [ ] **Step 4: Create `slurm_batch/render_figures.batch`**
+
+```bash
+#!/bin/bash
+#SBATCH -p cpu
+#SBATCH -A impd
+#SBATCH --job-name=render_figures
+#SBATCH --output=logs/job_%j.out
+#SBATCH --error=logs/job_%j.err
+#SBATCH --time=02:00:00
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=96G
+#
+# Headlessly (re)generate the fabric_results figures (nbconvert --execute). Loads
+# the full HRU fabric (~361k polygons for CONUS gfv2), so it runs as a SLURM job
+# rather than on the login node. Uses the `notebooks` pixi env (jupyter/nbconvert);
+# the script already forces MPLBACKEND=Agg.
+#   FABRIC=oregon sbatch slurm_batch/render_figures.batch
+# --mem/--time are starting points; right-size from `sacct -j <id> -o MaxRSS`.
+cd "$SLURM_SUBMIT_DIR"
+FABRIC=${FABRIC:-gfv2}
+
+pixi run --as-is -e notebooks python scripts/render_figures.py \
+    --fabric "$FABRIC" \
+    "$@"
+```
+
+- [ ] **Step 5: Syntax-check all four batch files**
+
+Run:
+```bash
+for f in prepare_fabric merge_and_fill_params merge_vpu_segments render_figures; do
+  bash -n slurm_batch/$f.batch && echo "$f: syntax OK"
+done
+```
+Expected: four `… syntax OK` lines, no errors.
+
+- [ ] **Step 6: Verify each wrapped script accepts the flags the batch passes**
+
+Run (argparse `--help` exits 0 and lists the flags; quick, login-safe single imports):
+```bash
+pixi run --as-is python scripts/prepare_fabric.py --help | grep -E -- "--fabric|--base_config"
+pixi run --as-is python scripts/merge_and_fill_params.py --help | grep -E -- "--base_config"
+pixi run --as-is python scripts/merge_vpu_segments.py --help | grep -E -- "--fabric|--base_config"
+pixi run --as-is -e notebooks python scripts/render_figures.py --help | grep -E -- "--fabric"
+```
+Expected: each `grep` prints the matching option line(s). If `merge_and_fill_params.py` shows a `--fabric` you did not expect, leave the batch as-is (it correctly passes only `--base_config`).
+
+- [ ] **Step 7: Validate the SBATCH directives without running**
+
+Run:
+```bash
+for f in prepare_fabric merge_and_fill_params merge_vpu_segments render_figures; do
+  sbatch --test-only slurm_batch/$f.batch 2>&1 | sed "s/^/$f: /"
+done
+```
+Expected: each prints a `sbatch: Job N to start at …` line (directives parse; nothing is submitted).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add slurm_batch/prepare_fabric.batch slurm_batch/merge_and_fill_params.batch \
+        slurm_batch/merge_vpu_segments.batch slurm_batch/render_figures.batch
+git commit -m "feat(slurm): wrappers for prepare_fabric, gap-fill, segment-merge, render (#131)
+
+Add batch wrappers so the compute/memory-intensive steps RUNME previously
+told users to run on the login node now go through SLURM:
+prepare_fabric (CONUS fabric + KD-tree), merge_and_fill_params (KNN gap-fill),
+merge_vpu_segments (CONUS geometry concat), render_figures (notebooks env).
+Wrappers only; the scripts are unchanged.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Write `slurm_batch/HPC_REFERENCE.md`
+
+**Files:**
+- Create: `slurm_batch/HPC_REFERENCE.md`
+
+The reference is the new home for everything the runbook will not carry. It
+**retains the detailed stage taxonomy** (Stage 0, 1, 1b, 1c1, 1c2, 2a, 2a',
+2b, 2c, 2d, 3, 4A, 4B, 5–9) so existing "RUNME Stage N" references in other
+docs resolve here after Task 4 repoints them. Rationale is trimmed to brief
+notes; PR/issue numbers are dropped (git history records them).
+
+- [ ] **Step 1: Write the reference document**
+
+Create `slurm_batch/HPC_REFERENCE.md` with these top-level sections, populated by
+**relocating and trimming** the corresponding content from the current
+`RUNME.md` (use `git show HEAD:slurm_batch/RUNME.md` to read the pre-rewrite
+source while writing this — do Task 2 before Task 3 so the source is intact):
+
+1. **Title + intro** — "Reference detail for the GFv2 HPC pipeline. The
+   step-by-step happy path is in [RUNME.md](RUNME.md); this file holds the
+   environment internals, per-stage detail, alternate execution paths,
+   per-fabric instructions, recovery, and the script→config map."
+2. **Environment internals** — from current RUNME §Prerequisites: the
+   `pixi run --as-is` (= `--no-install --frozen`) rationale and the
+   `~/.pixi/bin`-on-PATH-at-submit requirement, trimmed to ~4 sentences; the
+   `pixi shell -e …` interactive envs; the `geoenv` deprecation note.
+3. **Array concurrency throttle** — from current RUNME §Selecting a fabric: the
+   `SUBMIT_JOBS_MAX_CONCURRENT` / 5th-positional cap, why it exists (shared-FS
+   geo-import contention), one paragraph.
+4. **Data directory layout** — the full tree from current RUNME §Data Directory
+   Layout, plus the `migrate_to_shared_layout.py` legacy-upgrade note.
+5. **Selecting / running other fabrics** — `--fabric` / `FABRIC` / `default_fabric`
+   precedence; `gfv2_vpu01` and `oregon` resource overrides.
+6. **Part 1 stage detail** — the per-stage narrative for Stages 0, 1, 1b, 1c1,
+   1c2, 2a, 2a', 2b, 2c (keep the `### Stage N — <name>` headers verbatim so
+   anchors resolve), each trimmed to what it does + what it depends on + the
+   exact `sbatch`/orchestrator command. Heavy single-step rebuilds shown via
+   `sbatch slurm_batch/build_shared_rasters.batch --step <name>` (NOT login
+   `pixi run`); note only genuinely quick inspection steps may be run with
+   `pixi run … --step` on the login node.
+7. **Stage 2d depstor detail** — template/fdr clip, `vpu_id`, `carea_map`
+   threshold modes + TWI source pairing; the routing memory note (~80 GB
+   measured, `--mem=96G`).
+8. **Stage 3 fabric prep detail** — `merge_vpu_targets` (marimo) documented as
+   **compute-node only** (JupyterHub or `salloc`, never login); `merge_vpu_segments`
+   and `prepare_fabric` via their new batches (Task 1).
+9. **Stage 4A — incremental per-parameter runs** — the full by-parameter
+   zonal + depstor-fraction recipes (keep the `Stage 4A` label).
+10. **Stage 4B — wholesale wrappers** — `submit_zonal_params.sh` /
+    `submit_depstor_params.sh` detail; depstor output layout (merged vs
+    _intermediates).
+11. **Stages 5–9** — merge/validate, ssflux, KNN gap-fill (via
+    `merge_and_fill_params.batch`), NHM defaults (via
+    `merge_default_output_params.batch`), view results (via
+    `render_figures.batch`, with JupyterHub as the interactive alternative).
+12. **Adding a new fabric** — Case A (pre-merged) / Case B (per-VPU), trimmed.
+13. **Partial reruns & recovery** — single-batch rerun; refill-a-VPU recipe.
+14. **Monitoring** — `squeue` / `sacct` / `tail`.
+15. **Script → config → entry-point map** — the existing table, **plus rows for
+    the four new batches** from Task 1.
+
+Content rules: drop every `PR #NN` / `issue #NN` / "the legacy X was dropped"
+clause; convert "(resolved by PR #95)" style asides to plain present tense; keep
+every command exact.
+
+- [ ] **Step 2: Verify every command/file the reference names exists**
+
+Run:
+```bash
+# all .batch / .sh / .py tokens referenced should exist
+grep -oE "slurm_batch/[A-Za-z0-9_]+\.(batch|sh)|scripts/[A-Za-z0-9_]+\.py" slurm_batch/HPC_REFERENCE.md \
+  | sort -u | while read -r p; do [ -e "$p" ] && echo "OK $p" || echo "MISSING $p"; done
+```
+Expected: every line starts `OK` (no `MISSING`). The four new batches resolve because Task 1 created them.
+
+- [ ] **Step 3: Confirm no PR/issue archaeology leaked in**
+
+Run: `grep -nE "PR #[0-9]+|issue #[0-9]+|#[0-9]{2,}" slurm_batch/HPC_REFERENCE.md`
+Expected: no output (archaeology trimmed). If a hit is a genuine cross-link you intend to keep, leave it and note why.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add slurm_batch/HPC_REFERENCE.md
+git commit -m "docs(slurm): add HPC_REFERENCE.md (relocated RUNME detail) (#131)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Rewrite `slurm_batch/RUNME.md` as the lean runbook
+
+**Files:**
+- Rewrite: `slurm_batch/RUNME.md`
+
+Target ~150–180 lines. A hydrologist reads top-to-bottom and copy-pastes. Every
+heavy step is an `sbatch`; rationale links to `HPC_REFERENCE.md`.
+
+- [ ] **Step 1: Replace the file with the runbook**
+
+Overwrite `slurm_batch/RUNME.md` with exactly these sections:
+
+1. **Heading + audience line**: "GFv2 Pipeline — Runbook (CONUS `gfv2`). The
+   commands to take a fresh data root to finished parameters, in order. Running
+   a different fabric, re-running one piece, internals, and recovery are in
+   [HPC_REFERENCE.md](HPC_REFERENCE.md)."
+2. **Before you start** (bullets, each ≤1 line, "why?" → HPC_REFERENCE):
+   - `pixi install` once; ensure `~/.pixi/bin` is on `PATH`.
+   - Always run `sbatch`/`submit_*.sh` from a shell where `~/.pixi/bin` is on
+     `PATH` (SLURM inherits it).
+   - Run everything from the repo root (`cd <repo>`).
+3. **Pipeline at a glance** — a numbered list naming the 8 steps below (one line
+   each) so the whole arc is visible first.
+4. **Run it (CONUS gfv2)** — numbered steps; each = one fenced command block +
+   one "**What it does**" line + one "**Wait for**" line. Use these exact
+   command blocks:
+
+   - **0 · Initialize + stage inputs**
+     ```bash
+     pixi run init-data-root
+     sbatch slurm_batch/download_rpu_rasters.batch
+     sbatch slurm_batch/download_nalcms.batch
+     sbatch slurm_batch/download_nhm_v11.batch
+     sbatch slurm_batch/stage_twi.batch
+     pixi run init-data-root --check     # after downloads + manual inputs are in place
+     ```
+     What it does: scaffolds `data_root`, downloads the public rasters, stages
+     per-RPU TWI; `--check` verifies manually-staged inputs. (Manual-input table
+     + provenance → HPC_REFERENCE "Stage 0".)
+
+   - **1 · Build shared (CONUS) rasters**
+     ```bash
+     sbatch slurm_batch/build_shared_rasters.batch
+     ```
+     What it does: walks the whole shared-raster DAG (merge per-VPU → slope/aspect
+     → border DEM → land mask → TWI merge → VRTs → derived + LULC rasters).
+
+   - **2 · Prepare the fabric**
+     ```bash
+     # merge_vpu_targets is an interactive marimo notebook — run it on a COMPUTE
+     # node (JupyterHub or `salloc`), never the login node. See HPC_REFERENCE.
+     pixi run -e notebooks marimo run notebooks/merge_vpu_targets.py   # nhru merge (compute node)
+     sbatch slurm_batch/merge_vpu_segments.batch                        # nsegment merge (depstor)
+     sbatch slurm_batch/prepare_fabric.batch                            # spatial batching + manifest
+     ```
+     What it does: merges per-VPU `nhru`/`nsegment` into the CONUS fabric, then
+     batches it into per-batch geopackages.
+
+   - **3 · Build depstor rasters**
+     ```bash
+     pixi run --as-is python scripts/clip_shared_to_fabric.py --fabric gfv2   # tiny VRT (login OK)
+     sbatch slurm_batch/build_depstor_rasters.batch
+     ```
+     What it does: clips the fabric-bounds FDR template, then builds the full
+     depression-storage raster stack.
+
+   - **4 · Generate parameters**
+     ```bash
+     BATCHES=$(pixi run --as-is python -c "import yaml;print(yaml.safe_load(open('configs/base_config.yml'))['data_root'])")/gfv2/batches
+     slurm_batch/submit_zonal_params.sh   "$BATCHES" gfv2 configs/base_config.yml
+     slurm_batch/submit_depstor_params.sh "$BATCHES" gfv2 configs/base_config.yml
+     ```
+     What it does: fans out the zonal + depstor param array jobs and chains their
+     merges (+ ratios / ssflux weights) via `afterok`.
+
+   - **5 · Gap-fill missing values**
+     ```bash
+     sbatch slurm_batch/merge_and_fill_params.batch
+     ```
+     What it does: KNN-fills any missing per-HRU parameter values.
+
+   - **6 · (optional) Merge NHM defaults**
+     ```bash
+     sbatch slurm_batch/merge_default_output_params.batch
+     ```
+
+   - **7 · View results**
+     ```bash
+     sbatch slurm_batch/render_figures.batch     # PNGs -> docs/figures/gfv2/
+     ```
+     What it does: renders the fabric_results figure set headlessly. (Interactive
+     viewing via JupyterHub → HPC_REFERENCE "Stage 9".)
+
+5. **Monitoring**
+   ```bash
+   squeue -u "$USER"
+   sacct -j <JOBID> -o JobID,State,Elapsed,MaxRSS
+   tail -n 200 logs/job_<JOBID>.err
+   ```
+6. **Where outputs land** — `{data_root}/gfv2/params/merged/` (final CSVs, incl.
+   the 6 depstor ratios) and `…/merged/_intermediates/`; figures in
+   `docs/figures/gfv2/`.
+7. **Need more?** — bullet links into `HPC_REFERENCE.md`: other fabrics; running
+   one parameter at a time (Stage 4A); single-step raster rebuilds; recovery /
+   partial reruns; environment + throttle internals; the script→config map.
+
+Each "Wait for" line names the gating artifact or job state (e.g. "Wait for: all
+array + merge jobs `COMPLETED` in `squeue`") so a non-SLURM user knows when to
+proceed to the next step.
+
+- [ ] **Step 2: Verify every command references a real batch/script + the reference link resolves**
+
+Run:
+```bash
+grep -oE "slurm_batch/[A-Za-z0-9_]+\.(batch|sh)|scripts/[A-Za-z0-9_]+\.py|notebooks/[A-Za-z0-9_]+\.py" slurm_batch/RUNME.md \
+  | sort -u | while read -r p; do [ -e "$p" ] && echo "OK $p" || echo "MISSING $p"; done
+test -e slurm_batch/HPC_REFERENCE.md && echo "OK reference link target exists"
+```
+Expected: all `OK`, no `MISSING`.
+
+- [ ] **Step 3: Confirm the runbook is lean and login-heavy commands are gone**
+
+Run:
+```bash
+wc -l slurm_batch/RUNME.md
+# no heavy script run directly via login 'pixi run' (clip/init are the only allowed ones):
+grep -nE "pixi run( --as-is)? python scripts/(prepare_fabric|merge_and_fill_params|merge_vpu_segments|render_figures|merge_default_params)\.py" slurm_batch/RUNME.md
+```
+Expected: line count ≈150–200; the second `grep` returns **no output** (those run via `sbatch` now).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add slurm_batch/RUNME.md
+git commit -m "docs(slurm): rewrite RUNME.md as a lean CONUS-gfv2 runbook (#131)
+
+Linear, copy-paste happy path; every heavy step via sbatch; rationale and
+alternate paths moved to HPC_REFERENCE.md.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Update cross-references in the live docs
+
+**Files:**
+- Modify: `CLAUDE.md`
+- Modify: `README.md`
+- Modify: `docs/ARCHITECTURE.md`
+- Modify: `docs/depstor_workflow.md`
+- Modify: `docs/ADDING_A_PARAMETER.md`
+- Modify: `docs/hpc-workflow.md`
+
+Repoint references so the runbook is "the happy path" and stage-numbered detail
+points at `HPC_REFERENCE.md` (which retains the stage labels). Do **not** edit
+files under `docs/superpowers/` (archival).
+
+- [ ] **Step 1: `CLAUDE.md`** — update the line (currently ~57):
+  `` `slurm_batch/RUNME.md` is the authoritative step-by-step HPC workflow; ``
+  to: `` `slurm_batch/RUNME.md` is the step-by-step runbook (the CONUS-gfv2 happy path); `slurm_batch/HPC_REFERENCE.md` holds the per-stage detail, alternate paths, and recovery; ``
+  Leave the doc-audit-rule mention of RUNME (~line 96) but add `/ HPC_REFERENCE` alongside it.
+
+- [ ] **Step 2: `docs/ARCHITECTURE.md`** — the bullet (currently ~215)
+  `- [\`slurm_batch/RUNME.md\`](../slurm_batch/RUNME.md) — authoritative HPC workflow walkthrough`
+  becomes two bullets:
+  ```
+  - [`slurm_batch/RUNME.md`](../slurm_batch/RUNME.md) — the step-by-step runbook (CONUS-gfv2 happy path)
+  - [`slurm_batch/HPC_REFERENCE.md`](../slurm_batch/HPC_REFERENCE.md) — per-stage detail, alternate paths, recovery, script→config map
+  ```
+
+- [ ] **Step 3: `README.md`** — repoint the stage-specific references so they
+  resolve in the reference (which keeps the stage taxonomy). Edit these lines:
+  - ~119 "See `slurm_batch/RUNME.md` **Part 1** …" → "See `slurm_batch/HPC_REFERENCE.md` **Part 1** …"
+  - ~166 "See `slurm_batch/RUNME.md` **Stage 4A** …" → "… `slurm_batch/HPC_REFERENCE.md` **Stage 4A** …"
+  - ~178 "`slurm_batch/RUNME.md` **Part 2 / Stage 4** …" → "… `slurm_batch/HPC_REFERENCE.md` **Part 2 / Stage 4** …"
+  - ~279 "Stage 2d in `slurm_batch/RUNME.md` lists …" → "Stage 2d in `slurm_batch/HPC_REFERENCE.md` lists …"
+  - ~241 "See `slurm_batch/RUNME.md` for the full step-by-step workflow." → keep pointing at RUNME (it IS the runbook) but reword: "See `slurm_batch/RUNME.md` for the runbook; `slurm_batch/HPC_REFERENCE.md` for per-stage detail."
+  - ~22, ~66, ~216 (generic "RUNME is the walkthrough" mentions) → reword to "RUNME.md is the runbook; HPC_REFERENCE.md the detail" where it reads naturally; otherwise leave the plain RUNME link.
+
+- [ ] **Step 4: `docs/depstor_workflow.md`** — line ~122
+  "Runs as **RUNME Stage 1c1**, before the TWI merge." → "Runs as **Stage 1c1**
+  (see `slurm_batch/HPC_REFERENCE.md`), before the TWI merge."
+
+- [ ] **Step 5: `docs/ADDING_A_PARAMETER.md`** — line ~239
+  `- [\`slurm_batch/RUNME.md\`](../slurm_batch/RUNME.md) — Stage 4A walks the …`
+  → point at HPC_REFERENCE: `- [\`slurm_batch/HPC_REFERENCE.md\`](../slurm_batch/HPC_REFERENCE.md) — Stage 4A walks the …`
+
+- [ ] **Step 6: `docs/hpc-workflow.md`** — this mkdocs page `include-markdown`s
+  RUNME. Update it to surface both docs. Read the current file, then make it
+  include the runbook and add a second include (or a link) for the reference,
+  e.g. keep `include-markdown "../slurm_batch/RUNME.md"` and add below it:
+  ```
+  {%
+     include-markdown "../slurm_batch/HPC_REFERENCE.md"
+  %}
+  ```
+  with a `## Reference` heading between them. (Match the existing include block's
+  exact syntax/indentation in that file.)
+
+- [ ] **Step 7: Verify no live doc still implies RUNME carries the moved detail**
+
+Run:
+```bash
+grep -rn "RUNME" CLAUDE.md README.md docs/ARCHITECTURE.md docs/depstor_workflow.md docs/ADDING_A_PARAMETER.md docs/hpc-workflow.md
+grep -rn "HPC_REFERENCE" CLAUDE.md README.md docs/ARCHITECTURE.md docs/depstor_workflow.md docs/ADDING_A_PARAMETER.md docs/hpc-workflow.md
+```
+Expected: each remaining RUNME mention is either the runbook-as-happy-path link or paired with an HPC_REFERENCE pointer; stage-numbered references now name HPC_REFERENCE.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add CLAUDE.md README.md docs/ARCHITECTURE.md docs/depstor_workflow.md \
+        docs/ADDING_A_PARAMETER.md docs/hpc-workflow.md
+git commit -m "docs: repoint RUNME cross-refs to runbook + HPC_REFERENCE (#131)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Final verification + pre-commit
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: pre-commit on all changed files**
+
+Run:
+```bash
+pixi run -e dev pre-commit run --files \
+  slurm_batch/prepare_fabric.batch slurm_batch/merge_and_fill_params.batch \
+  slurm_batch/merge_vpu_segments.batch slurm_batch/render_figures.batch \
+  slurm_batch/HPC_REFERENCE.md slurm_batch/RUNME.md \
+  CLAUDE.md README.md docs/ARCHITECTURE.md docs/depstor_workflow.md \
+  docs/ADDING_A_PARAMETER.md docs/hpc-workflow.md
+```
+Expected: PASS (ShellCheck may lint the `.batch` files — fix any real warnings, e.g. quote expansions; amend the Task 1 commit if so). Re-run to green.
+
+- [ ] **Step 2: Repo-wide broken-reference sweep**
+
+Run:
+```bash
+# every batch/script token across the two slurm docs exists on disk:
+grep -rhoE "slurm_batch/[A-Za-z0-9_]+\.(batch|sh)|scripts/[A-Za-z0-9_]+\.py" \
+  slurm_batch/RUNME.md slurm_batch/HPC_REFERENCE.md | sort -u \
+  | while read -r p; do [ -e "$p" ] || echo "MISSING $p"; done
+echo "sweep done"
+```
+Expected: only `sweep done` (no `MISSING` lines).
+
+- [ ] **Step 3: Push and open the PR**
+
+```bash
+git push -u origin docs/runme-split-slurm-coverage
+gh pr create --base main --fill
+```
+Then verify CI passes. (CI runs `pytest`; this branch has no Python changes, so it should pass unchanged. The four new batches are validated by `sbatch --test-only` in Task 1, not CI.)
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Part A (4 new batches) → Task 1 (full content + verification). ✓
+- Part B doc fixes: `merge_default_params` via batch → Task 3 step 1 (step 6) + HPC_REFERENCE §11; heavy `build_shared_rasters --step` via sbatch → HPC_REFERENCE §6; `merge_vpu_targets` compute-node-only → RUNME step 2 + HPC_REFERENCE §8. ✓
+- Part C split: HPC_REFERENCE → Task 2; RUNME rewrite → Task 3; cross-refs → Task 4. ✓
+- Reference retains stage taxonomy (spec's "incremental Stage 4A" etc.) → Task 2 intro + §6/§9. ✓ (refinement: makes inbound stage refs resolve.)
+- Verification (commands exist, lossless relocation, docs gate) → Tasks 1/2/3 verify steps + Task 5. ✓
+- Newly discovered: `docs/hpc-workflow.md` include-markdown → Task 4 step 6 (not in spec; added). ✓
+
+**Placeholder scan:** no "TBD/TODO/handle edge cases". The doc tasks specify exact section lists + exact command blocks; connective prose is the deliverable written against that structure (not a placeholder). All four batch files are shown in full. `<JOBID>`/`<id>` are user-supplied runtime values, not plan gaps.
+
+**Type/name consistency:** batch filenames, script paths, and `--fabric`/`--base_config` flags are identical across Tasks 1–5; `HPC_REFERENCE.md` spelled consistently; the `BATCHES=` derivation in RUNME step 4 matches `submit_*.sh`'s documented positional args.

--- a/docs/superpowers/specs/2026-05-29-runme-split-and-slurm-coverage-design.md
+++ b/docs/superpowers/specs/2026-05-29-runme-split-and-slurm-coverage-design.md
@@ -1,0 +1,171 @@
+# RUNME split into runbook + reference, and full SLURM coverage
+
+**Status:** Design — 2026-05-29 · tracked in [#131](https://github.com/rmcd-mscb/gfv2-params/issues/131)
+
+## Problem
+
+`slurm_batch/RUNME.md` has grown to 826 lines and serves two audiences badly at
+once. A hydrologist who is **not** an HPC/SLURM expert cannot find "what do I run,
+in what order" — the ~8-command happy path is scattered across the file, every
+command is wrapped in HPC rationale (`pixi --as-is` metadata-race story,
+throttle/import-storm notes, memory tuning), PR/issue archaeology ("resolved by
+PR #95"), and two equivalent execution paths (Stage 4A incremental vs 4B
+wholesale) are presented as peers.
+
+Separately, an audit of every command RUNME tells the user to run **directly on
+the login node** found compute/memory-intensive steps with no SLURM wrapper —
+they run on the login node today, against the project rule that intensive work
+belongs in a batch job.
+
+## Goals
+
+1. **Split** RUNME into a lean linear **runbook** (the hydrologist's path) and a
+   co-located **reference** (the HPC/maintainer detail).
+2. **Close the SLURM-coverage gaps**: every compute/memory-intensive step gets a
+   batch wrapper; login-node use is reserved for genuinely trivial commands.
+3. Keep all the technical detail — relocate it, do not delete it (except PR/issue
+   archaeology, which git already records).
+
+## SLURM-coverage audit (login-node commands in RUNME today)
+
+| Script | What it does | Intensity | Wrapper today | Verdict |
+|---|---|---|---|---|
+| `init-data-root` (`--check`) | scaffold dirs / verify | trivial | — | login OK |
+| `migrate_to_shared_layout` | `os.rename` only | trivial | — | login OK |
+| `clip_shared_to_fabric` | read HRU bounds → tiny VRT | light | — | login OK |
+| `prepare_fabric` | load whole CONUS fabric + KD-tree bisection | heavy | none | **needs SLURM** |
+| `merge_and_fill_params` (gap-fill) | sklearn KNN over all HRUs × params | heavy | none | **needs SLURM** |
+| `merge_vpu_segments` | concat 21 VPU `nsegment` layers | moderate | none | **needs SLURM** |
+| `render_figures` | nbconvert-execute notebooks; ~361k polys | heavy (headless) | none | **needs SLURM** |
+| `merge_vpu_targets` (marimo) | merge 21 VPU `nhru` → CONUS | heavy, interactive | none | compute-node only (doc) |
+| `merge_default_params` | pandas CSV merges | moderate | `merge_default_output_params.batch` | use the batch (doc fix) |
+| `build_shared_rasters --step X` (direct) | single raster step (some 384 G) | heavy for some | `build_shared_rasters.batch` (`--step`) | use the batch (doc fix) |
+
+## Part A — new SLURM wrappers
+
+Four new `slurm_batch/*.batch` files, each mirroring the existing batch
+conventions (`#SBATCH` header; `cd "$SLURM_SUBMIT_DIR"`;
+`BASE_CONFIG=${BASE_CONFIG:-configs/base_config.yml}`; `FABRIC=${FABRIC:-gfv2}`
+where applicable; `pixi run --as-is python …`; forward `"$@"`). Default
+resources are starting points, flagged in-comment as "right-size after first
+run via `sacct MaxRSS`."
+
+| New batch | Command | env | default `--mem` / `--time` / cpus |
+|---|---|---|---|
+| `prepare_fabric.batch` | `prepare_fabric.py --fabric "$FABRIC" --base_config "$BASE_CONFIG" "$@"` | default | 64G / 02:00:00 / 4 |
+| `merge_and_fill_params.batch` | `merge_and_fill_params.py --base_config "$BASE_CONFIG" "$@"` | default | 64G / 02:00:00 / 8 |
+| `merge_vpu_segments.batch` | `merge_vpu_segments.py --fabric "$FABRIC" "$@"` | default | 32G / 01:00:00 / 4 |
+| `render_figures.batch` | `render_figures.py --fabric "$FABRIC" "$@"` | `-e notebooks` | 96G / 02:00:00 / 4 |
+
+Notes:
+- `render_figures.batch` uses `pixi run --as-is -e notebooks python …` (the only
+  new batch needing the `notebooks` env; the script already forces
+  `MPLBACKEND=Agg`).
+- `prepare_fabric.batch` / `merge_vpu_segments.batch` honour `FABRIC`;
+  `merge_and_fill_params.py` resolves the fabric from `base_config`'s
+  `default_fabric` (no `--fabric`), so its batch only passes `--base_config`.
+- These wrap **existing** scripts unchanged — no script edits in Part A.
+
+## Part B — doc-consistency fixes
+
+- `merge_default_params` shown via `sbatch slurm_batch/merge_default_output_params.batch`,
+  not a login `pixi run`.
+- Heavy single-step `build_shared_rasters` runs shown via
+  `sbatch slurm_batch/build_shared_rasters.batch --step <name>` (the orchestrator
+  batch already forwards `--step`), not login `pixi run … --step`. Trivial/quick
+  inspection steps may still be noted as login-runnable in reference.
+- `merge_vpu_targets` (marimo): documented as **compute-node only** — run under
+  JupyterHub or an `salloc` allocation, never the login node. No code change.
+
+## Part C — the split
+
+### `slurm_batch/RUNME.md` — the runbook (target ~150–180 lines)
+
+A hydrologist reads top-to-bottom and copy-pastes. Sections:
+
+1. **Title + "who this is for"** — one line.
+2. **Before you start** — 3 bullets: `pixi install` + `~/.pixi/bin` on PATH;
+   always submit from a PATH-enabled shell; `cd` to repo root. "Why?" links to
+   reference.
+3. **Pipeline at a glance** — short ordered list of the stages (the whole arc).
+4. **Run it (CONUS gfv2)** — one numbered linear sequence; each step is *one*
+   command block + a one-line "what it does" + "wait for: …". Spine:
+   - 0 · init data root + stage inputs (`init-data-root`; download `sbatch`es;
+     `stage_twi`) → input table
+   - 1 · build shared rasters (`sbatch build_shared_rasters.batch`)
+   - 2 · prepare fabric (`merge_vpu_targets` on a compute node; `sbatch
+     merge_vpu_segments.batch`; `sbatch prepare_fabric.batch`)
+   - 3 · build depstor rasters (`sbatch build_depstor_rasters.batch`)
+   - 4 · generate params (`submit_zonal_params.sh`; `submit_depstor_params.sh`)
+   - 5 · gap-fill (`sbatch merge_and_fill_params.batch`)
+   - 6 · (optional) NHM defaults (`sbatch merge_default_output_params.batch`)
+   - 7 · view results (`sbatch render_figures.batch`)
+5. **Monitoring** — `squeue` / `sacct` / `tail` (3 lines).
+6. **Where the outputs land** — the `{fabric}/params/` paths.
+7. **Need more?** — link list into the reference (other fabrics, incremental
+   4A runs, recovery, internals).
+
+Defaults (gfv2, `--mem`, throttle) are baked into the batches, so the runbook
+says "submit it" without tuning prose.
+
+### `slurm_batch/HPC_REFERENCE.md` — the reference (by topic, trimmed)
+
+Relocated, trimmed-to-brief-notes, PR/issue numbers dropped:
+- Environment: `pixi --as-is` + PATH requirement (brief).
+- Concurrency: the array throttle knob + why (one paragraph).
+- Data-directory layout (the tree).
+- Running other fabrics: `gfv2_vpu01`, `oregon` (`FABRIC=` overrides).
+- Adding a new fabric (Case A pre-merged / Case B per-VPU).
+- Incremental / per-parameter runs (today's Stage 4A) and `--step`/`--from`.
+- Partial reruns + VPU recovery.
+- Memory notes (routing ~80 GB measured; per-VPU merge 384 G; the new batches'
+  right-sizing).
+- depstor `carea_map` threshold modes + TWI source pairing.
+- Script → config → entry-point mapping table (incl. the 4 new batches).
+- `migrate_to_shared_layout` (legacy-layout upgrade).
+
+### Cross-reference updates (same change)
+
+- `CLAUDE.md`: the line calling RUNME "the authoritative step-by-step HPC
+  workflow" → RUNME = runbook (the happy path), HPC_REFERENCE = details.
+- `docs/ARCHITECTURE.md` and any doc that links "RUNME Stage 4A" / "RUNME
+  Stage N" → repoint to `HPC_REFERENCE.md` (the runbook drops the old stage
+  numbering). Audit inbound references with
+  `grep -rn "RUNME" docs/ README.md *.md src/`.
+- `README.md`: if it points at RUNME for HPC detail, confirm the link still
+  lands somewhere sensible.
+
+## Verification
+
+- Every command in the new runbook checked against the actual batch/script names
+  and argument names (no invented flags); `grep`-confirm each referenced
+  `.batch`/`.sh`/`.py` exists.
+- The 4 new batches: confirm they parse and submit
+  (`sbatch --test-only` or a real submit) and that a real run COMPLETEs and
+  reports a sane `MaxRSS` (the proof the `--mem` default is right-sized). The
+  CONUS submits are cluster runs the user may prefer to do.
+- Relocation is lossless except the deliberately-cut PR/issue archaeology: spot
+  every non-trivial "why" paragraph from the old RUNME and confirm it has a home
+  in HPC_REFERENCE (trimmed) or was intentionally dropped.
+- Docs gate (per CLAUDE.md): no other doc still describes a heavy step as a
+  login-node `pixi run`.
+
+## Non-goals
+
+- No changes to the scripts the new batches wrap (Part A is wrappers only).
+- Not converting `merge_vpu_targets` (marimo) into a headless script — it stays
+  interactive, documented as compute-node-only.
+- No change to the pipeline's behaviour, configs, or outputs.
+- Not re-sizing the *existing* batches' resources (only the 4 new ones get
+  starting defaults).
+
+## Risks
+
+- **Batch `--mem` defaults too low.** Mitigated by the "right-size after first
+  run" note and the `sacct MaxRSS` check; over-provisioned starting values
+  chosen deliberately.
+- **Broken inbound links** to old RUNME stage anchors. Mitigated by the
+  `grep -rn "RUNME"` audit in the cross-reference step.
+- **Runbook drift** if the reference and runbook disagree later. Mitigated by
+  keeping commands only in the runbook and rationale only in the reference (one
+  home per fact).

--- a/docs/superpowers/specs/2026-05-29-runme-split-and-slurm-coverage-design.md
+++ b/docs/superpowers/specs/2026-05-29-runme-split-and-slurm-coverage-design.md
@@ -96,7 +96,18 @@ A hydrologist reads top-to-bottom and copy-pastes. Sections:
    - 2 · prepare fabric (`merge_vpu_targets` on a compute node; `sbatch
      merge_vpu_segments.batch`; `sbatch prepare_fabric.batch`)
    - 3 · build depstor rasters (`sbatch build_depstor_rasters.batch`)
-   - 4 · generate params (`submit_zonal_params.sh`; `submit_depstor_params.sh`)
+   - 4 · generate params — **fully explicit** (addendum 2026-05-29): the runbook
+     spells out the per-parameter batch jobs to run in order
+     (`derive_zonal_params.batch` + `merge_zonal_param.batch` per zonal param,
+     `build_zonal_weights.batch` for ssflux, `create_depstor_zonal.batch` +
+     `merge_depstor_fraction.batch` per fraction, then `derive_depstor_ratios.batch`),
+     naming every parameter/fraction and the `slope`→`ssflux` order. The
+     `submit_zonal_params.sh` / `submit_depstor_params.sh` wrappers are presented
+     **only as the wholesale convenience** that runs exactly that sequence
+     (afterok-chained). Rationale: the shell wrappers are opaque to a
+     non-HPC reader; the batch scripts and their order must be visible.
+     HPC_REFERENCE's Stage 4A keeps the finer detail (throttle, single-param
+     rerun) and points back to the runbook for the sequence.
    - 5 · gap-fill (`sbatch merge_and_fill_params.batch`)
    - 6 · (optional) NHM defaults (`sbatch merge_default_output_params.batch`)
    - 7 · view results (`sbatch render_figures.batch`)

--- a/slurm_batch/HPC_REFERENCE.md
+++ b/slurm_batch/HPC_REFERENCE.md
@@ -1,0 +1,753 @@
+# GFv2 HPC Pipeline — Reference
+
+Reference detail for the GFv2 HPC pipeline. The step-by-step happy path is in
+[RUNME.md](RUNME.md); this file holds the environment internals, per-stage
+detail, alternate execution paths, per-fabric instructions, recovery, and the
+script→config map.
+
+---
+
+## Environment internals
+
+The pipeline uses [pixi](https://pixi.sh) for environment management. Install
+pixi once per user (`~/.pixi/bin` must be on your `PATH`). From the repo root
+run `pixi install` to materialise `.pixi/envs/default/` from `pixi.lock`
+(configuration lives in `pyproject.toml` under `[tool.pixi.*]`).
+
+SLURM batches invoke the env with `pixi run --as-is` (= `--no-install --frozen`):
+the already-installed env is used verbatim — no lock check, no env mutation, no
+PyPI/conda sync — so concurrent array tasks never race on
+`.pixi/envs/default/conda-meta/`. Because the batches use `--as-is`, the `pixi`
+binary must be on `PATH` on the compute node. SLURM jobs inherit the submitting
+shell's environment, so always submit (`sbatch ...`, `submit_*.sh`) from a shell
+where `~/.pixi/bin` is on your `PATH`. If a batch fails immediately with
+`pixi: command not found`, that PATH was missing at submit time. Re-run
+`pixi install` any time `pyproject.toml` or `pixi.lock` change.
+
+Interactive environments:
+
+```bash
+pixi shell                       # default env
+pixi shell -e notebooks          # default + marimo, plotly, hvplot, ...
+pixi shell -e dev                # default + pytest, ruff, pre-commit
+```
+
+> **Migrating from `geoenv`?** The legacy `environment.yml` / `geoenv` conda
+> env is retained as a deprecated fallback only. New work uses pixi.
+
+---
+
+## Array concurrency throttle
+
+`submit_jobs.sh` accepts an optional 5th positional argument (or the
+`SUBMIT_JOBS_MAX_CONCURRENT` env var) capping how many array tasks run
+simultaneously — defaults to 4. The cap exists because concurrent geo-library
+imports (rasterio / GDAL / PROJ / pyogrio) can deadlock under shared-FS
+metadata contention when many tasks start simultaneously. Set to `0` (or `off`)
+to disable the cap. For CONUS the default of 4 trades roughly one wave of
+wall-clock time for reliability. The same throttle (`%N`) is used as the modulo
+in every `--array=0-$((N-1))%$THROTTLE` invocation throughout Stage 4.
+
+---
+
+## Data directory layout
+
+All data lives under `data_root` (set in `configs/base_config.yml`):
+
+```
+gfv2_param/
+├── input/                  # External data (manually staged or downloaded)
+│   ├── fabric/             # Per-VPU watershed fabric gpkgs
+│   ├── soils_litho/        # TEXT_PRMS.tif, AWC.tif, Lithology_exp_Konly_Project.*
+│   ├── lulc_veg/           # RootDepth.tif, CNPY.tif, Imperv.tif
+│   │   └── nhm_v11/        # NHM v1.1 pre-derived LULC rasters (downloadable)
+│   ├── lulc/
+│   │   ├── nlcd_annual_imperv/   # NLCD fractional imperviousness (downloadable)
+│   │   └── nalcms_2020/    # NALCMS 2020 land cover (downloadable)
+│   ├── nhd/                # conus_waterbodies.gpkg (shared NHDPlusV2 waterbodies)
+│   ├── twi/<rpu>/          # Per-RPU TWI (twi.tif + sidecars; staged via stage_twi.sh)
+│   ├── nhm_default/        # NHM default parameter files
+│   └── nhd_downloads/      # Raw NHDPlus zip archives (downloadable)
+├── shared/                 # Fabric-independent intermediates (reused by every fabric)
+│   ├── source/             # Unzipped per-RPU NHDPlus rasters
+│   ├── per_vpu/<vpu>/      # Per-VPU merged GeoTIFFs (NED/Hydrodem/Fdr/Fac/Twi/slope/aspect/landmask)
+│   └── conus/
+│       ├── vrt/            # CONUS-wide GDAL virtual rasters (elevation/slope/aspect/fdr/twi)
+│       ├── derived/        # soil_moist_max.tif, radtrn, resampled CNPY/keep
+│       ├── borders/        # Copernicus border-DEM fill (Canada/Mexico)
+│       └── weights/        # P2P polygon weights for ssflux
+└── {fabric}/               # Per-fabric outputs (e.g., gfv2/, gfv2_vpu01/, oregon/)
+    ├── fabric/             # Merged fabric gpkg
+    ├── batches/            # Per-batch gpkgs + manifest
+    ├── depstor_rasters/    # Depression-storage intermediate rasters (per fabric)
+    └── params/             # Parameter outputs + merged + filled
+```
+
+> **Upgrading an existing `data_root` from the legacy `work/` layout?** Run
+> `pixi run python scripts/migrate_to_shared_layout.py --data-root <path> --dry-run`
+> to preview the 27 directory renames, then `--execute` to apply them.
+> Atomic `os.rename` on the same filesystem (metadata-only, near-instant);
+> regenerates CONUS VRTs at the end since they encode absolute source paths.
+> Idempotent — re-running after success is a no-op.
+
+---
+
+## Selecting / running other fabrics
+
+Fabric identities and all shared, required per-fabric inputs live as profiles in
+`configs/base_config.yml` under a `fabrics:` mapping. Every profile carries
+`hru_gpkg`/`hru_layer`, `id_feature`, `expected_max_hru_id`, and `batch_size`;
+depstor fabrics add `template_raster`, `fdr_raster`, `twi_raster`,
+`segments_gpkg`/`segments_layer`, and `waterbody_gpkg`/`waterbody_layer`. The
+active profile is selected via:
+
+1. `--fabric <name>` CLI flag on any script, OR
+2. `FABRIC` env var forwarded through `sbatch`, OR
+3. `default_fabric` in `configs/base_config.yml` (currently `gfv2`).
+
+SLURM batches default to `gfv2`. To run the same batch against a different fabric,
+set `FABRIC` and optionally override resource asks at submission:
+
+```bash
+# CONUS gfv2 — default
+sbatch slurm_batch/build_depstor_rasters.batch
+
+# VPU01 validation overlay — smaller; override resources
+FABRIC=gfv2_vpu01 sbatch --time=02:00:00 --mem=48G slurm_batch/build_depstor_rasters.batch
+
+# Oregon (pre-merged single-domain fabric)
+FABRIC=oregon sbatch slurm_batch/build_depstor_rasters.batch
+```
+
+`submit_jobs.sh` accepts fabric as its 4th positional argument and forwards it
+via `--export=ALL,FABRIC=...` to the array job.
+
+---
+
+## Part 1 stage detail
+
+All commands assume the repo root as working directory. The entire Part 1 DAG
+can be driven by one batch:
+
+```bash
+sbatch slurm_batch/build_shared_rasters.batch
+```
+
+Env knobs the batch honours:
+
+- `FORCE=1` — pass `--force` to rebuild outputs that already exist
+- `VPUS=01,02` — restrict per-VPU steps to a subset
+
+For interactive use or finer-grained flags, invoke the orchestrator directly:
+
+```bash
+pixi run python scripts/build_shared_rasters.py \
+    --config configs/shared_rasters/shared_rasters.yml
+```
+
+Use `--step <name>` for a single step or `--from <name>` to resume mid-DAG.
+Step names match keys in `configs/shared_rasters/shared_rasters.yml`. Heavy
+single-step rebuilds should be submitted via the batch
+(`sbatch slurm_batch/build_shared_rasters.batch --step <name>`), not run
+directly on the login node. Only genuinely quick inspection steps (e.g.
+`--step build_vrt` on already-built tiles) are login-node safe.
+
+### Stage 0 — Initialize data root and stage inputs
+
+Scaffold the full directory tree under `data_root`:
+
+```bash
+pixi run init-data-root
+pixi run init-data-root --check    # verify manually-staged inputs are present
+```
+
+Manually-staged files required before `--check`:
+
+| Destination | Required files |
+|---|---|
+| `input/fabric/` | `NHM_<VPU>_draft.gpkg` for each of the 21 VPUs |
+| `input/soils_litho/` | `TEXT_PRMS.tif`, `AWC.tif`, `Lithology_exp_Konly_Project.shp` (+ `.dbf`, `.prj`, `.shx`) |
+| `input/lulc_veg/` | `RootDepth.tif`, `CNPY.tif`, `Imperv.tif` |
+| `input/nhm_default/` | NHM default parameter files |
+| `input/nhd/` | `conus_waterbodies.gpkg` (layer `waterbodies`) |
+| `input/twi/<rpu>/` | Per-RPU `twi.tif` + sidecars (staged via `stage_twi.sh`) |
+
+Download jobs (idempotent — already-downloaded files are skipped):
+
+```bash
+mkdir -p logs
+sbatch slurm_batch/download_rpu_rasters.batch    # NHDPlus RPU rasters (~112 GB)
+sbatch slurm_batch/download_nalcms.batch         # NALCMS 2020 land cover (~2 GB)
+sbatch slurm_batch/download_nhm_v11.batch        # NHM v1.1 LULC rasters
+```
+
+Stage per-RPU TWI rasters (reads from the impd-group mirror by default):
+
+```bash
+sbatch slurm_batch/stage_twi.batch
+# or with an alternate source:
+SRC=/alt/path/to/data_bins sbatch slurm_batch/stage_twi.batch
+```
+
+The staging script normalises HRU06a's uppercase `TWI.*` source filenames to
+lowercase in the destination. Idempotent — re-running skips files already
+present and newer than the source.
+
+### Stage 1 — `merge_rpu_by_vpu` + `compute_slope_aspect`
+
+Merge per-RPU NHDPlus rasters into per-VPU GeoTIFFs (NED, Hydrodem, FDR, FAC),
+then derive slope/aspect on the fixed-nodata NEDSnapshot. Driven by the
+orchestrator batch; single-VPU rebuild:
+
+```bash
+VPUS=17 FORCE=1 sbatch --mem=384G slurm_batch/build_shared_rasters.batch --step merge_rpu_by_vpu
+```
+
+### Stage 1b — `build_border_dem`
+
+Download Copernicus GLO-30 tiles and build elevation/slope/aspect fill rasters
+for HRUs that extend into Canada or Mexico beyond NHDPlus coverage. Creates fill
+rasters in `shared/conus/borders/`; the subsequent `build_vrt` step composites
+these behind NHDPlus (NHDPlus takes priority where valid; Copernicus fills the
+border gaps). Depends on Stage 1.
+
+### Stage 1c1 — `build_vpu_landmask`
+
+Build the per-VPU HRU-fabric land mask consumed by both TWI pipelines. Produces
+`shared/per_vpu/<vpu>/land_mask_<vpu>.tif` — a uint8 1/255 raster where 1 =
+inside an HRU whose `vpu` attribute matches this VPU, 255 = outside. Rasterised
+onto the per-VPU `Hydrodem_merged_<vpu>.tif` grid. Depends only on Stage 1.
+
+### Stage 1c2 — `merge_rpu_by_vpu_twi`
+
+Merge per-RPU TWI rasters (staged in Stage 0) into per-VPU GeoTIFFs
+(`Twi_merged_<vpu>.tif`). Clips its output to the per-VPU HRU mask from Stage
+1c1. Depends on Stage 1c1. Single-VPU rebuild:
+
+```bash
+VPUS=17 FORCE=1 sbatch --mem=384G slurm_batch/build_shared_rasters.batch --step merge_rpu_by_vpu_twi
+```
+
+### Stage 2a — `build_vrt`
+
+Combine per-VPU rasters and optional Copernicus fill into CONUS-wide GDAL
+virtual rasters (elevation/slope/aspect/fdr/twi). Also builds
+`twi_hydrodem.vrt` (open-source WhiteboxTools TWI, CONUS-complete) if
+`Twi_hydrodem_*.tif` tiles are present in `per_vpu/`. Rebuild:
+
+```bash
+FORCE=1 sbatch slurm_batch/build_shared_rasters.batch --step build_vrt
+```
+
+Recovery wrapper for finishing ArcPy TWI tiles + both VRTs in one shot:
+
+```bash
+bash slurm_batch/submit_twi_completion.sh
+```
+
+This submits three chained jobs: `merge_rpu_by_vpu_twi --force` (all 18 VPUs)
+→ `build_vrt --force` (writes `twi.vrt` and `twi_hydrodem.vrt`) →
+`twi_reference --force` (writes per-VPU percentile CSVs). Verify afterwards
+with `gdalinfo` on both VRTs.
+
+### Stage 2a' — `twi_reference`
+
+Compute valid-land TWI percentile cutoffs per VPU (and CONUS) for each TWI
+source (`arcpy`, `hydrodem`). Outputs
+`shared/conus/twi_reference_percentiles.arcpy.csv` and
+`shared/conus/twi_reference_percentiles.hydrodem.csv`. These tables are the
+input to `carea_map threshold_mode: percentile` (Stage 2d). Runs automatically
+after `build_vrt` in the orchestrator DAG; run on its own with:
+
+```bash
+FORCE=1 sbatch slurm_batch/build_shared_rasters.batch --step twi_reference
+```
+
+### Stage 2b — `build_derived_rasters`
+
+Pre-compute `rd_250_raw.tif` and `soil_moist_max.tif`.
+
+### Stage 2c — `build_lulc_rasters`
+
+Pre-compute canopy-resampled + keep-resampled + radiation-transmission rasters
+for every LULC source listed in
+`configs/shared_rasters/shared_rasters.yml`'s `sources:` block (currently 4
+sources: nhm_v11, nalcms, nlcd, foresce).
+
+---
+
+## Stage 2d depstor detail
+
+Build the full depression-storage raster stack on a fabric-bounds template grid.
+Outputs go to `{fabric}/depstor_rasters/` and feed the Stage 4 depstor
+zonal-stats orchestrator.
+
+**Template / FDR clip.** `template_raster` and `fdr_raster` are a fabric-bounds
+clip of the CONUS FDR, staged with:
+
+```bash
+pixi run --as-is python scripts/clip_shared_to_fabric.py --fabric <name>
+```
+
+This writes `{data_root}/<name>/shared/<name>_fdr.vrt` — a zero-copy VRT clip
+on the hydrology lattice. The clip scopes compute to the fabric extent and is
+required because `carea_map` requires the template to share the hydrology
+lattice with `twi.vrt`. The `elevation.vrt` is on the offset DEM lattice and is
+rejected; never substitute it.
+
+**Other inputs (per-fabric profile):**
+- `twi_raster` — CONUS `shared/conus/vrt/twi.vrt`; warp-windowed onto the template.
+- `hru_gpkg`, `segments_gpkg`/`segments_layer`, `waterbody_gpkg`/`waterbody_layer` (waterbody is required; the step raises if unset).
+- `imperv_source` in `configs/depstor/depstor_rasters.yml` — NLCD fractional-impervious raster.
+
+**DAG order:** landmask → imperv / streambuffer / waterbody → dprst → perv →
+vpu_id → routing → drains_perv / drains_imperv → carea_map. Selective re-runs
+via `--step <name>` or `--from <name>` passed through to the Python script.
+
+**`vpu_id` step.** Rasterises the HRU fabric's `vpu` attribute onto the template
+grid. Required by `carea_map` when `threshold_mode: percentile` and the fabric
+spans multiple VPUs. Single-VPU fabrics set `vpu: "<id>"` in their profile and
+skip this step.
+
+**`routing` memory.** Tiles the in-process D8 routing pass per VPU — each VPU
+is routed in isolation (FDR masked to the VPU) and the results are mosaicked.
+Peak memory ~80 GB measured for CONUS. Run at `--mem=96G`, not 64G.
+
+**`carea_map` threshold modes** (configured in `configs/depstor/depstor_rasters.yml`):
+
+- `threshold_mode: absolute` — uses the 8.0/15.6 thresholds. Requires ArcPy
+  `twi.vrt` as `twi_raster`. Only calibrated for VPU 01 / `gfv2_vpu01`.
+- `threshold_mode: percentile` — derives the TWI cutoff from the per-VPU
+  reference table produced by Stage 2a'. Source-agnostic; use with `twi.vrt`
+  (ArcPy) or `twi_hydrodem.vrt` (open-source). The `reference_table` key in
+  `depstor_rasters.yml` and the profile's `twi_raster` must be set to the same
+  source together — there is no auto-selection or guard for the pairing.
+
+For multi-VPU or non-VPU-01 fabrics (e.g. `oregon`), use
+`threshold_mode: percentile` with `twi_raster` pointing at `twi_hydrodem.vrt`;
+the percentile cutoffs come from Stage 2a'.
+
+```bash
+sbatch slurm_batch/build_depstor_rasters.batch
+
+# VPU01 validation overlay — override resources:
+FABRIC=gfv2_vpu01 sbatch --time=02:00:00 --mem=48G \
+    slurm_batch/build_depstor_rasters.batch
+
+# Resume from a specific step (e.g. after a routing crash):
+sbatch slurm_batch/build_depstor_rasters.batch --from routing --force
+```
+
+---
+
+## Stage 3 fabric prep detail
+
+### Stage 3a — `merge_vpu_targets` (compute-node only)
+
+Merge per-VPU fabric geopackages (`nhru` layer) into a single CONUS fabric gpkg.
+Loads the full CONUS fabric into memory. **Run on a compute node only** — use
+JupyterHub on a compute node, or `salloc` for an interactive session. Never run
+on the login node.
+
+```bash
+# In JupyterHub on a compute node, or in an salloc session:
+pixi run -e notebooks marimo run notebooks/merge_vpu_targets.py
+```
+
+### Stage 3b — `merge_vpu_segments`
+
+Merge the per-VPU `nsegment` layers into a single CONUS stream-segments gpkg
+for the depstor `streambuffer` step (VPU-based fabrics only). Outputs
+`{data_root}/gfv2/fabric/gfv2_nsegment_merged.gpkg` (layer `nsegment`). Submit
+via the batch:
+
+```bash
+sbatch slurm_batch/merge_vpu_segments.batch
+# Other fabrics:
+FABRIC=<name> sbatch slurm_batch/merge_vpu_segments.batch
+```
+
+Idempotent; pass `--force` to rebuild. The `segments_gpkg` is consumed only by
+the depstor `streambuffer` step; routing connectivity comes from the FDR raster,
+so merged-segment graph topology is not required here.
+
+### Stage 3c — `prepare_fabric`
+
+Spatially batch the merged fabric into per-batch geopackages (KD-tree recursive
+bisection) and write a manifest. Loads the whole CONUS fabric into memory; runs
+as a SLURM job via the batch wrapper:
+
+```bash
+sbatch slurm_batch/prepare_fabric.batch
+# Other fabrics:
+FABRIC=<name> sbatch slurm_batch/prepare_fabric.batch
+```
+
+`hru_gpkg`/`hru_layer` and `batch_size` are read from the active profile in
+`configs/base_config.yml`; no `--fabric_gpkg` is needed. `--fabric_gpkg` /
+`--layer` remain as optional overrides for one-off runs.
+
+---
+
+## Stage 4A — Incremental per-parameter runs
+
+Each parameter is a two-step unit: an array job over every HRU batch, then a
+merge that runs `afterok` it.
+
+Common preamble:
+
+```bash
+BATCHES=/path/to/gfv2/batches            # holds manifest.yml
+FABRIC=gfv2
+BASE_CONFIG=configs/base_config.yml
+N=$(grep '^n_batches:' "$BATCHES/manifest.yml" | awk '{print $2}')
+THROTTLE=4
+```
+
+**Zonal params** — run in this order (`slope` must be merged before `ssflux`):
+
+| # | parameter | | # | parameter |
+|--|--|--|--|--|
+| 1 | elevation | | 6 | lulc_nhm_v11 |
+| 2 | slope | | 7 | lulc_nalcms |
+| 3 | aspect | | 8 | lulc_nlcd |
+| 4 | soils | | 9 | lulc_foresce |
+| 5 | soil_moist_max | | 10 | ssflux *(special — see below)* |
+
+```bash
+P=elevation                              # repeat for each parameter in the table
+AID=$(sbatch --parsable --array=0-$((N-1))%$THROTTLE \
+      --export=ALL,BASE_CONFIG=$BASE_CONFIG,FABRIC=$FABRIC,PARAM=$P \
+      slurm_batch/derive_zonal_params.batch)
+sbatch --dependency=afterok:$AID \
+      --export=ALL,BASE_CONFIG=$BASE_CONFIG,FABRIC=$FABRIC,PARAM=$P \
+      slurm_batch/merge_zonal_param.batch
+```
+
+`ssflux` needs the CONUS-wide P2P weight matrix and the merged `slope` CSV
+first. Build the weight matrix (idempotent; export `FORCE=1` to rebuild), then
+submit ssflux like any other parameter:
+
+```bash
+sbatch --export=ALL,BASE_CONFIG=$BASE_CONFIG,FABRIC=$FABRIC \
+    slurm_batch/build_zonal_weights.batch
+# after weights finish, submit ssflux's array + merge as above with P=ssflux
+```
+
+**Depstor params** — same two-step unit per fraction, then one ratios job after
+all fractions have merged:
+
+Fractions: `perv_frac`, `imperv_frac`, `dprst_frac`, `drains_perv_frac`,
+`drains_imperv_frac`, `onstream_storage_frac`, `drains_to_dprst_frac`,
+`carea_t8_frac`, `carea_t156_frac`, `hru_total`
+
+```bash
+F=perv_frac                              # repeat for each fraction
+AID=$(sbatch --parsable --array=0-$((N-1))%$THROTTLE \
+      --export=ALL,BASE_CONFIG=$BASE_CONFIG,FABRIC=$FABRIC,FRACTION=$F \
+      slurm_batch/create_depstor_zonal.batch)
+sbatch --dependency=afterok:$AID \
+      --export=ALL,BASE_CONFIG=$BASE_CONFIG,FABRIC=$FABRIC,FRACTION=$F \
+      slurm_batch/merge_depstor_fraction.batch
+
+# Once all 10 fraction merge jobs have COMPLETED (check `squeue -u $USER`),
+# derive the 6 PRMS ratios:
+sbatch --export=ALL,BASE_CONFIG=$BASE_CONFIG,FABRIC=$FABRIC \
+      slurm_batch/derive_depstor_ratios.batch
+```
+
+For a quick single-batch sanity check without SLURM:
+
+```bash
+pixi run python scripts/derive_zonal_params.py --mode zonal --param elevation --batch_id 42 \
+    --config configs/zonal/zonal_params.yml --base_config configs/base_config.yml
+```
+
+`--mode merge --param <name>` runs just the merge; `--mode build_weights` builds
+the ssflux prereq.
+
+---
+
+## Stage 4B — Wholesale wrappers
+
+Each wrapper loops the per-parameter steps from Stage 4A — the same array +
+merge (+ ratios) jobs, chained via `afterok`:
+
+```bash
+slurm_batch/submit_zonal_params.sh   $BATCHES $FABRIC $BASE_CONFIG   # all 10 zonal params
+slurm_batch/submit_depstor_params.sh $BATCHES $FABRIC $BASE_CONFIG   # 10 fractions + ratios
+```
+
+`submit_zonal_params.sh` auto-detects ssflux's `depends_on: build_weights`:
+submits `build_zonal_weights.batch` first and chains the ssflux array on its
+`afterok` (and on the merged slope CSV). `submit_depstor_params.sh` chains the
+single ratios job on every fraction's merge.
+
+Env knobs (both wrappers):
+
+- `FABRIC=gfv2_vpu01` — non-default fabric (or pass as the 2nd positional arg)
+- `SUBMIT_JOBS_MAX_CONCURRENT=4` — array concurrency cap (or the 4th positional arg)
+- `FORCE=1` — rebuild the ssflux weight matrix
+
+**Depstor outputs** land in two subdirectories under `{fabric}/params/merged/`:
+
+- `{fabric}/params/merged/` — **6 final PRMS-ready ratio CSVs**, dimensionless
+  and bounded in [0, 1]: `sro_to_dprst_perv`, `sro_to_dprst_imperv`,
+  `carea_max`, `smidx_coef`, `hru_percent_imperv`, `dprst_frac`.
+- `{fabric}/params/merged/_intermediates/` — **10 per-fraction count CSVs**
+  (`nhm_<name>_frac_params.csv` and `nhm_hru_total_count_params.csv`). Each
+  row's `count` column is the partial-pixel-weighted sum of `1`-valued cells
+  per HRU — **not** a [0, 1] fraction. Inputs to ratio derivation; not direct
+  PRMS parameters. To get a true area fraction divide by the HRU pixel count
+  (e.g. `areasqkm * 1e6 / 900` for the 30 m template grid; the `hru_total`
+  fraction aggregates `land_mask.tif` to give that denominator).
+
+---
+
+## Stages 5–9
+
+### Stage 5 — Merge and validate
+
+Merging is part of Stage 4: the by-parameter path (4A) submits each merge as
+the second command of every unit; the wholesale wrappers (4B) chain it via
+`afterok`. To re-run a single param's merge after manually fixing a batch CSV:
+
+```bash
+pixi run python scripts/derive_zonal_params.py --mode merge --param elevation \
+    --config configs/zonal/zonal_params.yml --base_config configs/base_config.yml
+```
+
+### Stage 6 — SSFlux (depends on merged slope)
+
+Handled automatically by `submit_zonal_params.sh` — the dispatcher submits
+`build_zonal_weights.batch` first and chains the ssflux array + merge on its
+`afterok` and on the merged slope CSV. To build the CONUS-once weight matrix on
+its own:
+
+```bash
+sbatch slurm_batch/build_zonal_weights.batch
+```
+
+Idempotent — skips if the matrix already exists; pass `FORCE=1` to overwrite.
+
+### Stage 7 — KNN gap-fill
+
+Fits sklearn NearestNeighbors over every HRU and fills all param columns. Loads
+the full fabric into memory; submit via the batch:
+
+```bash
+sbatch slurm_batch/merge_and_fill_params.batch
+# Other fabrics:
+FABRIC=<name> sbatch slurm_batch/merge_and_fill_params.batch
+```
+
+### Stage 8 — Merge NHM defaults
+
+```bash
+sbatch slurm_batch/merge_default_output_params.batch
+# Other fabrics:
+FABRIC=<name> sbatch slurm_batch/merge_default_output_params.batch
+```
+
+### Stage 9 — View results
+
+The notebooks in `notebooks/fabric_results/` view a fabric's full
+parameterization — input rasters, depstor rasters, and per-HRU param maps.
+They are parameterised by the `FABRIC` env var. **Run them in JupyterHub on a
+compute node** (not the login node — a full CONUS `gfv2` render loads ~361k HRU
+polygons).
+
+To regenerate the figure set headlessly:
+
+```bash
+sbatch slurm_batch/render_figures.batch
+# Other fabrics:
+FABRIC=<name> sbatch slurm_batch/render_figures.batch
+```
+
+Outputs: `docs/figures/<name>/{input_raster_*,depstor_*,param_*}.png`.
+JupyterHub is the interactive alternative for exploratory inspection.
+
+---
+
+## Adding a new fabric
+
+A new fabric is added by appending a profile to `configs/base_config.yml` —
+one file edit, no new YAMLs. Two cases:
+
+### Case A: Pre-merged fabric (single gpkg — e.g., oregon)
+
+1. Register the fabric and scaffold output directories:
+   ```bash
+   pixi run init-data-root --add-fabric oregon
+   ```
+   Fill the stub's TODO placeholders. Required fields: `expected_max_hru_id`,
+   `batch_size`, `id_feature`, `hru_gpkg`/`hru_layer`. For depstor, also set
+   `template_raster`, `fdr_raster`, `twi_raster`,
+   `segments_gpkg`/`segments_layer`, `waterbody_gpkg`/`waterbody_layer`.
+   Stage the `template_raster`/`fdr_raster` clip:
+   ```bash
+   pixi run --as-is python scripts/clip_shared_to_fabric.py --fabric <name>
+   ```
+   For a single-file fabric like `oregon`, `segments_gpkg` can point at the
+   same gpkg as `hru_gpkg` with `segments_layer: nsegment`.
+
+2. Place the fabric gpkg at the `hru_gpkg` path under
+   `{data_root}/oregon/fabric/` (NOT in `input/fabric/`).
+
+3. Prepare batches:
+   ```bash
+   sbatch slurm_batch/prepare_fabric.batch   # FABRIC= override if needed
+   ```
+
+4. Submit parameter jobs:
+   ```bash
+   BATCHES={data_root}/oregon/batches
+   slurm_batch/submit_zonal_params.sh $BATCHES oregon configs/base_config.yml
+   slurm_batch/submit_depstor_params.sh $BATCHES oregon configs/base_config.yml
+   ```
+
+> **TWI source pairing for non-VPU-01 fabrics:** the 8.0/15.6 absolute
+> thresholds are only calibrated for VPU 01. For multi-VPU or non-VPU-01
+> fabrics, use `threshold_mode: percentile` in
+> `configs/depstor/depstor_rasters.yml` with `twi_raster` pointing at
+> `twi_hydrodem.vrt`; the percentile cutoffs come from Stage 2a'.
+
+### Case B: VPU-based fabric (per-VPU gpkgs — e.g., gfv2)
+
+1. Register the fabric + scaffold dirs:
+   ```bash
+   pixi run init-data-root --add-fabric <name>
+   ```
+   Fill the stub's TODO placeholders.
+
+2. Place per-VPU gpkgs in `input/fabric/`.
+
+3. Merge `nhru` (and, for depstor, `nsegment`):
+   ```bash
+   # In JupyterHub on a compute node or salloc session:
+   pixi run -e notebooks marimo run notebooks/merge_vpu_targets.py
+   # depstor only:
+   sbatch slurm_batch/merge_vpu_segments.batch   # FABRIC=<name> if needed
+   ```
+
+4. Continue from Stage 3c (`prepare_fabric`) with `FABRIC=<name>`.
+
+---
+
+## Partial reruns & recovery
+
+### Single-batch rerun
+
+To rerun a single failed batch within an array job:
+
+```bash
+sbatch --array=37 \
+    --export=ALL,PARAM=elevation,FABRIC=gfv2,BASE_CONFIG=configs/base_config.yml \
+    slurm_batch/derive_zonal_params.batch
+```
+
+For Part 1 raster prep, re-run a single step via:
+
+```bash
+sbatch slurm_batch/build_shared_rasters.batch --step <name>
+```
+
+### Refill a VPU after a merge-manifest / source fix
+
+When a per-VPU source gap is fixed, re-merge just that VPU and rebuild
+dependent products. Run the steps in order, waiting for each to finish (they
+are not auto-chained). Example for VPU 17:
+
+```bash
+V=17
+# 1. re-merge NED / Hydrodem / Fdr / Fac for the VPU
+VPUS=$V FORCE=1 sbatch --mem=384G slurm_batch/build_shared_rasters.batch --step merge_rpu_by_vpu
+# 2. regenerate open-source hydrology derivatives (Fdr_hydrodem, Twi_hydrodem)
+VPUS=$V FORCE=1 sbatch --mem=192G slurm_batch/build_shared_rasters.batch --step compute_dem_derivatives
+# 3. re-merge the ArcPy TWI (masked) for the VPU
+VPUS=$V FORCE=1 sbatch --mem=384G slurm_batch/build_shared_rasters.batch --step merge_rpu_by_vpu_twi
+# 4. rebuild CONUS VRTs
+FORCE=1 sbatch slurm_batch/build_shared_rasters.batch --step build_vrt
+# 5. recompute TWI percentile reference tables
+FORCE=1 sbatch slurm_batch/build_shared_rasters.batch --step twi_reference
+```
+
+Then re-clip and re-run depstor for the affected fabric:
+
+```bash
+# re-clip the fabric template/fdr from the rebuilt fdr.vrt
+pixi run python scripts/clip_shared_to_fabric.py --fabric oregon
+# re-derive depstor rasters and params
+FABRIC=oregon sbatch slurm_batch/build_depstor_rasters.batch --force
+DR=$(grep '^data_root:' configs/base_config.yml | awk '{print $2}' | tr -d '"')
+slurm_batch/submit_depstor_params.sh "$DR/oregon/batches" oregon configs/base_config.yml
+```
+
+Zonal params (elevation/slope/aspect/soils/LULC/ssflux) are on the gap-free DEM
+lattice and do not need re-running after a VPU FDR/TWI fix.
+
+Verify with `notebooks/fabric_results/01_input_rasters.ipynb` (the `fdr` /
+`twi_hydrodem` panels should have no nodata void inside the fabric).
+
+---
+
+## Monitoring
+
+```bash
+squeue -u "$USER"
+tail -n 200 logs/job_*.out
+sacct -j <JOBID> -o JobID,State,Elapsed,MaxRSS
+```
+
+---
+
+## Script → config → entry-point map
+
+### Orchestrators (primary surface)
+
+| Batch / shell | Config | Script |
+|---|---|---|
+| `slurm_batch/build_shared_rasters.batch` | `configs/shared_rasters/shared_rasters.yml` | `scripts/build_shared_rasters.py` |
+| `slurm_batch/build_depstor_rasters.batch` | `configs/depstor/depstor_rasters.yml` | `scripts/build_depstor_rasters.py` |
+| `slurm_batch/submit_zonal_params.sh` | `configs/zonal/zonal_params.yml` | `scripts/derive_zonal_params.py` (dispatches 10 params × zonal+merge, with ssflux's `build_weights` prereq chained automatically) |
+| `slurm_batch/submit_depstor_params.sh` | `configs/depstor/depstor_params.yml` | `scripts/derive_depstor_params.py` (dispatches 10 fractions × zonal+merge, then ratios via afterok) |
+
+### Part-2 workers (looped by the wrappers; also runnable by hand per Stage 4A)
+
+| Batch | Used by | Config | Script |
+|---|---|---|---|
+| `slurm_batch/derive_zonal_params.batch` | `submit_zonal_params.sh` | `configs/zonal/zonal_params.yml` | `scripts/derive_zonal_params.py --mode zonal --param $PARAM` |
+| `slurm_batch/merge_zonal_param.batch` | `submit_zonal_params.sh` | `configs/zonal/zonal_params.yml` | `scripts/derive_zonal_params.py --mode merge --param $PARAM` |
+| `slurm_batch/build_zonal_weights.batch` | `submit_zonal_params.sh` (ssflux prereq) | `configs/zonal/zonal_params.yml` | `scripts/derive_zonal_params.py --mode build_weights` |
+| `slurm_batch/create_depstor_zonal.batch` | `submit_depstor_params.sh` | `configs/depstor/depstor_params.yml` | `scripts/derive_depstor_params.py --mode zonal --fraction $FRACTION` |
+| `slurm_batch/merge_depstor_fraction.batch` | `submit_depstor_params.sh` | `configs/depstor/depstor_params.yml` | `scripts/derive_depstor_params.py --mode merge --fraction $FRACTION` |
+| `slurm_batch/derive_depstor_ratios.batch` | `submit_depstor_params.sh` | `configs/depstor/depstor_params.yml` | `scripts/derive_depstor_params.py --mode ratios` |
+
+### Stage 3 / fabric-prep batches
+
+| Batch | Config | Script |
+|---|---|---|
+| `slurm_batch/merge_vpu_segments.batch` | `configs/base_config.yml` | `scripts/merge_vpu_segments.py` (merges per-VPU `nsegment` → `{fabric}/fabric/{fabric}_nsegment_merged.gpkg`; VPU-based fabrics only) |
+| `slurm_batch/prepare_fabric.batch` | `configs/base_config.yml` | `scripts/prepare_fabric.py` (spatial batching via KD-tree bisection + manifest) |
+
+### Post-processing batches
+
+| Batch | Config | Script |
+|---|---|---|
+| `slurm_batch/merge_and_fill_params.batch` | `configs/base_config.yml` | `scripts/merge_and_fill_params.py` (KNN gap-fill of missing parameter values) |
+| `slurm_batch/merge_default_output_params.batch` | `configs/base_config.yml` | `scripts/merge_default_params.py` |
+| `slurm_batch/render_figures.batch` | (none; fabric from `FABRIC` env) | `scripts/render_figures.py` (headless figure generation via nbconvert) |
+
+### Standalone / setup
+
+| Batch / shell | Config | Script |
+|---|---|---|
+| `slurm_batch/stage_twi.batch` | `configs/base_config.yml` (indirectly) | `scripts/stage_twi.sh` |
+| `slurm_batch/submit_twi_completion.sh` | `configs/shared_rasters/shared_rasters.yml` | `scripts/build_shared_rasters.py` — three chained jobs: `--step merge_rpu_by_vpu_twi --force` → `--step build_vrt --force` → `--step twi_reference --force` |
+| `slurm_batch/download_rpu_rasters.batch` | `configs/base_config.yml` | `gfv2_params.download.rpu_rasters` |
+| `slurm_batch/download_nalcms.batch` | `configs/base_config.yml` | `gfv2_params.download.nalcms_lulc` |
+| `slurm_batch/download_nhm_v11.batch` | `configs/base_config.yml` | `gfv2_params.download.nhm_v11_lulc` |
+| `slurm_batch/submit_jobs.sh` | (caller-provided) | generic per-VPU array dispatcher |
+| (run directly) | `configs/base_config.yml` | `scripts/migrate_to_shared_layout.py --data-root <path>` (legacy `work/` layout upgrade) |
+| (run directly) | `configs/base_config.yml` | `scripts/clip_shared_to_fabric.py --fabric <name>` (fabric-bounds FDR/template clip) |

--- a/slurm_batch/HPC_REFERENCE.md
+++ b/slurm_batch/HPC_REFERENCE.md
@@ -391,6 +391,8 @@ FABRIC=<name> sbatch slurm_batch/prepare_fabric.batch
 
 ## Stage 4A — Incremental per-parameter runs
 
+> The runbook ([RUNME.md](RUNME.md) Step 4) now walks this per-parameter batch sequence explicitly; this section keeps the finer points — the array throttle, single-parameter reruns, and the ssflux→slope dependency mechanics.
+
 Each parameter is a two-step unit: an array job over every HRU batch, then a
 merge that runs `afterok` it.
 

--- a/slurm_batch/HPC_REFERENCE.md
+++ b/slurm_batch/HPC_REFERENCE.md
@@ -679,7 +679,7 @@ Then re-clip and re-run depstor for the affected fabric:
 
 ```bash
 # re-clip the fabric template/fdr from the rebuilt fdr.vrt
-pixi run python scripts/clip_shared_to_fabric.py --fabric oregon
+pixi run --as-is python scripts/clip_shared_to_fabric.py --fabric oregon
 # re-derive depstor rasters and params
 FABRIC=oregon sbatch slurm_batch/build_depstor_rasters.batch --force
 DR=$(grep '^data_root:' configs/base_config.yml | awk '{print $2}' | tr -d '"')

--- a/slurm_batch/HPC_REFERENCE.md
+++ b/slurm_batch/HPC_REFERENCE.md
@@ -276,7 +276,7 @@ sources: nhm_v11, nalcms, nlcd, foresce).
 
 ---
 
-## Stage 2d depstor detail
+### Stage 2d depstor detail
 
 Build the full depression-storage raster stack on a fabric-bounds template grid.
 Outputs go to `{fabric}/depstor_rasters/` and feed the Stage 4 depstor
@@ -486,7 +486,7 @@ single ratios job on every fraction's merge.
 Env knobs (both wrappers):
 
 - `FABRIC=gfv2_vpu01` — non-default fabric (or pass as the 2nd positional arg)
-- `SUBMIT_JOBS_MAX_CONCURRENT=4` — array concurrency cap (or the 4th positional arg)
+- `SUBMIT_JOBS_MAX_CONCURRENT=4` — array concurrency cap (or the 4th positional arg to `submit_zonal_params.sh` / `submit_depstor_params.sh`)
 - `FORCE=1` — rebuild the ssflux weight matrix
 
 **Depstor outputs** land in two subdirectories under `{fabric}/params/merged/`:

--- a/slurm_batch/RUNME.md
+++ b/slurm_batch/RUNME.md
@@ -72,7 +72,7 @@ rasters).
 # merge_vpu_targets is an interactive marimo notebook — run it on a COMPUTE
 # node (JupyterHub or `salloc`), never the login node. See HPC_REFERENCE.
 pixi run -e notebooks marimo run notebooks/merge_vpu_targets.py   # nhru merge (compute node)
-sbatch slurm_batch/merge_vpu_segments.batch                        # nsegment merge (depstor)
+sbatch slurm_batch/merge_vpu_segments.batch                        # nsegment merge (for depstor streambuffer)
 sbatch slurm_batch/prepare_fabric.batch                            # spatial batching + manifest
 ```
 

--- a/slurm_batch/RUNME.md
+++ b/slurm_batch/RUNME.md
@@ -1,825 +1,186 @@
-# GFv2 Pipeline: HPC Workflow
+# GFv2 Pipeline — Runbook (CONUS `gfv2`)
 
-## Prerequisites
-
-This pipeline uses [pixi](https://pixi.sh) for environment management. Install
-pixi once per user (see https://pixi.sh/latest/installation/) and ensure
-`~/.pixi/bin` is on your `PATH`. From the repo root:
-
-```bash
-pixi install
-```
-
-This materialises `.pixi/envs/default/` from `pixi.lock` (config lives in
-`pyproject.toml` under `[tool.pixi.*]`). The slurm batches invoke the env with
-`pixi run --as-is` (= `--no-install --frozen`): the already-installed env is used
-verbatim — no lock check, no env mutation, no PyPI/conda sync — so concurrent
-array tasks never race on `.pixi/envs/default/conda-meta/`. (An earlier approach
-that ran `pixi shell-hook --locked` per task did race there: a fraction of array
-tasks failed with "File was modified during parsing" before reaching python.
-`--as-is` removes that surface entirely.)
-
-**Re-run `pixi install`** any time `pyproject.toml` or `pixi.lock` change.
-
-> Because the slurm batches invoke `pixi run --as-is`, the `pixi` binary must be
-> on `PATH` on the compute node. SLURM jobs inherit the submitting shell's
-> environment, so always submit (`sbatch ...`, `submit_*.sh`) from a shell where
-> `~/.pixi/bin` is on your `PATH` (e.g. after the install step above). If a
-> batch fails immediately with `pixi: command not found`, that PATH was missing
-> at submit time.
-
-For interactive use:
-
-```bash
-pixi shell                       # default env
-pixi shell -e notebooks          # default + marimo, plotly, hvplot, ...
-pixi shell -e dev                # default + pytest, ruff, pre-commit
-```
-
-Run a one-off command in the env without an interactive shell:
-
-```bash
-pixi run python scripts/build_shared_rasters.py --config configs/shared_rasters/shared_rasters.yml --step build_vrt
-```
-
-> **Migrating from `geoenv`?** The legacy `environment.yml` is retained as a
-> deprecated fallback only. New work should use pixi.
-
-## Data Directory Layout
-
-All data lives under `data_root` (set in `configs/base_config.yml`):
-
-```
-gfv2_param/
-├── input/                  # External data (manually staged or downloaded)
-│   ├── fabric/             # Per-VPU watershed fabric gpkgs
-│   ├── soils_litho/        # TEXT_PRMS.tif, AWC.tif, Lithology_exp_Konly_Project.*
-│   ├── lulc_veg/           # RootDepth.tif, CNPY.tif, Imperv.tif
-│   │   └── nhm_v11/        # NHM v1.1 pre-derived LULC rasters (downloadable)
-│   ├── lulc/
-│   │   ├── nlcd_annual_imperv/   # NLCD fractional imperviousness (downloadable)
-│   │   └── nalcms_2020/    # NALCMS 2020 land cover (downloadable)
-│   ├── nhd/                # conus_waterbodies.gpkg (shared NHDPlusV2 waterbodies, layer waterbodies)
-│   ├── twi/<rpu>/          # Per-RPU TWI (twi.tif + sidecars; staged via stage_twi.sh)
-│   ├── nhm_default/        # NHM default parameter files
-│   └── nhd_downloads/      # Raw NHDPlus zip archives (downloadable)
-├── shared/                 # Fabric-independent intermediates (reused by every fabric)
-│   ├── source/             # Unzipped per-RPU NHDPlus rasters
-│   ├── per_vpu/<vpu>/      # Per-VPU merged GeoTIFFs (NED/Hydrodem/Fdr/Fac/Twi/slope/aspect/landmask)
-│   └── conus/
-│       ├── vrt/            # CONUS-wide GDAL virtual rasters (elevation/slope/aspect/fdr/twi)
-│       ├── derived/        # soil_moist_max.tif, radtrn, resampled CNPY/keep
-│       ├── borders/        # Copernicus border-DEM fill (Canada/Mexico)
-│       └── weights/        # P2P polygon weights for ssflux
-└── {fabric}/               # Per-fabric outputs (e.g., gfv2/, gfv2_vpu01/, oregon/)
-    ├── fabric/             # Merged fabric gpkg
-    ├── batches/            # Per-batch gpkgs + manifest
-    ├── depstor_rasters/    # Depression-storage intermediate rasters (per fabric)
-    └── params/             # Parameter outputs + merged + filled
-```
-
-> **Upgrading an existing `data_root` from the legacy `work/` layout?** Run
-> `pixi run python scripts/migrate_to_shared_layout.py --data-root <path> --dry-run`
-> to preview the 27 directory renames, then `--execute` to apply them.
-> Atomic `os.rename` on the same filesystem (metadata-only, near-instant);
-> regenerates CONUS VRTs at the end since they encode absolute source paths.
-> Idempotent — re-running after success is a no-op.
-
-## Selecting a fabric
-
-Fabric identities and **all shared, required per-fabric inputs** live as profiles
-in a single `configs/base_config.yml` under a `fabrics:` mapping — nothing
-required lives only on a CLI arg or is inferred from a naming convention. Every
-profile carries `hru_gpkg`/`hru_layer` (the fabric geopackage + layer),
-`id_feature`, `expected_max_hru_id`, and `batch_size`; depstor fabrics add
-`template_raster`, `fdr_raster`, `twi_raster`, `segments_gpkg`/`segments_layer`,
-and the required `waterbody_gpkg`/`waterbody_layer`. The active profile is
-selected via:
-
-1. `--fabric <name>` CLI flag on any script, OR
-2. `FABRIC` env var passed through sbatch, OR
-3. `default_fabric` in `configs/base_config.yml` (currently `gfv2`).
-
-Slurm batches default to `gfv2`. To run the same batch against a different
-fabric, set `FABRIC` and (optionally) override resource asks at submission:
-
-```bash
-# CONUS gfv2 — default
-sbatch slurm_batch/build_depstor_rasters.batch
-
-# VPU01 validation overlay — smaller; override resources
-FABRIC=gfv2_vpu01 sbatch --time=02:00:00 --mem=48G slurm_batch/build_depstor_rasters.batch
-```
-
-`submit_jobs.sh` accepts fabric as its 4th positional argument and forwards it
-via `--export=ALL,FABRIC=...` to the array job. (The legacy 4th-position
-`merge_config` argument was dropped — for chained merges, use
-`submit_zonal_params.sh` / `submit_depstor_params.sh`.)
-
-It also accepts an optional 5th argument (or `SUBMIT_JOBS_MAX_CONCURRENT` env
-var) capping how many array tasks run at once — defaults to 4. The cap exists
-because concurrent geo-library imports (rasterio / GDAL / PROJ / pyogrio) can
-deadlock under shared-FS metadata contention when many tasks start
-simultaneously; one of eight VPU01 array tasks hung indefinitely during the
-issue-#61 smoke test. Set to `0` (or `off`) to disable the cap. For CONUS the
-default of 4 trades ~1 wave of wall-clock time for reliability.
-
-## Pipeline Stages
-
-All commands below assume the repo root as your working directory, e.g.:
-```bash
-cd /caldera/hovenweep/projects/usgs/water/impd/nhgf/gfv2-params
-```
+The commands to take a fresh data root to finished parameters, in order.
+Running a different fabric, re-running one piece, internals, and recovery are
+in [HPC_REFERENCE.md](HPC_REFERENCE.md).
 
 ---
 
-## Part 1: Fabric-Independent Tasks
+## Before you start
 
-These stages do not require a watershed fabric and can be run while fabric preparation proceeds in parallel. Complete all Part 1 stages before moving to Part 2.
+- Run `pixi install` once from the repo root; ensure `~/.pixi/bin` is on `PATH`.
+- Always run `sbatch` / `submit_*.sh` from a shell where `~/.pixi/bin` is on
+  `PATH` (SLURM inherits it — a missing PATH causes immediate `pixi: command not found`).
+- Run everything from the repo root (`cd <repo>`).
 
-### Recommended: run Part 1 via the unified shared-rasters orchestrator
+---
 
-After Stage 0 completes and the downloads in Stages 1/1b have finished, every
-remaining raster prep step can be driven from one sbatch:
+## Pipeline at a glance
+
+1. **Step 0** — Initialize data root, download public rasters, stage TWI.
+2. **Step 1** — Build shared (CONUS) rasters (one orchestrator batch).
+3. **Step 2** — Prepare the fabric: merge nhru/nsegment, spatial batching.
+4. **Step 3** — Clip fabric-bounds FDR template; build depstor raster stack.
+5. **Step 4** — Fan out zonal + depstor parameter array jobs.
+6. **Step 5** — KNN gap-fill missing parameter values.
+7. **Step 6** — (optional) Merge NHM default parameter tables.
+8. **Step 7** — Render results figures headlessly.
+
+---
+
+## Run it (CONUS gfv2)
+
+### 0 · Initialize + stage inputs
+
+```bash
+pixi run init-data-root
+sbatch slurm_batch/download_rpu_rasters.batch
+sbatch slurm_batch/download_nalcms.batch
+sbatch slurm_batch/download_nhm_v11.batch
+sbatch slurm_batch/stage_twi.batch
+pixi run init-data-root --check     # after downloads + manual inputs are in place
+```
+
+**What it does:** scaffolds `data_root`, downloads the public rasters (~112 GB
+NHDPlus RPU, ~2 GB NALCMS, NHM v1.1 LULC), stages per-RPU TWI; `--check`
+verifies manually-staged inputs. (Manual-input table + provenance →
+HPC_REFERENCE "Stage 0".)
+
+**Wait for:** the four download/stage jobs `COMPLETED` in `squeue`, and
+`init-data-root --check` reporting all inputs present.
+
+---
+
+### 1 · Build shared (CONUS) rasters
 
 ```bash
 sbatch slurm_batch/build_shared_rasters.batch
 ```
 
-This walks the full DAG (merge_rpu_by_vpu → compute_slope_aspect →
-build_border_dem → build_vpu_landmask → merge_rpu_by_vpu_twi → build_vrt →
-build_derived_rasters → build_lulc_rasters) in dependency order, replacing
-the per-stage sbatch invocations below. Per-VPU steps iterate the `vpus`
-list inside `configs/shared_rasters/shared_rasters.yml` rather than launching one sbatch
-per VPU. Env knobs the batch honours:
+**What it does:** walks the whole shared-raster DAG (per-VPU merge →
+slope/aspect → border DEM → land mask → TWI merge → VRTs → derived + LULC
+rasters).
 
-- `FORCE=1` — pass `--force` to rebuild outputs that already exist
-- `VPUS=01,02` — pass `--vpus 01,02` to restrict per-VPU steps to a subset
-
-For interactive use (or finer-grained flags like `--step <name>` or
-`--from <name>`), invoke the orchestrator directly:
-
-```bash
-pixi run python scripts/build_shared_rasters.py --config configs/shared_rasters/shared_rasters.yml
-```
-
-The individual `slurm_batch/*.batch` files and per-script CLIs documented in
-Stages 1 through 2c below are preserved as thin shells around the same
-library builders. Use them when you want per-step granularity or per-VPU
-parallelism via SLURM arrays; use the orchestrator batch when you want one
-job that walks the whole DAG.
-
-### Stage 0: Initialize data root and stage inputs
-
-Scaffold the full directory tree under your `data_root`:
-
-```bash
-pixi run init-data-root
-```
-
-Verify that staged inputs are present:
-
-```bash
-pixi run init-data-root --check
-```
-
-The following externally-provided files must be placed in the scaffolded directories before running `--check`:
-
-| Destination | Required files |
-|---|---|
-| `input/fabric/` | `NHM_<VPU>_draft.gpkg` for each of the 21 VPUs: `01 02 03N 03S 03W 04 05 06 07 08 09 10L 10U 11 12 13 14 15 16 17 18` |
-| `input/soils_litho/` | `TEXT_PRMS.tif`, `AWC.tif`, `Lithology_exp_Konly_Project.shp` (+ sidecar files: `.dbf`, `.prj`, `.shx`) |
-| `input/lulc_veg/` | `RootDepth.tif`, `CNPY.tif`, `Imperv.tif` |
-| `input/nhm_default/` | NHM default parameter files (input to final merge step) |
-| `input/nhd/` | `conus_waterbodies.gpkg` (layer `waterbodies`) — shared CONUS NHDPlusV2 depression-storage polygons, used by every depstor fabric. Stream segments are **not** staged here: for a VPU-based fabric (gfv2) they are merged from the per-VPU `nsegment` layers by `scripts/merge_vpu_segments.py` (→ `{fabric}/fabric/{fabric}_nsegment_merged.gpkg`); a pre-merged fabric (oregon) reads `nsegment` from its own model gpkg. The D8 flow-direction raster comes from the shared `shared/conus/vrt/fdr.vrt`, not a per-fabric FDR. |
-| `input/twi/<rpu>/` | Per-RPU TWI raster `twi.tif` (+ `.tfw`, `.aux.xml`, `.ovr`, `.xml` sidecars). Stage with `bash scripts/stage_twi.sh` (see below). |
-
-The NALCMS 2020 land cover raster can be downloaded automatically (see below).
-
-**Download NHDPlus RPU rasters** from S3 (network-bound, ~112 GB, submit as a SLURM job):
-
-```bash
-mkdir -p logs
-sbatch slurm_batch/download_rpu_rasters.batch
-```
-
-**Download NALCMS 2020 land cover raster** from CEC (~2 GB zip, submit as a SLURM job):
-
-```bash
-sbatch slurm_batch/download_nalcms.batch
-```
-
-**Download NHM v1.1 LULC rasters** from ScienceBase item `5ebb182b82ce25b5136181cf`
-(`LULC.zip`, `keep.zip`, `CNPY.zip` — network-bound; submit as a SLURM job):
-
-```bash
-sbatch slurm_batch/download_nhm_v11.batch
-```
-
-All download scripts are idempotent — already-downloaded files are skipped on resubmission.
-
-**Stage per-RPU TWI rasters** — provenance is USGS ScienceBase item
-`5f5154ba82ce4c3d12386a02`
-(<https://www.sciencebase.gov/catalog/item/5f5154ba82ce4c3d12386a02> — **not a
-public link**; access is gated). For impd-group users, an operational mirror
-lives on the shared cluster filesystem; the staging script reads from it by
-default and copies into `input/twi/<rpu>/twi.tif`:
-
-```bash
-bash scripts/stage_twi.sh
-# or pass an alternate source:
-bash scripts/stage_twi.sh /alt/path/to/data_bins
-```
-
-This is a ~30 GB single-threaded `cp` against the shared filesystem. Running it
-on a login node is borderline (busy login nodes don't love sustained I/O) — the
-recommended path for an unattended run is the slurm wrapper:
-
-```bash
-sbatch slurm_batch/stage_twi.batch
-# or with an alternate source:
-SRC=/alt/path/to/data_bins sbatch slurm_batch/stage_twi.batch
-```
-
-The script handles HRU06a's uppercase `TWI.*` source filenames by normalizing
-to lowercase in the destination so the merge config can reference all 18 VPUs
-without per-RPU casing exceptions. Idempotent — re-running skips files already
-present and newer than the source.
-
-Note: `--check` only validates manually-staged inputs (soils, litho, lulc_veg, twi). Verify downloads completed successfully by checking the job logs before proceeding.
-
-### Stages 1, 1b, 1c1, 1c2, 2a, 2b, 2c — Shared raster prep (one orchestrator)
-
-**All of these are now driven by `sbatch slurm_batch/build_shared_rasters.batch`** (or the
-`pixi run python scripts/build_shared_rasters.py --config configs/shared_rasters/shared_rasters.yml`
-interactive equivalent). The orchestrator walks the canonical 9-step DAG in
-dependency order — there is no longer a per-step batch surface; all the
-per-step CLIs/sbatches were retired now that the orchestrator covers them.
-
-For a single-step rebuild, pass `--step <name>` to the orchestrator (e.g.
-`--step build_border_dem` or `--step build_vrt`). Use `--from <name>` to
-resume mid-DAG. Step names match the keys in
-[configs/shared_rasters/shared_rasters.yml](../configs/shared_rasters/shared_rasters.yml).
-
-The narrative below describes what each step does and what it depends on;
-the bash invocation is always the same orchestrator.
-
-**Stage 1 — `merge_rpu_by_vpu` + `compute_slope_aspect`:** Merge per-RPU
-NHDPlus rasters into per-VPU GeoTIFFs (NED, Hydrodem, FDR, FAC), then derive
-slope/aspect on the fixed-nodata NEDSnapshot.
-
-**Stage 1b — `build_border_dem`:** Download Copernicus GLO-30 tiles and
-build elevation/slope/aspect fill rasters for HRUs that extend into Canada or
-Mexico beyond NHDPlus coverage. Creates fill rasters in `shared/conus/borders/`;
-the subsequent `build_vrt` step composites these behind NHDPlus so NHDPlus
-takes priority where it has valid data and Copernicus fills the border gaps.
-Depends on Stage 1 — needs the NHDPlus `_fixed_` elevation tiles to build a
-seamless composite for slope/aspect computation.
-
-**Stage 1c1 — `build_vpu_landmask`:** Build the per-VPU HRU-fabric land mask
-consumed by both TWI pipelines. Produces `shared/per_vpu/<vpu>/land_mask_<vpu>.tif`
-— a uint8 1/255 raster where 1 = inside an HRU whose `vpu` attribute matches
-this VPU, 255 = outside. The mask is rasterised onto the per-VPU
-`Hydrodem_merged_<vpu>.tif` grid, so TWI products downstream get a strict match
-to their VPU's HRU coverage rather than the CONUS-wide depstor `land_mask.tif`
-(which leaves cells unmasked wherever adjacent-VPU HRUs drape into a VPU's
-Hydrodem footprint). Depends only on Stage 1; independent of Stage 2d.
-
-**Stage 1c2 — `merge_rpu_by_vpu_twi`:** Merge the per-RPU TWI rasters staged
-in Stage 0 into per-VPU GeoTIFFs (`Twi_merged_<vpu>.tif`). The merge clips its
-output to the per-VPU HRU mask from Stage 1c1 so the per-RPU TWI bulges
-(coast on the east, adjacent-VPU/border drape on the west/north) never reach
-downstream zonal aggregation. Depends on Stage 1c1.
-
-**Stage 2a — `build_vrt`:** Combine per-VPU rasters and optional Copernicus
-fill into CONUS-wide GDAL virtual rasters (elevation/slope/aspect/fdr/twi).
-Also builds `twi_hydrodem.vrt` (open-source WhiteboxTools TWI, CONUS-complete)
-if `Twi_hydrodem_*.tif` tiles are present in `per_vpu/`. The historical
-staging gap where `Twi_merged_<vpu>.tif` was only populated for VPU 01 was
-resolved by PR #95; if you ever need to re-finish the ArcPy TWI tiles + both
-VRTs in one shot, the recovery wrapper is:
-
-```bash
-bash slurm_batch/submit_twi_completion.sh
-```
-
-This submits three chained jobs: `merge_rpu_by_vpu_twi --force` (rebuilds all
-18 VPUs idempotently) → `build_vrt --force` (writes `twi.vrt` and
-`twi_hydrodem.vrt`) → `twi_reference --force` (writes the per-VPU percentile
-CSVs used by `carea_map threshold_mode: percentile`). Verify afterwards with
-`gdalinfo` on both VRTs.
-
-**Stage 2a' — `twi_reference`:** Compute valid-land TWI percentile cutoffs
-per VPU (and CONUS) for each TWI source (`arcpy`, `hydrodem`). Outputs
-`shared/conus/twi_reference_percentiles.arcpy.csv` and
-`shared/conus/twi_reference_percentiles.hydrodem.csv`. These tables are the
-input to `carea_map threshold_mode: percentile` (Stage 2d). The default
-percentiles are derived by inverting the legacy 8.0/15.6 thresholds through
-VPU 01's ArcPy TWI CDF. Runs automatically after `build_vrt` in the
-orchestrator DAG; run on its own with:
-
-```bash
-pixi run python scripts/build_shared_rasters.py \
-    --config configs/shared_rasters/shared_rasters.yml --step twi_reference
-```
-
-**Stage 2b — `build_derived_rasters`:** Pre-compute `rd_250_raw.tif` and
-`soil_moist_max.tif`.
-
-**Stage 2c — `build_lulc_rasters`:** Pre-compute canopy-resampled + keep-resampled
-+ radiation-transmission rasters for every LULC source listed in
-[configs/shared_rasters/shared_rasters.yml](../configs/shared_rasters/shared_rasters.yml)'s
-`sources:` block (currently 4 sources: nhm_v11, nalcms, nlcd, foresce).
-
-**Per-fabric overrides:** All of the above are fabric-independent (CONUS).
-For depstor-only fabric overrides (Stage 2d), use `FABRIC=...` env in the
-sbatch command.
-
-### Stage 2d: Build depstor rasters (per fabric)
-
-Build the full depression-storage raster stack on a fabric-bounds template
-grid. Outputs go to `{fabric}/depstor_rasters/` and feed the Stage 4 depstor
-zonal-stats orchestrator below.
-
-Inputs (per fabric, from `base_config.yml`):
-- `template_raster` **and** `fdr_raster`: a fabric-bounds clip of the CONUS FDR,
-  staged with `pixi run --as-is python scripts/clip_shared_to_fabric.py --fabric <name>`
-  (writes `{data_root}/<name>/shared/<name>_fdr.vrt`). The template grid sizes
-  every builder's arrays, so this scopes compute to the fabric; the clip is on
-  the hydrology lattice `carea_map` requires the template to share with `twi.vrt`.
-- `twi_raster` (CONUS `shared/conus/vrt/twi.vrt`; warp-windowed onto the template).
-- `hru_gpkg`, `segments_gpkg`/`segments_layer`, `waterbody_gpkg`/`waterbody_layer`.
-- The NLCD fractional-impervious raster (`imperv_source` in
-  `configs/depstor/depstor_rasters.yml`).
-
-One sbatch builds the entire stack in dependency order
-(landmask → imperv/streambuffer/waterbody → dprst → perv → vpu_id → routing →
-drains_perv/drains_imperv → carea_map). The 11-step DAG is encoded
-in `src/gfv2_params/depstor_builders/__init__.py`; selective re-runs are
-supported via `--step <name>` or `--from <name>` passed through to the python
-script. `routing` runs **after** `vpu_id` because it tiles the in-process D8
-routing pass per VPU — each VPU is routed in isolation (FDR masked to the VPU)
-and the results are mosaicked. That keeps CONUS memory bounded (~80 GB peak
-measured — run at `--mem=96G` — vs ~405 GB for a whole-CONUS WBT float64 load)
-and is correct because VPU boundaries follow drainage divides.
-
-**`vpu_id` step:** rasterises the HRU fabric's `vpu` attribute onto the
-template grid. Required by `carea_map` when `threshold_mode: percentile` and
-the fabric spans multiple VPUs (multi-VPU fabrics look up each cell's VPU in
-the reference table; single-VPU fabrics set `vpu: "17"` in their profile and
-skip this step).
-
-**`carea_map` threshold modes:** configured in `configs/depstor/depstor_rasters.yml`.
-- `threshold_mode: absolute` — legacy 8.0/15.6 thresholds. Requires ArcPy
-  `twi.vrt` as `twi_raster`; the builder warns if paired with a non-ArcPy
-  (hydrodem) source.
-- `threshold_mode: percentile` — derives the TWI cutoff from the data by
-  reading the per-VPU reference table produced by Stage 2a'. Source-agnostic:
-  use with `twi.vrt` (ArcPy) or `twi_hydrodem.vrt` (open-source). The
-  `reference_table` key (here in `depstor_rasters.yml`) and the profile's
-  `twi_raster` must be set to the same source together — there is no
-  auto-selection or guard for the pairing.
-
-```bash
-sbatch slurm_batch/build_depstor_rasters.batch
-
-# VPU01 validation overlay — smaller; override resources:
-FABRIC=gfv2_vpu01 sbatch --time=02:00:00 --mem=48G \
-    slurm_batch/build_depstor_rasters.batch
-
-# Resume from a specific step (e.g. after a routing crash):
-sbatch slurm_batch/build_depstor_rasters.batch --from routing --force
-```
-
-Default resources size the job for the long pole (`routing` — per-VPU D8
-routing pass). Because `routing` tiles per VPU, whole-CONUS FDR is never held
-in memory, so the default `--mem` can be right-sized down once a clean CONUS
-run reports its peak. For VPU01 / smaller fabrics, override `--time` and
-`--mem` at submission as shown above.
-
-Note: Stage 2d depends on the Part 1 FDR VRT (`shared/conus/vrt/fdr.vrt`, the
-source the per-fabric clip is cut from) but is otherwise fabric-independent of
-the rest of Part 1. Stage the clip (`clip_shared_to_fabric.py`) first; it can
-run in parallel with Part 2's fabric prep.
+**Wait for:** the job `COMPLETED`; `shared/conus/vrt/` holds the VRTs (esp.
+`fdr.vrt`, `twi.vrt`, `twi_hydrodem.vrt`).
 
 ---
 
-## Part 2: Fabric-Dependent Tasks
-
-These stages require the merged fabric geopackage and the per-batch gpkgs produced by `prepare_fabric.py`. Complete Part 1 before proceeding.
-
-### Stage 3: Prepare fabric (one-time per fabric)
-
-Merge per-VPU fabric geopackages into a single CONUS fabric:
+### 2 · Prepare the fabric
 
 ```bash
-pixi run -e notebooks marimo run notebooks/merge_vpu_targets.py
+# merge_vpu_targets is an interactive marimo notebook — run it on a COMPUTE
+# node (JupyterHub or `salloc`), never the login node. See HPC_REFERENCE.
+pixi run -e notebooks marimo run notebooks/merge_vpu_targets.py   # nhru merge (compute node)
+sbatch slurm_batch/merge_vpu_segments.batch                        # nsegment merge (depstor)
+sbatch slurm_batch/prepare_fabric.batch                            # spatial batching + manifest
 ```
 
-If you will run the depstor pipeline for this fabric, also merge the per-VPU
-`nsegment` layers into the single CONUS stream-network gpkg that the depstor
-`streambuffer` step needs (the notebook above merges only `nhru`):
+**What it does:** merges per-VPU `nhru`/`nsegment` into the CONUS fabric, then
+batches it into per-batch geopackages.
+
+**Wait for:** `{fabric}/fabric/` has the merged nhru + nsegment gpkgs and
+`{fabric}/batches/manifest.yml` exists.
+
+---
+
+### 3 · Build depstor rasters
 
 ```bash
-pixi run --as-is python scripts/merge_vpu_segments.py --fabric gfv2
-# → {data_root}/gfv2/fabric/gfv2_nsegment_merged.gpkg (layer nsegment),
-#   the profile's segments_gpkg. Idempotent; pass --force to rebuild.
+pixi run --as-is python scripts/clip_shared_to_fabric.py --fabric gfv2   # tiny VRT (login OK)
+sbatch slurm_batch/build_depstor_rasters.batch
 ```
 
-Then spatially batch the merged fabric into per-batch geopackages. The fabric
-gpkg + layer and `batch_size` are read from the active profile in
-`base_config.yml` (`hru_gpkg`/`hru_layer`), so no `--fabric_gpkg` is needed:
+**What it does:** clips the fabric-bounds FDR template, then builds the full
+depression-storage raster stack.
+
+**Wait for:** the job `COMPLETED`; `{fabric}/depstor_rasters/` holds the full
+stack (through `carea_map_t8/t156_binary.tif`).
+
+---
+
+### 4 · Generate parameters
 
 ```bash
-pixi run python scripts/prepare_fabric.py \
-    --fabric gfv2 \
-    --base_config configs/base_config.yml
+BATCHES=$(pixi run --as-is python -c \
+  "import yaml;print(yaml.safe_load(open('configs/base_config.yml'))['data_root'])")/gfv2/batches
+slurm_batch/submit_zonal_params.sh   "$BATCHES" gfv2 configs/base_config.yml
+slurm_batch/submit_depstor_params.sh "$BATCHES" gfv2 configs/base_config.yml
 ```
 
-`--fabric_gpkg`/`--layer` remain as optional overrides for one-off runs.
+**What it does:** fans out the zonal + depstor param array jobs and chains
+their merges (+ ratios / ssflux weights) via `afterok`.
 
-### Stage 4: Generate parameters (SLURM array jobs)
+**Wait for:** all array + merge (+ ratios) jobs `COMPLETED` in `squeue`.
 
-There are two equivalent ways to run Part 2, and they produce identical
-outputs. Use **4A (run by parameter)** to follow the workflow one parameter at
-a time, inspect each output, or re-run a single one; use **4B (run wholesale)**
-to submit everything in one command. 4B is just a loop over the 4A steps.
+---
 
-Common preamble for both (after Stage 3 — fabric merged + batched):
+### 5 · Gap-fill missing values
 
 ```bash
-BATCHES=/path/to/gfv2/batches            # from scripts/prepare_fabric.py; holds manifest.yml
-FABRIC=gfv2
-BASE_CONFIG=configs/base_config.yml
-N=$(grep '^n_batches:' "$BATCHES/manifest.yml" | awk '{print $2}')   # SLURM array size
-THROTTLE=4                               # %N array concurrency cap (avoids shared-FS import storms)
+sbatch slurm_batch/merge_and_fill_params.batch
 ```
 
-#### Stage 4A: Run by parameter (incremental)
+**What it does:** KNN-fills any missing per-HRU parameter values.
 
-**Zonal params.** Each parameter is a two-step unit: an array job over every
-HRU batch, then a merge that runs `afterok` it. Run them in this order — `slope`
-must be merged before `ssflux`:
+**Wait for:** the job `COMPLETED`.
 
-| # | parameter | | # | parameter |
-|--|--|--|--|--|
-| 1 | elevation | | 6 | lulc_nhm_v11 |
-| 2 | slope | | 7 | lulc_nalcms |
-| 3 | aspect | | 8 | lulc_nlcd |
-| 4 | soils | | 9 | lulc_foresce |
-| 5 | soil_moist_max | | 10 | ssflux *(special — see below)* |
+---
+
+### 6 · (optional) Merge NHM defaults
 
 ```bash
-P=elevation                              # repeat for each parameter in the table
-AID=$(sbatch --parsable --array=0-$((N-1))%$THROTTLE \
-      --export=ALL,BASE_CONFIG=$BASE_CONFIG,FABRIC=$FABRIC,PARAM=$P \
-      slurm_batch/derive_zonal_params.batch)
-sbatch --dependency=afterok:$AID \
-      --export=ALL,BASE_CONFIG=$BASE_CONFIG,FABRIC=$FABRIC,PARAM=$P \
-      slurm_batch/merge_zonal_param.batch
+sbatch slurm_batch/merge_default_output_params.batch
 ```
 
-`ssflux` needs the CONUS-wide P2P weight matrix and the merged `slope` CSV
-first. If you ran the table in order, slope is already merged — just build the
-weights, then submit ssflux like any other parameter (`P=ssflux`):
+**What it does:** merges the NHM default parameter tables into the per-HRU
+outputs.
+
+**Wait for:** the job `COMPLETED`.
+
+---
+
+### 7 · View results
 
 ```bash
-sbatch --export=ALL,BASE_CONFIG=$BASE_CONFIG,FABRIC=$FABRIC slurm_batch/build_zonal_weights.batch
-# after weights finish, submit ssflux's array + merge as above with P=ssflux
+sbatch slurm_batch/render_figures.batch     # PNGs -> docs/figures/gfv2/
 ```
 
-The weight matrix is CONUS-once per fabric and idempotent; export `FORCE=1` to
-rebuild it.
+**What it does:** renders the fabric_results figure set headlessly.
+(Interactive viewing via JupyterHub → HPC_REFERENCE "Stage 9".)
 
-**Depstor params.** Same two-step unit per fraction, then one ratios job after
-**all** fractions have merged. Fractions (`hru_total` is the denominator for two
-of the ratios):
+**Wait for:** the job `COMPLETED`; PNGs in `docs/figures/gfv2/`.
 
-`perv_frac`, `imperv_frac`, `dprst_frac`, `drains_perv_frac`,
-`drains_imperv_frac`, `onstream_storage_frac`, `drains_to_dprst_frac`,
-`carea_t8_frac`, `carea_t156_frac`, `hru_total`
-
-```bash
-F=perv_frac                              # repeat for each fraction
-AID=$(sbatch --parsable --array=0-$((N-1))%$THROTTLE \
-      --export=ALL,BASE_CONFIG=$BASE_CONFIG,FABRIC=$FABRIC,FRACTION=$F \
-      slurm_batch/create_depstor_zonal.batch)
-sbatch --dependency=afterok:$AID \
-      --export=ALL,BASE_CONFIG=$BASE_CONFIG,FABRIC=$FABRIC,FRACTION=$F \
-      slurm_batch/merge_depstor_fraction.batch
-
-# once all 10 fraction merge jobs have COMPLETED (check `squeue -u $USER` — not
-# just submitted; the by-parameter path has no afterok on the ratios job),
-# derive the 6 PRMS ratios:
-sbatch --export=ALL,BASE_CONFIG=$BASE_CONFIG,FABRIC=$FABRIC \
-      slurm_batch/derive_depstor_ratios.batch
-```
-
-(The wholesale path 4B instead chains this ratios job `afterok` on every merge,
-so it can be submitted up front.)
-
-For a quick single-batch sanity check without SLURM, invoke an orchestrator
-directly:
-
-```bash
-pixi run python scripts/derive_zonal_params.py --mode zonal --param elevation --batch_id 42 \
-    --config configs/zonal/zonal_params.yml --base_config configs/base_config.yml
-```
-
-`--mode merge --param <name>` runs just one merge; `--mode build_weights` builds
-the ssflux prereq.
-
-#### Stage 4B: Run wholesale (one command per stage)
-
-Each wrapper loops the per-parameter steps from 4A — the same array + merge
-(+ ratios) jobs, chained via `afterok`:
-
-```bash
-slurm_batch/submit_zonal_params.sh   $BATCHES $FABRIC $BASE_CONFIG   # all 10 zonal params
-slurm_batch/submit_depstor_params.sh $BATCHES $FABRIC $BASE_CONFIG   # 10 fractions + ratios
-```
-
-`submit_zonal_params.sh` auto-detects ssflux's `depends_on: build_weights`:
-it submits `build_zonal_weights.batch` first and chains the ssflux array on its
-`afterok` (and on the merged slope CSV). `submit_depstor_params.sh` chains the
-single ratios job on every fraction's merge. Env knobs (both wrappers):
-
-- `FABRIC=gfv2_vpu01` — non-default fabric (or pass as the 2nd positional arg)
-- `SUBMIT_JOBS_MAX_CONCURRENT=4` — array concurrency cap (or the 4th positional arg)
-- `FORCE=1` — rebuild the ssflux weight matrix
-
-#### Depstor outputs (either path)
-
-Depstor results land in two subdirectories under `{fabric}/params/merged/`:
-
-- `{fabric}/params/merged/` — **6 final PRMS-ready ratio CSVs**, all
-  dimensionless and bounded in [0, 1]:
-  `sro_to_dprst_perv`, `sro_to_dprst_imperv`, `carea_max`, `smidx_coef`,
-  `hru_percent_imperv`, `dprst_frac`.
-- `{fabric}/params/merged/_intermediates/` — **10 per-fraction count CSVs**
-  (`nhm_<name>_frac_params.csv` and `nhm_hru_total_count_params.csv`).
-  Each row's `count` column is the partial-pixel-weighted sum of `1`-valued
-  cells per HRU — **NOT** a [0, 1] fraction. Inputs to the ratio derivation;
-  not direct PRMS parameters. To get a true area fraction divide by the HRU
-  pixel count (e.g. `areasqkm * 1e6 / 900` for the 30 m template grid; the
-  `hru_total` fraction aggregates `land_mask.tif` to give exactly that
-  denominator).
-
-### Stage 5: Merge and validate
-
-Merging is part of Stage 4, not a separate stage: the by-parameter path (4A)
-submits each merge as the second command of every unit, and the wholesale
-wrappers (4B) chain it automatically via `afterok`. Either way, to re-run a
-single param's merge on its own (e.g., after manually fixing a batch CSV):
-
-```bash
-pixi run python scripts/derive_zonal_params.py --mode merge --param elevation \
-    --config configs/zonal/zonal_params.yml --base_config configs/base_config.yml
-```
-
-### Stage 6: SSFlux (depends on merged slope)
-
-Handled automatically by `submit_zonal_params.sh` — the dispatcher sees
-`depends_on: build_weights` on the ssflux entry in
-`configs/zonal/zonal_params.yml`, submits `build_zonal_weights.batch`
-first, and chains the ssflux array + merge on its `afterok`. ssflux also
-chains on the merged slope CSV. (To run ssflux by hand, see Stage 4A.)
-
-To build the CONUS-once weight matrix on its own (idempotent — skips if
-the matrix already exists, pass `FORCE=1` to overwrite):
-
-```bash
-sbatch slurm_batch/build_zonal_weights.batch
-```
-
-### Stage 7: KNN gap-fill
-
-```bash
-pixi run python scripts/merge_and_fill_params.py --base_config configs/base_config.yml
-```
-
-### Stage 8: Merge NHM defaults (optional)
-
-```bash
-pixi run python scripts/merge_default_params.py --base_config configs/base_config.yml
-```
-
-### Stage 9: View results (notebooks)
-
-The three notebooks in `notebooks/fabric_results/` view a fabric's full
-parameterization — input rasters (clipped to the fabric), depstor rasters, and
-per-HRU param maps. They are parameterized by the `FABRIC` env var. **Run them in
-JupyterHub on a compute node with enough `--mem`** (not the login node — a full
-CONUS `gfv2` render loads ~361k HRU polygons). See
-`notebooks/<fabric>/README.md` for the launch recipe. To regenerate the figure
-set for a report headlessly:
-
-```bash
-pixi run -e notebooks python scripts/render_figures.py --fabric <name>
-# -> docs/figures/<name>/{input_raster_*,depstor_*,param_*}.png  (committed)
-```
-
-## Adding a new fabric (e.g., Oregon)
-
-A new fabric is added by appending a profile to `configs/base_config.yml` —
-one file edit, no new YAMLs. Two cases depending on whether the fabric is
-already merged or comes as per-VPU gpkgs.
-
-**Case A: Pre-merged fabric** (single gpkg covering the full domain — e.g., Oregon)
-
-1. Register the fabric and scaffold its output directories in one step:
-   ```bash
-   pixi run init-data-root --add-fabric oregon
-   ```
-   This appends a profile stub under `fabrics:` in `configs/base_config.yml`
-   (preserving comments) and creates the fabric's dirs. Then fill the stub's
-   TODO placeholders. **All shared, required fabric inputs live in the
-   profile.** Every fabric needs `expected_max_hru_id`, `batch_size`,
-   `id_feature` (the HRU id column present in the fabric — e.g. `nat_hru_id`
-   for gfv2, `hru_id` for oregon — which flows through to the merged parameter
-   CSVs), and `hru_gpkg`/`hru_layer` (the fabric geopackage + layer,
-   authoritative for `prepare_fabric`, the ssflux `build_weights` step, and
-   gap-fill). If the depstor pipeline will be run for this fabric, also set
-   `template_raster`, `fdr_raster`, `twi_raster`, `segments_gpkg`/`segments_layer`,
-   and `waterbody_gpkg`/`waterbody_layer` (waterbody is **required** for depstor —
-   the step raises if unset). Stage the `template_raster`/`fdr_raster` clip with
-   `pixi run --as-is python scripts/clip_shared_to_fabric.py --fabric <name>`
-   (writes `{data_root}/<name>/shared/<name>_fdr.vrt`, a fabric-bounds clip of
-   the CONUS FDR) and point both keys at it — this scopes depstor compute to the
-   fabric extent and stays VPU-agnostic (see the boxed note below). `twi_raster`
-   uses the CONUS `twi.vrt`. For a single-file fabric like `oregon`,
-   `segments_gpkg` can point at the same gpkg as `hru_gpkg` with
-   `segments_layer: nsegment`. The `oregon` profile has the depstor keys
-   **active** (issue #90) — the FDR clip for template/fdr, CONUS `twi.vrt`,
-   `segments_gpkg` at the model gpkg, and the CONUS NHDPlusV2 waterbodies at
-   `input/nhd/conus_waterbodies.gpkg` (layer `waterbodies`). To get valid
-   `carea_max`/`smidx_coef` outside VPU 01, set `threshold_mode: percentile`
-   in `configs/depstor/depstor_rasters.yml` (the new default after PR #95)
-   and point `twi_raster` at the CONUS-complete `twi_hydrodem.vrt`; the
-   percentile cutoffs come from the `twi_reference` step (Stage 2a'). (Prefer
-   hand-editing? Just add the profile block directly — the stub is a convenience.)
-2. Place the fabric gpkg at the `hru_gpkg` path you set, under
-   `{data_root}/oregon/fabric/` (NOT in `input/fabric/`)
-3. Prepare batches (the fabric gpkg + layer come from the profile's
-   `hru_gpkg`/`hru_layer` — no `--fabric_gpkg` needed):
-   ```bash
-   pixi run python scripts/prepare_fabric.py --fabric oregon
-   ```
-4. Submit parameter jobs. Easiest is the unified Part 2 dispatcher (one
-   invocation walks every param + chained merges + ssflux's weights prereq):
-   ```bash
-   BATCHES={data_root}/oregon/batches
-   slurm_batch/submit_zonal_params.sh $BATCHES oregon configs/base_config.yml
-   ```
-   For per-param granularity, invoke the orchestrator directly with
-   `--mode zonal --param <name> --batch_id <N>` (see "Single-batch run"
-   in README.md or Stage 4 above).
-
-> **Scoping depstor to a fabric (e.g. Oregon):** every depstor builder sizes its
-> arrays to the `template_raster` grid, so the template controls compute extent.
-> A CONUS template would force CONUS-scale memory/time; a per-VPU tile is cheap
-> but breaks for fabrics that straddle VPU boundaries. Instead, clip the CONUS
-> FDR to the fabric bounds with
-> `pixi run --as-is python scripts/clip_shared_to_fabric.py --fabric oregon`
-> (a tiny zero-copy VRT) and use it for `template_raster`/`fdr_raster`. Oregon's
-> clip is ~0.56B cells vs ~15B CONUS. The clip comes from `fdr.vrt` because
-> `carea_map` requires the template to share the hydrology lattice with
-> `twi.vrt`; `elevation.vrt` is on the offset DEM lattice and is rejected. The
-> `fdr.vrt` source also lets `routing` read only the fabric window. `twi_raster`
-> and `imperv` stay CONUS (their builders warp-window them onto the template);
-> the waterbody source is the CONUS NHDPlusV2 gpkg. Part 1 itself can still be
-> scoped per-VPU (`VPUS=17 sbatch slurm_batch/build_shared_rasters.batch`) to
-> avoid rebuilding all of CONUS. Then run Stage 2d:
-> `FABRIC=oregon sbatch slurm_batch/build_depstor_rasters.batch`.
->
-> **TWI source pairing (resolved by PR #95):** the legacy 8.0/15.6 absolute
-> thresholds were calibrated against VPU 01's ArcPy TWI distribution, so
-> `threshold_mode: absolute` is only meaningful when paired with `twi.vrt`
-> on VPU 01 (the `gfv2_vpu01` profile). For multi-VPU or non-VPU-01 fabrics
-> like `oregon`, use `threshold_mode: percentile` (the default in
-> `configs/depstor/depstor_rasters.yml`) with `twi_raster` pointing at the
-> CONUS-complete `twi_hydrodem.vrt`; the percentile cutoffs are sourced from
-> the `twi_reference` step (Stage 2a'). With this pairing Stage 2d produces
-> valid `carea_max`/`smidx_coef` everywhere. `twi.vrt` itself is CONUS-wide
-> after PR #95's staging completion — what's VPU-01-specific is the threshold
-> calibration, not the data coverage.
-
-**Case B: VPU-based fabric** (per-VPU gpkgs that need merging — e.g., gfv2)
-
-1. Register the fabric + scaffold dirs: `pixi run init-data-root --add-fabric <name>`
-   (or hand-edit `fabrics:` in `configs/base_config.yml`), then fill the stub's
-   TODO placeholders.
-2. Place per-VPU gpkgs in `input/fabric/`
-3. Merge `nhru` (and, for depstor, `nsegment`):
-   ```bash
-   pixi run -e notebooks marimo run notebooks/merge_vpu_targets.py
-   pixi run --as-is python scripts/merge_vpu_segments.py --fabric <name>   # depstor only
-   ```
-4. Continue from Stage 3 above, passing `--fabric <name>` (or `FABRIC=<name>` env)
-
-## Partial Reruns
-
-To rerun a single failed batch within one of the orchestrator's array
-jobs, submit a one-task array against the generic per-batch worker with
-`$PARAM` set:
-
-```bash
-sbatch --array=37 --export=ALL,PARAM=elevation,FABRIC=gfv2,BASE_CONFIG=configs/base_config.yml \
-    slurm_batch/derive_zonal_params.batch
-```
-
-(For Part 1 raster prep, re-run the single step via the orchestrator's
-`--step` flag: `pixi run python scripts/build_shared_rasters.py
---config configs/shared_rasters/shared_rasters.yml --step <name>`.)
-
-### Recovery: refill a VPU after a merge-manifest / source fix
-
-When a per-VPU source gap is fixed (e.g. an RPU added to a VPU's merge entry in
-`configs/shared_rasters/merge_rpu_by_vpu.yml`, or a stale merge that predates a
-staged RPU), re-merge **just that VPU** and rebuild the products that depend on
-it, then re-run the affected fabric's depstor stage. Run the steps in order,
-waiting for each to finish (they aren't auto-chained). Example for **VPU 17**
-(the W Oregon 17d FDR gap); the per-VPU merge is memory-heavy, so bump `--mem`:
-
-```bash
-V=17
-# 1. re-merge NED / Hydrodem / Fdr / Fac for the VPU (now incl. the added RPU)
-VPUS=$V FORCE=1 sbatch --mem=384G slurm_batch/build_shared_rasters.batch --step merge_rpu_by_vpu
-# 2. regenerate the open-source hydrology derivatives (Fdr_hydrodem, Twi_hydrodem)
-#    from the refreshed Hydrodem — NOT in the default DAG, so name it explicitly
-VPUS=$V FORCE=1 sbatch --mem=192G slurm_batch/build_shared_rasters.batch --step compute_dem_derivatives
-# 3. re-merge the ArcPy TWI (masked) for the VPU
-VPUS=$V FORCE=1 sbatch --mem=384G slurm_batch/build_shared_rasters.batch --step merge_rpu_by_vpu_twi
-# 4. rebuild the CONUS VRTs (fdr.vrt, twi.vrt, twi_hydrodem.vrt, elevation/slope/aspect)
-FORCE=1 sbatch slurm_batch/build_shared_rasters.batch --step build_vrt
-# 5. recompute the TWI percentile reference tables
-FORCE=1 sbatch slurm_batch/build_shared_rasters.batch --step twi_reference
-```
-
-Then refresh the affected fabric and re-run **only its depstor stage** (the
-zonal params — elevation/slope/aspect/soils/LULC/ssflux — are on the gap-free
-DEM lattice and do not need re-running):
-
-```bash
-# resolve data_root from the base config (the submit script needs a real path,
-# not the {data_root} placeholder)
-DR=$(grep '^data_root:' configs/base_config.yml | awk '{print $2}' | tr -d '"')
-
-# re-clip the fabric template/fdr from the rebuilt fdr.vrt
-pixi run python scripts/clip_shared_to_fabric.py --fabric oregon
-# re-derive depstor rasters (routing + carea_map) and params
-FABRIC=oregon sbatch slurm_batch/build_depstor_rasters.batch --force
-slurm_batch/submit_depstor_params.sh "$DR/oregon/batches" oregon configs/base_config.yml
-```
-
-Verify with `notebooks/fabric_results/01_input_rasters.ipynb` (the `fdr` /
-`twi_hydrodem` panels should no longer have a nodata void inside the fabric).
+---
 
 ## Monitoring
 
 ```bash
 squeue -u "$USER"
-tail -n 200 logs/job_*.out
 sacct -j <JOBID> -o JobID,State,Elapsed,MaxRSS
+tail -n 200 logs/job_<JOBID>.err
 ```
 
-## Script -> Config -> Entry Point Mapping
+---
 
-Every production workflow is driven by an orchestrator (Part 1 / depstor
-rasters) or a Part-2 submission wrapper. The old per-step *Python* CLIs were
-retired — the library code they delegated to lives under `src/gfv2_params/` —
-but the Part-2 worker `.batch` files remain a supported surface you can drive
-by hand, one parameter at a time (see Stage 4A); the wrappers just loop them.
+## Where outputs land
 
-### Orchestrators (the primary surface)
+- `{data_root}/gfv2/params/merged/` — final parameter CSVs, including the 6
+  depstor ratios (`sro_to_dprst_perv`, `sro_to_dprst_imperv`, `carea_max`,
+  `smidx_coef`, `hru_percent_imperv`, `dprst_frac`).
+- `{data_root}/gfv2/params/merged/_intermediates/` — 10 per-fraction count
+  CSVs (inputs to ratio derivation; `count` is NOT a [0, 1] fraction).
+- `docs/figures/gfv2/` — rendered PNG figures.
 
-| Batch / shell | Config | Script |
-|---|---|---|
-| `build_shared_rasters.batch` | `shared_rasters/shared_rasters.yml` | `build_shared_rasters.py` |
-| `build_depstor_rasters.batch` | `depstor/depstor_rasters.yml` | `build_depstor_rasters.py` |
-| `submit_depstor_params.sh` | `depstor/depstor_params.yml` | `derive_depstor_params.py` (dispatches 10 fractions × zonal+merge, then ratios via afterok) |
-| `submit_zonal_params.sh` | `zonal/zonal_params.yml` | `derive_zonal_params.py` (dispatches 10 params × zonal+merge, with ssflux's `build_weights` prereq chained automatically) |
+---
 
-### Part-2 workers (looped by the wrappers; also runnable by hand per Stage 4A)
+## Need more?
 
-| Batch | Used by | Config | Script |
-|---|---|---|---|
-| `derive_zonal_params.batch` | `submit_zonal_params.sh` | `zonal/zonal_params.yml` | `derive_zonal_params.py --mode zonal --param $PARAM` |
-| `merge_zonal_param.batch` | `submit_zonal_params.sh` | `zonal/zonal_params.yml` | `derive_zonal_params.py --mode merge --param $PARAM` |
-| `build_zonal_weights.batch` | `submit_zonal_params.sh` (for ssflux prereq) | `zonal/zonal_params.yml` | `derive_zonal_params.py --mode build_weights` |
-| `create_depstor_zonal.batch` | `submit_depstor_params.sh` | `depstor/depstor_params.yml` | `derive_depstor_params.py --mode zonal --fraction $FRACTION` |
-| `merge_depstor_fraction.batch` | `submit_depstor_params.sh` | `depstor/depstor_params.yml` | `derive_depstor_params.py --mode merge --fraction $FRACTION` |
-| `derive_depstor_ratios.batch` | `submit_depstor_params.sh` | `depstor/depstor_params.yml` | `derive_depstor_params.py --mode ratios` |
+See [HPC_REFERENCE.md](HPC_REFERENCE.md) for:
 
-### Standalone (one-off / setup / post-processing)
-
-| Batch / shell | Config | Script |
-|---|---|---|
-| (run directly) | `base_config.yml` | `scripts/merge_vpu_segments.py --fabric <name>` (merges per-VPU `nsegment` → `{fabric}/fabric/{fabric}_nsegment_merged.gpkg` for depstor `streambuffer`; VPU-based fabrics only) |
-| `stage_twi.batch` | `base_config.yml` (indirectly) | `scripts/stage_twi.sh` |
-| `submit_twi_completion.sh` | `shared_rasters/shared_rasters.yml` | `build_shared_rasters.py --step merge_rpu_by_vpu_twi --force` → `--step build_vrt --force` → `--step twi_reference --force` (three chained jobs: finishes `twi.vrt` + `twi_hydrodem.vrt` + writes percentile CSVs) |
-| `download_rpu_rasters.batch` | `base_config.yml` | `gfv2_params.download.rpu_rasters` |
-| `download_nalcms.batch` | `base_config.yml` | `gfv2_params.download.nalcms_lulc` |
-| `download_nhm_v11.batch` | `base_config.yml` | `gfv2_params.download.nhm_v11_lulc` |
-| `merge_default_output_params.batch` (Stage 8) | `base_config.yml` | `merge_default_params.py` |
-| `submit_jobs.sh` | (caller-provided) | generic per-VPU array dispatcher |
+- Running other fabrics (VPU01 validation, Oregon, new fabric registration).
+- Running one parameter at a time (Stage 4A incremental path).
+- Single-step raster rebuilds (`--step <name>`, `--from <name>`).
+- Recovery / partial reruns (single-batch array resubmit, VPU source refill).
+- Environment internals and array concurrency throttle.
+- The script → config → entry-point map.

--- a/slurm_batch/RUNME.md
+++ b/slurm_batch/RUNME.md
@@ -101,17 +101,77 @@ stack (through `carea_map_t8/t156_binary.tif`).
 
 ### 4 · Generate parameters
 
+Each parameter is **two batch jobs**: an array job over every HRU batch, then a
+merge that runs after it (`afterok`). Submit them **in order, waiting for each
+merge before the next** — `slope` must merge before `ssflux`. First set the
+shared variables:
+
 ```bash
 BATCHES=$(pixi run --as-is python -c \
   "import yaml;print(yaml.safe_load(open('configs/base_config.yml'))['data_root'])")/gfv2/batches
-slurm_batch/submit_zonal_params.sh   "$BATCHES" gfv2 configs/base_config.yml
-slurm_batch/submit_depstor_params.sh "$BATCHES" gfv2 configs/base_config.yml
+FABRIC=gfv2
+BASE_CONFIG=configs/base_config.yml
+N=$(grep '^n_batches:' "$BATCHES/manifest.yml" | awk '{print $2}')   # array size
+THROTTLE=4                                                            # concurrent array tasks
 ```
 
-**What it does:** fans out the zonal + depstor param array jobs and chains
-their merges (+ ratios / ssflux weights) via `afterok`.
+**Zonal parameters** — run this pair for each `P`, in order: `elevation`,
+`slope`, `aspect`, `soils`, `soil_moist_max`, `lulc_nhm_v11`, `lulc_nalcms`,
+`lulc_nlcd`, `lulc_foresce`:
 
-**Wait for:** all array + merge (+ ratios) jobs `COMPLETED` in `squeue`.
+```bash
+P=elevation     # change P and re-run for each parameter above, in order
+AID=$(sbatch --parsable --array=0-$((N-1))%$THROTTLE \
+      --export=ALL,BASE_CONFIG=$BASE_CONFIG,FABRIC=$FABRIC,PARAM=$P \
+      slurm_batch/derive_zonal_params.batch)
+sbatch --dependency=afterok:$AID \
+      --export=ALL,BASE_CONFIG=$BASE_CONFIG,FABRIC=$FABRIC,PARAM=$P \
+      slurm_batch/merge_zonal_param.batch
+```
+
+**ssflux** needs the CONUS P2P weight matrix and the merged `slope` CSV first.
+Build the weights, then run the pair above with `P=ssflux`:
+
+```bash
+sbatch --export=ALL,BASE_CONFIG=$BASE_CONFIG,FABRIC=$FABRIC slurm_batch/build_zonal_weights.batch
+# after weights + slope merge finish, submit ssflux's array + merge with P=ssflux
+```
+
+**Depstor fractions** — same pair per `F` (any order): `perv_frac`,
+`imperv_frac`, `dprst_frac`, `drains_perv_frac`, `drains_imperv_frac`,
+`onstream_storage_frac`, `drains_to_dprst_frac`, `carea_t8_frac`,
+`carea_t156_frac`, `hru_total`:
+
+```bash
+F=perv_frac     # change F and re-run for each fraction above
+AID=$(sbatch --parsable --array=0-$((N-1))%$THROTTLE \
+      --export=ALL,BASE_CONFIG=$BASE_CONFIG,FABRIC=$FABRIC,FRACTION=$F \
+      slurm_batch/create_depstor_zonal.batch)
+sbatch --dependency=afterok:$AID \
+      --export=ALL,BASE_CONFIG=$BASE_CONFIG,FABRIC=$FABRIC,FRACTION=$F \
+      slurm_batch/merge_depstor_fraction.batch
+```
+
+**Depstor ratios** — after **all 10** fraction merges have `COMPLETED`, derive
+the 6 PRMS ratios:
+
+```bash
+sbatch --export=ALL,BASE_CONFIG=$BASE_CONFIG,FABRIC=$FABRIC slurm_batch/derive_depstor_ratios.batch
+```
+
+**What it does:** computes every per-HRU zonal parameter and the 6 depstor ratios.
+
+**Wait for:** all array + merge jobs `COMPLETED` (`squeue -u "$USER"`), then the
+ratios job `COMPLETED`.
+
+> **Convenience — run wholesale.** The two wrappers below submit exactly the
+> batch jobs above for you, chained with `afterok` (and they handle the
+> `slope`→`ssflux` dependency and the weights prereq automatically):
+>
+> ```bash
+> slurm_batch/submit_zonal_params.sh   "$BATCHES" gfv2 configs/base_config.yml
+> slurm_batch/submit_depstor_params.sh "$BATCHES" gfv2 configs/base_config.yml
+> ```
 
 ---
 

--- a/slurm_batch/RUNME.md
+++ b/slurm_batch/RUNME.md
@@ -117,7 +117,8 @@ THROTTLE=4                                                            # concurre
 
 **Zonal parameters** — run this pair for each `P`, in order: `elevation`,
 `slope`, `aspect`, `soils`, `soil_moist_max`, `lulc_nhm_v11`, `lulc_nalcms`,
-`lulc_nlcd`, `lulc_foresce`:
+`lulc_nlcd`, `lulc_foresce`, and `ssflux` (`ssflux` last — it has an extra
+prereq, see below):
 
 ```bash
 P=elevation     # change P and re-run for each parameter above, in order

--- a/slurm_batch/merge_and_fill_params.batch
+++ b/slurm_batch/merge_and_fill_params.batch
@@ -11,12 +11,14 @@
 #
 # KNN gap-fill of missing parameter values against the fabric (Stage 7). Fits
 # sklearn NearestNeighbors over every HRU and fills all param columns, so it
-# runs as a SLURM job rather than on the login node. The fabric is read from
-# base_config's default_fabric (the script takes no --fabric).
+# runs as a SLURM job rather than on the login node.
+#   FABRIC=oregon sbatch slurm_batch/merge_and_fill_params.batch
 # --mem/--time are starting points; right-size from `sacct -j <id> -o MaxRSS`.
 cd "$SLURM_SUBMIT_DIR"
 BASE_CONFIG=${BASE_CONFIG:-configs/base_config.yml}
+FABRIC=${FABRIC:-gfv2}
 
 pixi run --as-is python scripts/merge_and_fill_params.py \
+    --fabric "$FABRIC" \
     --base_config "$BASE_CONFIG" \
     "$@"

--- a/slurm_batch/merge_and_fill_params.batch
+++ b/slurm_batch/merge_and_fill_params.batch
@@ -1,0 +1,22 @@
+#!/bin/bash
+#SBATCH -p cpu
+#SBATCH -A impd
+#SBATCH --job-name=merge_and_fill_params
+#SBATCH --output=logs/job_%j.out
+#SBATCH --error=logs/job_%j.err
+#SBATCH --time=02:00:00
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=64G
+#
+# KNN gap-fill of missing parameter values against the fabric (Stage 7). Fits
+# sklearn NearestNeighbors over every HRU and fills all param columns, so it
+# runs as a SLURM job rather than on the login node. The fabric is read from
+# base_config's default_fabric (the script takes no --fabric).
+# --mem/--time are starting points; right-size from `sacct -j <id> -o MaxRSS`.
+cd "$SLURM_SUBMIT_DIR"
+BASE_CONFIG=${BASE_CONFIG:-configs/base_config.yml}
+
+pixi run --as-is python scripts/merge_and_fill_params.py \
+    --base_config "$BASE_CONFIG" \
+    "$@"

--- a/slurm_batch/merge_vpu_segments.batch
+++ b/slurm_batch/merge_vpu_segments.batch
@@ -13,6 +13,7 @@
 # depstor `streambuffer` step (VPU-based fabrics only). Concatenates 21 VPU
 # geometry layers in memory, so it runs as a SLURM job rather than on the login
 # node.  FABRIC=gfv2 sbatch slurm_batch/merge_vpu_segments.batch
+# --mem/--time are starting points; right-size from `sacct -j <id> -o MaxRSS`.
 cd "$SLURM_SUBMIT_DIR"
 BASE_CONFIG=${BASE_CONFIG:-configs/base_config.yml}
 FABRIC=${FABRIC:-gfv2}

--- a/slurm_batch/merge_vpu_segments.batch
+++ b/slurm_batch/merge_vpu_segments.batch
@@ -1,0 +1,23 @@
+#!/bin/bash
+#SBATCH -p cpu
+#SBATCH -A impd
+#SBATCH --job-name=merge_vpu_segments
+#SBATCH --output=logs/job_%j.out
+#SBATCH --error=logs/job_%j.err
+#SBATCH --time=01:00:00
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=32G
+#
+# Merge the per-VPU `nsegment` layers into one CONUS stream-segments gpkg for the
+# depstor `streambuffer` step (VPU-based fabrics only). Concatenates 21 VPU
+# geometry layers in memory, so it runs as a SLURM job rather than on the login
+# node.  FABRIC=gfv2 sbatch slurm_batch/merge_vpu_segments.batch
+cd "$SLURM_SUBMIT_DIR"
+BASE_CONFIG=${BASE_CONFIG:-configs/base_config.yml}
+FABRIC=${FABRIC:-gfv2}
+
+pixi run --as-is python scripts/merge_vpu_segments.py \
+    --fabric "$FABRIC" \
+    --base_config "$BASE_CONFIG" \
+    "$@"

--- a/slurm_batch/prepare_fabric.batch
+++ b/slurm_batch/prepare_fabric.batch
@@ -1,0 +1,24 @@
+#!/bin/bash
+#SBATCH -p cpu
+#SBATCH -A impd
+#SBATCH --job-name=prepare_fabric
+#SBATCH --output=logs/job_%j.out
+#SBATCH --error=logs/job_%j.err
+#SBATCH --time=02:00:00
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=64G
+#
+# Spatially batch a merged fabric into per-batch geopackages (KD-tree recursive
+# bisection) + a manifest. Loads the whole CONUS fabric into memory, so it runs
+# as a SLURM job rather than on the login node. Override FABRIC for other
+# fabrics:  FABRIC=oregon sbatch slurm_batch/prepare_fabric.batch
+# --mem/--time are starting points; right-size from `sacct -j <id> -o MaxRSS`.
+cd "$SLURM_SUBMIT_DIR"
+BASE_CONFIG=${BASE_CONFIG:-configs/base_config.yml}
+FABRIC=${FABRIC:-gfv2}
+
+pixi run --as-is python scripts/prepare_fabric.py \
+    --fabric "$FABRIC" \
+    --base_config "$BASE_CONFIG" \
+    "$@"

--- a/slurm_batch/render_figures.batch
+++ b/slurm_batch/render_figures.batch
@@ -1,0 +1,23 @@
+#!/bin/bash
+#SBATCH -p cpu
+#SBATCH -A impd
+#SBATCH --job-name=render_figures
+#SBATCH --output=logs/job_%j.out
+#SBATCH --error=logs/job_%j.err
+#SBATCH --time=02:00:00
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=96G
+#
+# Headlessly (re)generate the fabric_results figures (nbconvert --execute). Loads
+# the full HRU fabric (~361k polygons for CONUS gfv2), so it runs as a SLURM job
+# rather than on the login node. Uses the `notebooks` pixi env (jupyter/nbconvert);
+# the script already forces MPLBACKEND=Agg.
+#   FABRIC=oregon sbatch slurm_batch/render_figures.batch
+# --mem/--time are starting points; right-size from `sacct -j <id> -o MaxRSS`.
+cd "$SLURM_SUBMIT_DIR"
+FABRIC=${FABRIC:-gfv2}
+
+pixi run --as-is -e notebooks python scripts/render_figures.py \
+    --fabric "$FABRIC" \
+    "$@"


### PR DESCRIPTION
Closes #131.

## Why
`slurm_batch/RUNME.md` (826 lines) served a non-HPC-expert hydrologist badly: no linear happy path, HPC rationale + PR/issue archaeology inline with every command, and two equivalent execution paths as peers. Separately, several compute/memory-intensive steps were documented as login-node `pixi run` commands with no SLURM wrapper.

## What

**A — new SLURM wrappers** (intensive steps that were run on the login node; wrappers only, no script changes):
- `prepare_fabric.batch` (CONUS fabric + KD-tree bisection)
- `merge_and_fill_params.batch` (sklearn KNN gap-fill, Stage 7)
- `merge_vpu_segments.batch` (CONUS geometry concat)
- `render_figures.batch` (headless figure render, `notebooks` env)

**B — doc-consistency**: `merge_default_params` shown via its existing batch; heavy `build_shared_rasters --step` via `sbatch`; `merge_vpu_targets` (marimo) documented compute-node-only.

**C — the split**:
- `RUNME.md` → a lean ~246-line CONUS-gfv2 **runbook**: a single linear step 0→7, every heavy step an `sbatch`. **Step 4 (params) documents the underlying batch jobs to run in order** — `derive_zonal_params`/`merge_zonal_param` per param (+ `build_zonal_weights` for ssflux), `create_depstor_zonal`/`merge_depstor_fraction` per fraction, then `derive_depstor_ratios` — with the `submit_*.sh` wrappers offered as the wholesale convenience (the wrappers are opaque to a non-HPC reader).
- `HPC_REFERENCE.md` (new) → relocated per-stage detail, retains the stage taxonomy (so inbound "Stage N" refs resolve), PR/issue archaeology dropped.
- Cross-refs repointed: `CLAUDE.md`, `README.md`, `docs/ARCHITECTURE.md`, `docs/depstor_workflow.md`, `docs/ADDING_A_PARAMETER.md`, and the mkdocs `docs/hpc-workflow.md` (now includes both docs).

## Verification
- All four batches: `bash -n`, `--help` flag checks, `sbatch --test-only` pass.
- Every batch/script referenced in both slurm docs resolves on disk (broken-ref sweep clean).
- pre-commit green. No Python changes → CI `pytest` unaffected.
- Each task spec- and quality-reviewed during subagent-driven execution.

Docs-only change. The new batches' `--mem`/`--time` are starting points (noted in-file) to right-size from `sacct MaxRSS` after a first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)