### PR TITLE
fix: KNN-fill NaN parameter values, not just absent HRU rows (#133)

### DIFF
--- a/scripts/merge_and_fill_params.py
+++ b/scripts/merge_and_fill_params.py
@@ -56,6 +56,11 @@ def fill_missing_values_knn(param_df, missing_ids, merged_gdf, param_columns, k,
         logger.info("No missing values to fill!")
         return param_df
 
+    # Capture NaN count from the *original* frame before absent rows are appended
+    # so the log line reflects only genuinely missing parameter cells, not the
+    # all-NaN rows we are about to synthesise for absent ids.
+    n_input_nan = param_df[param_columns].isna().to_numpy().sum() if param_columns else 0
+
     # Compute centroids once (avoid mutating caller's GDF).
     merged_gdf = merged_gdf.copy()
     merged_gdf["centroid"] = merged_gdf["geometry"].centroid
@@ -97,6 +102,12 @@ def fill_missing_values_knn(param_df, missing_ids, merged_gdf, param_columns, k,
         if not fill_mask.any():
             continue
 
+        if not fit_mask.any():
+            raise ValueError(
+                f"Column '{param_column}' has no valid (non-NaN) values to fit from; "
+                "cannot KNN-fill with an empty training set."
+            )
+
         fit_coords = np.column_stack([x_vals[fit_mask], y_vals[fit_mask]])
         fit_values = col_vals[fit_mask]
         fill_coords = np.column_stack([x_vals[fill_mask], y_vals[fill_mask]])
@@ -109,14 +120,13 @@ def fill_missing_values_knn(param_df, missing_ids, merged_gdf, param_columns, k,
         full_df.loc[fill_mask, param_column] = filled_values
 
     # Step 4: drop helper columns, sort, reset index.
-    full_df = full_df.drop(columns=["x", "y", "centroid"], errors="ignore")
+    full_df = full_df.drop(columns=["x", "y"], errors="ignore")
     full_df = full_df.sort_values(id_feature).reset_index(drop=True)
 
     n_absent = len(missing_ids)
-    total_nan_cells = param_df[param_columns].isna().to_numpy().sum() if has_nan_cells else 0
     logger.info(
         "Filled %d absent id(s) and %d NaN cell(s) across %d column(s)",
-        n_absent, total_nan_cells, len(param_columns),
+        n_absent, n_input_nan, len(param_columns),
     )
     return full_df
 

--- a/scripts/merge_and_fill_params.py
+++ b/scripts/merge_and_fill_params.py
@@ -32,12 +32,17 @@ def find_missing_ids(param_file, expected_max, id_feature, logger):
 
 
 def fill_missing_values_knn(param_df, missing_ids, merged_gdf, param_columns, k, id_feature, logger):
-    """KNN-interpolate every missing HRU across all `param_columns` at once.
+    """KNN-interpolate absent HRU rows AND present-but-NaN parameter cells.
 
-    Builds a single block of filled rows (one row per missing id, every column
-    populated) and appends it to `param_df` exactly once. Filling per column
-    and re-appending would duplicate each missing id once per column, leaving
-    most cells NaN — see the multi-column regression test.
+    For absent ids: appends a new all-NaN row so every expected id exists in
+    the frame before per-column filling begins.
+
+    For NaN cells: per column, the fit set is rows where that column has a
+    valid (non-NaN) value AND valid coordinates; the fill set is rows where
+    that column is NaN AND coords are valid. NaN-valued rows are excluded from
+    the fit set so they cannot be chosen as a fill source.
+
+    Exactly one row per id is guaranteed in the output; no duplicate ids.
     """
     logger.info("Filling missing values using KNN interpolation (k=%d)...", k)
 
@@ -45,57 +50,75 @@ def fill_missing_values_knn(param_df, missing_ids, merged_gdf, param_columns, k,
     if isinstance(param_columns, str):
         param_columns = [param_columns]
 
-    if not missing_ids:
+    # Check whether there is anything to do before loading centroids.
+    has_nan_cells = param_df[param_columns].isna().to_numpy().any() if param_columns else False
+    if not missing_ids and not has_nan_cells:
         logger.info("No missing values to fill!")
         return param_df
 
+    # Compute centroids once (avoid mutating caller's GDF).
+    merged_gdf = merged_gdf.copy()
     merged_gdf["centroid"] = merged_gdf["geometry"].centroid
     merged_gdf["x"] = merged_gdf["centroid"].x
     merged_gdf["y"] = merged_gdf["centroid"].y
+    coords_df = merged_gdf[[id_feature, "x", "y"]].copy()
 
-    existing_df = param_df.merge(merged_gdf[[id_feature, "x", "y"]], on=id_feature, how="left")
-    missing_df = merged_gdf[merged_gdf[id_feature].isin(missing_ids)][[id_feature, "x", "y"]]
+    # Step 1: append all-NaN rows for absent ids so every expected id is present.
+    if missing_ids:
+        absent_rows = pd.DataFrame({id_feature: missing_ids})
+        # gfv2 CSVs carry a secondary local hru_id; populate it for appended rows.
+        # When id_feature is already hru_id (e.g. oregon) this is a harmless self-assignment.
+        absent_rows["hru_id"] = absent_rows[id_feature]
+        param_df = pd.concat([param_df, absent_rows], ignore_index=True)
 
-    existing_coords = existing_df[["x", "y"]].values
-    missing_coords = missing_df[["x", "y"]].values
+    # Step 2: attach centroid x,y to every row (left join preserves all ids).
+    full_df = param_df.merge(coords_df, on=id_feature, how="left")
 
-    # Coordinates are column-independent, so the NaN-coordinate mask and the
-    # null-geometry guard are computed once for the whole block.
-    nan_mask = np.isnan(existing_coords).any(axis=1)
-    if nan_mask.any():
-        logger.warning(
-            "%d features have NaN coordinates (null/invalid geometry). "
-            "Excluding from KNN fitting.", nan_mask.sum()
-        )
-
-    nan_missing = np.isnan(missing_coords).any(axis=1)
-    if nan_missing.any():
-        raise ValueError(
-            f"{nan_missing.sum()} missing features have null geometry "
-            "and cannot be filled via KNN interpolation."
-        )
-
-    fit_coords = existing_coords[~nan_mask]
-    knn = NearestNeighbors(n_neighbors=k)
-    knn.fit(fit_coords)
-    distances, indices = knn.kneighbors(missing_coords)
-
-    # One filled row per missing id, with every parameter column populated.
-    missing_filled = pd.DataFrame({id_feature: missing_df[id_feature].values})
+    # Step 3: per-column KNN fill.
     for param_column in tqdm(param_columns, desc="Filling param columns"):
-        existing_values = existing_df[param_column].values[~nan_mask]
-        missing_filled[param_column] = [
-            np.mean(existing_values[neighbor_indices]) for neighbor_indices in indices
-        ]
-    # gfv2's merged CSVs carry a secondary local `hru_id` alongside the
-    # national nat_hru_id key; populate it for filled rows. When id_feature
-    # is already `hru_id` (e.g. oregon) this is a harmless self-assignment.
-    missing_filled["hru_id"] = missing_filled[id_feature]
+        col_vals = full_df[param_column].values
+        x_vals = full_df["x"].values
+        y_vals = full_df["y"].values
 
-    complete_df = pd.concat([param_df, missing_filled], ignore_index=True)
-    complete_df = complete_df.sort_values(id_feature).reset_index(drop=True)
-    logger.info("Filled %d missing values across %d column(s)", len(missing_ids), len(param_columns))
-    return complete_df
+        has_valid_coord = ~(np.isnan(x_vals) | np.isnan(y_vals))
+        has_valid_value = ~np.isnan(col_vals)
+
+        fill_mask = (~has_valid_value) & has_valid_coord
+        fit_mask = has_valid_value & has_valid_coord
+
+        # Null-geometry guard: any fill row with NaN coords cannot be KNN-filled.
+        null_geom_fill = (~has_valid_value) & (~has_valid_coord)
+        if null_geom_fill.any():
+            raise ValueError(
+                f"{null_geom_fill.sum()} features needing fill for '{param_column}' "
+                "have null geometry and cannot be filled via KNN interpolation."
+            )
+
+        if not fill_mask.any():
+            continue
+
+        fit_coords = np.column_stack([x_vals[fit_mask], y_vals[fit_mask]])
+        fit_values = col_vals[fit_mask]
+        fill_coords = np.column_stack([x_vals[fill_mask], y_vals[fill_mask]])
+
+        knn = NearestNeighbors(n_neighbors=k)
+        knn.fit(fit_coords)
+        _, indices = knn.kneighbors(fill_coords)
+
+        filled_values = np.array([np.mean(fit_values[neighbor_idx]) for neighbor_idx in indices])
+        full_df.loc[fill_mask, param_column] = filled_values
+
+    # Step 4: drop helper columns, sort, reset index.
+    full_df = full_df.drop(columns=["x", "y", "centroid"], errors="ignore")
+    full_df = full_df.sort_values(id_feature).reset_index(drop=True)
+
+    n_absent = len(missing_ids)
+    total_nan_cells = param_df[param_columns].isna().to_numpy().sum() if has_nan_cells else 0
+    logger.info(
+        "Filled %d absent id(s) and %d NaN cell(s) across %d column(s)",
+        n_absent, total_nan_cells, len(param_columns),
+    )
+    return full_df
 
 
 def main():
@@ -163,11 +186,13 @@ def main():
 
     param_df, missing_ids = find_missing_ids(param_file, expected_max, id_feature, logger)
 
-    if missing_ids:
-        param_columns = [col for col in param_df.columns if col not in {id_feature, "hru_id", "nat_hru_id", "vpu"}]
-        if not param_columns:
-            raise ValueError("No parameter columns found in the data")
+    param_columns = [col for col in param_df.columns if col not in {id_feature, "hru_id", "nat_hru_id", "vpu"}]
+    if not param_columns:
+        raise ValueError("No parameter columns found in the data")
 
+    needs_fill = bool(missing_ids) or param_df[param_columns].isna().to_numpy().any()
+
+    if needs_fill:
         logger.info("Filling parameter columns: %s", param_columns)
 
         complete_df = fill_missing_values_knn(

--- a/tests/test_merge_and_fill_params.py
+++ b/tests/test_merge_and_fill_params.py
@@ -1,15 +1,13 @@
 """Tests for scripts/merge_and_fill_params.py"""
 
-import tempfile
+import importlib.util
 from pathlib import Path
 
 import geopandas as gpd
 import numpy as np
 import pandas as pd
 import pytest
-from shapely.geometry import Point, box
-
-import importlib.util
+from shapely.geometry import Point
 
 _spec = importlib.util.spec_from_file_location(
     "merge_and_fill_params",

--- a/tests/test_merge_and_fill_params.py
+++ b/tests/test_merge_and_fill_params.py
@@ -237,6 +237,19 @@ class TestFillMissingValuesKnn:
         # id=4 at (9,0): nearest valid is id=2 (10,0) → 200.0
         assert result.loc[result["nat_hru_id"] == 4, "my_param"].iloc[0] == 200.0
 
+    def test_raises_when_column_has_no_valid_source(self):
+        import logging
+        logger = logging.getLogger("test")
+        merged_gdf = gpd.GeoDataFrame(
+            {"nat_hru_id": [1, 2]},
+            geometry=[Point(0, 0), Point(1, 0)],
+            crs="EPSG:5070",
+        )
+        # both rows NaN for the column -> no valid fit source
+        param_df = pd.DataFrame({"nat_hru_id": [1, 2], "my_param": [np.nan, np.nan]})
+        with pytest.raises(ValueError, match="no valid"):
+            fill_missing_values_knn(param_df, [], merged_gdf, "my_param", 1, "nat_hru_id", logger)
+
     def test_nan_valued_row_not_used_as_fill_source(self):
         """NaN-valued rows must not be included in the KNN fit set (they can't donate values)."""
         import logging

--- a/tests/test_merge_and_fill_params.py
+++ b/tests/test_merge_and_fill_params.py
@@ -186,3 +186,77 @@ class TestFillMissingValuesKnn:
         assert 3 in result["hru_id"].values
         filled_val = result.loc[result["hru_id"] == 3, "my_param"].iloc[0]
         assert filled_val in [100.0, 200.0]
+
+    def test_knn_fills_nan_value_in_present_row(self):
+        """A row present in param_df but with NaN value is filled by KNN."""
+        import logging
+        logger = logging.getLogger("test")
+
+        # id=3 at Point(1,0) — nearest to id=1 at (0,0), distance 1 vs id=2 at (10,0), distance 9
+        merged_gdf = gpd.GeoDataFrame(
+            {"nat_hru_id": [1, 2, 3]},
+            geometry=[Point(0, 0), Point(10, 0), Point(1, 0)],
+            crs="EPSG:5070",
+        )
+        param_df = pd.DataFrame({
+            "nat_hru_id": [1, 2, 3],
+            "hru_id": [1, 2, 3],
+            "my_param": [100.0, 200.0, np.nan],
+        })
+
+        result = fill_missing_values_knn(param_df, [], merged_gdf, "my_param", 1, "nat_hru_id", logger)
+        assert len(result) == 3
+        assert not result["my_param"].isna().any()
+        filled_val = result.loc[result["nat_hru_id"] == 3, "my_param"].iloc[0]
+        # id=1 (0,0) is distance 1; id=2 (10,0) is distance 9 — nearest is unambiguously id=1
+        assert filled_val == 100.0
+
+    def test_knn_fills_absent_and_nan_together(self):
+        """Absent rows AND present-but-NaN cells are both filled in one pass."""
+        import logging
+        logger = logging.getLogger("test")
+
+        merged_gdf = gpd.GeoDataFrame(
+            {"nat_hru_id": [1, 2, 3, 4]},
+            geometry=[Point(0, 0), Point(10, 0), Point(1, 0), Point(9, 0)],
+            crs="EPSG:5070",
+        )
+        # id=3 present but NaN; id=4 absent
+        param_df = pd.DataFrame({
+            "nat_hru_id": [1, 2, 3],
+            "hru_id": [1, 2, 3],
+            "my_param": [100.0, 200.0, np.nan],
+        })
+
+        result = fill_missing_values_knn(param_df, [4], merged_gdf, "my_param", 1, "nat_hru_id", logger)
+        assert len(result) == 4
+        assert not result["my_param"].isna().any()
+        assert result["nat_hru_id"].duplicated().sum() == 0
+        # id=3 at (1,0): nearest valid is id=1 (0,0) → 100.0
+        assert result.loc[result["nat_hru_id"] == 3, "my_param"].iloc[0] == 100.0
+        # id=4 at (9,0): nearest valid is id=2 (10,0) → 200.0
+        assert result.loc[result["nat_hru_id"] == 4, "my_param"].iloc[0] == 200.0
+
+    def test_nan_valued_row_not_used_as_fill_source(self):
+        """NaN-valued rows must not be included in the KNN fit set (they can't donate values)."""
+        import logging
+        logger = logging.getLogger("test")
+
+        # id=1 NaN at (0,0); id=2 val=5.0 at (1,0); id=3 NaN at (100,0)
+        merged_gdf = gpd.GeoDataFrame(
+            {"nat_hru_id": [1, 2, 3]},
+            geometry=[Point(0, 0), Point(1, 0), Point(100, 0)],
+            crs="EPSG:5070",
+        )
+        param_df = pd.DataFrame({
+            "nat_hru_id": [1, 2, 3],
+            "hru_id": [1, 2, 3],
+            "my_param": [np.nan, 5.0, np.nan],
+        })
+
+        result = fill_missing_values_knn(param_df, [], merged_gdf, "my_param", 1, "nat_hru_id", logger)
+        assert len(result) == 3
+        assert not result["my_param"].isna().any()
+        # Only id=2 (val=5.0) is in the fit set — both NaN rows must get 5.0
+        assert result.loc[result["nat_hru_id"] == 1, "my_param"].iloc[0] == 5.0
+        assert result.loc[result["nat_hru_id"] == 3, "my_param"].iloc[0] == 5.0


### PR DESCRIPTION
Closes #133.

## Problem
`merge_and_fill_params` only filled HRUs **absent** from the merged CSV; it ignored rows that are *present* but have a **NaN parameter value**. On CONUS gfv2, `nhm_soil_moist_max_params.csv` had all 361,471 rows but **2,009 (0.56%) with NaN `soil_moist_max`** — scattered nationwide where the derived raster has nodata, even though those HRUs have valid elevation/slope/soils. They reached the model-ready output unfilled (`find_missing_ids` saw 0 missing rows → no-op).

## Fix
Generalize `fill_missing_values_knn` (k=1, unchanged default):
- Append all-NaN rows for absent ids (as before), then **per param column, KNN-fill every NaN cell** (appended rows + pre-existing NaNs) from that column's *valid-valued* neighbours by HRU centroid distance.
- Each column's KNN fit set **excludes NaN-valued rows**, so a present-but-NaN row can never be selected as a fill source (no NaN propagation).
- Guard: raise a clear `ValueError` if a column has no valid source (empty fit set) or a fill row has null geometry.
- `main()` now triggers fill on absent ids **or** any NaN cell.

## Tests (14, all pass)
New: fills a present-but-NaN cell from the nearest valid neighbour; fills absent + NaN together; **NaN row not used as a fill source**; raises on an all-NaN column. Existing append/no-op/multi-column/no-duplicate tests still pass.

## Validated on real CONUS data (pre-merge)
Ran the fill on `nhm_soil_moist_max_params.csv` with the branch code (job 24194117, 1m19s):
- log: `Filled 0 absent id(s) and 2009 NaN cell(s) across 1 column(s)`
- `filled_nhm_soil_moist_max_params.csv`: 361,471 rows, **0 NaN**, range [0, 12.17] (unchanged), mean 3.155 (was 3.152).

## Scope note
This generalizes the fill but does not change the script's hardcoded `nhm_ssflux_params.csv` default or run on other params; per-file usage is unchanged (`--param_file`). The deferred LULC-coverage gap-fill rework (experimental params) is out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)