### PR TITLE
feat(lulc): rad_trncf + faithful NHM v1.1 path (Workstreams A & B)

### DIFF
--- a/configs/zonal/zonal_params.yml
+++ b/configs/zonal/zonal_params.yml
@@ -80,6 +80,9 @@ params:
     source_raster:  "{data_root}/input/lulc_veg/nhm_v11/LULC.tif"
     canopy_raster:  "{data_root}/input/lulc_veg/nhm_v11/CNPY.tif"
     keep_raster:    "{data_root}/input/lulc_veg/nhm_v11/keep.tif"
+    # radtrn raster (cnpy*keep/100 over trees) built by the shared-rasters
+    # build_lulc_rasters step -> zonal-meaned + Beer's-law -> rad_trncf column.
+    radtrn_raster:  "{data_root}/shared/conus/derived/radtrn_nhm_v11.tif"
     crosswalk_file: crosswalks/nhm_v11_nhm.csv
     categorical:    true
     merged_file:    nhm_lulc_nhm_v11_params.csv

--- a/configs/zonal/zonal_params.yml
+++ b/configs/zonal/zonal_params.yml
@@ -72,18 +72,26 @@ params:
     categorical:   false
     merged_file:   nhm_soil_moist_max_params.csv
 
-  # --- LULC sources (each derives cov_type / covden / interception / retention) ---
-  # NHM v1.1: keep raster present -> raster-based retention.
+  # --- LULC sources (each derives cov_type / covden / interception + rad_trncf
+  #     or retention) ---
+  # NHM v1.1: faithful pre-derived-raster path (script: lulc_prederived) — each
+  # param is a direct zonal stat of a ScienceBase P971JAGF raster, reproducing
+  # the legacy 3_coverDen.py exactly (no crosswalk collapse; covden_win from
+  # loss not keep). Outputs rad_trncf, not retention. The crosswalk supplies
+  # only the lu_code -> nhm_cov_type mapping for the cov_type decision tree.
 
   - name: lulc_nhm_v11
-    script: lulc
-    source_raster:  "{data_root}/input/lulc_veg/nhm_v11/LULC.tif"
-    canopy_raster:  "{data_root}/input/lulc_veg/nhm_v11/CNPY.tif"
-    keep_raster:    "{data_root}/input/lulc_veg/nhm_v11/keep.tif"
+    script: lulc_prederived
+    source_raster:  "{data_root}/input/lulc_veg/nhm_v11/LULC.tif"   # cov_type (5-class)
+    canopy_raster:  "{data_root}/input/lulc_veg/nhm_v11/CNPY.tif"   # covden_sum (MODIS VCF)
+    loss_raster:    "{data_root}/input/lulc_veg/nhm_v11/loss.tif"   # covden_win = covden_sum*(1-loss/100)
+    snow_raster:    "{data_root}/input/lulc_veg/nhm_v11/Snow.tif"   # snow_intcp  (/100 -> inch)
+    srain_raster:   "{data_root}/input/lulc_veg/nhm_v11/SRain.tif"  # srain_intcp (/100 -> inch)
+    wrain_raster:   "{data_root}/input/lulc_veg/nhm_v11/WRain.tif"  # wrain_intcp (/100 -> inch)
     # radtrn raster (cnpy*keep/100 over trees) built by the shared-rasters
-    # build_lulc_rasters step -> zonal-meaned + Beer's-law -> rad_trncf column.
+    # build_lulc_rasters step -> zonal-meaned + Beer's-law -> rad_trncf.
     radtrn_raster:  "{data_root}/shared/conus/derived/radtrn_nhm_v11.tif"
-    crosswalk_file: crosswalks/nhm_v11_nhm.csv
+    crosswalk_file: crosswalks/nhm_v11_nhm.csv  # cov_type mapping only
     categorical:    true
     merged_file:    nhm_lulc_nhm_v11_params.csv
 

--- a/docs/ADDING_A_PARAMETER.md
+++ b/docs/ADDING_A_PARAMETER.md
@@ -210,11 +210,13 @@ For `elevation` that is
 2. **Confirm the source raster exists on disk.** Resolve any
    `{data_root}` placeholders by hand and `ls` the path.
 3. **Choose the `script:` tag** — `zonal` (continuous raster),
-   `soils` (categorical/continuous from soils/litho), `lulc` (cov_type /
-   covden / interception / retention / rad_trncf bundle — rad_trncf only
-   when a `radtrn_raster` is configured), or `ssflux` (litho-weighted
+   `soils` (categorical/continuous from soils/litho), `lulc` (crosswalk-driven
+   cov_type / covden / interception / retention / rad_trncf bundle — rad_trncf
+   only when a `radtrn_raster` is configured), `lulc_prederived` (faithful
+   NHM v1.1 path: each param a direct zonal stat of a pre-derived ScienceBase
+   raster; outputs rad_trncf, not retention), or `ssflux` (litho-weighted
    PRMS flux params). The dispatch table is
-   [`src/gfv2_params/zonal_runners/__init__.py:92-97`](../src/gfv2_params/zonal_runners/__init__.py#L92-L97).
+   [`src/gfv2_params/zonal_runners/__init__.py:99-105`](../src/gfv2_params/zonal_runners/__init__.py#L99-L105).
    If your param doesn't fit any existing `script:` family you're adding
    a new runner, not a new param — see "How to add a new pipeline step"
    in [ARCHITECTURE.md](ARCHITECTURE.md#how-to-add-a-new-pipeline-step).

--- a/docs/ADDING_A_PARAMETER.md
+++ b/docs/ADDING_A_PARAMETER.md
@@ -125,7 +125,7 @@ For `--param elevation --fabric gfv2_vpu01`, `param_cfg` ends up roughly:
 
 ### Hop 4 — Dispatch table
 
-[`src/gfv2_params/zonal_runners/__init__.py:92-97`](../src/gfv2_params/zonal_runners/__init__.py#L92-L97)
+[`src/gfv2_params/zonal_runners/__init__.py:99-105`](../src/gfv2_params/zonal_runners/__init__.py#L99-L105)
 maps each `script:` tag to the runner that handles it:
 
 ```python
@@ -133,6 +133,7 @@ BATCH_RUNNERS = {
     "zonal":  run_zonal_batch,    # continuous-zonal stats from one raster
     "soils":  run_soils_batch,
     "lulc":   run_lulc_batch,
+    "lulc_prederived": run_lulc_prederived_batch,
     "ssflux": run_ssflux_batch,
 }
 ```

--- a/docs/ADDING_A_PARAMETER.md
+++ b/docs/ADDING_A_PARAMETER.md
@@ -211,7 +211,8 @@ For `elevation` that is
    `{data_root}` placeholders by hand and `ls` the path.
 3. **Choose the `script:` tag** — `zonal` (continuous raster),
    `soils` (categorical/continuous from soils/litho), `lulc` (cov_type /
-   covden / interception / retention bundle), or `ssflux` (litho-weighted
+   covden / interception / retention / rad_trncf bundle — rad_trncf only
+   when a `radtrn_raster` is configured), or `ssflux` (litho-weighted
    PRMS flux params). The dispatch table is
    [`src/gfv2_params/zonal_runners/__init__.py:92-97`](../src/gfv2_params/zonal_runners/__init__.py#L92-L97).
    If your param doesn't fit any existing `script:` family you're adding

--- a/docs/superpowers/plans/2026-06-08-lulc-rad-trncf-and-faithful-nhm-v11.md
+++ b/docs/superpowers/plans/2026-06-08-lulc-rad-trncf-and-faithful-nhm-v11.md
@@ -55,14 +55,19 @@ Key facts established:
       the new column. Docs: ARCHITECTURE + RUNME/HPC_REFERENCE param table.
 
 ### B. Faithful nhm_v11 (pre-derived raster source mode)
-- [ ] Download step: stage `Snow/SRain/WRain/loss` from P971JAGF (keep, CNPY,
-      LULC already on disk) into `input/lulc_veg/nhm_v11/`.
-- [ ] "Pre-derived raster" mode in the lulc runner (or a sibling runner): each
-      param = direct zonal mean (snow/wrain/srain = raster/100; covden_sum from
+- [x] Stage `Snow/SRain/WRain/loss` from P971JAGF (keep, CNPY, LULC already on
+      disk) into `input/lulc_veg/nhm_v11/` — all co-registered to the 30 m LULC
+      grid; Snow/SRain/WRain Byte (nodata 15), loss/keep Int8 (0-100).
+- [x] New `lulc_prederived` runner (`zonal_runners/lulc_prederived.py`): each
+      param = direct zonal stat (snow/wrain/srain = raster/100; covden_sum from
       CNPY/100 zeroed on bare; covden_win = covden_sum*(1-loss/100); cov_type
-      from 5-class TabulateArea decision tree; rad_trncf from radtrn). Ports
-      `3_coverDen.py`. Supersedes the nhm_v11 crosswalk path.
-- [ ] Test + config + docs. Re-run CONUS nhm_v11.
+      from 5-class decision tree; rad_trncf from radtrn). Ports `3_coverDen.py`;
+      outputs rad_trncf, not retention. Registered in BATCH_RUNNERS.
+- [x] `covden_win_from_loss` helper + tests (the keep-vs-loss correction);
+      dispatch-registration test; config switched to `script: lulc_prederived`
+      with per-param raster keys; docs (ADDING_A_PARAMETER).
+- [ ] Re-run CONUS nhm_v11 (supersedes the on-disk CSV, which has the keep-based
+      covden_win error). radtrn_nhm_v11.tif prerequisite confirmed present.
 
 ### C. Corrected NALCMS
 - [ ] Regenerate `crosswalks/nalcms_nhm.csv` from the authoritative table (exact

--- a/docs/superpowers/plans/2026-06-08-lulc-rad-trncf-and-faithful-nhm-v11.md
+++ b/docs/superpowers/plans/2026-06-08-lulc-rad-trncf-and-faithful-nhm-v11.md
@@ -1,0 +1,84 @@
+# LULC follow-through: rad_trncf, faithful nhm_v11, corrected NALCMS
+
+> Continuation of the 2026-04-02 multi-source LULC work (#24/#25, plan
+> `2026-04-02-lulc-parameterization.md`). Driven by the crosswalk validation
+> against the authoritative source (see below). Tracker: issue #26.
+
+## Source of truth (validation result)
+
+The authoritative NHM v1.1 LULC crosswalk is the **Viger & Leavesley (2007)**
+remap table reproduced verbatim in the **ScienceBase P971JAGF metadata**
+("Remapped Data" process step; shipped as `CrossWalk.xlsx`). It maps each
+**NALCMS** class (1-19) -> PRMS `lulc`(cov_type), `Keep`, `Loss`,
+`Rooting_Depth`, `Snow`, `Wrain`, `Srain`. The legacy ArcPy `3_coverDen.py`
+zonal-means the rasters this table built.
+
+Key facts established:
+- **Units**: Snow/SRain/WRain are *hundredths of inches* (Snow 0-10, S/WRain
+  0-5); legacy divides by 100 -> inches. Crosswalk `snow_intcp=0.10` == Snow 10.
+- **NHM canopy = MODIS VCF** (MOD44B, 250 m), not NLCD TCC. The generic
+  `input/lulc_veg/CNPY.tif` used by the CONUS NALCMS run is therefore
+  NHM-consistent (confirm `CNPY.tif` is that product).
+- **rad_trncf** = `exp(-2.7557 * density/100) * 0.9917`, density = zonal-mean of
+  `radtrn = Con(LULC>=3, cnpy) * keep/100`. The new pipeline builds the `radtrn`
+  raster but never zonal-means it or applies Beer's law -> **rad_trncf is absent
+  from every LULC output**; it emits a `retention` surrogate instead.
+
+### Per-crosswalk verdict
+- `nhm_v11_nhm.csv`: keep/cov_type **exact**; 5-class interception is a lossy
+  collapse. Quantified over CONUS (decimated NALCMS-2020 sample, ~2.9 M px):
+  area-weighted mean |delta| ~0.005 in, but **24.6% of CONUS land** has an
+  interception param shifted >0.005 in, with local errors up to 0.05 in
+  (mixed-forest snow, wetland snow, grassland srain/wrain). -> fix by staging
+  the real rasters.
+- `nalcms_nhm.csv`: **drifted** from authoritative (needleleaf snow 0.05->0.10,
+  mixed-forest snow ->0.07, forest keep ->0.60, class-2 taiga, etc.). ->
+  regenerate from the table.
+- `nlcd_nhm.csv`: no USGS NLCD->PRMS authority exists (NHM v1.1 used NALCMS).
+  -> derive by analogy to NALCMS-equivalent classes.
+
+## Scope decisions
+- Sources: **nhm_v11 + NLCD + corrected NALCMS**. **FORE-SCE dropped.**
+- nhm_v11: **stage real Snow/SRain/WRain/loss rasters + direct zonal-mean**
+  (reproduce NHM v1.1 exactly; the crosswalk path is unnecessary for nhm_v11).
+- NALCMS: regenerate crosswalk from the authoritative table, then re-run CONUS.
+
+## Workstreams
+
+### A. rad_trncf (start here; mostly independent)
+- [ ] Pure helper `compute_rad_trncf(density_mean_series)` in `lulc.py`:
+      `exp(-2.7557 * density/100) * 0.9917`; density 0 -> ~0.9917, density 100
+      -> ~0.063. Unit tests (`tests/test_lulc.py` or `test_rad_trncf.py`).
+- [ ] Wire into `run_lulc_batch`: when a `radtrn_raster` is configured, zonal-mean
+      it (continuous) -> density -> `compute_rad_trncf` -> `rad_trncf` column.
+- [ ] Config: add `radtrn_raster` to the nhm_v11 zonal entry; DAG/merge picks up
+      the new column. Docs: ARCHITECTURE + RUNME/HPC_REFERENCE param table.
+
+### B. Faithful nhm_v11 (pre-derived raster source mode)
+- [ ] Download step: stage `Snow/SRain/WRain/loss` from P971JAGF (keep, CNPY,
+      LULC already on disk) into `input/lulc_veg/nhm_v11/`.
+- [ ] "Pre-derived raster" mode in the lulc runner (or a sibling runner): each
+      param = direct zonal mean (snow/wrain/srain = raster/100; covden_sum from
+      CNPY/100 zeroed on bare; covden_win = covden_sum*(1-loss/100); cov_type
+      from 5-class TabulateArea decision tree; rad_trncf from radtrn). Ports
+      `3_coverDen.py`. Supersedes the nhm_v11 crosswalk path.
+- [ ] Test + config + docs. Re-run CONUS nhm_v11.
+
+### C. Corrected NALCMS
+- [ ] Regenerate `crosswalks/nalcms_nhm.csv` from the authoritative table (exact
+      19-class cov_type/keep/snow/wrain/srain; covden_win = keep/100).
+- [ ] Synthesize a per-pixel keep raster from the crosswalk keep column applied
+      to the NALCMS raster so the existing `compute_radtrn` + A's helper produce
+      rad_trncf without a native keep raster. (Same approach for NLCD.)
+- [ ] Update crosswalk test. Re-run CONUS NALCMS (supersedes the drifted CSV).
+
+### D. NLCD (last)
+- [ ] Build `nlcd_nhm.csv` by analogy to NALCMS-equivalent classes.
+- [ ] Stage NLCD 2021 land cover + canopy (MODIS VCF vs NLCD TCC — decide).
+- [ ] Run CONUS.
+
+## Notes
+- Single rad_trncf code path for all sources via the synthesized-keep approach
+  (C) + the radtrn builder that already exists.
+- Per repo convention each builder change ships with its test + config + a docs
+  audit on the same branch.

--- a/src/gfv2_params/lulc.py
+++ b/src/gfv2_params/lulc.py
@@ -3,9 +3,16 @@
 import logging
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
 
 logger = logging.getLogger(__name__)
+
+# Beer's-law constants for the winter-canopy radiation transmission coefficient,
+# lifted verbatim from the NHM v1.1 ArcPy 3_coverDen.py rad_trncf() (Wieczorek &
+# Bock, 2021): rad_trncf = exp(-2.7557 * density/100) * 0.9917.
+_RAD_TRNCF_K = 2.7557
+_RAD_TRNCF_SCALE = 0.9917
 
 REQUIRED_CROSSWALK_COLUMNS = {
     "lu_code",
@@ -124,7 +131,10 @@ def assign_cov_type(class_perc_df: pd.DataFrame, crosswalk: pd.DataFrame, id_col
 
     # Merge class percentages with cover types; drop unmatched codes
     merged = class_perc_df.merge(
-        crosswalk[["nhm_cov_type"]], left_on="lu_code", right_index=True, how="left",
+        crosswalk[["nhm_cov_type"]],
+        left_on="lu_code",
+        right_index=True,
+        how="left",
     )
     merged = merged.dropna(subset=["nhm_cov_type"])
     merged["nhm_cov_type"] = merged["nhm_cov_type"].astype(int)
@@ -156,9 +166,7 @@ def assign_cov_type(class_perc_df: pd.DataFrame, crosswalk: pd.DataFrame, id_col
         else:
             assigned[hru_id] = int(hru.idxmax())
 
-    result = pd.DataFrame(
-        {id_col: list(assigned.keys()), "cov_type": list(assigned.values())}
-    )
+    result = pd.DataFrame({id_col: list(assigned.keys()), "cov_type": list(assigned.values())})
     return result
 
 
@@ -316,3 +324,30 @@ def compute_retention(
 
     result = merged.groupby(id_col)[["retention"]].sum().reset_index()
     return result
+
+
+def compute_rad_trncf(density):
+    """Winter-canopy radiation transmission coefficient per HRU.
+
+    Ports the NHM v1.1 ArcPy ``3_coverDen.py`` ``rad_trncf()`` (Wieczorek &
+    Bock, 2021):
+
+        rad_trncf = exp(-2.7557 * density / 100) * 0.9917
+
+    where ``density`` is the per-HRU zonal mean (0-100) of the ``radtrn``
+    raster (``cnpy * keep / 100`` over tree pixels, ``lulc >= 3``). Density 0
+    (no winter canopy) gives ~0.9917 (near-full transmission); density 100
+    (dense evergreen) gives ~0.063.
+
+    Parameters
+    ----------
+    density : pandas.Series or numpy.ndarray
+        Per-HRU winter-canopy density in percent (0-100). A Series input
+        preserves its HRU index so the result merges by HRU id.
+
+    Returns
+    -------
+    Same type as ``density`` with the transmission coefficient applied
+    element-wise.
+    """
+    return np.exp(-_RAD_TRNCF_K * density / 100.0) * _RAD_TRNCF_SCALE

--- a/src/gfv2_params/lulc.py
+++ b/src/gfv2_params/lulc.py
@@ -361,10 +361,12 @@ def covden_win_from_loss(covden_sum, loss_pct):
         covden_win = covden_sum * (1 - loss / 100)
 
     where ``loss_pct`` is the per-HRU zonal mean of ``loss.tif`` (leaf-loss
-    percent, 0-100). NB: this uses leaf-LOSS, not leaf-keep. In the Viger &
-    Leavesley (2007) table ``loss`` and ``keep`` are NOT complements (e.g.
-    grass loss=100/keep=80), so deriving winter retention from ``keep`` (as the
-    crosswalk path's ``nhm_covden_win`` column does) overstates it for
+    percent, 0-100). NB: this uses leaf-LOSS, not leaf-keep. In the upstream
+    Viger & Leavesley (2007) source table (the ``Loss``/``Keep`` columns that
+    built ``loss.tif``/``keep.tif`` — not columns in this repo's crosswalk CSVs)
+    ``loss`` and ``keep`` are NOT complements (e.g. grass Loss=100/Keep=80), so
+    deriving winter retention from keep — as the crosswalk path's
+    ``nhm_covden_win`` column does (it equals keep/100) — overstates it for
     grass/shrub/deciduous. The raster-based ``lulc_prederived`` path uses this
     function with ``loss.tif`` to match NHM v1.1 exactly.
 

--- a/src/gfv2_params/lulc.py
+++ b/src/gfv2_params/lulc.py
@@ -351,3 +351,32 @@ def compute_rad_trncf(density):
     element-wise.
     """
     return np.exp(-_RAD_TRNCF_K * density / 100.0) * _RAD_TRNCF_SCALE
+
+
+def covden_win_from_loss(covden_sum, loss_pct):
+    """Winter canopy density from summer density and leaf-loss percent.
+
+    Ports the NHM v1.1 ArcPy ``3_coverDen.py`` ``covden_win()``:
+
+        covden_win = covden_sum * (1 - loss / 100)
+
+    where ``loss_pct`` is the per-HRU zonal mean of ``loss.tif`` (leaf-loss
+    percent, 0-100). NB: this uses leaf-LOSS, not leaf-keep. In the Viger &
+    Leavesley (2007) table ``loss`` and ``keep`` are NOT complements (e.g.
+    grass loss=100/keep=80), so deriving winter retention from ``keep`` (as the
+    crosswalk path's ``nhm_covden_win`` column does) overstates it for
+    grass/shrub/deciduous. The raster-based ``lulc_prederived`` path uses this
+    function with ``loss.tif`` to match NHM v1.1 exactly.
+
+    Parameters
+    ----------
+    covden_sum : pandas.Series or numpy.ndarray
+        Per-HRU summer canopy density (0-1).
+    loss_pct : pandas.Series or numpy.ndarray
+        Per-HRU zonal mean of leaf-loss percent (0-100).
+
+    Returns
+    -------
+    Same type as ``covden_sum`` with the winter retention applied.
+    """
+    return covden_sum * (1.0 - loss_pct / 100.0)

--- a/src/gfv2_params/zonal_runners/__init__.py
+++ b/src/gfv2_params/zonal_runners/__init__.py
@@ -72,6 +72,7 @@ osr.UseExceptions()
 # tests/test_merge_params.py) import these names from gfv2_params.zonal_runners
 # directly.
 from .lulc import run_lulc_batch
+from .lulc_prederived import run_lulc_prederived_batch
 from .merge import run_merge
 from .soils import run_soils_batch
 from .ssflux import run_ssflux_batch
@@ -82,6 +83,7 @@ __all__ = [
     "BATCH_RUNNERS",
     "run_build_weights",
     "run_lulc_batch",
+    "run_lulc_prederived_batch",
     "run_merge",
     "run_soils_batch",
     "run_ssflux_batch",
@@ -95,8 +97,9 @@ __all__ = [
 # submodule under zonal_runners/, (b) re-exporting its run_*_batch above,
 # and (c) adding an entry below — keep them in sync.
 BATCH_RUNNERS = {
-    "zonal":  run_zonal_batch,
-    "soils":  run_soils_batch,
-    "lulc":   run_lulc_batch,
+    "zonal": run_zonal_batch,
+    "soils": run_soils_batch,
+    "lulc": run_lulc_batch,
+    "lulc_prederived": run_lulc_prederived_batch,
     "ssflux": run_ssflux_batch,
 }

--- a/src/gfv2_params/zonal_runners/lulc.py
+++ b/src/gfv2_params/zonal_runners/lulc.py
@@ -3,8 +3,9 @@
 Not to be confused with ``gfv2_params.lulc`` (the crosswalk/computation helpers
 that this module imports from).
 
-One ``run_lulc_batch`` covers all four LULC source types (nhm_v11, nalcms,
-nlcd, foresce) — the orchestrator normalises ``source_type`` to ``lulc_<source>``
+One ``run_lulc_batch`` covers the crosswalk-driven LULC source types (nalcms,
+nlcd, foresce); nhm_v11 uses the faithful ``lulc_prederived`` runner instead.
+The orchestrator normalises ``source_type`` to ``lulc_<source>``
 so each source writes per-batch CSVs to its own subdir. Pipeline: categorical
 zonal stats on the LULC raster, continuous zonal stats on the canopy raster,
 optional zonal stats on a ``keep`` raster, optional zonal stats on a ``radtrn``

--- a/src/gfv2_params/zonal_runners/lulc.py
+++ b/src/gfv2_params/zonal_runners/lulc.py
@@ -24,6 +24,7 @@ from ..lulc import (
     class_percentages_from_histogram,
     compute_covden,
     compute_interception,
+    compute_rad_trncf,
     compute_retention,
     load_crosswalk,
 )
@@ -74,13 +75,23 @@ def run_lulc_batch(config: dict, batch_id: int, logger) -> None:
     logger.info("Loaded LULC raster: shape=%s", lulc_da.shape)
 
     lulc_data = UserTiffData(
-        var="lulc", ds=lulc_da, proj_ds=lulc_da.rio.crs,
-        x_coord="x", y_coord="y", band=1, bname="band",
-        f_feature=nhru_gdf, id_feature=id_feature,
+        var="lulc",
+        ds=lulc_da,
+        proj_ds=lulc_da.rio.crs,
+        x_coord="x",
+        y_coord="y",
+        band=1,
+        bname="band",
+        f_feature=nhru_gdf,
+        id_feature=id_feature,
     )
     lulc_zonal = ZonalGen(
-        user_data=lulc_data, zonal_engine="exactextract", zonal_writer="csv",
-        out_path=output_dir, file_prefix=f"{file_prefix}_lulc_temp", jobs=4,
+        user_data=lulc_data,
+        zonal_engine="exactextract",
+        zonal_writer="csv",
+        out_path=output_dir,
+        file_prefix=f"{file_prefix}_lulc_temp",
+        jobs=4,
     )
     histogram = lulc_zonal.calculate_zonal(categorical=True)
     logger.info("LULC categorical zonal stats computed")
@@ -103,13 +114,23 @@ def run_lulc_batch(config: dict, batch_id: int, logger) -> None:
     logger.info("Loaded canopy raster: shape=%s", cnpy_da.shape)
 
     cnpy_data = UserTiffData(
-        var="canopy", ds=cnpy_da, proj_ds=cnpy_da.rio.crs,
-        x_coord="x", y_coord="y", band=1, bname="band",
-        f_feature=nhru_gdf, id_feature=id_feature,
+        var="canopy",
+        ds=cnpy_da,
+        proj_ds=cnpy_da.rio.crs,
+        x_coord="x",
+        y_coord="y",
+        band=1,
+        bname="band",
+        f_feature=nhru_gdf,
+        id_feature=id_feature,
     )
     cnpy_zonal = ZonalGen(
-        user_data=cnpy_data, zonal_engine="exactextract", zonal_writer="csv",
-        out_path=output_dir, file_prefix=f"{file_prefix}_cnpy_temp", jobs=4,
+        user_data=cnpy_data,
+        zonal_engine="exactextract",
+        zonal_writer="csv",
+        out_path=output_dir,
+        file_prefix=f"{file_prefix}_cnpy_temp",
+        jobs=4,
     )
     cnpy_stats = cnpy_zonal.calculate_zonal(categorical=False)
     logger.info("Canopy continuous zonal stats computed")
@@ -132,13 +153,23 @@ def run_lulc_batch(config: dict, batch_id: int, logger) -> None:
         logger.info("Loaded keep raster: shape=%s", keep_da.shape)
 
         keep_data = UserTiffData(
-            var="keep", ds=keep_da, proj_ds=keep_da.rio.crs,
-            x_coord="x", y_coord="y", band=1, bname="band",
-            f_feature=nhru_gdf, id_feature=id_feature,
+            var="keep",
+            ds=keep_da,
+            proj_ds=keep_da.rio.crs,
+            x_coord="x",
+            y_coord="y",
+            band=1,
+            bname="band",
+            f_feature=nhru_gdf,
+            id_feature=id_feature,
         )
         keep_zonal = ZonalGen(
-            user_data=keep_data, zonal_engine="exactextract", zonal_writer="csv",
-            out_path=output_dir, file_prefix=f"{file_prefix}_keep_temp", jobs=4,
+            user_data=keep_data,
+            zonal_engine="exactextract",
+            zonal_writer="csv",
+            out_path=output_dir,
+            file_prefix=f"{file_prefix}_keep_temp",
+            jobs=4,
         )
         keep_stats = keep_zonal.calculate_zonal(categorical=False)
         logger.info("Keep raster zonal stats computed")
@@ -157,6 +188,54 @@ def run_lulc_batch(config: dict, batch_id: int, logger) -> None:
         retention_df = compute_retention(class_perc, crosswalk, id_col=id_feature)
         logger.info("Retention computed from crosswalk evergreen_retention (crosswalk-based)")
 
+    # --- Step 3b: rad_trncf (winter-canopy radiation transmission coef) ---
+    # When a radtrn raster is configured (cnpy*keep/100 over tree pixels, built
+    # by the shared-rasters build_lulc_rasters step), zonal-mean it per HRU and
+    # apply the NHM v1.1 Beer's-law transform (compute_rad_trncf). Sources with
+    # no keep/radtrn raster (NLCD/NALCMS, pending a synthesized keep raster)
+    # skip this column.
+    rad_trncf_df = None
+    radtrn_raster_str = config.get("radtrn_raster")
+    if radtrn_raster_str:
+        radtrn_path = Path(radtrn_raster_str)
+        if not radtrn_path.exists():
+            raise FileNotFoundError(f"radtrn raster not found: {radtrn_path}")
+        radtrn_da = rioxarray.open_rasterio(radtrn_path, masked=True)
+        logger.info("Loaded radtrn raster: shape=%s", radtrn_da.shape)
+
+        radtrn_data = UserTiffData(
+            var="radtrn",
+            ds=radtrn_da,
+            proj_ds=radtrn_da.rio.crs,
+            x_coord="x",
+            y_coord="y",
+            band=1,
+            bname="band",
+            f_feature=nhru_gdf,
+            id_feature=id_feature,
+        )
+        radtrn_zonal = ZonalGen(
+            user_data=radtrn_data,
+            zonal_engine="exactextract",
+            zonal_writer="csv",
+            out_path=output_dir,
+            file_prefix=f"{file_prefix}_radtrn_temp",
+            jobs=4,
+        )
+        radtrn_stats = radtrn_zonal.calculate_zonal(categorical=False)
+        logger.info("radtrn raster zonal stats computed")
+
+        temp_csv = output_dir / f"{file_prefix}_radtrn_temp.csv"
+        if temp_csv.exists():
+            temp_csv.unlink()
+
+        # radtrn zonal mean is the per-HRU winter-canopy density (0-100).
+        rad_trncf_df = radtrn_stats[["mean"]].rename(columns={"mean": "rad_trncf"})
+        rad_trncf_df["rad_trncf"] = compute_rad_trncf(rad_trncf_df["rad_trncf"])
+        rad_trncf_df.index.name = id_feature
+        rad_trncf_df = rad_trncf_df.reset_index()
+        logger.info("rad_trncf computed from radtrn raster (Beer's-law transform)")
+
     # --- Step 4: Compute parameters ---
     cov_type_df = assign_cov_type(class_perc, crosswalk, id_col=id_feature)
     logger.info("Cover types assigned")
@@ -170,15 +249,13 @@ def run_lulc_batch(config: dict, batch_id: int, logger) -> None:
     # --- Step 5: Merge and write ---
     expected_hrus = class_perc[id_feature].nunique()
     result = (
-        cov_type_df
-        .merge(intcp_df, on=id_feature)
-        .merge(covden_df, on=id_feature)
-        .merge(retention_df, on=id_feature)
+        cov_type_df.merge(intcp_df, on=id_feature).merge(covden_df, on=id_feature).merge(retention_df, on=id_feature)
     )
+    if rad_trncf_df is not None:
+        result = result.merge(rad_trncf_df, on=id_feature)
     if len(result) != expected_hrus:
         logger.warning(
-            "Row count mismatch after merge: expected %d HRUs, got %d. "
-            "Some HRUs may have been dropped.",
+            "Row count mismatch after merge: expected %d HRUs, got %d. Some HRUs may have been dropped.",
             expected_hrus,
             len(result),
         )

--- a/src/gfv2_params/zonal_runners/lulc.py
+++ b/src/gfv2_params/zonal_runners/lulc.py
@@ -5,10 +5,11 @@ that this module imports from).
 
 One ``run_lulc_batch`` covers all four LULC source types (nhm_v11, nalcms,
 nlcd, foresce) — the orchestrator normalises ``source_type`` to ``lulc_<source>``
-so each source writes per-batch CSVs to its own subdir. Five-step pipeline:
-categorical zonal stats on the LULC raster, continuous zonal stats on the
-canopy raster, optional zonal stats on a ``keep`` raster, crosswalk lookup +
-cov_type assignment, interception/covden/retention computation.
+so each source writes per-batch CSVs to its own subdir. Pipeline: categorical
+zonal stats on the LULC raster, continuous zonal stats on the canopy raster,
+optional zonal stats on a ``keep`` raster, optional zonal stats on a ``radtrn``
+raster (-> rad_trncf), crosswalk lookup + cov_type assignment,
+interception/covden/retention computation.
 """
 
 from __future__ import annotations
@@ -34,11 +35,13 @@ def run_lulc_batch(config: dict, batch_id: int, logger) -> None:
     """One HRU batch of LULC parameter derivation.
 
     Originally extracted from the now-retired scripts/create_lulc_params.py
-    (see PR #85). Five steps:
+    (see PR #85). Steps:
       1. categorical zonal stats on LULC raster -> class percentages
       2. continuous zonal stats on canopy raster -> canopy_mean per HRU
       3. retention: either zonal mean from keep raster (FORE-SCE / NHM v1.1)
          or crosswalk evergreen_retention (NLCD / NALCMS)
+      3b. rad_trncf: when a radtrn_raster is configured, zonal-mean it and
+         apply the Beer's-law transform (compute_rad_trncf)
       4. compute cov_type / interception / covden via gfv2_params.lulc helpers
       5. merge + write CSV
     """

--- a/src/gfv2_params/zonal_runners/lulc_prederived.py
+++ b/src/gfv2_params/zonal_runners/lulc_prederived.py
@@ -1,0 +1,180 @@
+"""Per-batch LULC parameters from pre-derived rasters (faithful NHM v1.1).
+
+Not to be confused with ``gfv2_params.zonal_runners.lulc`` (the crosswalk-driven
+runner). This module reproduces the NHM v1.1 ArcPy ``3_coverDen.py`` (Wieczorek
+& Bock, 2021): each parameter is a direct zonal statistic of a pre-derived
+raster shipped in the ScienceBase P971JAGF release, so it carries none of the
+5-class crosswalk's collapse error or the keep-vs-loss covden_win mistake.
+
+Per HRU:
+  - cov_type     categorical zonal stats on LULC.tif -> 5-class decision tree
+                 (``assign_cov_type``; the crosswalk supplies only the
+                 lu_code -> nhm_cov_type mapping)
+  - covden_sum   zonal mean of CNPY.tif / 100, zeroed where cov_type == 0
+  - covden_win   covden_sum * (1 - zonal_mean(loss.tif)/100)
+  - srain_intcp  zonal mean of SRain.tif / 100   (hundredths of inch -> inch)
+  - wrain_intcp  zonal mean of WRain.tif / 100
+  - snow_intcp   zonal mean of Snow.tif  / 100
+  - rad_trncf    Beer's-law transform of zonal_mean(radtrn raster) (compute_rad_trncf)
+
+There is no ``retention`` column: it was only ever a stand-in for rad_trncf,
+which this path computes directly.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import geopandas as gpd
+import rioxarray
+from gdptools import UserTiffData, ZonalGen
+
+from ..lulc import (
+    assign_cov_type,
+    class_percentages_from_histogram,
+    compute_rad_trncf,
+    covden_win_from_loss,
+    load_crosswalk,
+)
+
+
+def _zonal(raster_path, nhru_gdf, id_feature, output_dir, prefix, var, *, categorical):
+    """Run one zonal pass over ``raster_path`` and return the result frame.
+
+    Cleans up the temp CSV ZonalGen writes. Returns the raw ZonalGen frame
+    (indexed by HRU id); callers pull ``mean`` (continuous) or the category
+    histogram columns (categorical).
+    """
+    raster_path = Path(raster_path)
+    if not raster_path.exists():
+        raise FileNotFoundError(f"{var} raster not found: {raster_path}")
+    da = rioxarray.open_rasterio(raster_path, masked=True)
+    data = UserTiffData(
+        var=var,
+        ds=da,
+        proj_ds=da.rio.crs,
+        x_coord="x",
+        y_coord="y",
+        band=1,
+        bname="band",
+        f_feature=nhru_gdf,
+        id_feature=id_feature,
+    )
+    zonal = ZonalGen(
+        user_data=data,
+        zonal_engine="exactextract",
+        zonal_writer="csv",
+        out_path=output_dir,
+        file_prefix=f"{prefix}_{var}_temp",
+        jobs=4,
+    )
+    result = zonal.calculate_zonal(categorical=categorical)
+    temp_csv = output_dir / f"{prefix}_{var}_temp.csv"
+    if temp_csv.exists():
+        temp_csv.unlink()
+    return result
+
+
+def _zonal_mean_col(raster_path, nhru_gdf, id_feature, output_dir, prefix, var, scale=1.0):
+    """Per-HRU zonal mean of a continuous raster as a 2-col frame [id, var].
+
+    ``scale`` multiplies the mean (e.g. 0.01 to convert hundredths-of-inch
+    interception rasters or 0-100 canopy percent to a 0-1 fraction). HRUs with
+    no valid (non-nodata) pixels get NaN here; the caller decides fill policy.
+    """
+    stats = _zonal(raster_path, nhru_gdf, id_feature, output_dir, prefix, var, categorical=False)
+    out = stats[["mean"]].rename(columns={"mean": var})
+    out[var] = out[var] * scale
+    out.index.name = id_feature
+    return out.reset_index()
+
+
+def run_lulc_prederived_batch(config: dict, batch_id: int, logger) -> None:
+    """One HRU batch of faithful (pre-derived-raster) LULC parameters.
+
+    Config keys: source_raster (LULC), canopy_raster (CNPY), loss_raster,
+    snow_raster, srain_raster, wrain_raster, radtrn_raster, crosswalk_file
+    (cov_type mapping only), plus the usual batch_dir/output_dir/target_layer/
+    id_feature/fabric/source_type.
+    """
+    source_type = config["source_type"]
+    id_feature = config["id_feature"]
+    target_layer = config["target_layer"]
+    fabric = config["fabric"]
+
+    output_dir = Path(config["output_dir"]) / source_type
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    batch_dir = Path(config["batch_dir"])
+    batch_gpkg = batch_dir / f"batch_{batch_id:04d}.gpkg"
+    if not batch_gpkg.exists():
+        raise FileNotFoundError(f"Batch GPKG not found: {batch_gpkg}")
+    nhru_gdf = gpd.read_file(batch_gpkg, layer=target_layer)
+    logger.info("Loaded %s layer: %d features (batch %d)", target_layer, len(nhru_gdf), batch_id)
+
+    crosswalk_path = Path(config["crosswalk_file"])
+    if not crosswalk_path.is_absolute():
+        crosswalk_path = Path(__file__).resolve().parents[3] / crosswalk_path
+    crosswalk = load_crosswalk(crosswalk_path)
+
+    prefix = f"base_nhm_{source_type}_{fabric}_batch_{batch_id:04d}_param"
+
+    # --- cov_type: categorical zonal on LULC -> 5-class decision tree ---
+    histogram = _zonal(config["source_raster"], nhru_gdf, id_feature, output_dir, prefix, "lulc", categorical=True)
+    class_perc = class_percentages_from_histogram(histogram)
+    id_name = histogram.index.name or "id"
+    if id_name != id_feature:
+        class_perc = class_perc.rename(columns={id_name: id_feature})
+    cov_type_df = assign_cov_type(class_perc, crosswalk, id_col=id_feature)
+    logger.info("cov_type assigned for %d HRUs", len(cov_type_df))
+
+    # --- covden_sum: zonal mean of canopy / 100, zeroed where cov_type == 0 ---
+    covden_sum_df = _zonal_mean_col(
+        config["canopy_raster"], nhru_gdf, id_feature, output_dir, prefix, "covden_sum", scale=0.01
+    )
+    covden_sum_df = covden_sum_df.merge(cov_type_df, on=id_feature, how="left")
+    covden_sum_df.loc[covden_sum_df["cov_type"] == 0, "covden_sum"] = 0.0
+    covden_sum_df = covden_sum_df[[id_feature, "covden_sum"]]
+
+    # --- covden_win: covden_sum * (1 - loss/100) ---
+    loss_df = _zonal_mean_col(config["loss_raster"], nhru_gdf, id_feature, output_dir, prefix, "loss")
+    covden_win_df = covden_sum_df.merge(loss_df, on=id_feature, how="left")
+    covden_win_df["covden_win"] = covden_win_from_loss(covden_win_df["covden_sum"], covden_win_df["loss"].fillna(0.0))
+    covden_win_df = covden_win_df[[id_feature, "covden_win"]]
+    logger.info("covden_sum / covden_win computed")
+
+    # --- interception: zonal mean / 100 (hundredths of inch -> inch) ---
+    intcp_specs = [
+        ("snow_raster", "snow_intcp"),
+        ("srain_raster", "srain_intcp"),
+        ("wrain_raster", "wrain_intcp"),
+    ]
+    intcp_dfs = []
+    for cfg_key, col in intcp_specs:
+        df = _zonal_mean_col(config[cfg_key], nhru_gdf, id_feature, output_dir, prefix, col, scale=0.01)
+        df[col] = df[col].fillna(0.0)  # HRUs with no valid pixels -> 0 (legacy)
+        intcp_dfs.append(df)
+    logger.info("interception parameters computed")
+
+    # --- rad_trncf: Beer's-law transform of the radtrn zonal mean ---
+    rad_trncf_df = _zonal_mean_col(config["radtrn_raster"], nhru_gdf, id_feature, output_dir, prefix, "rad_trncf")
+    rad_trncf_df["rad_trncf"] = compute_rad_trncf(rad_trncf_df["rad_trncf"])
+    logger.info("rad_trncf computed")
+
+    # --- merge + write ---
+    expected_hrus = len(cov_type_df)
+    result = cov_type_df.merge(covden_sum_df, on=id_feature).merge(covden_win_df, on=id_feature)
+    for df in intcp_dfs:
+        result = result.merge(df, on=id_feature)
+    result = result.merge(rad_trncf_df, on=id_feature)
+    if len(result) != expected_hrus:
+        logger.warning(
+            "Row count mismatch after merge: expected %d HRUs, got %d.",
+            expected_hrus,
+            len(result),
+        )
+    result = result.sort_values(id_feature).set_index(id_feature)
+
+    result_csv = output_dir / f"{prefix}.csv"
+    result.to_csv(result_csv)
+    logger.info("LULC (pre-derived) parameters saved to: %s (%d HRUs)", result_csv, len(result))

--- a/src/gfv2_params/zonal_runners/lulc_prederived.py
+++ b/src/gfv2_params/zonal_runners/lulc_prederived.py
@@ -48,6 +48,11 @@ def _zonal(raster_path, nhru_gdf, id_feature, output_dir, prefix, var, *, catego
     raster_path = Path(raster_path)
     if not raster_path.exists():
         raise FileNotFoundError(f"{var} raster not found: {raster_path}")
+    # NB on nodata: masked=True relies on each GeoTIFF's declared nodata tag.
+    # The staged interception/loss rasters carry one (Snow/SRain/WRain=15,
+    # loss/keep Int8=-128), so sentinels are masked. The derived radtrn raster
+    # legitimately has no nodata tag — its non-tree 0s are valid data that must
+    # count in the mean — so we must NOT blanket-require a nodata tag here.
     da = rioxarray.open_rasterio(raster_path, masked=True)
     data = UserTiffData(
         var=var,
@@ -137,9 +142,21 @@ def run_lulc_prederived_batch(config: dict, batch_id: int, logger) -> None:
     covden_sum_df = covden_sum_df[[id_feature, "covden_sum"]]
 
     # --- covden_win: covden_sum * (1 - loss/100) ---
+    # NB: do NOT zero-fill a missing loss mean. Unlike interception (where the
+    # legacy sets missing -> 0), loss=0 means "no leaf loss" -> covden_win =
+    # covden_sum, i.e. FULL winter canopy — the max-impact wrong value. A NaN
+    # loss mean signals an HRU with no loss-raster overlap (CRS/extent bug, or
+    # an edge HRU), so leave covden_win NaN and let the downstream KNN gap-fill
+    # (PR #134) handle it, matching the legacy null -> CL_HRU fill.
     loss_df = _zonal_mean_col(config["loss_raster"], nhru_gdf, id_feature, output_dir, prefix, "loss")
     covden_win_df = covden_sum_df.merge(loss_df, on=id_feature, how="left")
-    covden_win_df["covden_win"] = covden_win_from_loss(covden_win_df["covden_sum"], covden_win_df["loss"].fillna(0.0))
+    no_loss = covden_win_df["loss"].isna() & (covden_win_df["covden_sum"] > 0)
+    if no_loss.any():
+        logger.warning(
+            "%d HRUs have canopy but no loss-raster overlap; covden_win left NaN for gap-fill",
+            int(no_loss.sum()),
+        )
+    covden_win_df["covden_win"] = covden_win_from_loss(covden_win_df["covden_sum"], covden_win_df["loss"])
     covden_win_df = covden_win_df[[id_feature, "covden_win"]]
     logger.info("covden_sum / covden_win computed")
 
@@ -162,16 +179,25 @@ def run_lulc_prederived_batch(config: dict, batch_id: int, logger) -> None:
     logger.info("rad_trncf computed")
 
     # --- merge + write ---
-    expected_hrus = len(cov_type_df)
     result = cov_type_df.merge(covden_sum_df, on=id_feature).merge(covden_win_df, on=id_feature)
     for df in intcp_dfs:
         result = result.merge(df, on=id_feature)
     result = result.merge(rad_trncf_df, on=id_feature)
-    if len(result) != expected_hrus:
+
+    # Diagnose dropped HRUs against the batch geometry (the true baseline), not
+    # cov_type_df: an HRU with no LULC pixels is absent from cov_type_df and
+    # would silently vanish from the param table. The inner merges can also drop
+    # an HRU missing from any per-param frame. Report ids so a CRS/extent bug is
+    # visible rather than swallowed (the downstream gap-fill backfills absent
+    # rows, but only if we know they were dropped here vs. genuinely missing).
+    dropped = set(nhru_gdf[id_feature]) - set(result[id_feature])
+    if dropped:
         logger.warning(
-            "Row count mismatch after merge: expected %d HRUs, got %d.",
-            expected_hrus,
-            len(result),
+            "%d/%d HRUs absent from LULC output (no LULC pixels or merge loss): %s%s",
+            len(dropped),
+            len(nhru_gdf),
+            sorted(dropped)[:20],
+            " ..." if len(dropped) > 20 else "",
         )
     result = result.sort_values(id_feature).set_index(id_feature)
 

--- a/tests/test_lulc.py
+++ b/tests/test_lulc.py
@@ -391,3 +391,26 @@ def test_covden_win_from_loss_deciduous():
     """Deciduous (loss 60%) -> covden_win = covden_sum * 0.4."""
     result = covden_win_from_loss(pd.Series([0.5]), pd.Series([60.0]))
     assert result.iloc[0] == pytest.approx(0.2)
+
+
+# --- pure-helper edge cases (contract the lulc_prederived runner relies on) ---
+
+
+def test_compute_rad_trncf_nan_density_propagates():
+    """No radtrn overlap -> NaN density -> NaN rad_trncf (left for gap-fill)."""
+    result = compute_rad_trncf(pd.Series([np.nan, 0.0]))
+    assert np.isnan(result.iloc[0])
+    assert result.iloc[1] == pytest.approx(0.9917, abs=1e-6)
+
+
+def test_compute_rad_trncf_empty_series():
+    """Zero-HRU batch returns an empty Series, not an error."""
+    result = compute_rad_trncf(pd.Series([], dtype=float))
+    assert len(result) == 0
+
+
+def test_covden_win_from_loss_nan_loss_propagates():
+    """Missing loss mean -> NaN covden_win (runner leaves it for gap-fill,
+    rather than fabricating full winter canopy via a 0 fill)."""
+    result = covden_win_from_loss(pd.Series([0.5]), pd.Series([np.nan]))
+    assert np.isnan(result.iloc[0])

--- a/tests/test_lulc.py
+++ b/tests/test_lulc.py
@@ -13,6 +13,7 @@ from gfv2_params.lulc import (
     compute_interception,
     compute_rad_trncf,
     compute_retention,
+    covden_win_from_loss,
     load_crosswalk,
 )
 
@@ -365,3 +366,28 @@ def test_compute_rad_trncf_preserves_index():
     density = pd.Series([0.0, 50.0], index=[101, 202])
     result = compute_rad_trncf(density)
     assert list(result.index) == [101, 202]
+
+
+# --- covden_win_from_loss ---
+# Faithful NHM v1.1 (3_coverDen.py): covden_win = covden_sum * (1 - loss/100),
+# where `loss` is the per-HRU zonal mean of loss.tif (leaf-loss percent, 0-100).
+# NB: this uses leaf-LOSS, not leaf-keep — they are NOT complements in the
+# Viger & Leavesley table (grass loss=100/keep=80).
+
+
+def test_covden_win_from_loss_grass_full_loss():
+    """Grass (loss 100%) -> no winter canopy: covden_win = 0."""
+    result = covden_win_from_loss(pd.Series([0.5]), pd.Series([100.0]))
+    assert result.iloc[0] == pytest.approx(0.0)
+
+
+def test_covden_win_from_loss_evergreen_no_loss():
+    """Evergreen (loss 0%) retains all summer canopy: covden_win = covden_sum."""
+    result = covden_win_from_loss(pd.Series([0.5]), pd.Series([0.0]))
+    assert result.iloc[0] == pytest.approx(0.5)
+
+
+def test_covden_win_from_loss_deciduous():
+    """Deciduous (loss 60%) -> covden_win = covden_sum * 0.4."""
+    result = covden_win_from_loss(pd.Series([0.5]), pd.Series([60.0]))
+    assert result.iloc[0] == pytest.approx(0.2)

--- a/tests/test_lulc.py
+++ b/tests/test_lulc.py
@@ -11,6 +11,7 @@ from gfv2_params.lulc import (
     class_percentages_from_histogram,
     compute_covden,
     compute_interception,
+    compute_rad_trncf,
     compute_retention,
     load_crosswalk,
 )
@@ -121,27 +122,21 @@ def test_assign_cov_type_shrub_20pct(crosswalk):
 
 def test_assign_cov_type_shrub_tree_combined(crosswalk):
     # 18% deciduous(3) + 18% shrub(2) = 36% >= 35%, shrub higher -> cov_type=2
-    perc = pd.DataFrame(
-        {"nat_hru_id": [1, 1, 1], "lu_code": [3, 2, 1], "perc": [17.0, 19.0, 64.0]}
-    )
+    perc = pd.DataFrame({"nat_hru_id": [1, 1, 1], "lu_code": [3, 2, 1], "perc": [17.0, 19.0, 64.0]})
     result = assign_cov_type(perc, crosswalk)
     assert result.loc[result["nat_hru_id"] == 1, "cov_type"].iloc[0] == 2
 
 
 def test_assign_cov_type_shrub_tree_combined_tree_higher(crosswalk):
     # 19% deciduous(3) + 17% shrub(2) = 36% >= 35%, tree higher -> cov_type=3
-    perc = pd.DataFrame(
-        {"nat_hru_id": [1, 1, 1], "lu_code": [3, 2, 1], "perc": [19.0, 17.0, 64.0]}
-    )
+    perc = pd.DataFrame({"nat_hru_id": [1, 1, 1], "lu_code": [3, 2, 1], "perc": [19.0, 17.0, 64.0]})
     result = assign_cov_type(perc, crosswalk)
     assert result.loc[result["nat_hru_id"] == 1, "cov_type"].iloc[0] == 3
 
 
 def test_assign_cov_type_grass_50pct(crosswalk):
     # 5% bare(0), 10% shrub(2), 5% tree(3), 80% grass(1) -> grass wins at 50%
-    perc = pd.DataFrame(
-        {"nat_hru_id": [1, 1, 1, 1], "lu_code": [0, 2, 3, 1], "perc": [5.0, 10.0, 5.0, 80.0]}
-    )
+    perc = pd.DataFrame({"nat_hru_id": [1, 1, 1, 1], "lu_code": [0, 2, 3, 1], "perc": [5.0, 10.0, 5.0, 80.0]})
     result = assign_cov_type(perc, crosswalk)
     assert result.loc[result["nat_hru_id"] == 1, "cov_type"].iloc[0] == 1
 
@@ -150,20 +145,20 @@ def test_assign_cov_type_fallback_max(crosswalk):
     # 40% bare(0), 10% tree(3), 10% shrub(2), 40% grass(1)
     # No rule triggers: bare < 90, tree < 20, shrub < 20, tree+shrub < 35, grass < 50
     # Fallback: bare and grass tied at 40%, picks whichever idxmax returns
-    perc = pd.DataFrame(
-        {"nat_hru_id": [1, 1, 1, 1], "lu_code": [0, 3, 2, 1], "perc": [35.0, 10.0, 10.0, 45.0]}
-    )
+    perc = pd.DataFrame({"nat_hru_id": [1, 1, 1, 1], "lu_code": [0, 3, 2, 1], "perc": [35.0, 10.0, 10.0, 45.0]})
     result = assign_cov_type(perc, crosswalk)
     # grass has 45% which is highest -> cov_type=1
     assert result.loc[result["nat_hru_id"] == 1, "cov_type"].iloc[0] == 1
 
 
 def test_assign_cov_type_multiple_hrus(crosswalk):
-    perc = pd.DataFrame({
-        "nat_hru_id": [1, 1, 2, 2],
-        "lu_code": [0, 1, 3, 1],
-        "perc": [95.0, 5.0, 30.0, 70.0],
-    })
+    perc = pd.DataFrame(
+        {
+            "nat_hru_id": [1, 1, 2, 2],
+            "lu_code": [0, 1, 3, 1],
+            "perc": [95.0, 5.0, 30.0, 70.0],
+        }
+    )
     result = assign_cov_type(perc, crosswalk)
     assert len(result) == 2
     assert result.loc[result["nat_hru_id"] == 1, "cov_type"].iloc[0] == 0
@@ -174,11 +169,13 @@ def test_assign_cov_type_multiple_hrus(crosswalk):
 
 
 def test_compute_interception(crosswalk):
-    perc = pd.DataFrame({
-        "nat_hru_id": [1, 1],
-        "lu_code": [1, 3],  # grass(srain=0.02) and deciduous(srain=0.05)
-        "perc": [60.0, 40.0],
-    })
+    perc = pd.DataFrame(
+        {
+            "nat_hru_id": [1, 1],
+            "lu_code": [1, 3],  # grass(srain=0.02) and deciduous(srain=0.05)
+            "perc": [60.0, 40.0],
+        }
+    )
     result = compute_interception(perc, crosswalk)
     # srain = 0.60*0.02 + 0.40*0.05 = 0.012 + 0.020 = 0.032
     assert result.loc[0, "srain_intcp"] == pytest.approx(0.032)
@@ -189,11 +186,13 @@ def test_compute_interception(crosswalk):
 
 
 def test_compute_interception_bare_zero(crosswalk):
-    perc = pd.DataFrame({
-        "nat_hru_id": [1, 1],
-        "lu_code": [0, 1],  # bare + grass
-        "perc": [50.0, 50.0],
-    })
+    perc = pd.DataFrame(
+        {
+            "nat_hru_id": [1, 1],
+            "lu_code": [0, 1],  # bare + grass
+            "perc": [50.0, 50.0],
+        }
+    )
     result = compute_interception(perc, crosswalk)
     # Only grass contributes: 0.50*0.02 = 0.01
     assert result.loc[0, "srain_intcp"] == pytest.approx(0.01)
@@ -203,11 +202,13 @@ def test_compute_interception_bare_zero(crosswalk):
 
 
 def test_compute_covden(crosswalk):
-    perc = pd.DataFrame({
-        "nat_hru_id": [1, 1],
-        "lu_code": [3, 4],  # deciduous(nhm_covden_win=0.6) + evergreen(nhm_covden_win=1.0)
-        "perc": [50.0, 50.0],
-    })
+    perc = pd.DataFrame(
+        {
+            "nat_hru_id": [1, 1],
+            "lu_code": [3, 4],  # deciduous(nhm_covden_win=0.6) + evergreen(nhm_covden_win=1.0)
+            "perc": [50.0, 50.0],
+        }
+    )
     canopy = pd.DataFrame({"nat_hru_id": [1], "canopy_mean": [80.0]})
     result = compute_covden(perc, crosswalk, canopy)
 
@@ -221,11 +222,13 @@ def test_compute_covden(crosswalk):
 
 
 def test_compute_covden_bare_zero(crosswalk):
-    perc = pd.DataFrame({
-        "nat_hru_id": [1],
-        "lu_code": [0],  # bare
-        "perc": [100.0],
-    })
+    perc = pd.DataFrame(
+        {
+            "nat_hru_id": [1],
+            "lu_code": [0],  # bare
+            "perc": [100.0],
+        }
+    )
     canopy = pd.DataFrame({"nat_hru_id": [1], "canopy_mean": [50.0]})
     result = compute_covden(perc, crosswalk, canopy)
     assert result.loc[0, "covden_sum"] == pytest.approx(0.0)
@@ -236,38 +239,44 @@ def test_compute_covden_bare_zero(crosswalk):
 
 
 def test_compute_retention_mixed():
-    cw = pd.DataFrame({
-        "lu_code": [1, 4],
-        "lu_desc": ["Grass", "Evergreen"],
-        "nhm_cov_type": [1, 3],
-        "srain_intcp": [0.02, 0.05],
-        "wrain_intcp": [0.02, 0.05],
-        "snow_intcp": [0.02, 0.05],
-        "nhm_covden_win": [0.0, 0.0],
-        "evergreen_retention": [0.0, 1.0],
-    }).set_index("lu_code")
+    cw = pd.DataFrame(
+        {
+            "lu_code": [1, 4],
+            "lu_desc": ["Grass", "Evergreen"],
+            "nhm_cov_type": [1, 3],
+            "srain_intcp": [0.02, 0.05],
+            "wrain_intcp": [0.02, 0.05],
+            "snow_intcp": [0.02, 0.05],
+            "nhm_covden_win": [0.0, 0.0],
+            "evergreen_retention": [0.0, 1.0],
+        }
+    ).set_index("lu_code")
 
-    perc = pd.DataFrame({
-        "nat_hru_id": [1, 1],
-        "lu_code": [1, 4],
-        "perc": [60.0, 40.0],
-    })
+    perc = pd.DataFrame(
+        {
+            "nat_hru_id": [1, 1],
+            "lu_code": [1, 4],
+            "perc": [60.0, 40.0],
+        }
+    )
     result = compute_retention(perc, cw)
     # retention = 0.60*0.0 + 0.40*1.0 = 0.40
     assert result.loc[0, "retention"] == pytest.approx(0.40)
 
 
 def test_compute_retention_all_evergreen():
-    cw = pd.DataFrame({
-        "lu_code": [42],
-        "lu_desc": ["Evergreen_Forest"],
-        "nhm_cov_type": [3],
-        "srain_intcp": [0.05],
-        "wrain_intcp": [0.05],
-        "snow_intcp": [0.05],
-        "nhm_covden_win": [0.0],
-        "evergreen_retention": [1.0],
-    }).set_index("lu_code")
+    cw = pd.DataFrame(
+        {
+            "lu_code": [42],
+            "lu_desc": ["Evergreen_Forest"],
+            "nhm_cov_type": [3],
+            "srain_intcp": [0.05],
+            "wrain_intcp": [0.05],
+            "snow_intcp": [0.05],
+            "nhm_covden_win": [0.0],
+            "evergreen_retention": [1.0],
+        }
+    ).set_index("lu_code")
 
     perc = pd.DataFrame({"nat_hru_id": [1], "lu_code": [42], "perc": [100.0]})
     result = compute_retention(perc, cw)
@@ -275,22 +284,26 @@ def test_compute_retention_all_evergreen():
 
 
 def test_compute_retention_bare_contributes_zero():
-    cw = pd.DataFrame({
-        "lu_code": [0, 42],
-        "lu_desc": ["Bare", "Evergreen"],
-        "nhm_cov_type": [0, 3],
-        "srain_intcp": [0.0, 0.05],
-        "wrain_intcp": [0.0, 0.05],
-        "snow_intcp": [0.0, 0.05],
-        "nhm_covden_win": [0.0, 0.0],
-        "evergreen_retention": [0.5, 1.0],  # bare has 0.5 but should be zeroed out
-    }).set_index("lu_code")
+    cw = pd.DataFrame(
+        {
+            "lu_code": [0, 42],
+            "lu_desc": ["Bare", "Evergreen"],
+            "nhm_cov_type": [0, 3],
+            "srain_intcp": [0.0, 0.05],
+            "wrain_intcp": [0.0, 0.05],
+            "snow_intcp": [0.0, 0.05],
+            "nhm_covden_win": [0.0, 0.0],
+            "evergreen_retention": [0.5, 1.0],  # bare has 0.5 but should be zeroed out
+        }
+    ).set_index("lu_code")
 
-    perc = pd.DataFrame({
-        "nat_hru_id": [1, 1],
-        "lu_code": [0, 42],
-        "perc": [50.0, 50.0],
-    })
+    perc = pd.DataFrame(
+        {
+            "nat_hru_id": [1, 1],
+            "lu_code": [0, 42],
+            "perc": [50.0, 50.0],
+        }
+    )
     result = compute_retention(perc, cw)
     # bare zeroed out: 0.50*0.0 + 0.50*1.0 = 0.50
     assert result.loc[0, "retention"] == pytest.approx(0.50)
@@ -298,22 +311,57 @@ def test_compute_retention_bare_contributes_zero():
 
 def test_compute_retention_mixed_forest():
     """NLCD-style: deciduous=0.0, evergreen=1.0, mixed=0.5."""
-    cw = pd.DataFrame({
-        "lu_code": [41, 42, 43],
-        "lu_desc": ["Deciduous", "Evergreen", "Mixed"],
-        "nhm_cov_type": [3, 3, 3],
-        "srain_intcp": [0.05, 0.05, 0.05],
-        "wrain_intcp": [0.02, 0.05, 0.035],
-        "snow_intcp": [0.05, 0.05, 0.05],
-        "nhm_covden_win": [0.5, 0.0, 0.25],
-        "evergreen_retention": [0.0, 1.0, 0.5],
-    }).set_index("lu_code")
+    cw = pd.DataFrame(
+        {
+            "lu_code": [41, 42, 43],
+            "lu_desc": ["Deciduous", "Evergreen", "Mixed"],
+            "nhm_cov_type": [3, 3, 3],
+            "srain_intcp": [0.05, 0.05, 0.05],
+            "wrain_intcp": [0.02, 0.05, 0.035],
+            "snow_intcp": [0.05, 0.05, 0.05],
+            "nhm_covden_win": [0.5, 0.0, 0.25],
+            "evergreen_retention": [0.0, 1.0, 0.5],
+        }
+    ).set_index("lu_code")
 
-    perc = pd.DataFrame({
-        "nat_hru_id": [1, 1, 1],
-        "lu_code": [41, 42, 43],
-        "perc": [30.0, 40.0, 30.0],
-    })
+    perc = pd.DataFrame(
+        {
+            "nat_hru_id": [1, 1, 1],
+            "lu_code": [41, 42, 43],
+            "perc": [30.0, 40.0, 30.0],
+        }
+    )
     result = compute_retention(perc, cw)
     # retention = 0.30*0.0 + 0.40*1.0 + 0.30*0.5 = 0.0 + 0.40 + 0.15 = 0.55
     assert result.loc[0, "retention"] == pytest.approx(0.55)
+
+
+# --- compute_rad_trncf ---
+# rad_trncf = exp(-2.7557 * density/100) * 0.9917, where `density` is the
+# per-HRU zonal mean (0-100) of the radtrn raster (cnpy*keep/100 over trees).
+# Ported from the NHM v1.1 ArcPy `3_coverDen.py` rad_trncf() (Wieczorek & Bock).
+
+
+def test_compute_rad_trncf_zero_density():
+    """No winter canopy (density 0) -> near-full radiation transmission 0.9917."""
+    result = compute_rad_trncf(pd.Series([0.0]))
+    assert result.iloc[0] == pytest.approx(0.9917, abs=1e-6)
+
+
+def test_compute_rad_trncf_full_density():
+    """Density 100% -> exp(-2.7557) * 0.9917 ~= 0.0633 (dense evergreen)."""
+    result = compute_rad_trncf(pd.Series([100.0]))
+    assert result.iloc[0] == pytest.approx(np.exp(-2.7557) * 0.9917, rel=1e-9)
+
+
+def test_compute_rad_trncf_monotonic_decreasing():
+    """Transmission falls monotonically as winter canopy density rises."""
+    result = compute_rad_trncf(pd.Series([0.0, 25.0, 50.0, 75.0, 100.0]))
+    assert (result.diff().dropna() < 0).all()
+
+
+def test_compute_rad_trncf_preserves_index():
+    """Output is aligned to the input HRU index (so it merges by HRU id)."""
+    density = pd.Series([0.0, 50.0], index=[101, 202])
+    result = compute_rad_trncf(density)
+    assert list(result.index) == [101, 202]

--- a/tests/test_zonal_orchestrator.py
+++ b/tests/test_zonal_orchestrator.py
@@ -127,7 +127,10 @@ def test_lulc_entries_use_per_source_names():
     """Each LULC source must have its own `name` (lulc_<source>) to avoid
     per-batch output collisions when multiple LULC sources run in parallel."""
     config = _load_config_raw()
-    lulc_names = {e["name"] for e in config["params"] if e.get("script") == "lulc"}
+    # Both the crosswalk-driven (lulc) and faithful pre-derived (lulc_prederived)
+    # runners are LULC sources and need per-source names.
+    lulc_scripts = {"lulc", "lulc_prederived"}
+    lulc_names = {e["name"] for e in config["params"] if e.get("script") in lulc_scripts}
     assert lulc_names >= {"lulc_nhm_v11", "lulc_nalcms", "lulc_nlcd", "lulc_foresce"}
     # No bare "lulc" entry (would collide with the legacy CLI's source_type).
     assert "lulc" not in lulc_names

--- a/tests/test_zonal_runners_package.py
+++ b/tests/test_zonal_runners_package.py
@@ -12,6 +12,7 @@ from gfv2_params.zonal_runners import (
     BATCH_RUNNERS,
     run_build_weights,
     run_lulc_batch,
+    run_lulc_prederived_batch,
     run_merge,
     run_soils_batch,
     run_ssflux_batch,
@@ -20,10 +21,11 @@ from gfv2_params.zonal_runners import (
 
 
 def test_public_reexports_resolve():
-    """All 6 public re-exports + BATCH_RUNNERS must be callable / dict."""
+    """All 7 public re-exports + BATCH_RUNNERS must be callable / dict."""
     assert callable(run_zonal_batch)
     assert callable(run_soils_batch)
     assert callable(run_lulc_batch)
+    assert callable(run_lulc_prederived_batch)
     assert callable(run_ssflux_batch)
     assert callable(run_build_weights)
     assert callable(run_merge)
@@ -31,16 +33,17 @@ def test_public_reexports_resolve():
 
 
 def test_batch_runners_keys_and_identity():
-    """BATCH_RUNNERS dispatch must match the 4 script: tags and the re-exports.
+    """BATCH_RUNNERS dispatch must match the 5 script: tags and the re-exports.
 
     Function identity (not just name) — guarantees the orchestrator's
     BATCH_RUNNERS[tag](...) call reaches the same function the test suite
     can import directly.
     """
-    assert sorted(BATCH_RUNNERS) == ["lulc", "soils", "ssflux", "zonal"]
+    assert sorted(BATCH_RUNNERS) == ["lulc", "lulc_prederived", "soils", "ssflux", "zonal"]
     assert BATCH_RUNNERS["zonal"] is run_zonal_batch
     assert BATCH_RUNNERS["soils"] is run_soils_batch
     assert BATCH_RUNNERS["lulc"] is run_lulc_batch
+    assert BATCH_RUNNERS["lulc_prederived"] is run_lulc_prederived_batch
     assert BATCH_RUNNERS["ssflux"] is run_ssflux_batch
 
 


### PR DESCRIPTION
Returns to the LULC parameters and acts on a crosswalk validation against the **authoritative source** — the Viger & Leavesley (2007) remap table embedded in the ScienceBase **P971JAGF** metadata (the table that built every NHM v1.1 LULC raster; legacy `3_coverDen.py` zonal-means them). Implements the first two workstreams from [the plan](docs/superpowers/plans/2026-06-08-lulc-rad-trncf-and-faithful-nhm-v11.md). Refs #26.

## A — `rad_trncf` was missing entirely

The pipeline built the `radtrn` raster but never zonal-meaned it or applied the Beer's-law transform, so the PRMS **radiation transmission coefficient was absent from every LULC output** (a `retention` surrogate was emitted instead).

- `compute_rad_trncf()` in `gfv2_params.lulc`: `exp(-2.7557·density/100)·0.9917`, ported verbatim from `3_coverDen.py`. Density = per-HRU zonal mean (0–100) of the `radtrn` raster.
- `run_lulc_batch` Step 3b: zonal-mean the `radtrn` raster → `rad_trncf` column when a `radtrn_raster` is configured.
- 4 unit tests (density 0→0.9917, 100→0.063, monotonic, index-preserving).

## B — faithful `nhm_v11` from the staged rasters (`lulc_prederived`)

New `lulc_prederived` runner: every `nhm_v11` LULC param is now a **direct zonal stat of the pre-derived P971JAGF rasters**, reproducing `3_coverDen.py` exactly instead of the lossy 5-class crosswalk.

**Two correctness wins, both quantified:**

1. **`covden_win` bug.** The crosswalk path computed `covden_win` from leaf-**keep** (`nhm_covden_win = keep/100`) where the legacy uses **`1 − leaf-loss`**. These are *not* complements in the authoritative table (grass loss=100/keep=80), so the on-disk `nhm_v11` `covden_win` is too high for grass/shrub/deciduous (grassland ≈ 0.8·covden_sum, should be ≈ 0). The raster path uses `loss.tif` directly and fixes it.
2. **Interception collapse.** The 5-class crosswalk flattens within-class detail (mixed-forest snow 0.07 and wetland snow 0.05 both → deciduous 0.02). Measured over a CONUS-windowed NALCMS sample: **24.6% of CONUS land** has an interception param shifted by >0.005 in, up to 0.05 in locally. The raster path eliminates it.

Output params: `cov_type, covden_sum, covden_win, srain/wrain/snow_intcp, rad_trncf` (the legacy set — no `retention`, which was only ever a stand-in for `rad_trncf`).

- new `zonal_runners/lulc_prederived.py` (registered in `BATCH_RUNNERS`); `covden_win_from_loss()` helper (+3 tests); dispatch-registration test; `zonal_params.yml` `lulc_nhm_v11` → `script: lulc_prederived` with per-param raster keys; docs.

## Testing

TDD throughout (RED→GREEN verified for both pure helpers). Per repo policy, `pytest` is not run on the HPC head node — pure helpers were exercised via direct import checks; **CI is the gate** and runs the full suite on this PR. Real raster integration verifies on the CONUS re-run.

## Not in this PR (follow-on, tracked in #26)

- **CONUS re-run of `nhm_v11`** to supersede the `covden_win`-wrong CSV (faithful path is wired; `radtrn_nhm_v11.tif` prerequisite confirmed present).
- **C. NALCMS** — regenerate `nalcms_nhm.csv` from the authoritative table (it has drifted) + re-run.
- **D. NLCD** — crosswalk by analogy + stage + run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)