### PR TITLE
feat(depstor): NHD WBAREACOMI waterbody connectivity (retire streambuffer)

### DIFF
--- a/configs/base_config.yml
+++ b/configs/base_config.yml
@@ -72,6 +72,10 @@ fabrics:
     segments_gpkg: "{data_root}/input/fabric/NHM_01_draft.gpkg"
     waterbody_gpkg: "{data_root}/input/fabric/NHM_01_draft.gpkg"
     waterbody_layer: wbs
+    # No `connected_comids_table`: the `wbs` layer has no COMID/member_comid
+    # column, so the WBAREACOMI join cannot run. The depstor
+    # `wbody_connectivity`/`dprst` steps therefore fail-fast on this profile —
+    # use the `gfv2` profile for depstor validation.
     hru_gpkg: "{data_root}/{fabric}/fabric/gfv2_vpu01_nhru.gpkg"
     hru_layer: nhru
     id_feature: nat_hru_id

--- a/configs/base_config.yml
+++ b/configs/base_config.yml
@@ -41,6 +41,9 @@ fabrics:
     # waterbody builder reprojects to the template grid and clips to land_mask.
     waterbody_gpkg: "{data_root}/input/nhd/conus_waterbodies.gpkg"
     waterbody_layer: waterbodies
+    # Connected-waterbody COMIDs distilled from NHD WBAREACOMI artificial paths
+    # (see gfv2_params.download.nhd_flowlines). Drives wbody_connectivity.
+    connected_comids_table: "{data_root}/input/nhd/connected_waterbody_comids.parquet"
     # HRU polygon fabric — authoritative land/domain mask for the depstor
     # builders. gfv2_params.depstor_builders.landmask rasterises this to
     # land_mask.tif (driven by scripts/build_depstor_rasters.py).
@@ -113,6 +116,9 @@ fabrics:
     # reprojects to the template grid and clips to the Oregon land mask.
     waterbody_gpkg: "{data_root}/input/nhd/conus_waterbodies.gpkg"
     waterbody_layer: waterbodies
+    # Connected-waterbody COMIDs distilled from NHD WBAREACOMI artificial paths
+    # (see gfv2_params.download.nhd_flowlines). Drives wbody_connectivity.
+    connected_comids_table: "{data_root}/input/nhd/connected_waterbody_comids.parquet"
 
   tjc:
     # Small regional fabric inside VPU 12 (Texas-Gulf); pre-merged single gpkg
@@ -149,3 +155,6 @@ fabrics:
     # the template grid and clips to the tjc land mask.
     waterbody_gpkg: "{data_root}/input/nhd/conus_waterbodies.gpkg"
     waterbody_layer: waterbodies
+    # Connected-waterbody COMIDs distilled from NHD WBAREACOMI artificial paths
+    # (see gfv2_params.download.nhd_flowlines). Drives wbody_connectivity.
+    connected_comids_table: "{data_root}/input/nhd/connected_waterbody_comids.parquet"

--- a/configs/base_config.yml
+++ b/configs/base_config.yml
@@ -33,7 +33,9 @@ fabrics:
     # Stream segments: one CONUS nsegment layer assembled by
     # scripts/merge_vpu_segments.py from the input/fabric/NHM_<vpu>_draft.gpkg
     # drafts (the fabric-merge notebook merges only nhru, so segments are merged
-    # separately). streambuffer buffers geometry only — no id reconciliation.
+    # separately). NOTE: as of the WBAREACOMI connectivity change, segments no
+    # longer feed any depstor step (the streambuffer step was retired); this layer
+    # is retained for other tooling.
     # Run: pixi run --as-is python scripts/merge_vpu_segments.py --fabric gfv2
     segments_gpkg: "{data_root}/{fabric}/fabric/{fabric}_nsegment_merged.gpkg"
     segments_layer: nsegment

--- a/configs/depstor/depstor_rasters.yml
+++ b/configs/depstor/depstor_rasters.yml
@@ -37,6 +37,9 @@ steps:
       binary: wbody_binary.tif
       regions: wbody_regions.tif
 
+  - name: wbody_connectivity
+    output: connected_wbody.tif
+
   - name: dprst
     outputs:
       dprst: dprst_binary.tif

--- a/configs/depstor/depstor_rasters.yml
+++ b/configs/depstor/depstor_rasters.yml
@@ -27,10 +27,6 @@ steps:
     threshold: 50
     output: imperv_binary.tif
 
-  - name: streambuffer
-    buffer_distance: 60
-    output: stream_buffer.tif
-
   - name: waterbody
     min_area_threshold: 900.0
     outputs:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -132,8 +132,9 @@ whether the depstor pipeline will be run for the fabric:
 | `template_raster` | — | ✓ | Fabric-bounds clip of `fdr.vrt`; produced by `clip_shared_to_fabric.py` |
 | `fdr_raster` | — | ✓ | Same fabric-bounds clip (typically points at the same file as `template_raster`) |
 | `twi_raster` | — | ✓ | CONUS `twi.vrt` (ArcPy, calibrated) or `twi_hydrodem.vrt` (open-source, CONUS-complete) |
-| `segments_gpkg` | — | ✓ | Stream segments for the depstor `streambuffer` step. A pre-merged fabric can point at `hru_gpkg`; a VPU-based fabric (gfv2) merges the per-VPU `nsegment` layers into one CONUS gpkg via `scripts/merge_vpu_segments.py` |
+| `segments_gpkg` | — | ✓ | Stream-segment gpkg (no longer feeds any depstor step — the `streambuffer` step is retired). A VPU-based fabric (gfv2) merges per-VPU `nsegment` layers via `scripts/merge_vpu_segments.py` for other potential uses. |
 | `segments_layer` | — | ✓ | Layer name inside `segments_gpkg` (typically `nsegment`) |
+| `connected_comids_table` | — | ✓ | Path to `input/nhd/connected_waterbody_comids.parquet` — the set of NHDPlusV2 waterbody COMIDs that an NHD artificial path flows through (i.e. on-stream). Produced by `download/nhd_flowlines.py`; consumed by the depstor `wbody_connectivity` builder. |
 | `waterbody_gpkg` | — | ✓ | NHDPlus waterbodies; depstor's `waterbody` step **raises** if unset |
 | `waterbody_layer` | — | ✓ | Layer name inside `waterbody_gpkg` |
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -134,7 +134,7 @@ whether the depstor pipeline will be run for the fabric:
 | `twi_raster` | — | ✓ | CONUS `twi.vrt` (ArcPy, calibrated) or `twi_hydrodem.vrt` (open-source, CONUS-complete) |
 | `segments_gpkg` | — | ✓ | Stream-segment gpkg (no longer feeds any depstor step — the `streambuffer` step is retired). A VPU-based fabric (gfv2) merges per-VPU `nsegment` layers via `scripts/merge_vpu_segments.py` for other potential uses. |
 | `segments_layer` | — | ✓ | Layer name inside `segments_gpkg` (typically `nsegment`) |
-| `connected_comids_table` | — | ✓ | Path to `input/nhd/connected_waterbody_comids.parquet` — the set of NHDPlusV2 waterbody COMIDs that an NHD artificial path flows through (i.e. on-stream). Produced by `download/nhd_flowlines.py`; consumed by the depstor `wbody_connectivity` builder. |
+| `connected_comids_table` | — | ✓ | Path to `input/nhd/connected_waterbody_comids.parquet` — the set of NHDPlusV2 waterbody COMIDs that an NHD artificial path flows through (i.e. on-stream). Produced by `download/nhd_flowlines.py`; consumed by the depstor `wbody_connectivity` builder. Required only for fabrics whose waterbody layer is COMID-keyed (`gfv2`, `oregon`, `tjc`); the `gfv2_vpu01` profile omits it (its `wbs` layer has no COMID), so `wbody_connectivity`/`dprst` fail-fast there — use `gfv2` for depstor validation. |
 | `waterbody_gpkg` | — | ✓ | NHDPlus waterbodies; depstor's `waterbody` step **raises** if unset |
 | `waterbody_layer` | — | ✓ | Layer name inside `waterbody_gpkg` |
 

--- a/docs/depstor_port_summary.md
+++ b/docs/depstor_port_summary.md
@@ -39,7 +39,7 @@ that walks them in dependency order is
 | `RasterPipeline.{rasterize, raster_create, vector_raster_mask, raster_raster_mask, open_raster, set_template}` (42-410) | [`src/gfv2_params/depstor.py`](../src/gfv2_params/depstor.py) — `RasterInfo`, `rasterize_binary`, `threshold_above`, `clump_regions`, `regions_touching_mask`, `regions_to_binary`, `write_uint8_binary`, `write_int32_regions`, `read_aligned_uint8`, `read_land_mask_for_grid` | Raster I/O + binary/region helpers |
 | `whitebox_run` (412-449) | [`src/gfv2_params/depstor_builders/routing.py`](../src/gfv2_params/depstor_builders/routing.py) | In-process cycle-safe D8 upslope traversal (`d8_routing.drains_to_dprst_kernel`); replaced WBT `Watershed` (spec 2026-05-29) |
 | `getHruImperv` (452-518) | [`src/gfv2_params/depstor_builders/imperv.py`](../src/gfv2_params/depstor_builders/imperv.py) | Threshold the impervious raster to a binary mask |
-| `getSegBuff` (521-577) | [`src/gfv2_params/depstor_builders/streambuffer.py`](../src/gfv2_params/depstor_builders/streambuffer.py) | Buffer NHD segments and rasterize |
+| `getSegBuff` (521-577) | [`src/gfv2_params/depstor_builders/streambuffer.py`](../src/gfv2_params/depstor_builders/streambuffer.py) *(retired — kept on disk as reference; replaced by `wbody_connectivity`)* | Buffer NHD segments and rasterize — **superseded** by NHD WBAREACOMI connectivity: `download/nhd_flowlines.py` → `connected_waterbody_comids.parquet` → [`depstor_builders/wbody_connectivity.py`](../src/gfv2_params/depstor_builders/wbody_connectivity.py) → `connected_wbody.tif` |
 | `getWBinHRUs` (580-663) | [`src/gfv2_params/depstor_builders/waterbody.py`](../src/gfv2_params/depstor_builders/waterbody.py) | Filter wbody polys by area, rasterize, then label connected components |
 | `getDprst` (666-701) | [`src/gfv2_params/depstor_builders/dprst.py`](../src/gfv2_params/depstor_builders/dprst.py) | Region-level intersection logic (depression = wbody region with zero stream/imperv overlap) |
 | `getHruSro_to_dprst` (704-739) | [`src/gfv2_params/depstor_builders/routing.py`](../src/gfv2_params/depstor_builders/routing.py) | In-process cycle-safe D8 upslope traversal (`d8_routing.drains_to_dprst_kernel`); replaced WBT `Watershed` (spec 2026-05-29) |
@@ -225,7 +225,7 @@ build steps in dependency order. Each `name` maps to a module under
 that exposes `build(step_cfg, ctx, logger) -> {output_key: Path}`. The
 orchestrator [`scripts/build_depstor_rasters.py`](../scripts/build_depstor_rasters.py)
 walks the canonical `STEP_ORDER`
-(landmask → imperv / streambuffer / waterbody → dprst → perv / routing →
+(landmask → imperv / wbody_connectivity / waterbody → dprst → perv / routing →
 drains_perv / drains_imperv → carea_map), wires outputs through a
 `BuildContext`, supports `--step <name>` / `--from <name>` for selective
 re-runs, and runs under a single sbatch

--- a/docs/depstor_workflow.md
+++ b/docs/depstor_workflow.md
@@ -407,7 +407,7 @@ produce, per fabric:
 {fabric}/depstor_rasters/           # 13 generation outputs
 ├── land_mask.tif                   # (built first; every other raster masks against it)
 ├── imperv_binary.tif
-├── stream_buffer.tif
+├── connected_wbody.tif             # NHD-WBAREACOMI connected waterbodies (replaces stream_buffer.tif)
 ├── wbody_binary.tif    wbody_regions.tif
 ├── dprst_binary.tif    onstream_binary.tif
 ├── perv_binary.tif

--- a/docs/depstor_workflow.md
+++ b/docs/depstor_workflow.md
@@ -140,6 +140,9 @@ Runs as **Stage 1c1** (see `slurm_batch/HPC_REFERENCE.md`), before the TWI merge
      - `hruImperv`: raster with impervious areas labeled with HRU IDs
 
 4. **getSegBuff**
+   - **gfv2-params:** Retired — replaced by the `wbody_connectivity` builder, which
+     derives on-stream waterbodies from NHD `WBAREACOMI` artificial-path topology
+     instead of a 60 m segment buffer. See `docs/depstor_port_summary.md`.
    - Buffers the stream segments, converts to grid, assigns HRU IDs within the
      buffer part of grid, NAs outside
    - **Inputs**

--- a/docs/python-patterns.md
+++ b/docs/python-patterns.md
@@ -106,9 +106,9 @@ up the function by name and calls it.
 ```python
 # src/gfv2_params/depstor_builders/__init__.py
 BUILDERS = {
-    "landmask":      landmask.build,
-    "imperv":        imperv.build,
-    "streambuffer":  streambuffer.build,
+    "landmask":          landmask.build,
+    "imperv":            imperv.build,
+    "wbody_connectivity": wbody_connectivity.build,
     # ... etc.
 }
 ```

--- a/docs/superpowers/plans/2026-06-23-nhd-wbareacomi-connectivity.md
+++ b/docs/superpowers/plans/2026-06-23-nhd-wbareacomi-connectivity.md
@@ -1,0 +1,848 @@
+# NHD WBAREACOMI Waterbody Connectivity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the 60 m stream-buffer proximity heuristic for on-stream vs. depression-storage waterbody classification with NHD's authoritative `WBAREACOMI` artificial-path topology, joined to `conus_waterbodies.gpkg` by COMID.
+
+**Architecture:** A new download module stages NHDPlusV2 `NHDFlowline` attribute tables per VPU and distills them to a flat "connected waterbody COMID" parquet. A new depstor builder (`wbody_connectivity`) rasterizes the waterbody polygons whose COMID is in that set, producing `connected_wbody.tif`. `dprst.py` consumes that mask in place of `stream_buffer.tif` (integration option A — drop-in mask, clump/region and impervious logic unchanged), and the `streambuffer` step is retired.
+
+**Tech Stack:** Python, geopandas/pyogrio, pandas, rasterio, scipy.ndimage, py7zr, requests; pixi-managed env; pipeline driven by `configs/depstor/depstor_rasters.yml` + fabric profiles in `configs/base_config.yml`.
+
+## Global Constraints
+
+- **Paths come from the profile, never hardcoded.** Read fabric inputs via `require_config_key`/`config.get` against the active fabric profile in `configs/base_config.yml`; use `{data_root}`/`{fabric}`/`{vpu}` placeholders. (CLAUDE.md)
+- **Builder + test together.** A new pipeline step is a builder module + DAG registration + config block *and* a `tests/test_<builder>.py`. No standalone scripts or orphan YAML. (CLAUDE.md)
+- **Do not run pytest on the HPC head node.** CI (`.github/workflows/ci.yml`) is the authoritative test gate. Local `py_compile`/import checks are fine. (CLAUDE.md)
+- **Add deps via `pyproject.toml`** (conda-forge vs pypi split per its comment block), then `pixi install`. `py7zr`, `requests`, `pyogrio`, `geopandas`, `pandas`, `pyarrow` are already present (used by `download/rpu_rasters.py` and the depstor builders).
+- **SLURM batches invoke `pixi run --as-is`** — never a flow that mutates the env per task.
+- **Every code change needs a docs check** — audit `docs/`, `README.md`, `slurm_batch/RUNME.md` + `HPC_REFERENCE.md`; update on this branch.
+- **Atomic commits** — one deliverable per commit. End commit messages with the `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>` trailer.
+- **Branch:** all work lands on `feat/wbareacomi-connectivity` (already created; spec already committed there).
+- **WBAREACOMI sentinel:** `0` and null mean "not through a waterbody" — excluded from the connected set.
+
+---
+
+### Task 1: Connected-COMID extraction helper (pure)
+
+The testable core of the staging step: given flowline attributes, produce the set of connected waterbody COMIDs. No network, no disk — pure pandas.
+
+**Files:**
+- Create: `src/gfv2_params/download/nhd_flowlines.py` (helper portion only this task)
+- Test: `tests/test_download_nhd_flowlines.py`
+
+**Interfaces:**
+- Produces:
+  - `connected_comids_from_flowlines(df: pd.DataFrame) -> set[int]` — given a DataFrame with a `WBAREACOMI` column, return distinct non-zero, non-null `WBAREACOMI` values as a set of `int`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_download_nhd_flowlines.py
+"""Unit tests for the NHD flowline -> connected-waterbody-COMID distillation."""
+
+import pandas as pd
+
+from gfv2_params.download.nhd_flowlines import connected_comids_from_flowlines
+
+
+def test_connected_comids_distinct_nonzero():
+    df = pd.DataFrame(
+        {
+            "COMID": [1, 2, 3, 4, 5],
+            "FTYPE": ["ArtificialPath", "ArtificialPath", "StreamRiver",
+                      "ArtificialPath", "ArtificialPath"],
+            # 0 = not through a waterbody; duplicates collapse; None excluded.
+            "WBAREACOMI": [100, 100, 0, 200, None],
+        }
+    )
+    assert connected_comids_from_flowlines(df) == {100, 200}
+
+
+def test_connected_comids_empty_when_all_zero():
+    df = pd.DataFrame({"WBAREACOMI": [0, 0, 0]})
+    assert connected_comids_from_flowlines(df) == set()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run -e dev pytest tests/test_download_nhd_flowlines.py -v`
+Expected: FAIL — `ModuleNotFoundError` / `ImportError: cannot import name 'connected_comids_from_flowlines'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# src/gfv2_params/download/nhd_flowlines.py
+"""Stage NHDPlusV2 NHDFlowline attributes and distill connected-waterbody COMIDs.
+
+NHD encodes waterbody connectivity directly: an artificial-path NHDFlowline that
+runs through a waterbody carries WBAREACOMI = that waterbody's COMID. The distinct
+set of populated WBAREACOMI values is the set of on-stream (connected) waterbodies.
+This module downloads the per-VPU NHDSnapshot archives, reads NHDFlowline, and
+writes a flat parquet of connected COMIDs consumed by the depstor
+`wbody_connectivity` builder.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+# WBAREACOMI == 0 (and null) means the flowline does not pass through a waterbody.
+_NO_WATERBODY = 0
+
+
+def connected_comids_from_flowlines(df: pd.DataFrame) -> set[int]:
+    """Distinct non-zero, non-null WBAREACOMI values as a set of ints."""
+    col = pd.to_numeric(df["WBAREACOMI"], errors="coerce")
+    vals = col[(col.notna()) & (col != _NO_WATERBODY)]
+    return {int(v) for v in vals.unique()}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pixi run -e dev pytest tests/test_download_nhd_flowlines.py -v`
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/gfv2_params/download/nhd_flowlines.py tests/test_download_nhd_flowlines.py
+git commit -m "feat(nhd): connected-COMID distillation from WBAREACOMI
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: NHD flowline download/staging module + SLURM batch
+
+Wrap the Task-1 helper in the network/disk glue that downloads per-VPU NHDSnapshot archives, reads `NHDFlowline`, and writes the connected-COMID parquet. This mirrors `download/rpu_rasters.py`. Network and 7z extraction are not exercised in CI; the unit-tested core is the parquet writer.
+
+**Files:**
+- Modify: `src/gfv2_params/download/nhd_flowlines.py`
+- Create: `slurm_batch/download_nhd_flowlines.batch`
+- Test: `tests/test_download_nhd_flowlines.py` (add a writer test)
+
+**Interfaces:**
+- Consumes: `connected_comids_from_flowlines` (Task 1); `load_base_config` from `gfv2_params.config`; `configure_logging` from `gfv2_params.log`.
+- Produces:
+  - `write_connected_comids(comids: set[int], out_path: Path) -> None` — write a single-column (`comid`, int64) parquet, sorted ascending, to `out_path` (parent dirs created).
+  - `read_flowline_attrs(flowline_path: Path) -> pd.DataFrame` — read `COMID`, `FTYPE`, `WBAREACOMI` from an OGR-readable NHDFlowline source (shp/dbf), no geometry.
+  - `main() -> None` — download every VPU's NHDSnapshot, accumulate connected COMIDs across all VPUs, write `{data_root}/input/nhd/connected_waterbody_comids.parquet`.
+  - Module entrypoint runnable as `python -m gfv2_params.download.nhd_flowlines`.
+
+NHDSnapshot is a **per-VPU** component (no RPU suffix): the archive is `NHDPlusV21_{dd}_{vpu}_NHDSnapshot_{ver}.7z` and unpacks `NHDSnapshot/Hydrography/NHDFlowline.shp` (+ sidecars).
+
+> **Implementation note (verify before coding the path template):** confirm the exact NHDSnapshot archive name and version-candidate list against a live S3 listing of `https://dmap-data-commons-ow.s3.amazonaws.com/NHDPlusV21/Data/NHDPlus{dd}/...`. Reuse the `version_candidates = ["05","04","03","02","01"]` HEAD-probe fallback and the base-URL branch (some VPUs nest under `/NHDPlus{vpu}`) from `rpu_rasters.py:154-191` verbatim. The relative path of `NHDFlowline.shp` inside the archive can vary in case (`NHDSnapshot` vs `NHDSnapshot/Hydrography`); glob for `**/NHDFlowline.shp` after extraction rather than hardcoding.
+
+- [ ] **Step 1: Write the failing test (parquet writer round-trip)**
+
+```python
+# add to tests/test_download_nhd_flowlines.py
+import pandas as pd
+from gfv2_params.download.nhd_flowlines import write_connected_comids
+
+
+def test_write_connected_comids_roundtrip(tmp_path):
+    out = tmp_path / "nested" / "connected_waterbody_comids.parquet"
+    write_connected_comids({300, 100, 200}, out)
+
+    assert out.exists()
+    got = pd.read_parquet(out)
+    assert list(got.columns) == ["comid"]
+    assert got["comid"].tolist() == [100, 200, 300]  # sorted ascending
+    assert str(got["comid"].dtype) in ("int64", "Int64")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run -e dev pytest tests/test_download_nhd_flowlines.py::test_write_connected_comids_roundtrip -v`
+Expected: FAIL — `ImportError: cannot import name 'write_connected_comids'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `src/gfv2_params/download/nhd_flowlines.py`:
+
+```python
+from pathlib import Path
+
+import py7zr
+import pyogrio
+import requests
+
+from gfv2_params.config import load_base_config
+from gfv2_params.log import configure_logging
+
+logger = configure_logging("download_nhd_flowlines")
+
+# VPU -> drainage-area code (DD). NHDSnapshot is per-VPU (no RPU split).
+vpu_index = {
+    "01": "NE", "02": "MA", "03N": "SA", "03S": "SA", "03W": "SA",
+    "04": "GL", "05": "MS", "06": "MS", "07": "MS", "08": "MS",
+    "09": "SR", "10L": "MS", "10U": "MS", "11": "MS", "12": "TX",
+    "13": "RG", "14": "CO", "15": "CO", "16": "GB", "17": "PN", "18": "CA",
+}
+
+_VERSION_CANDIDATES = ["05", "04", "03", "02", "01"]
+
+
+def write_connected_comids(comids: set[int], out_path: Path) -> None:
+    """Write the connected COMIDs to a single-column int64 parquet, sorted."""
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    df = pd.DataFrame({"comid": sorted(int(c) for c in comids)}).astype({"comid": "int64"})
+    df.to_parquet(out_path, index=False)
+
+
+def read_flowline_attrs(flowline_path: Path) -> pd.DataFrame:
+    """Read COMID/FTYPE/WBAREACOMI from an NHDFlowline source (no geometry)."""
+    return pyogrio.read_dataframe(
+        flowline_path,
+        columns=["COMID", "FTYPE", "WBAREACOMI"],
+        read_geometry=False,
+    )
+
+
+def _base_url(dd: str, vpu: str) -> str:
+    nested = {"03", "10", "05", "06", "07", "08", "11", "14", "15"}
+    if any(code in vpu for code in nested):
+        return f"https://dmap-data-commons-ow.s3.amazonaws.com/NHDPlusV21/Data/NHDPlus{dd}/NHDPlus{vpu}"
+    return f"https://dmap-data-commons-ow.s3.amazonaws.com/NHDPlusV21/Data/NHDPlus{dd}"
+
+
+def download_snapshot(dd: str, vpu: str, download_dir: Path, extract_dir: Path) -> Path | None:
+    """Download + extract a VPU's NHDSnapshot; return the NHDFlowline.shp path."""
+    base_url = _base_url(dd, vpu)
+    local_path = None
+    for version in _VERSION_CANDIDATES:
+        filename = f"NHDPlusV21_{dd}_{vpu}_NHDSnapshot_{version}.7z"
+        candidate = download_dir / filename
+        url = f"{base_url}/{filename}"
+        if candidate.exists():
+            local_path = candidate
+            break
+        logger.info(f"Checking: {url}")
+        if requests.head(url, timeout=60).status_code == 200:
+            logger.info(f"Downloading {filename} ...")
+            with requests.get(url, stream=True, timeout=120) as r:
+                r.raise_for_status()
+                with open(candidate, "wb") as f:
+                    for chunk in r.iter_content(chunk_size=8192):
+                        f.write(chunk)
+            local_path = candidate
+            break
+
+    if local_path is None:
+        logger.error(f"NHDSnapshot not found for VPU {vpu}")
+        return None
+
+    out_dir = extract_dir / vpu / "NHDSnapshot"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    with py7zr.SevenZipFile(local_path, mode="r") as archive:
+        archive.extractall(path=out_dir)
+
+    shps = list(out_dir.glob("**/NHDFlowline.shp"))
+    if not shps:
+        logger.error(f"NHDFlowline.shp not found in extracted snapshot for VPU {vpu}")
+        return None
+    return shps[0]
+
+
+def main() -> None:
+    base = load_base_config()
+    data_root = Path(base["data_root"])
+    download_dir = data_root / "input/nhd_downloads"
+    extract_dir = data_root / "shared/source"
+    download_dir.mkdir(parents=True, exist_ok=True)
+    extract_dir.mkdir(parents=True, exist_ok=True)
+
+    connected: set[int] = set()
+    failures = []
+    for vpu, dd in vpu_index.items():
+        flowline = download_snapshot(dd, vpu, download_dir, extract_dir)
+        if flowline is None:
+            failures.append(vpu)
+            continue
+        df = read_flowline_attrs(flowline)
+        vpu_connected = connected_comids_from_flowlines(df)
+        logger.info(f"VPU {vpu}: {len(vpu_connected)} connected waterbody COMIDs")
+        connected |= vpu_connected
+
+    if failures:
+        # A silently dropped VPU under-flags connectivity there — make it loud.
+        raise RuntimeError(f"NHDSnapshot download/read failed for VPU(s): {failures}")
+
+    out_path = data_root / "input/nhd/connected_waterbody_comids.parquet"
+    write_connected_comids(connected, out_path)
+    logger.info(f"Wrote {len(connected)} connected COMIDs -> {out_path}")
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 4: Run test + import check**
+
+Run: `pixi run -e dev pytest tests/test_download_nhd_flowlines.py -v`
+Expected: PASS (3 passed).
+Run: `pixi run --as-is python -c "import gfv2_params.download.nhd_flowlines"`
+Expected: no output, exit 0.
+
+- [ ] **Step 5: Create the SLURM batch**
+
+```bash
+# slurm_batch/download_nhd_flowlines.batch
+#!/bin/bash
+#SBATCH -p cpu
+#SBATCH -A impd
+#SBATCH --job-name=download_nhd_flow
+#SBATCH --output=logs/job_%j.out
+#SBATCH --error=logs/job_%j.err
+#SBATCH --time=12:00:00
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=1
+#SBATCH --mem=8G
+
+cd "$SLURM_SUBMIT_DIR"
+pixi run --as-is python -m gfv2_params.download.nhd_flowlines
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/gfv2_params/download/nhd_flowlines.py tests/test_download_nhd_flowlines.py slurm_batch/download_nhd_flowlines.batch
+git commit -m "feat(nhd): per-VPU NHDSnapshot download -> connected-COMID parquet
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Connectivity join helper (pure, in depstor.py)
+
+Given the waterbody GeoDataFrame and the connected-COMID set, select the connected polygons. Pure compute, lives with the other depstor helpers.
+
+**Files:**
+- Modify: `src/gfv2_params/depstor.py` (add two functions)
+- Test: `tests/test_wbody_connectivity.py` (new file; helper tests here, builder test added in Task 5)
+
+**Interfaces:**
+- Produces:
+  - `load_connected_comids(path: Path) -> set[int]` — read the parquet from Task 2 into a set of ints.
+  - `select_connected_waterbodies(wb_gdf, connected: set[int]) -> GeoDataFrame` — return the subset of rows whose `COMID` **or** `member_comid` is in `connected`. `member_comid` is a single COMID string (equals `COMID` in 99.94% of rows; 280 multipart exceptions differ) — coerce to numeric and union the two membership tests.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_wbody_connectivity.py
+"""Tests for WBAREACOMI-driven waterbody connectivity (helper + builder)."""
+
+import geopandas as gpd
+import pandas as pd
+from shapely.geometry import Polygon
+
+from gfv2_params.depstor import load_connected_comids, select_connected_waterbodies
+
+
+def _wb_gdf():
+    geoms = [Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])] * 4
+    return gpd.GeoDataFrame(
+        {
+            "COMID": [10, 20, 30, 40],
+            # row 3 is a multipart case: COMID 30 not connected, but its
+            # member_comid 999 is.
+            "member_comid": ["10", "20", "999", "40"],
+        },
+        geometry=geoms,
+        crs="EPSG:5070",
+    )
+
+
+def test_select_connected_by_comid_or_member():
+    out = select_connected_waterbodies(_wb_gdf(), {10, 999})
+    assert sorted(out["COMID"].tolist()) == [10, 30]  # 10 by COMID, 30 by member
+
+
+def test_select_connected_empty_set():
+    out = select_connected_waterbodies(_wb_gdf(), set())
+    assert len(out) == 0
+
+
+def test_load_connected_comids(tmp_path):
+    p = tmp_path / "c.parquet"
+    pd.DataFrame({"comid": [5, 7, 9]}).to_parquet(p, index=False)
+    assert load_connected_comids(p) == {5, 7, 9}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run -e dev pytest tests/test_wbody_connectivity.py -v`
+Expected: FAIL — `ImportError: cannot import name 'load_connected_comids'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `src/gfv2_params/depstor.py` (near the other vector/region helpers):
+
+```python
+def load_connected_comids(path: Path) -> set[int]:
+    """Load the connected-waterbody COMID parquet into a set of ints."""
+    df = pd.read_parquet(path, columns=["comid"])
+    return {int(v) for v in df["comid"].to_numpy()}
+
+
+def select_connected_waterbodies(wb_gdf, connected: set[int]):
+    """Subset waterbodies whose COMID or member_comid is in `connected`."""
+    comid = pd.to_numeric(wb_gdf["COMID"], errors="coerce")
+    member = pd.to_numeric(wb_gdf["member_comid"], errors="coerce")
+    mask = comid.isin(connected) | member.isin(connected)
+    return wb_gdf[mask].copy()
+```
+
+> Ensure `import pandas as pd` and `from pathlib import Path` are present at the top of `depstor.py` (add if missing).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pixi run -e dev pytest tests/test_wbody_connectivity.py -v`
+Expected: PASS (3 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/gfv2_params/depstor.py tests/test_wbody_connectivity.py
+git commit -m "feat(depstor): connected-waterbody selection by COMID/member_comid
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Thread the connected-COMID table path through config + context
+
+Make the connected-COMID parquet a profile-declared input, threaded into `BuildContext` like `waterbody_gpkg`.
+
+**Files:**
+- Modify: `configs/base_config.yml` (add `connected_comids_table` to the `gfv2`, `oregon`, `tjc` profiles that use `conus_waterbodies.gpkg`)
+- Modify: `src/gfv2_params/depstor_builders/context.py:24-33` (add field)
+- Modify: `scripts/build_depstor_rasters.py:74-89` (wire it)
+
+**Interfaces:**
+- Produces: `BuildContext.connected_comids_table: Path | None` — absolute path to the connected-COMID parquet, or `None` if the profile omits it.
+
+- [ ] **Step 1: Add the profile key**
+
+In `configs/base_config.yml`, under each profile that sets `waterbody_gpkg: "{data_root}/input/nhd/conus_waterbodies.gpkg"` (the `gfv2`, `oregon`, and `tjc` profiles), add directly beneath the `waterbody_layer` line:
+
+```yaml
+    # Connected-waterbody COMIDs distilled from NHD WBAREACOMI artificial paths
+    # (see gfv2_params.download.nhd_flowlines). Drives wbody_connectivity.
+    connected_comids_table: "{data_root}/input/nhd/connected_waterbody_comids.parquet"
+```
+
+> The VPU-01 `gfv2_vpu01` profile uses `NHM_01_draft.gpkg` (layer `wbs`), which has no COMID column; do **not** add the key there — `wbody_connectivity` will require it and that profile is not a target for this feature. (Validation runs use the `gfv2` profile.)
+
+- [ ] **Step 2: Add the BuildContext field**
+
+In `src/gfv2_params/depstor_builders/context.py`, add after the `waterbody_layer` field (line 27):
+
+```python
+    connected_comids_table: Path | None = None
+```
+
+- [ ] **Step 3: Wire it in the orchestrator**
+
+In `scripts/build_depstor_rasters.py`, inside `_build_context`'s `BuildContext(...)` call (after the `waterbody_layer=` line, ~line 83), add:
+
+```python
+        connected_comids_table=(
+            Path(config["connected_comids_table"])
+            if config.get("connected_comids_table") else None
+        ),
+```
+
+- [ ] **Step 4: Import + config sanity check**
+
+Run: `pixi run --as-is python -c "from gfv2_params.depstor_builders.context import BuildContext; BuildContext(fabric='x', template_path='t', output_dir='o', hru_gpkg='h', hru_layer='l')"`
+Expected: exit 0 (field defaults to None).
+Run: `pixi run --as-is python -c "import yaml; yaml.safe_load(open('configs/base_config.yml'))"`
+Expected: exit 0 (YAML still parses).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add configs/base_config.yml src/gfv2_params/depstor_builders/context.py scripts/build_depstor_rasters.py
+git commit -m "feat(depstor): thread connected_comids_table through profile + context
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: `wbody_connectivity` builder + registration + config block
+
+The new depstor step: rasterize the connected waterbody polygons to `connected_wbody.tif`.
+
+**Files:**
+- Create: `src/gfv2_params/depstor_builders/wbody_connectivity.py`
+- Modify: `src/gfv2_params/depstor_builders/__init__.py` (register builder, STEP_ORDER, key table comment)
+- Modify: `scripts/build_depstor_rasters.py:111-128` (`_expected_outputs` single-key map)
+- Modify: `configs/depstor/depstor_rasters.yml` (add step block)
+- Test: `tests/test_wbody_connectivity.py` (add builder test)
+
+**Interfaces:**
+- Consumes: `BuildContext.waterbody_gpkg`, `.waterbody_layer`, `.connected_comids_table`, `.template_path`; `ctx.require("landmask")`; `select_connected_waterbodies`, `load_connected_comids` (Task 3); `RasterInfo`, `rasterize_binary`, `read_land_mask`, `write_uint8_binary` from `..depstor`.
+- Produces: registered output key `connected_wbody` → `connected_wbody.tif` (uint8: 1 = connected waterbody cell, 255 = nodata/off-land).
+
+- [ ] **Step 1: Write the failing builder test**
+
+```python
+# add to tests/test_wbody_connectivity.py
+import logging
+from pathlib import Path
+
+import numpy as np
+import rasterio
+from rasterio.transform import from_origin
+
+from gfv2_params.depstor_builders.context import BuildContext
+from gfv2_params.depstor_builders import wbody_connectivity
+
+
+def _write_template(path: Path, n: int = 10) -> None:
+    transform = from_origin(0, n * 30, 30, 30)
+    with rasterio.open(
+        path, "w", driver="GTiff", height=n, width=n, count=1, dtype="float32",
+        crs="EPSG:5070", transform=transform, nodata=-9999.0,
+    ) as dst:
+        dst.write(np.full((n, n), 100.0, dtype=np.float32), 1)
+
+
+def _write_landmask(path: Path, n: int = 10) -> None:
+    transform = from_origin(0, n * 30, 30, 30)
+    with rasterio.open(
+        path, "w", driver="GTiff", height=n, width=n, count=1, dtype="uint8",
+        crs="EPSG:5070", transform=transform, nodata=255,
+    ) as dst:
+        dst.write(np.ones((n, n), dtype=np.uint8), 1)  # all land
+
+
+def test_wbody_connectivity_rasterizes_only_connected(tmp_path):
+    from shapely.geometry import box
+
+    template = tmp_path / "template.tif"
+    landmask = tmp_path / "land_mask.tif"
+    wb_gpkg = tmp_path / "wb.gpkg"
+    table = tmp_path / "connected.parquet"
+    _write_template(template)
+    _write_landmask(landmask)
+
+    import geopandas as gpd
+    import pandas as pd
+
+    # Connected polygon (COMID 10) at top-left; disconnected (COMID 20) bottom-right.
+    gdf = gpd.GeoDataFrame(
+        {"COMID": [10, 20], "member_comid": ["10", "20"]},
+        geometry=[box(0, 270, 60, 300), box(240, 0, 300, 30)],
+        crs="EPSG:5070",
+    )
+    gdf.to_file(wb_gpkg, layer="waterbodies", driver="GPKG")
+    pd.DataFrame({"comid": [10]}).to_parquet(table, index=False)
+
+    ctx = BuildContext(
+        fabric="t", template_path=template, output_dir=tmp_path,
+        hru_gpkg=wb_gpkg, hru_layer="waterbodies",
+        waterbody_gpkg=wb_gpkg, waterbody_layer="waterbodies",
+        connected_comids_table=table,
+    )
+    ctx.paths["landmask"] = landmask
+
+    produced = wbody_connectivity.build(
+        {"output": "connected_wbody.tif"}, ctx, logging.getLogger("test")
+    )
+
+    out = produced["connected_wbody"]
+    with rasterio.open(out) as src:
+        arr = src.read(1)
+        assert src.nodata == 255
+    assert arr[0, 0] == 1     # connected polygon burned
+    assert arr[9, 9] != 1     # disconnected polygon NOT burned
+    assert int((arr == 1).sum()) > 0
+
+
+def test_wbody_connectivity_requires_table(tmp_path):
+    import pytest
+
+    template = tmp_path / "template.tif"
+    _write_template(template)
+    ctx = BuildContext(
+        fabric="t", template_path=template, output_dir=tmp_path,
+        hru_gpkg=tmp_path / "x.gpkg", hru_layer="waterbodies",
+        waterbody_gpkg=tmp_path / "x.gpkg", waterbody_layer="waterbodies",
+        connected_comids_table=None,
+    )
+    with pytest.raises(KeyError):
+        wbody_connectivity.build({"output": "connected_wbody.tif"}, ctx, logging.getLogger("test"))
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run -e dev pytest tests/test_wbody_connectivity.py -k connectivity -v`
+Expected: FAIL — `ModuleNotFoundError: ... wbody_connectivity`.
+
+- [ ] **Step 3: Write the builder**
+
+```python
+# src/gfv2_params/depstor_builders/wbody_connectivity.py
+"""Rasterise the NHD-connected waterbody polygons to a uint8 binary mask.
+
+Connectivity comes from NHD's WBAREACOMI artificial-path topology (staged by
+gfv2_params.download.nhd_flowlines into a connected-COMID parquet), joined to the
+waterbody polygons by COMID / member_comid. Replaces the old streambuffer mask as
+the on-stream signal consumed by the dprst step.
+"""
+
+from __future__ import annotations
+
+import geopandas as gpd
+
+from ..depstor import (
+    RasterInfo,
+    load_connected_comids,
+    rasterize_binary,
+    read_land_mask,
+    select_connected_waterbodies,
+    write_uint8_binary,
+)
+from .context import BuildContext
+
+
+def build(step_cfg: dict, ctx: BuildContext, logger) -> dict:
+    if ctx.waterbody_gpkg is None or ctx.waterbody_layer is None:
+        raise KeyError(
+            "wbody_connectivity step needs `waterbody_gpkg` and `waterbody_layer`."
+        )
+    if ctx.connected_comids_table is None:
+        raise KeyError(
+            "wbody_connectivity step needs `connected_comids_table` in the fabric "
+            "profile. Stage it first: "
+            "`python -m gfv2_params.download.nhd_flowlines`."
+        )
+    output_path = ctx.resolve_output(step_cfg["output"])
+    landmask_path = ctx.require("landmask")
+
+    logger.info("--- wbody_connectivity ---")
+    logger.info("  Waterbody gpkg : %s (layer=%s)", ctx.waterbody_gpkg, ctx.waterbody_layer)
+    logger.info("  Connected table: %s", ctx.connected_comids_table)
+    logger.info("  Output         : %s", output_path)
+
+    if output_path.exists() and not ctx.force:
+        logger.info("  Output already exists — skipping (pass --force to rebuild)")
+        return {"connected_wbody": output_path}
+
+    if not ctx.connected_comids_table.exists():
+        raise FileNotFoundError(
+            f"Connected-COMID table not found: {ctx.connected_comids_table}. "
+            f"Run `python -m gfv2_params.download.nhd_flowlines` first."
+        )
+
+    info = RasterInfo.from_path(ctx.template_path)
+    connected = load_connected_comids(ctx.connected_comids_table)
+    try:
+        wb_gdf = gpd.read_file(ctx.waterbody_gpkg, layer=ctx.waterbody_layer, use_arrow=True)
+    except ImportError:
+        logger.warning("PyArrow unavailable for vector load; falling back to fiona.")
+        wb_gdf = gpd.read_file(ctx.waterbody_gpkg, layer=ctx.waterbody_layer)
+
+    if wb_gdf.crs != info.crs:
+        logger.info("  Reprojecting wbodies from %s to %s", wb_gdf.crs, info.crs)
+        wb_gdf = wb_gdf.to_crs(info.crs)
+    wb_gdf = wb_gdf[wb_gdf.geometry.notna() & ~wb_gdf.geometry.is_empty]
+
+    sel = select_connected_waterbodies(wb_gdf, connected)
+    logger.info(
+        "  %d connected COMIDs; %d of %d waterbody polygons flagged connected",
+        len(connected), len(sel), len(wb_gdf),
+    )
+
+    binary = rasterize_binary(sel, info, all_touched=False)
+    binary[~read_land_mask(landmask_path)] = 255  # drop off-land (ocean) cells
+    write_uint8_binary(binary, info, output_path)
+    n_in = int((binary == 1).sum())
+    logger.info("  %d connected-waterbody cells after land mask", n_in)
+
+    return {"connected_wbody": output_path}
+```
+
+- [ ] **Step 4: Register the builder + STEP_ORDER**
+
+In `src/gfv2_params/depstor_builders/__init__.py`:
+- Add `wbody_connectivity` to the import line (line 17): `from . import carea_map, dprst, imperv, intersect, landmask, perv, routing, vpu_id, waterbody, wbody_connectivity` (note: `streambuffer` removed in Task 6).
+- Add to `BUILDERS` (replace the `"streambuffer": streambuffer.build,` line): `"wbody_connectivity": wbody_connectivity.build,`
+- In `STEP_ORDER`, replace `"streambuffer",` with `"wbody_connectivity",`.
+- Update the key-table comment block: replace the `streambuffer -> "stream_buffer"` line with `wbody_connectivity -> "connected_wbody"      connected_wbody.tif (uint8, 1=connected)`.
+
+> Task 6 performs the matching `streambuffer` removals; if executing strictly in order, leave the `streambuffer` import/entry intact here and do the swap in Task 6. Either way the end state has `wbody_connectivity` registered and `streambuffer` gone.
+
+- [ ] **Step 5: Add `_expected_outputs` mapping**
+
+In `scripts/build_depstor_rasters.py`, in the `single_key` dict (~line 120), add `"wbody_connectivity": "connected_wbody",` (and remove the `"streambuffer": "stream_buffer",` entry in Task 6).
+
+- [ ] **Step 6: Add the config step block**
+
+In `configs/depstor/depstor_rasters.yml`, replace the `streambuffer` block (lines 30-32) with:
+
+```yaml
+  - name: wbody_connectivity
+    output: connected_wbody.tif
+```
+
+- [ ] **Step 7: Run tests + import check**
+
+Run: `pixi run -e dev pytest tests/test_wbody_connectivity.py -v`
+Expected: PASS (5 passed: 3 helper + 2 builder).
+Run: `pixi run --as-is python -c "from gfv2_params.depstor_builders import BUILDERS, STEP_ORDER; assert 'wbody_connectivity' in BUILDERS and 'wbody_connectivity' in STEP_ORDER"`
+Expected: exit 0.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/gfv2_params/depstor_builders/wbody_connectivity.py src/gfv2_params/depstor_builders/__init__.py scripts/build_depstor_rasters.py configs/depstor/depstor_rasters.yml tests/test_wbody_connectivity.py
+git commit -m "feat(depstor): wbody_connectivity builder (WBAREACOMI -> connected_wbody.tif)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Swap dprst.py to `connected_wbody` + retire streambuffer
+
+Point `dprst` at the new mask and remove the streambuffer step entirely.
+
+**Files:**
+- Modify: `src/gfv2_params/depstor_builders/dprst.py:27,40,46,50-53`
+- Modify: `src/gfv2_params/depstor_builders/__init__.py` (remove streambuffer import/BUILDERS/STEP_ORDER/comment — if not already done in Task 5)
+- Modify: `scripts/build_depstor_rasters.py` (remove `streambuffer` from `single_key`)
+- Modify: `src/gfv2_params/depstor_builders/context.py` (optional: drop now-unused `segments_gpkg`/`segments_layer`? **No** — leave them; other tooling/profiles still declare segments. Out of scope.)
+- Test: any test referencing `stream_buffer` as a dprst input (search and update).
+
+**Interfaces:**
+- Consumes: registered key `connected_wbody` (Task 5) instead of `stream_buffer`.
+- Produces: unchanged — `dprst`, `onstream`.
+
+- [ ] **Step 1: Search for stream_buffer references**
+
+Run: `grep -rn "stream_buffer\|streambuffer" src/ scripts/ configs/ tests/`
+Expected: hits in `dprst.py`, `__init__.py`, `build_depstor_rasters.py`, `depstor_rasters.yml`, and `streambuffer.py` itself. Record each; all but `streambuffer.py` (the retired module, left on disk) must be updated.
+
+- [ ] **Step 2: Edit dprst.py**
+
+- Line 27: replace `stream_buffer_path = ctx.require("stream_buffer")` with `connected_path = ctx.require("connected_wbody")`.
+- Line 40: replace `stream_binary = read_aligned_uint8(stream_buffer_path, info)` with `connected_binary = read_aligned_uint8(connected_path, info)`.
+- Line 46: replace `stream_regions = regions_touching_mask(regions, stream_binary)` with `onstream_regions = regions_touching_mask(regions, connected_binary)`.
+- Line 48: replace `excluded = stream_regions | imperv_regions` with `excluded = onstream_regions | imperv_regions`.
+- Lines 50-53 logger: replace `%d touch stream` / `len(stream_regions)` with `%d touch connected wbody` / `len(onstream_regions)`.
+- Update the module docstring (line 1) to `"""Combine wbody regions + connected-wbody mask + imperv into dprst + onstream."""`.
+
+- [ ] **Step 3: Remove streambuffer from the registry (if not already)**
+
+In `__init__.py`: drop `streambuffer` from the import line, the `BUILDERS` dict, `STEP_ORDER`, and the key-table comment. In `build_depstor_rasters.py`: remove `"streambuffer": "stream_buffer",` from `single_key`. In `depstor_rasters.yml`: ensure the streambuffer block is gone (done in Task 5 Step 6).
+
+- [ ] **Step 4: Update/confirm tests**
+
+If Step 1 found a test asserting `stream_buffer` as a dprst input, update it to provide `connected_wbody` instead. Then run the depstor suite:
+
+Run: `pixi run -e dev pytest tests/ -k "depstor or dprst or wbody or connectivity" -v`
+Expected: PASS (no references to a missing `stream_buffer` key).
+Run: `pixi run --as-is python -c "from gfv2_params.depstor_builders import STEP_ORDER; assert 'streambuffer' not in STEP_ORDER"`
+Expected: exit 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/gfv2_params/depstor_builders/dprst.py src/gfv2_params/depstor_builders/__init__.py scripts/build_depstor_rasters.py
+git commit -m "feat(depstor): dprst consumes connected_wbody; retire streambuffer step
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Docs + memory updates
+
+**Files:**
+- Modify: `docs/ARCHITECTURE.md` (depstor step list / data-flow)
+- Modify: `slurm_batch/RUNME.md` and `slurm_batch/HPC_REFERENCE.md` (add the NHD-flowline download step; replace streambuffer with wbody_connectivity in the depstor stage)
+- Modify: `README.md` if it enumerates depstor steps or NHD inputs
+- Modify: memory notes `dprst_connectivity_via_nhd_wbareacomi.md`, `depstor_segments_streambuffer_only.md`, and `MEMORY.md` index
+
+- [ ] **Step 1: Audit the docs**
+
+Run: `grep -rni "streambuffer\|stream buffer\|stream_buffer\|60 m\|60m\|WBAREACOMI" docs/ README.md slurm_batch/*.md`
+Expected: a list of every place describing the old buffer step and any NHD-download enumeration.
+
+- [ ] **Step 2: Update prose**
+
+For each hit: replace the streambuffer description with the WBAREACOMI/`wbody_connectivity` mechanism (connected = NHD artificial path through the waterbody, joined by COMID; full-NHD scope; fabric segments no longer feed the depstor connectivity classification). Add the new staging command to the runbook before the depstor raster stage:
+
+```bash
+# Stage NHD-connected waterbody COMIDs (one-time, CONUS):
+sbatch slurm_batch/download_nhd_flowlines.batch
+```
+
+- [ ] **Step 3: Update memory**
+
+- In `dprst_connectivity_via_nhd_wbareacomi.md`: mark implemented — connectivity now comes from `download/nhd_flowlines.py` → `connected_waterbody_comids.parquet` → `wbody_connectivity` builder → `connected_wbody.tif`; join on `COMID`/`member_comid`; integration option A; streambuffer retired (resurrect from git if needed).
+- In `depstor_segments_streambuffer_only.md`: note that the streambuffer step is retired and `segments_gpkg` no longer feeds any depstor step; depstor connectivity is now NHD-WBAREACOMI-driven.
+- Reflect any one-line changes in `MEMORY.md` hooks.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/ README.md slurm_batch/RUNME.md slurm_batch/HPC_REFERENCE.md
+git commit -m "docs: NHD WBAREACOMI connectivity replaces streambuffer in depstor
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+# memory files are outside the repo; write them separately via the memory tool.
+```
+
+---
+
+### Task 8: Pre-PR verification + validation run
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Lint + full local-safe checks**
+
+Run: `pixi run -e dev pre-commit run --all-files`
+Expected: all hooks pass (or auto-fix, then re-stage and amend the relevant commit).
+
+- [ ] **Step 2: Full test suite (CI is the gate; this is a local dry check if not on the head node)**
+
+Run (only off the HPC head node): `pixi run -e dev pytest tests/ -q`
+Expected: PASS. On the head node, skip and rely on CI.
+
+- [ ] **Step 3: Open the PR**
+
+```bash
+git push -u origin feat/wbareacomi-connectivity
+gh pr create --title "feat(depstor): NHD WBAREACOMI waterbody connectivity (retire streambuffer)" --body "<summary + spec/plan links + scope-expansion callout if any>"
+```
+
+- [ ] **Step 4: CONUS validation (after merge-ready)**
+
+Once `connected_waterbody_comids.parquet` is staged, run the `gfv2` depstor stack and compare `dprst_frac` / `onstream_storage_frac` against the prior buffer-based outputs on a small fabric; spot-check known on-stream impoundments vs. isolated ponds. (Tracked in the spec's "Validation after first run".)
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Component 1 (download module) → Tasks 1, 2. ✓
+- Component 2 (connected-COMID table) → Task 2 (`write_connected_comids`, `main`). ✓
+- Component 3 (`wbody_connectivity` builder) → Tasks 3 (helpers), 4 (config/context wiring), 5 (builder). ✓
+- Component 4 (modify dprst + retire streambuffer) → Task 6. ✓
+- Component 5 (docs + memory) → Task 7. ✓
+- Error handling (missing table fail-fast, WBAREACOMI=0 sentinel, download VPU failure loud, coverage logging) → Task 2 `main` RuntimeError, Task 1 sentinel, Task 5 fail-fast + count logging. ✓
+- Decisions (medium-res, full-NHD, build download, integration A) → reflected throughout; no segment↔COMID reconciliation introduced. ✓
+- Validation → Task 8 Step 4. ✓
+
+**Placeholder scan:** No TBD/TODO/"handle edge cases" — the one open item (exact NHDSnapshot archive name) is called out as a pre-coding verification with a concrete fallback (HEAD-probe version candidates + glob), not a deferred design hole.
+
+**Type consistency:** `connected_comids_from_flowlines(df)->set[int]`, `write_connected_comids(set,Path)`, `load_connected_comids(Path)->set[int]`, `select_connected_waterbodies(gdf,set)->gdf`, builder output key `connected_wbody` — names match across Tasks 1–6. `dprst.py` consumes `connected_wbody` (Task 5 produces it, Task 6 requires it). Profile key `connected_comids_table` consistent across config/context/orchestrator/builder.

--- a/docs/superpowers/specs/2026-06-23-nhd-wbareacomi-connectivity-design.md
+++ b/docs/superpowers/specs/2026-06-23-nhd-wbareacomi-connectivity-design.md
@@ -1,0 +1,228 @@
+# NHD WBAREACOMI-driven waterbody connectivity (depression storage)
+
+**Date:** 2026-06-23
+**Status:** Design approved (integration option A); ready for implementation plan
+**Author:** Rich McDonald (with Claude Code)
+
+## Problem
+
+The depression-storage (depstor) pipeline must decide which waterbodies are
+**on-stream** (the modeled stream flows through them — handled by routing, not
+depression storage) versus **depression storage** (off-stream ponds/closed
+basins that contribute to `dprst_frac`).
+
+Today this is a geometric heuristic. The `streambuffer` step buffers the fabric
+stream segments by a flat **60 m**
+([`streambuffer.py`](../../../src/gfv2_params/depstor_builders/streambuffer.py)),
+rasterizes the buffer, and `dprst.py` excludes any waterbody clump-region that
+shares **at least one pixel** with the buffer
+([`dprst.py:46`](../../../src/gfv2_params/depstor_builders/dprst.py#L46)).
+
+Weaknesses:
+
+- A single overlapping pixel flips an entire waterbody from depression storage
+  to on-stream.
+- The 60 m distance is uncalibrated and applied uniformly.
+- Proximity is not connectivity: a hydrologically isolated pond 50 m from a
+  segment is flagged on-stream; a connected impoundment whose polygon edge sits
+  70 m away is kept as depression storage.
+
+## Approach
+
+Replace the proximity heuristic with NHD's authoritative topology. In NHDPlusV2,
+an **artificial-path** `NHDFlowline` drawn through a waterbody carries
+`WBAREACOMI` = the COMID of that waterbody. The set of distinct populated
+`WBAREACOMI` values is exactly the set of waterbodies the NHD stream network
+flows through — i.e. the on-stream (connected) waterbodies.
+
+Connectivity is therefore decided in NHD's own COMID space and joined to our
+waterbody polygons by COMID. **Our fabric `nsegment` layer plays no role in the
+classification.** This is the deliberate workaround for the fact that the fabric
+segments are a subset of NHD and discretized differently — we never have to
+reconcile `seg_id` to NHD COMID (the segments carry no COMID anyway).
+
+### Decisions locked during brainstorming
+
+- **Resolution: medium-res (NHDPlusV2).** Our `conus_waterbodies.gpkg` polygons
+  are NHDPlusV2 COMIDs, so `WBAREACOMI` must come from the same resolution to
+  share the COMID namespace. High-res (NHDPlus HR) uses a different identifier
+  namespace and would require re-staging HR waterbodies — explicitly out of
+  scope.
+- **Connectivity scope: full NHD.** Any NHD artificial path through a waterbody
+  marks it on-stream, regardless of whether that reach is in our fabric. This is
+  physically cleanest and avoids segment reconciliation. Consequence: a pond on
+  a dropped headwater reach becomes on-stream, not depression storage.
+- **Data sourcing: build the download + staging step** (reproducible), mirroring
+  the existing `download/rpu_rasters.py` pattern.
+- **Integration: option A — connected-mask drop-in** (see below). Option B (pure
+  attribute split, dropping pixel-clumping for the stream side) is deferred; we
+  want an efficient path to first results and can refactor later.
+
+### Grounding facts (verified during design)
+
+- `conus_waterbodies.gpkg` (layer `waterbodies`, 448,124 features, EPSG:5070)
+  carries `COMID` (Integer) and `member_comid` (String). `member_comid` is a
+  **single COMID, not a delimited list**, and equals `COMID` in 99.94% of rows
+  (280 multipart exceptions). The join is therefore
+  `waterbody.COMID ∈ connected_set`, with `member_comid` unioned in to catch the
+  280 multipart cases.
+- `waterbody.py` currently rasterizes **geometry only** — it reads no attribute
+  columns. The new connectivity step will read `COMID`/`member_comid`.
+- The stream-connectivity test is a single line,
+  [`dprst.py:46`](../../../src/gfv2_params/depstor_builders/dprst.py#L46):
+  `stream_regions = regions_touching_mask(regions, stream_binary)`. The imperv
+  branch (line 47) is independent.
+- `stream_buffer.tif` is consumed **only** by `dprst.py`.
+
+## Architecture
+
+Integration **option A (connected-mask drop-in):** build a new
+`connected_wbody.tif` raster — the waterbody polygons whose COMID is in the
+connected set, rasterized and land-masked — and feed it into `dprst.py` in place
+of `stream_buffer.tif`. The existing clump/region machinery and the entire
+impervious branch are unchanged; only the *definition* of the connected mask
+changes.
+
+```
+NHDPlusV2 NHDSnapshot (per VPU, S3)
+  └─ NHDFlowline.dbf  (COMID, FTYPE, WBAREACOMI)
+        │  distinct WBAREACOMI != 0
+        ▼
+  connected_waterbody_comids.parquet          [staging artifact]
+        │  join on COMID (∪ member_comid)
+        ▼
+  conus_waterbodies.gpkg polygons ── flag connected ──► connected_wbody.tif
+        │                                                      │
+        ▼                                                      ▼
+  wbody_binary / wbody_regions (unchanged)        dprst.py stream side:
+                                                  stream_regions =
+                                                  regions_touching_mask(
+                                                    regions, connected_wbody)
+                                                  imperv branch unchanged
+                                                      │
+                                                      ▼
+                                            dprst_binary.tif / onstream_binary.tif
+                                                      │
+                                                      ▼
+                                  dprst_frac, onstream_storage_frac (PRMS params)
+```
+
+### Components
+
+1. **Download module — `src/gfv2_params/download/nhd_flowlines.py`**
+   Mirrors [`download/rpu_rasters.py`](../../../src/gfv2_params/download/rpu_rasters.py).
+   Pulls NHDPlusV2 **NHDSnapshot** archives per VPU from the
+   `dmap-data-commons-ow` S3 bucket
+   (`NHDPlusV21_{dd}_{vpu}_NHDSnapshot_{ver}.7z`), extracts only
+   `NHDFlowline.dbf` (no geometry needed — only `COMID`, `FTYPE`, `WBAREACOMI`).
+   Reads `data_root` via the base config; writes archives to
+   `input/nhd_downloads/` and extracted DBFs under `shared/source/`. CLI:
+   `python -m gfv2_params.download.nhd_flowlines`. New SLURM batch
+   `slurm_batch/download_nhd_flowlines.batch` invoking `pixi run --as-is`.
+   **Open item to confirm at implementation time:** the exact NHDSnapshot
+   component filename and version-candidate list per VPU (the bucket layout is
+   the same family as the rasters, but the `NHDSnapshot` archive name must be
+   verified against an actual S3 listing before coding the path template).
+
+2. **Connected-COMID table build**
+   Reads every extracted `NHDFlowline.dbf`, collects distinct `WBAREACOMI` where
+   `WBAREACOMI != 0`, writes a flat artifact
+   `input/nhd/connected_waterbody_comids.parquet` (single column of connected
+   waterbody COMIDs). Implemented as a function/entry in the download module so a
+   single `python -m gfv2_params.download.nhd_flowlines` run downloads and
+   produces the table. This is a one-time staging artifact alongside
+   `conus_waterbodies.gpkg`.
+
+3. **New depstor step — `wbody_connectivity` builder**
+   `src/gfv2_params/depstor_builders/wbody_connectivity.py`. Reads
+   `waterbody_gpkg`/`waterbody_layer` pulling `COMID` + `member_comid`, loads the
+   connected-COMID parquet, flags polygons whose `COMID` (or `member_comid`) is
+   in the connected set, rasterizes the flagged polygons land-masked, and
+   registers output `connected_wbody` → `connected_wbody.tif` (uint8: 1 =
+   connected, 255 = nodata/off-land). Registered in `BUILDERS` and `STEP_ORDER`
+   in
+   [`depstor_builders/__init__.py`](../../../src/gfv2_params/depstor_builders/__init__.py)
+   (after `landmask`, before `dprst`; occupies the former `streambuffer` slot).
+   Config block added to
+   [`configs/depstor/depstor_rasters.yml`](../../../configs/depstor/depstor_rasters.yml)
+   with keys for the connected-COMID table path and the output filename. Path
+   inputs come from the fabric profile via `require_config_key`, never
+   hardcoded. Ships with `tests/test_wbody_connectivity.py` (repo rule: builder +
+   test together; match the synthetic tiny-raster + small-GeoDataFrame style of
+   the existing depstor tests).
+
+4. **Modify `dprst.py`**
+   Consume `connected_wbody` (via `ctx.require("connected_wbody")`) instead of
+   `stream_buffer`. The line becomes
+   `stream_regions = regions_touching_mask(regions, connected_binary)`. No other
+   logic changes; the imperv branch and outputs (`dprst`, `onstream`) are
+   untouched. **Retire the `streambuffer` step**: remove it from `STEP_ORDER`,
+   `BUILDERS`, and `depstor_rasters.yml`. Leave `streambuffer.py` on disk as
+   reference but do not extend it. (Its only consumer was `dprst.py`.)
+
+5. **Docs + memory**
+   Audit and update on the same branch:
+   [`docs/ARCHITECTURE.md`](../../../docs/ARCHITECTURE.md),
+   [`slurm_batch/RUNME.md`](../../../slurm_batch/RUNME.md),
+   [`slurm_batch/HPC_REFERENCE.md`](../../../slurm_batch/HPC_REFERENCE.md), and
+   the depstor sections describing the streambuffer step. Update memory notes
+   `dprst_connectivity_via_nhd_wbareacomi` and
+   `depstor_segments_streambuffer_only` (segments no longer feed even the
+   streambuffer step).
+
+## Data flow
+
+1. `download/nhd_flowlines.py` → per-VPU `NHDFlowline.dbf` under `shared/source/`.
+2. Same module → `input/nhd/connected_waterbody_comids.parquet` (distinct
+   `WBAREACOMI != 0`).
+3. `wbody_connectivity` builder (depstor) → `connected_wbody.tif`.
+4. `dprst` builder → `dprst_binary.tif` / `onstream_binary.tif` (stream side now
+   driven by `connected_wbody.tif`; imperv side unchanged).
+5. Zonal aggregation → `dprst_frac`, `onstream_storage_frac` PRMS params
+   (unchanged downstream).
+
+## Error handling
+
+- **Missing connected-COMID table:** the `wbody_connectivity` builder fails fast
+  with a clear message pointing at the `download/nhd_flowlines` step (do not
+  silently fall back to an empty set, which would mark every waterbody as
+  depression storage).
+- **WBAREACOMI semantics:** `0` (and null) means "not through a waterbody" and
+  is excluded from the connected set. Verify the sentinel against real DBF data
+  during implementation; treat both `0` and null as not-connected.
+- **Download robustness:** reuse `rpu_rasters.py`'s version-candidate fallback
+  and archive-extraction handling; a missing VPU archive is a hard error, not a
+  skip (a silently dropped VPU would under-flag connectivity there).
+- **Join coverage:** log the count of waterbody polygons flagged connected and
+  the count of connected COMIDs with no matching polygon, so coverage gaps are
+  visible rather than silent.
+
+## Testing
+
+- `tests/test_wbody_connectivity.py`: synthetic tiny raster + small waterbody
+  GeoDataFrame with known COMIDs; assert that only polygons whose COMID is in the
+  connected set are rasterized to 1, that `member_comid` matches are honored, and
+  that off-land cells are masked to 255.
+- Download/table-build: a small unit test over a synthetic in-memory or fixture
+  DBF asserting distinct `WBAREACOMI != 0` extraction (network download itself
+  not exercised in CI).
+- Existing `dprst` behavior: confirm the swap is mask-source-only — the imperv
+  branch and output shapes are unchanged. Update any test that referenced
+  `stream_buffer` as a `dprst` input.
+- CI (`.github/workflows/ci.yml`) is the authoritative gate; do not run pytest on
+  the HPC head node.
+
+## Out of scope (YAGNI)
+
+- Segment ↔ COMID reconciliation (the whole point is to avoid it).
+- High-res (NHDPlus HR) staging.
+- Downloading flowline geometry (only the DBF attribute table is needed).
+- Option B (pure attribute split, removing pixel-clumping for the stream side) —
+  deferred; revisit if the clump-merge edge case proves material.
+
+## Validation after first run
+
+- Compare `dprst_frac` / `onstream_storage_frac` against the current
+  buffer-based outputs on a small fabric (e.g. VPU 01) to see how the
+  classification shifts.
+- Spot-check a handful of known on-stream impoundments and isolated ponds.

--- a/scripts/build_depstor_rasters.py
+++ b/scripts/build_depstor_rasters.py
@@ -125,6 +125,7 @@ def _expected_outputs(step: dict) -> dict:
             "landmask": "landmask",
             "imperv": "imperv",
             "streambuffer": "stream_buffer",
+            "wbody_connectivity": "connected_wbody",
             "perv": "perv",
             "routing": "drains_to_dprst",
             "vpu_id": "vpu_id",

--- a/scripts/build_depstor_rasters.py
+++ b/scripts/build_depstor_rasters.py
@@ -120,11 +120,10 @@ def _expected_outputs(step: dict) -> dict:
             return {"drains_perv": step["output"]}
         if name == "drains_imperv":
             return {"drains_imperv": step["output"]}
-        # landmask, imperv, streambuffer, perv, routing each map to a single key.
+        # landmask, imperv, wbody_connectivity, perv, routing each map to a single key.
         single_key = {
             "landmask": "landmask",
             "imperv": "imperv",
-            "streambuffer": "stream_buffer",
             "wbody_connectivity": "connected_wbody",
             "perv": "perv",
             "routing": "drains_to_dprst",

--- a/scripts/build_depstor_rasters.py
+++ b/scripts/build_depstor_rasters.py
@@ -81,6 +81,10 @@ def _build_context(config: dict, force: bool) -> BuildContext:
         segments_layer=config.get("segments_layer", "nsegment"),
         waterbody_gpkg=Path(config["waterbody_gpkg"]) if config.get("waterbody_gpkg") else None,
         waterbody_layer=config.get("waterbody_layer"),
+        connected_comids_table=(
+            Path(config["connected_comids_table"])
+            if config.get("connected_comids_table") else None
+        ),
         fdr_raster=Path(config["fdr_raster"]) if config.get("fdr_raster") else None,
         twi_raster=Path(config["twi_raster"]) if config.get("twi_raster") else None,
         vpu=config.get("vpu"),

--- a/scripts/init_data_root.py
+++ b/scripts/init_data_root.py
@@ -142,8 +142,8 @@ def _fabric_tree(fabric: str) -> list:
                           prepare_fabric.py (used by zonal stats scripts)
               depstor_rasters/
                           Per-fabric depression-storage intermediate rasters
-                          produced by build_depstor_*.py
-                          (imperv_binary.tif, stream_buffer.tif,
+                          produced by build_depstor_rasters.py
+                          (imperv_binary.tif, connected_wbody.tif,
                            wbody_binary.tif, wbody_regions.tif,
                            dprst_binary.tif, onstream_binary.tif,
                            drains_to_dprst.tif)

--- a/scripts/merge_vpu_segments.py
+++ b/scripts/merge_vpu_segments.py
@@ -1,6 +1,11 @@
 """Merge the per-VPU `nsegment` layers into one CONUS stream-segments GeoPackage.
 
-The depstor `streambuffer` step needs a single stream-network layer covering the
+NOTE: the depstor `streambuffer` step (the original consumer of this merged layer)
+was retired when waterbody connectivity moved to NHD WBAREACOMI topology. Segments
+no longer feed any depstor step; this merge is retained for other tooling. The
+historical rationale follows.
+
+The depstor `streambuffer` step needed a single stream-network layer covering the
 whole fabric, but a VPU-based fabric like ``gfv2`` only ships per-VPU draft
 geopackages (``input/fabric/NHM_<vpu>_draft.gpkg``). The fabric-merge notebook
 (``notebooks/merge_vpu_targets.py``) merges only the ``nhru`` layer, so the

--- a/slurm_batch/HPC_REFERENCE.md
+++ b/slurm_batch/HPC_REFERENCE.md
@@ -98,7 +98,8 @@ Fabric identities and all shared, required per-fabric inputs live as profiles in
 `configs/base_config.yml` under a `fabrics:` mapping. Every profile carries
 `hru_gpkg`/`hru_layer`, `id_feature`, `expected_max_hru_id`, and `batch_size`;
 depstor fabrics add `template_raster`, `fdr_raster`, `twi_raster`,
-`segments_gpkg`/`segments_layer`, and `waterbody_gpkg`/`waterbody_layer`. The
+`connected_comids_table`, `segments_gpkg`/`segments_layer`, and
+`waterbody_gpkg`/`waterbody_layer`. The
 active profile is selected via:
 
 1. `--fabric <name>` CLI flag on any script, OR
@@ -169,7 +170,7 @@ Manually-staged files required before `--check`:
 | `input/soils_litho/` | `TEXT_PRMS.tif`, `AWC.tif`, `Lithology_exp_Konly_Project.shp` (+ `.dbf`, `.prj`, `.shx`) |
 | `input/lulc_veg/` | `RootDepth.tif`, `CNPY.tif`, `Imperv.tif` |
 | `input/nhm_default/` | NHM default parameter files |
-| `input/nhd/` | `conus_waterbodies.gpkg` (layer `waterbodies`) |
+| `input/nhd/` | `conus_waterbodies.gpkg` (layer `waterbodies`); `connected_waterbody_comids.parquet` (produced by `download_nhd_flowlines.batch`) |
 | `input/twi/<rpu>/` | Per-RPU `twi.tif` + sidecars (staged via `stage_twi.sh`) |
 
 Download jobs (idempotent — already-downloaded files are skipped):
@@ -179,6 +180,7 @@ mkdir -p logs
 sbatch slurm_batch/download_rpu_rasters.batch    # NHDPlus RPU rasters (~112 GB)
 sbatch slurm_batch/download_nalcms.batch         # NALCMS 2020 land cover (~2 GB)
 sbatch slurm_batch/download_nhm_v11.batch        # NHM v1.1 LULC rasters
+sbatch slurm_batch/download_nhd_flowlines.batch  # NHD-connected waterbody COMIDs (one-time, CONUS)
 ```
 
 Stage per-RPU TWI rasters (reads from the impd-group mirror by default):
@@ -300,7 +302,7 @@ rejected; never substitute it.
 - `hru_gpkg`, `segments_gpkg`/`segments_layer`, `waterbody_gpkg`/`waterbody_layer` (waterbody is required; the step raises if unset).
 - `imperv_source` in `configs/depstor/depstor_rasters.yml` — NLCD fractional-impervious raster.
 
-**DAG order:** landmask → imperv / streambuffer / waterbody → dprst → perv →
+**DAG order:** landmask → imperv / wbody_connectivity / waterbody → dprst → perv →
 vpu_id → routing → drains_perv / drains_imperv → carea_map. Selective re-runs
 via `--step <name>` or `--from <name>` passed through to the Python script.
 
@@ -357,7 +359,7 @@ pixi run -e notebooks marimo run notebooks/merge_vpu_targets.py
 ### Stage 3b — `merge_vpu_segments`
 
 Merge the per-VPU `nsegment` layers into a single CONUS stream-segments gpkg
-for the depstor `streambuffer` step (VPU-based fabrics only). Outputs
+(VPU-based fabrics only). Outputs
 `{data_root}/gfv2/fabric/gfv2_nsegment_merged.gpkg` (layer `nsegment`). Submit
 via the batch:
 
@@ -367,9 +369,11 @@ sbatch slurm_batch/merge_vpu_segments.batch
 FABRIC=<name> sbatch slurm_batch/merge_vpu_segments.batch
 ```
 
-Idempotent; pass `--force` to rebuild. The `segments_gpkg` is consumed only by
-the depstor `streambuffer` step; routing connectivity comes from the FDR raster,
-so merged-segment graph topology is not required here.
+Idempotent; pass `--force` to rebuild. The `segments_gpkg` is no longer consumed
+by any depstor step — the `streambuffer` step is retired; depstor connectivity
+is now NHD-WBAREACOMI-driven (see `wbody_connectivity` builder). Routing
+connectivity comes from the FDR raster, so merged-segment graph topology is not
+required here.
 
 ### Stage 3c — `prepare_fabric`
 
@@ -754,6 +758,7 @@ sacct -j <JOBID> -o JobID,State,Elapsed,MaxRSS
 | `slurm_batch/download_rpu_rasters.batch` | `configs/base_config.yml` | `gfv2_params.download.rpu_rasters` |
 | `slurm_batch/download_nalcms.batch` | `configs/base_config.yml` | `gfv2_params.download.nalcms_lulc` |
 | `slurm_batch/download_nhm_v11.batch` | `configs/base_config.yml` | `gfv2_params.download.nhm_v11_lulc` |
+| `slurm_batch/download_nhd_flowlines.batch` | `configs/base_config.yml` | `gfv2_params.download.nhd_flowlines` — downloads per-VPU NHDPlusV2 `NHDFlowline` attributes and distills distinct non-zero `WBAREACOMI` values to `input/nhd/connected_waterbody_comids.parquet` (one-time, CONUS) |
 | `slurm_batch/submit_jobs.sh` | (caller-provided) | generic per-VPU array dispatcher |
 | (run directly) | `configs/base_config.yml` | `scripts/migrate_to_shared_layout.py --data-root <path>` (legacy `work/` layout upgrade) |
 | (run directly) | `configs/base_config.yml` | `scripts/clip_shared_to_fabric.py --fabric <name>` (fabric-bounds FDR/template clip) |

--- a/slurm_batch/RUNME.md
+++ b/slurm_batch/RUNME.md
@@ -72,7 +72,7 @@ rasters).
 # merge_vpu_targets is an interactive marimo notebook — run it on a COMPUTE
 # node (JupyterHub or `salloc`), never the login node. See HPC_REFERENCE.
 pixi run -e notebooks marimo run notebooks/merge_vpu_targets.py   # nhru merge (compute node)
-sbatch slurm_batch/merge_vpu_segments.batch                        # nsegment merge (for depstor streambuffer)
+sbatch slurm_batch/merge_vpu_segments.batch                        # nsegment merge (VPU-based fabrics)
 sbatch slurm_batch/prepare_fabric.batch                            # spatial batching + manifest
 ```
 
@@ -87,6 +87,8 @@ batches it into per-batch geopackages.
 ### 3 · Build depstor rasters
 
 ```bash
+# Stage NHD-connected waterbody COMIDs (one-time, CONUS):
+sbatch slurm_batch/download_nhd_flowlines.batch
 pixi run --as-is python scripts/clip_shared_to_fabric.py --fabric gfv2   # tiny VRT (login OK)
 sbatch slurm_batch/build_depstor_rasters.batch
 ```

--- a/slurm_batch/build_depstor_rasters.batch
+++ b/slurm_batch/build_depstor_rasters.batch
@@ -10,7 +10,7 @@
 #SBATCH --mem=192G
 #
 # Build the entire depression-storage raster stack in dependency order
-# (landmask -> imperv/streambuffer/waterbody -> dprst -> perv/routing
+# (landmask -> imperv/wbody_connectivity/waterbody -> dprst -> perv/routing
 #  -> drains_perv/drains_imperv -> carea_map). Resources are sized for the
 # long pole (per-VPU D8 routing pass). For VPU01 / smaller fabrics,
 # override at submission:

--- a/slurm_batch/download_nhd_flowlines.batch
+++ b/slurm_batch/download_nhd_flowlines.batch
@@ -1,0 +1,13 @@
+#!/bin/bash
+#SBATCH -p cpu
+#SBATCH -A impd
+#SBATCH --job-name=download_nhd_flow
+#SBATCH --output=logs/job_%j.out
+#SBATCH --error=logs/job_%j.err
+#SBATCH --time=12:00:00
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=1
+#SBATCH --mem=8G
+
+cd "$SLURM_SUBMIT_DIR"
+pixi run --as-is python -m gfv2_params.download.nhd_flowlines

--- a/src/gfv2_params/depstor.py
+++ b/src/gfv2_params/depstor.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Optional
 
 import numpy as np
+import pandas as pd
 import rasterio
 from rasterio.coords import BoundingBox
 from rasterio.crs import CRS
@@ -250,6 +251,20 @@ def regions_to_binary(regions: np.ndarray, keep_ids: set[int]) -> np.ndarray:
         return np.full(regions.shape, 255, dtype=np.uint8)
     keep = np.isin(regions, list(keep_ids))
     return np.where(keep, np.uint8(1), np.uint8(255))
+
+
+def load_connected_comids(path: Path) -> set[int]:
+    """Load the connected-waterbody COMID parquet into a set of ints."""
+    df = pd.read_parquet(path, columns=["comid"])
+    return {int(v) for v in df["comid"].to_numpy()}
+
+
+def select_connected_waterbodies(wb_gdf, connected: set[int]):
+    """Subset waterbodies whose COMID or member_comid is in `connected`."""
+    comid = pd.to_numeric(wb_gdf["COMID"], errors="coerce")
+    member = pd.to_numeric(wb_gdf["member_comid"], errors="coerce")
+    mask = comid.isin(connected) | member.isin(connected)
+    return wb_gdf[mask].copy()
 
 
 def assert_raster_aligned(src, info: RasterInfo, name: str) -> None:

--- a/src/gfv2_params/depstor.py
+++ b/src/gfv2_params/depstor.py
@@ -261,6 +261,13 @@ def load_connected_comids(path: Path) -> set[int]:
 
 def select_connected_waterbodies(wb_gdf, connected: set[int]):
     """Subset waterbodies whose COMID or member_comid is in `connected`."""
+    missing = {"COMID", "member_comid"} - set(wb_gdf.columns)
+    if missing:
+        raise KeyError(
+            f"waterbody layer is missing connectivity join column(s) "
+            f"{sorted(missing)}; wbody_connectivity needs both COMID and "
+            f"member_comid to join against the connected-COMID set."
+        )
     comid = pd.to_numeric(wb_gdf["COMID"], errors="coerce")
     member = pd.to_numeric(wb_gdf["member_comid"], errors="coerce")
     mask = comid.isin(connected) | member.isin(connected)

--- a/src/gfv2_params/depstor_builders/__init__.py
+++ b/src/gfv2_params/depstor_builders/__init__.py
@@ -14,13 +14,12 @@ These modules are thin orchestration wrappers around those helpers.
 
 from __future__ import annotations
 
-from . import carea_map, dprst, imperv, intersect, landmask, perv, routing, streambuffer, vpu_id, waterbody, wbody_connectivity
+from . import carea_map, dprst, imperv, intersect, landmask, perv, routing, vpu_id, waterbody, wbody_connectivity
 from .context import BuildContext
 
 BUILDERS = {
     "landmask":          landmask.build,
     "imperv":            imperv.build,
-    "streambuffer":      streambuffer.build,
     "waterbody":         waterbody.build,
     "wbody_connectivity": wbody_connectivity.build,
     "dprst":             dprst.build,
@@ -41,7 +40,6 @@ BUILDERS = {
 #   step               -> registered key(s)        on-disk artifact (default name)
 #   landmask           -> "landmask"               land_mask.tif (uint8, 1=land)
 #   imperv             -> "imperv"                 imperv_binary.tif
-#   streambuffer       -> "stream_buffer"          stream_buffer.tif
 #   waterbody          -> "wbody_binary",          wbody_binary.tif,
 #                         "wbody_regions"          wbody_regions.tif
 #   wbody_connectivity -> "connected_wbody"        connected_wbody.tif (uint8, 1=connected)
@@ -57,7 +55,6 @@ BUILDERS = {
 STEP_ORDER = [
     "landmask",
     "imperv",
-    "streambuffer",
     "waterbody",
     "wbody_connectivity",
     "dprst",

--- a/src/gfv2_params/depstor_builders/__init__.py
+++ b/src/gfv2_params/depstor_builders/__init__.py
@@ -14,21 +14,22 @@ These modules are thin orchestration wrappers around those helpers.
 
 from __future__ import annotations
 
-from . import carea_map, dprst, imperv, intersect, landmask, perv, routing, streambuffer, vpu_id, waterbody
+from . import carea_map, dprst, imperv, intersect, landmask, perv, routing, streambuffer, vpu_id, waterbody, wbody_connectivity
 from .context import BuildContext
 
 BUILDERS = {
-    "landmask":      landmask.build,
-    "imperv":        imperv.build,
-    "streambuffer":  streambuffer.build,
-    "waterbody":     waterbody.build,
-    "dprst":         dprst.build,
-    "perv":          perv.build,
-    "routing":       routing.build,
-    "drains_perv":   intersect.build,
-    "drains_imperv": intersect.build,
-    "vpu_id":        vpu_id.build,
-    "carea_map":     carea_map.build,
+    "landmask":          landmask.build,
+    "imperv":            imperv.build,
+    "streambuffer":      streambuffer.build,
+    "waterbody":         waterbody.build,
+    "wbody_connectivity": wbody_connectivity.build,
+    "dprst":             dprst.build,
+    "perv":              perv.build,
+    "routing":           routing.build,
+    "drains_perv":       intersect.build,
+    "drains_imperv":     intersect.build,
+    "vpu_id":            vpu_id.build,
+    "carea_map":         carea_map.build,
 }
 
 # Outputs registered into ctx.paths by each builder (consumable downstream via
@@ -37,26 +38,28 @@ BUILDERS = {
 # scripts/build_depstor_rasters.py). Keys are stable string handles — change
 # them only with a coordinated update of every downstream consumer.
 #
-#   step              -> registered key(s)        on-disk artifact (default name)
-#   landmask          -> "landmask"               land_mask.tif (uint8, 1=land)
-#   imperv            -> "imperv"                 imperv_binary.tif
-#   streambuffer      -> "stream_buffer"          stream_buffer.tif
-#   waterbody         -> "wbody_binary",          wbody_binary.tif,
-#                        "wbody_regions"          wbody_regions.tif
-#   dprst             -> "dprst",                 dprst_binary.tif,
-#                        "onstream"               onstream_binary.tif
-#   perv              -> "perv"                   perv_binary.tif
-#   routing           -> "drains_to_dprst"        drains_to_dprst.tif (in-process D8 kernel)
-#   drains_perv       -> "drains_perv"            drains_perv_binary.tif (output_key from config)
-#   drains_imperv     -> "drains_imperv"          drains_imperv_binary.tif (output_key from config)
-#   vpu_id            -> "vpu_id"                 vpu_id.tif (per-cell VPU code, multi-VPU only)
-#   carea_map         -> "carea_max",             carea_max_*.tif,
-#                        "smidx"                  smidx_*.tif
+#   step               -> registered key(s)        on-disk artifact (default name)
+#   landmask           -> "landmask"               land_mask.tif (uint8, 1=land)
+#   imperv             -> "imperv"                 imperv_binary.tif
+#   streambuffer       -> "stream_buffer"          stream_buffer.tif
+#   waterbody          -> "wbody_binary",          wbody_binary.tif,
+#                         "wbody_regions"          wbody_regions.tif
+#   wbody_connectivity -> "connected_wbody"        connected_wbody.tif (uint8, 1=connected)
+#   dprst              -> "dprst",                 dprst_binary.tif,
+#                         "onstream"               onstream_binary.tif
+#   perv               -> "perv"                   perv_binary.tif
+#   routing            -> "drains_to_dprst"        drains_to_dprst.tif (in-process D8 kernel)
+#   drains_perv        -> "drains_perv"            drains_perv_binary.tif (output_key from config)
+#   drains_imperv      -> "drains_imperv"          drains_imperv_binary.tif (output_key from config)
+#   vpu_id             -> "vpu_id"                 vpu_id.tif (per-cell VPU code, multi-VPU only)
+#   carea_map          -> "carea_max",             carea_max_*.tif,
+#                         "smidx"                  smidx_*.tif
 STEP_ORDER = [
     "landmask",
     "imperv",
     "streambuffer",
     "waterbody",
+    "wbody_connectivity",
     "dprst",
     "perv",
     "vpu_id",

--- a/src/gfv2_params/depstor_builders/context.py
+++ b/src/gfv2_params/depstor_builders/context.py
@@ -25,6 +25,7 @@ class BuildContext:
     segments_layer: str = "nsegment"
     waterbody_gpkg: Path | None = None
     waterbody_layer: str | None = None
+    connected_comids_table: Path | None = None
     fdr_raster: Path | None = None
     twi_raster: Path | None = None
     vpu: str | None = None  # single-VPU fabric's VPU label (e.g. "17"); None = use fabric `vpu` attr

--- a/src/gfv2_params/depstor_builders/dprst.py
+++ b/src/gfv2_params/depstor_builders/dprst.py
@@ -1,4 +1,4 @@
-"""Combine wbody regions + stream-buffer + imperv into dprst + onstream."""
+"""Combine wbody regions + connected-wbody mask + imperv into dprst + onstream."""
 
 from __future__ import annotations
 
@@ -24,7 +24,7 @@ def build(step_cfg: dict, ctx: BuildContext, logger) -> dict:
     landmask_path = ctx.require("landmask")
     wbody_binary_path = ctx.require("wbody_binary")
     wbody_regions_path = ctx.require("wbody_regions")
-    stream_buffer_path = ctx.require("stream_buffer")
+    connected_path = ctx.require("connected_wbody")
     imperv_path = ctx.require("imperv")
 
     logger.info("--- dprst ---")
@@ -37,19 +37,19 @@ def build(step_cfg: dict, ctx: BuildContext, logger) -> dict:
 
     info = RasterInfo.from_path(ctx.template_path)
     wbody_binary = read_aligned_uint8(wbody_binary_path, info)
-    stream_binary = read_aligned_uint8(stream_buffer_path, info)
+    connected_binary = read_aligned_uint8(connected_path, info)
     imperv_binary = read_aligned_uint8(imperv_path, info)
     with rasterio.open(wbody_regions_path) as src:
         regions = src.read(1)
     land_valid = read_land_mask(landmask_path)
 
-    stream_regions = regions_touching_mask(regions, stream_binary)
+    onstream_regions = regions_touching_mask(regions, connected_binary)
     imperv_regions = regions_touching_mask(regions, imperv_binary)
-    excluded = stream_regions | imperv_regions
+    excluded = onstream_regions | imperv_regions
     n_total = int(regions.max())
     logger.info(
-        "  %d total wbody regions; %d touch stream, %d touch imperv, %d excluded",
-        n_total, len(stream_regions), len(imperv_regions), len(excluded),
+        "  %d total wbody regions; %d touch connected wbody, %d touch imperv, %d excluded",
+        n_total, len(onstream_regions), len(imperv_regions), len(excluded),
     )
 
     all_ids = set(int(v) for v in np.unique(regions) if v != 0)

--- a/src/gfv2_params/depstor_builders/wbody_connectivity.py
+++ b/src/gfv2_params/depstor_builders/wbody_connectivity.py
@@ -1,0 +1,78 @@
+"""Rasterise the NHD-connected waterbody polygons to a uint8 binary mask.
+
+Connectivity comes from NHD's WBAREACOMI artificial-path topology (staged by
+gfv2_params.download.nhd_flowlines into a connected-COMID parquet), joined to the
+waterbody polygons by COMID / member_comid. Replaces the old streambuffer mask as
+the on-stream signal consumed by the dprst step.
+"""
+
+from __future__ import annotations
+
+import geopandas as gpd
+
+from ..depstor import (
+    RasterInfo,
+    load_connected_comids,
+    rasterize_binary,
+    read_land_mask,
+    select_connected_waterbodies,
+    write_uint8_binary,
+)
+from .context import BuildContext
+
+
+def build(step_cfg: dict, ctx: BuildContext, logger) -> dict:
+    if ctx.waterbody_gpkg is None or ctx.waterbody_layer is None:
+        raise KeyError(
+            "wbody_connectivity step needs `waterbody_gpkg` and `waterbody_layer`."
+        )
+    if ctx.connected_comids_table is None:
+        raise KeyError(
+            "wbody_connectivity step needs `connected_comids_table` in the fabric "
+            "profile. Stage it first: "
+            "`python -m gfv2_params.download.nhd_flowlines`."
+        )
+    output_path = ctx.resolve_output(step_cfg["output"])
+    landmask_path = ctx.require("landmask")
+
+    logger.info("--- wbody_connectivity ---")
+    logger.info("  Waterbody gpkg : %s (layer=%s)", ctx.waterbody_gpkg, ctx.waterbody_layer)
+    logger.info("  Connected table: %s", ctx.connected_comids_table)
+    logger.info("  Output         : %s", output_path)
+
+    if output_path.exists() and not ctx.force:
+        logger.info("  Output already exists — skipping (pass --force to rebuild)")
+        return {"connected_wbody": output_path}
+
+    if not ctx.connected_comids_table.exists():
+        raise FileNotFoundError(
+            f"Connected-COMID table not found: {ctx.connected_comids_table}. "
+            f"Run `python -m gfv2_params.download.nhd_flowlines` first."
+        )
+
+    info = RasterInfo.from_path(ctx.template_path)
+    connected = load_connected_comids(ctx.connected_comids_table)
+    try:
+        wb_gdf = gpd.read_file(ctx.waterbody_gpkg, layer=ctx.waterbody_layer, use_arrow=True)
+    except ImportError:
+        logger.warning("PyArrow unavailable for vector load; falling back to fiona.")
+        wb_gdf = gpd.read_file(ctx.waterbody_gpkg, layer=ctx.waterbody_layer)
+
+    if wb_gdf.crs != info.crs:
+        logger.info("  Reprojecting wbodies from %s to %s", wb_gdf.crs, info.crs)
+        wb_gdf = wb_gdf.to_crs(info.crs)
+    wb_gdf = wb_gdf[wb_gdf.geometry.notna() & ~wb_gdf.geometry.is_empty]
+
+    sel = select_connected_waterbodies(wb_gdf, connected)
+    logger.info(
+        "  %d connected COMIDs; %d of %d waterbody polygons flagged connected",
+        len(connected), len(sel), len(wb_gdf),
+    )
+
+    binary = rasterize_binary(sel, info, all_touched=False)
+    binary[~read_land_mask(landmask_path)] = 255  # drop off-land (ocean) cells
+    write_uint8_binary(binary, info, output_path)
+    n_in = int((binary == 1).sum())
+    logger.info("  %d connected-waterbody cells after land mask", n_in)
+
+    return {"connected_wbody": output_path}

--- a/src/gfv2_params/depstor_builders/wbody_connectivity.py
+++ b/src/gfv2_params/depstor_builders/wbody_connectivity.py
@@ -68,6 +68,17 @@ def build(step_cfg: dict, ctx: BuildContext, logger) -> dict:
         "  %d connected COMIDs; %d of %d waterbody polygons flagged connected",
         len(connected), len(sel), len(wb_gdf),
     )
+    if len(sel) == 0:
+        # An empty connected mask makes dprst classify every waterbody as
+        # depression storage, silently inflating dprst_frac domain-wide. Fail
+        # loud instead of writing an all-nodata raster the orchestrator accepts.
+        raise ValueError(
+            f"wbody_connectivity matched 0 of {len(wb_gdf)} waterbodies against "
+            f"{len(connected)} connected COMIDs — this would misclassify every "
+            f"waterbody as depression storage. Check that "
+            f"{ctx.connected_comids_table} is complete and that the "
+            f"COMID/member_comid join keys align with the waterbody layer."
+        )
 
     binary = rasterize_binary(sel, info, all_touched=False)
     binary[~read_land_mask(landmask_path)] = 255  # drop off-land (ocean) cells

--- a/src/gfv2_params/download/nhd_flowlines.py
+++ b/src/gfv2_params/download/nhd_flowlines.py
@@ -1,0 +1,23 @@
+"""Stage NHDPlusV2 NHDFlowline attributes and distill connected-waterbody COMIDs.
+
+NHD encodes waterbody connectivity directly: an artificial-path NHDFlowline that
+runs through a waterbody carries WBAREACOMI = that waterbody's COMID. The distinct
+set of populated WBAREACOMI values is the set of on-stream (connected) waterbodies.
+This module downloads the per-VPU NHDSnapshot archives, reads NHDFlowline, and
+writes a flat parquet of connected COMIDs consumed by the depstor
+`wbody_connectivity` builder.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+# WBAREACOMI == 0 (and null) means the flowline does not pass through a waterbody.
+_NO_WATERBODY = 0
+
+
+def connected_comids_from_flowlines(df: pd.DataFrame) -> set[int]:
+    """Distinct non-zero, non-null WBAREACOMI values as a set of ints."""
+    col = pd.to_numeric(df["WBAREACOMI"], errors="coerce")
+    vals = col[(col.notna()) & (col != _NO_WATERBODY)]
+    return {int(v) for v in vals.unique()}

--- a/src/gfv2_params/download/nhd_flowlines.py
+++ b/src/gfv2_params/download/nhd_flowlines.py
@@ -10,10 +10,30 @@ writes a flat parquet of connected COMIDs consumed by the depstor
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pandas as pd
+import py7zr
+import pyogrio
+import requests
+
+from gfv2_params.config import load_base_config
+from gfv2_params.log import configure_logging
+
+logger = configure_logging("download_nhd_flowlines")
 
 # WBAREACOMI == 0 (and null) means the flowline does not pass through a waterbody.
 _NO_WATERBODY = 0
+
+# VPU -> drainage-area code (DD). NHDSnapshot is per-VPU (no RPU split).
+vpu_index = {
+    "01": "NE", "02": "MA", "03N": "SA", "03S": "SA", "03W": "SA",
+    "04": "GL", "05": "MS", "06": "MS", "07": "MS", "08": "MS",
+    "09": "SR", "10L": "MS", "10U": "MS", "11": "MS", "12": "TX",
+    "13": "RG", "14": "CO", "15": "CO", "16": "GB", "17": "PN", "18": "CA",
+}
+
+_VERSION_CANDIDATES = ["05", "04", "03", "02", "01"]
 
 
 def connected_comids_from_flowlines(df: pd.DataFrame) -> set[int]:
@@ -21,3 +41,97 @@ def connected_comids_from_flowlines(df: pd.DataFrame) -> set[int]:
     col = pd.to_numeric(df["WBAREACOMI"], errors="coerce")
     vals = col[(col.notna()) & (col != _NO_WATERBODY)]
     return {int(v) for v in vals.unique()}
+
+
+def write_connected_comids(comids: set[int], out_path: Path) -> None:
+    """Write the connected COMIDs to a single-column int64 parquet, sorted."""
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    df = pd.DataFrame({"comid": sorted(int(c) for c in comids)}).astype({"comid": "int64"})
+    df.to_parquet(out_path, index=False)
+
+
+def read_flowline_attrs(flowline_path: Path) -> pd.DataFrame:
+    """Read COMID/FTYPE/WBAREACOMI from an NHDFlowline source (no geometry)."""
+    return pyogrio.read_dataframe(
+        flowline_path,
+        columns=["COMID", "FTYPE", "WBAREACOMI"],
+        read_geometry=False,
+    )
+
+
+def _base_url(dd: str, vpu: str) -> str:
+    nested = {"03", "10", "05", "06", "07", "08", "11", "14", "15"}
+    if any(code in vpu for code in nested):
+        return f"https://dmap-data-commons-ow.s3.amazonaws.com/NHDPlusV21/Data/NHDPlus{dd}/NHDPlus{vpu}"
+    return f"https://dmap-data-commons-ow.s3.amazonaws.com/NHDPlusV21/Data/NHDPlus{dd}"
+
+
+def download_snapshot(dd: str, vpu: str, download_dir: Path, extract_dir: Path) -> Path | None:
+    """Download + extract a VPU's NHDSnapshot; return the NHDFlowline.shp path."""
+    base_url = _base_url(dd, vpu)
+    local_path = None
+    for version in _VERSION_CANDIDATES:
+        filename = f"NHDPlusV21_{dd}_{vpu}_NHDSnapshot_{version}.7z"
+        candidate = download_dir / filename
+        url = f"{base_url}/{filename}"
+        if candidate.exists():
+            local_path = candidate
+            break
+        logger.info(f"Checking: {url}")
+        if requests.head(url, timeout=60).status_code == 200:
+            logger.info(f"Downloading {filename} ...")
+            with requests.get(url, stream=True, timeout=120) as r:
+                r.raise_for_status()
+                with open(candidate, "wb") as f:
+                    for chunk in r.iter_content(chunk_size=8192):
+                        f.write(chunk)
+            local_path = candidate
+            break
+
+    if local_path is None:
+        logger.error(f"NHDSnapshot not found for VPU {vpu}")
+        return None
+
+    out_dir = extract_dir / vpu / "NHDSnapshot"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    with py7zr.SevenZipFile(local_path, mode="r") as archive:
+        archive.extractall(path=out_dir)
+
+    shps = list(out_dir.glob("**/NHDFlowline.shp"))
+    if not shps:
+        logger.error(f"NHDFlowline.shp not found in extracted snapshot for VPU {vpu}")
+        return None
+    return shps[0]
+
+
+def main() -> None:
+    base = load_base_config()
+    data_root = Path(base["data_root"])
+    download_dir = data_root / "input/nhd_downloads"
+    extract_dir = data_root / "shared/source"
+    download_dir.mkdir(parents=True, exist_ok=True)
+    extract_dir.mkdir(parents=True, exist_ok=True)
+
+    connected: set[int] = set()
+    failures = []
+    for vpu, dd in vpu_index.items():
+        flowline = download_snapshot(dd, vpu, download_dir, extract_dir)
+        if flowline is None:
+            failures.append(vpu)
+            continue
+        df = read_flowline_attrs(flowline)
+        vpu_connected = connected_comids_from_flowlines(df)
+        logger.info(f"VPU {vpu}: {len(vpu_connected)} connected waterbody COMIDs")
+        connected |= vpu_connected
+
+    if failures:
+        # A silently dropped VPU under-flags connectivity there — make it loud.
+        raise RuntimeError(f"NHDSnapshot download/read failed for VPU(s): {failures}")
+
+    out_path = data_root / "input/nhd/connected_waterbody_comids.parquet"
+    write_connected_comids(connected, out_path)
+    logger.info(f"Wrote {len(connected)} connected COMIDs -> {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/gfv2_params/download/nhd_flowlines.py
+++ b/src/gfv2_params/download/nhd_flowlines.py
@@ -64,10 +64,14 @@ def write_connected_comids(comids: set[int], out_path: Path) -> None:
 
 
 def read_flowline_attrs(flowline_path: Path) -> pd.DataFrame:
-    """Read COMID/FTYPE/WBAREACOMI from an NHDFlowline source (no geometry)."""
+    """Read COMID/WBAREACOMI from an NHDFlowline source (no geometry).
+
+    Connectivity is keyed purely off non-zero WBAREACOMI (which NHD populates
+    only on artificial paths), so FTYPE is not read.
+    """
     return pyogrio.read_dataframe(
         flowline_path,
-        columns=["COMID", "FTYPE", "WBAREACOMI"],
+        columns=["COMID", "WBAREACOMI"],
         read_geometry=False,
     )
 
@@ -91,15 +95,35 @@ def download_snapshot(dd: str, vpu: str, download_dir: Path, extract_dir: Path) 
             local_path = candidate
             break
         logger.info(f"Checking: {url}")
-        if requests.head(url, timeout=60).status_code == 200:
-            logger.info(f"Downloading {filename} ...")
-            with requests.get(url, stream=True, timeout=120) as r:
-                r.raise_for_status()
-                with open(candidate, "wb") as f:
-                    for chunk in r.iter_content(chunk_size=8192):
-                        f.write(chunk)
-            local_path = candidate
-            break
+        status = requests.head(url, timeout=60, allow_redirects=True).status_code
+        if status != 200:
+            # Distinguish "archive absent" (404) from a transient/redirect issue
+            # that a GET might still satisfy — the latter shouldn't be read as
+            # "this version doesn't exist" without a trace.
+            if status != 404:
+                logger.warning(
+                    "HEAD %s returned %d (not 200/404) — treating as absent", url, status
+                )
+            continue
+        logger.info(f"Downloading {filename} ...")
+        # Download to a .part sidecar and atomically rename only after a
+        # size-verified, complete write, so an interrupted download (node
+        # preemption, walltime) can't leave a truncated archive that the next
+        # run silently reuses via the candidate.exists() short-circuit above.
+        tmp = candidate.with_suffix(candidate.suffix + ".part")
+        with requests.get(url, stream=True, timeout=120) as r:
+            r.raise_for_status()
+            expected = int(r.headers.get("Content-Length", 0))
+            with open(tmp, "wb") as f:
+                for chunk in r.iter_content(chunk_size=8192):
+                    f.write(chunk)
+        got = tmp.stat().st_size
+        if expected and got != expected:
+            tmp.unlink(missing_ok=True)
+            raise OSError(f"{filename}: downloaded {got} bytes, expected {expected}")
+        tmp.rename(candidate)
+        local_path = candidate
+        break
 
     if local_path is None:
         logger.error(f"NHDSnapshot not found for VPU {vpu}")

--- a/src/gfv2_params/download/nhd_flowlines.py
+++ b/src/gfv2_params/download/nhd_flowlines.py
@@ -37,8 +37,21 @@ _VERSION_CANDIDATES = ["05", "04", "03", "02", "01"]
 
 
 def connected_comids_from_flowlines(df: pd.DataFrame) -> set[int]:
-    """Distinct non-zero, non-null WBAREACOMI values as a set of ints."""
-    col = pd.to_numeric(df["WBAREACOMI"], errors="coerce")
+    """Distinct non-zero, non-null WBAREACOMI values as a set of ints.
+
+    Raises ValueError if any non-null WBAREACOMI fails to parse as a number.
+    WBAREACOMI is a numeric COMID field, so a parse failure means a column-format
+    change in the snapshot; silently coercing those to NaN would drop a VPU to an
+    empty connected set and misclassify its waterbodies as depression storage.
+    """
+    raw = df["WBAREACOMI"]
+    col = pd.to_numeric(raw, errors="coerce")
+    n_lost = int(raw.notna().sum() - col.notna().sum())
+    if n_lost:
+        raise ValueError(
+            f"{n_lost} non-null WBAREACOMI value(s) failed numeric parse — "
+            "likely a column-format change in this NHDFlowline snapshot."
+        )
     vals = col[(col.notna()) & (col != _NO_WATERBODY)]
     return {int(v) for v in vals.unique()}
 

--- a/src/gfv2_params/viz.py
+++ b/src/gfv2_params/viz.py
@@ -465,7 +465,7 @@ _DEPSTOR_RASTERS = [
     "perv_binary.tif",
     "dprst_binary.tif",
     "onstream_binary.tif",
-    "stream_buffer.tif",
+    "connected_wbody.tif",
     "wbody_binary.tif",
     "wbody_regions.tif",
     "carea_map_t8_binary.tif",
@@ -482,6 +482,7 @@ def depstor_raster_inventory(cfg) -> list[RasterEntry]:
 
     All are discrete (binary masks / region or VPU labels), so kind is
     "categorical". Missing files are skipped with a warning.
+    ``connected_wbody.tif`` replaced the retired ``stream_buffer.tif``.
     """
     base = Path(cfg["data_root"]) / cfg["fabric"] / "depstor_rasters"
     entries = [
@@ -578,7 +579,7 @@ def save_figure(fig, name, *, dpi: int = 150) -> None:
 # Curated list of depstor binaries that directly feed a PRMS ratio CSV (i.e.
 # appear as a numerator or denominator of one of the 6 ratios in
 # configs/depstor/depstor_params.yml). Intentionally excludes intermediates
-# (stream_buffer, wbody_binary, onstream_binary, drains_to_dprst) and the
+# (connected_wbody, wbody_binary, onstream_binary, drains_to_dprst) and the
 # non-ratio rasters (land_mask, wbody_regions, vpu_id). Each entry carries a
 # distinct hex color so layers stay visually distinguishable when stacked on
 # an interactive map. Maintained alongside _DEPSTOR_RASTERS above.

--- a/tests/test_build_depstor_dprst.py
+++ b/tests/test_build_depstor_dprst.py
@@ -1,0 +1,81 @@
+"""Behavioural test for the dprst builder's connected-vs-depression split.
+
+The feature's whole point: a waterbody region that the NHD-connected mask touches
+is on-stream (excluded from depression storage and placed in onstream), while a
+region touching neither the connected mask nor imperv is kept as depression
+storage. This pins that contract at the dprst level on a tiny synthetic grid.
+"""
+
+import logging
+from pathlib import Path
+
+import numpy as np
+import rasterio
+from rasterio.transform import from_origin
+
+from gfv2_params.depstor_builders import dprst
+from gfv2_params.depstor_builders.context import BuildContext
+
+_N = 10
+_TRANSFORM = from_origin(0, _N * 30, 30, 30)
+
+
+def _write(path: Path, arr: np.ndarray, dtype: str, nodata) -> None:
+    with rasterio.open(
+        path, "w", driver="GTiff", height=_N, width=_N, count=1, dtype=dtype,
+        crs="EPSG:5070", transform=_TRANSFORM, nodata=nodata,
+    ) as dst:
+        dst.write(arr.astype(dtype), 1)
+
+
+def test_dprst_excludes_connected_region_keeps_isolated(tmp_path):
+    template = tmp_path / "template.tif"
+    _write(template, np.full((_N, _N), 100.0), "float32", -9999.0)
+
+    # Two waterbody regions: region 1 top-left (rows 0-1, cols 0-1),
+    # region 2 bottom-right (rows 8-9, cols 8-9).
+    regions = np.zeros((_N, _N), dtype=np.int32)
+    regions[0:2, 0:2] = 1
+    regions[8:10, 8:10] = 2
+    _write(tmp_path / "wbody_regions.tif", regions, "int32", 0)
+
+    wbody_binary = np.where(regions > 0, np.uint8(1), np.uint8(255))
+    _write(tmp_path / "wbody_binary.tif", wbody_binary, "uint8", 255)
+
+    # Connected mask overlaps region 1 only -> region 1 is on-stream.
+    connected = np.full((_N, _N), 255, dtype=np.uint8)
+    connected[0:2, 0:2] = 1
+    _write(tmp_path / "connected_wbody.tif", connected, "uint8", 255)
+
+    # Nothing impervious, all land.
+    _write(tmp_path / "imperv.tif", np.full((_N, _N), 255, dtype=np.uint8), "uint8", 255)
+    _write(tmp_path / "land_mask.tif", np.ones((_N, _N), dtype=np.uint8), "uint8", 255)
+
+    ctx = BuildContext(
+        fabric="t", template_path=template, output_dir=tmp_path,
+        hru_gpkg=tmp_path / "x.gpkg", hru_layer="nhru",
+    )
+    ctx.paths.update({
+        "landmask": tmp_path / "land_mask.tif",
+        "wbody_binary": tmp_path / "wbody_binary.tif",
+        "wbody_regions": tmp_path / "wbody_regions.tif",
+        "connected_wbody": tmp_path / "connected_wbody.tif",
+        "imperv": tmp_path / "imperv.tif",
+    })
+
+    produced = dprst.build(
+        {"outputs": {"dprst": "dprst_binary.tif", "onstream": "onstream_binary.tif"}},
+        ctx, logging.getLogger("test"),
+    )
+
+    with rasterio.open(produced["dprst"]) as src:
+        dprst_arr = src.read(1)
+    with rasterio.open(produced["onstream"]) as src:
+        onstream_arr = src.read(1)
+
+    # Region 2 (isolated) is kept as depression storage; region 1 (connected) is not.
+    assert dprst_arr[9, 9] == 1
+    assert dprst_arr[0, 0] != 1
+    # Region 1 lands in on-stream storage; region 2 does not.
+    assert onstream_arr[0, 0] == 1
+    assert onstream_arr[9, 9] != 1

--- a/tests/test_download_nhd_flowlines.py
+++ b/tests/test_download_nhd_flowlines.py
@@ -1,6 +1,7 @@
 """Unit tests for the NHD flowline -> connected-waterbody-COMID distillation."""
 
 import pandas as pd
+import pytest
 
 from gfv2_params.download.nhd_flowlines import (
     connected_comids_from_flowlines,
@@ -24,6 +25,22 @@ def test_connected_comids_distinct_nonzero():
 def test_connected_comids_empty_when_all_zero():
     df = pd.DataFrame({"WBAREACOMI": [0, 0, 0]})
     assert connected_comids_from_flowlines(df) == set()
+
+
+def test_connected_comids_numeric_strings_ok():
+    # NHD shapefiles can deliver WBAREACOMI as a string field; numeric strings
+    # must still parse so a VPU isn't silently dropped to the empty set.
+    df = pd.DataFrame({"WBAREACOMI": ["100", "0", "200"]})
+    assert connected_comids_from_flowlines(df) == {100, 200}
+
+
+def test_connected_comids_raises_on_coercion_loss():
+    # A populated-but-unparseable WBAREACOMI (column-format drift) would coerce
+    # to NaN and silently contribute zero connected COMIDs for that VPU. That is
+    # the catastrophic silent-failure path, so it must fail loud.
+    df = pd.DataFrame({"WBAREACOMI": ["100", "bogus", "200"]})
+    with pytest.raises(ValueError, match="failed numeric parse"):
+        connected_comids_from_flowlines(df)
 
 
 def test_write_connected_comids_roundtrip(tmp_path):

--- a/tests/test_download_nhd_flowlines.py
+++ b/tests/test_download_nhd_flowlines.py
@@ -4,9 +4,20 @@ import pandas as pd
 import pytest
 
 from gfv2_params.download.nhd_flowlines import (
+    _base_url,
     connected_comids_from_flowlines,
     write_connected_comids,
 )
+
+
+def test_base_url_nested_vs_flat():
+    # VPUs whose code contains a "nested" drainage code get the extra
+    # /NHDPlus{vpu} path segment; others sit directly under /NHDPlus{dd}.
+    root = "https://dmap-data-commons-ow.s3.amazonaws.com/NHDPlusV21/Data"
+    assert _base_url("MS", "05") == f"{root}/NHDPlusMS/NHDPlus05"   # nested
+    assert _base_url("SA", "03N") == f"{root}/NHDPlusSA/NHDPlus03N"  # nested
+    assert _base_url("NE", "01") == f"{root}/NHDPlusNE"             # flat
+    assert _base_url("GL", "04") == f"{root}/NHDPlusGL"             # flat
 
 
 def test_connected_comids_distinct_nonzero():

--- a/tests/test_download_nhd_flowlines.py
+++ b/tests/test_download_nhd_flowlines.py
@@ -2,7 +2,10 @@
 
 import pandas as pd
 
-from gfv2_params.download.nhd_flowlines import connected_comids_from_flowlines
+from gfv2_params.download.nhd_flowlines import (
+    connected_comids_from_flowlines,
+    write_connected_comids,
+)
 
 
 def test_connected_comids_distinct_nonzero():
@@ -21,3 +24,14 @@ def test_connected_comids_distinct_nonzero():
 def test_connected_comids_empty_when_all_zero():
     df = pd.DataFrame({"WBAREACOMI": [0, 0, 0]})
     assert connected_comids_from_flowlines(df) == set()
+
+
+def test_write_connected_comids_roundtrip(tmp_path):
+    out = tmp_path / "nested" / "connected_waterbody_comids.parquet"
+    write_connected_comids({300, 100, 200}, out)
+
+    assert out.exists()
+    got = pd.read_parquet(out)
+    assert list(got.columns) == ["comid"]
+    assert got["comid"].tolist() == [100, 200, 300]  # sorted ascending
+    assert str(got["comid"].dtype) in ("int64", "Int64")

--- a/tests/test_download_nhd_flowlines.py
+++ b/tests/test_download_nhd_flowlines.py
@@ -1,0 +1,23 @@
+"""Unit tests for the NHD flowline -> connected-waterbody-COMID distillation."""
+
+import pandas as pd
+
+from gfv2_params.download.nhd_flowlines import connected_comids_from_flowlines
+
+
+def test_connected_comids_distinct_nonzero():
+    df = pd.DataFrame(
+        {
+            "COMID": [1, 2, 3, 4, 5],
+            "FTYPE": ["ArtificialPath", "ArtificialPath", "StreamRiver",
+                      "ArtificialPath", "ArtificialPath"],
+            # 0 = not through a waterbody; duplicates collapse; None excluded.
+            "WBAREACOMI": [100, 100, 0, 200, None],
+        }
+    )
+    assert connected_comids_from_flowlines(df) == {100, 200}
+
+
+def test_connected_comids_empty_when_all_zero():
+    df = pd.DataFrame({"WBAREACOMI": [0, 0, 0]})
+    assert connected_comids_from_flowlines(df) == set()

--- a/tests/test_wbody_connectivity.py
+++ b/tests/test_wbody_connectivity.py
@@ -1,7 +1,13 @@
 """Tests for WBAREACOMI-driven waterbody connectivity (helper + builder)."""
 
+import logging
+from pathlib import Path
+
 import geopandas as gpd
+import numpy as np
 import pandas as pd
+import rasterio
+from rasterio.transform import from_origin
 from shapely.geometry import Polygon
 
 from gfv2_params.depstor import load_connected_comids, select_connected_waterbodies
@@ -35,3 +41,87 @@ def test_load_connected_comids(tmp_path):
     p = tmp_path / "c.parquet"
     pd.DataFrame({"comid": [5, 7, 9]}).to_parquet(p, index=False)
     assert load_connected_comids(p) == {5, 7, 9}
+
+
+# ---------------------------------------------------------------------------
+# Builder tests
+# ---------------------------------------------------------------------------
+
+
+def _write_template(path: Path, n: int = 10) -> None:
+    transform = from_origin(0, n * 30, 30, 30)
+    with rasterio.open(
+        path, "w", driver="GTiff", height=n, width=n, count=1, dtype="float32",
+        crs="EPSG:5070", transform=transform, nodata=-9999.0,
+    ) as dst:
+        dst.write(np.full((n, n), 100.0, dtype=np.float32), 1)
+
+
+def _write_landmask(path: Path, n: int = 10) -> None:
+    transform = from_origin(0, n * 30, 30, 30)
+    with rasterio.open(
+        path, "w", driver="GTiff", height=n, width=n, count=1, dtype="uint8",
+        crs="EPSG:5070", transform=transform, nodata=255,
+    ) as dst:
+        dst.write(np.ones((n, n), dtype=np.uint8), 1)  # all land
+
+
+def test_wbody_connectivity_rasterizes_only_connected(tmp_path):
+    from shapely.geometry import box
+
+    from gfv2_params.depstor_builders import wbody_connectivity
+    from gfv2_params.depstor_builders.context import BuildContext
+
+    template = tmp_path / "template.tif"
+    landmask = tmp_path / "land_mask.tif"
+    wb_gpkg = tmp_path / "wb.gpkg"
+    table = tmp_path / "connected.parquet"
+    _write_template(template)
+    _write_landmask(landmask)
+
+    # Connected polygon (COMID 10) at top-left; disconnected (COMID 20) bottom-right.
+    gdf = gpd.GeoDataFrame(
+        {"COMID": [10, 20], "member_comid": ["10", "20"]},
+        geometry=[box(0, 270, 60, 300), box(240, 0, 300, 30)],
+        crs="EPSG:5070",
+    )
+    gdf.to_file(wb_gpkg, layer="waterbodies", driver="GPKG")
+    pd.DataFrame({"comid": [10]}).to_parquet(table, index=False)
+
+    ctx = BuildContext(
+        fabric="t", template_path=template, output_dir=tmp_path,
+        hru_gpkg=wb_gpkg, hru_layer="waterbodies",
+        waterbody_gpkg=wb_gpkg, waterbody_layer="waterbodies",
+        connected_comids_table=table,
+    )
+    ctx.paths["landmask"] = landmask
+
+    produced = wbody_connectivity.build(
+        {"output": "connected_wbody.tif"}, ctx, logging.getLogger("test")
+    )
+
+    out = produced["connected_wbody"]
+    with rasterio.open(out) as src:
+        arr = src.read(1)
+        assert src.nodata == 255
+    assert arr[0, 0] == 1     # connected polygon burned
+    assert arr[9, 9] != 1     # disconnected polygon NOT burned
+    assert int((arr == 1).sum()) > 0
+
+
+def test_wbody_connectivity_requires_table(tmp_path):
+    import pytest
+
+    from gfv2_params.depstor_builders import wbody_connectivity
+    from gfv2_params.depstor_builders.context import BuildContext
+
+    template = tmp_path / "template.tif"
+    _write_template(template)
+    ctx = BuildContext(
+        fabric="t", template_path=template, output_dir=tmp_path,
+        hru_gpkg=tmp_path / "x.gpkg", hru_layer="waterbodies",
+        waterbody_gpkg=tmp_path / "x.gpkg", waterbody_layer="waterbodies",
+        connected_comids_table=None,
+    )
+    with pytest.raises(KeyError):
+        wbody_connectivity.build({"output": "connected_wbody.tif"}, ctx, logging.getLogger("test"))

--- a/tests/test_wbody_connectivity.py
+++ b/tests/test_wbody_connectivity.py
@@ -125,3 +125,87 @@ def test_wbody_connectivity_requires_table(tmp_path):
     )
     with pytest.raises(KeyError):
         wbody_connectivity.build({"output": "connected_wbody.tif"}, ctx, logging.getLogger("test"))
+
+
+def test_wbody_connectivity_zero_match_raises(tmp_path):
+    """Zero waterbodies matched would misclassify everything as dprst -> fail loud."""
+    import pytest
+    from shapely.geometry import box
+
+    from gfv2_params.depstor_builders import wbody_connectivity
+    from gfv2_params.depstor_builders.context import BuildContext
+
+    template = tmp_path / "template.tif"
+    landmask = tmp_path / "land_mask.tif"
+    wb_gpkg = tmp_path / "wb.gpkg"
+    table = tmp_path / "connected.parquet"
+    _write_template(template)
+    _write_landmask(landmask)
+
+    gpd.GeoDataFrame(
+        {"COMID": [10, 20], "member_comid": ["10", "20"]},
+        geometry=[box(0, 270, 60, 300), box(240, 0, 300, 30)],
+        crs="EPSG:5070",
+    ).to_file(wb_gpkg, layer="waterbodies", driver="GPKG")
+    # Connected set shares no COMID with the waterbodies -> 0 matches.
+    pd.DataFrame({"comid": [999]}).to_parquet(table, index=False)
+
+    ctx = BuildContext(
+        fabric="t", template_path=template, output_dir=tmp_path,
+        hru_gpkg=wb_gpkg, hru_layer="waterbodies",
+        waterbody_gpkg=wb_gpkg, waterbody_layer="waterbodies",
+        connected_comids_table=table,
+    )
+    ctx.paths["landmask"] = landmask
+
+    with pytest.raises(ValueError, match="matched 0 of"):
+        wbody_connectivity.build({"output": "connected_wbody.tif"}, ctx, logging.getLogger("test"))
+
+
+def test_wbody_connectivity_drops_non_land_cells(tmp_path):
+    """A connected polygon over a non-land cell must still be masked to nodata."""
+    from shapely.geometry import box
+
+    from gfv2_params.depstor_builders import wbody_connectivity
+    from gfv2_params.depstor_builders.context import BuildContext
+
+    template = tmp_path / "template.tif"
+    landmask = tmp_path / "land_mask.tif"
+    wb_gpkg = tmp_path / "wb.gpkg"
+    table = tmp_path / "connected.parquet"
+    _write_template(template)
+
+    # Land mask: all land EXCEPT the top-left cell [0, 0] (ocean), which the
+    # connected polygon below covers. Land=1, off-land=255 (nodata).
+    transform = from_origin(0, 10 * 30, 30, 30)
+    mask = np.ones((10, 10), dtype=np.uint8)
+    mask[0, 0] = 255
+    with rasterio.open(
+        landmask, "w", driver="GTiff", height=10, width=10, count=1, dtype="uint8",
+        crs="EPSG:5070", transform=transform, nodata=255,
+    ) as dst:
+        dst.write(mask, 1)
+
+    # Connected polygon covers the top-left 2x2 block (cells [0,0],[0,1],[1,0],[1,1]).
+    gpd.GeoDataFrame(
+        {"COMID": [10], "member_comid": ["10"]},
+        geometry=[box(0, 240, 60, 300)],
+        crs="EPSG:5070",
+    ).to_file(wb_gpkg, layer="waterbodies", driver="GPKG")
+    pd.DataFrame({"comid": [10]}).to_parquet(table, index=False)
+
+    ctx = BuildContext(
+        fabric="t", template_path=template, output_dir=tmp_path,
+        hru_gpkg=wb_gpkg, hru_layer="waterbodies",
+        waterbody_gpkg=wb_gpkg, waterbody_layer="waterbodies",
+        connected_comids_table=table,
+    )
+    ctx.paths["landmask"] = landmask
+
+    produced = wbody_connectivity.build(
+        {"output": "connected_wbody.tif"}, ctx, logging.getLogger("test")
+    )
+    with rasterio.open(produced["connected_wbody"]) as src:
+        arr = src.read(1)
+    assert arr[0, 0] == 255   # ocean cell dropped despite connected polygon
+    assert arr[0, 1] == 1     # adjacent land cell under the polygon still burned

--- a/tests/test_wbody_connectivity.py
+++ b/tests/test_wbody_connectivity.py
@@ -43,6 +43,20 @@ def test_load_connected_comids(tmp_path):
     assert load_connected_comids(p) == {5, 7, 9}
 
 
+def test_select_connected_missing_join_columns_raises():
+    import pytest
+
+    # A waterbody layer without COMID/member_comid can't be joined; the error
+    # must name the missing column rather than surface a bare pandas KeyError.
+    gdf = gpd.GeoDataFrame(
+        {"GNIS_NAME": ["a"]},
+        geometry=[Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])],
+        crs="EPSG:5070",
+    )
+    with pytest.raises(KeyError, match="member_comid"):
+        select_connected_waterbodies(gdf, {1})
+
+
 # ---------------------------------------------------------------------------
 # Builder tests
 # ---------------------------------------------------------------------------

--- a/tests/test_wbody_connectivity.py
+++ b/tests/test_wbody_connectivity.py
@@ -1,0 +1,37 @@
+"""Tests for WBAREACOMI-driven waterbody connectivity (helper + builder)."""
+
+import geopandas as gpd
+import pandas as pd
+from shapely.geometry import Polygon
+
+from gfv2_params.depstor import load_connected_comids, select_connected_waterbodies
+
+
+def _wb_gdf():
+    geoms = [Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])] * 4
+    return gpd.GeoDataFrame(
+        {
+            "COMID": [10, 20, 30, 40],
+            # row 3 is a multipart case: COMID 30 not connected, but its
+            # member_comid 999 is.
+            "member_comid": ["10", "20", "999", "40"],
+        },
+        geometry=geoms,
+        crs="EPSG:5070",
+    )
+
+
+def test_select_connected_by_comid_or_member():
+    out = select_connected_waterbodies(_wb_gdf(), {10, 999})
+    assert sorted(out["COMID"].tolist()) == [10, 30]  # 10 by COMID, 30 by member
+
+
+def test_select_connected_empty_set():
+    out = select_connected_waterbodies(_wb_gdf(), set())
+    assert len(out) == 0
+
+
+def test_load_connected_comids(tmp_path):
+    p = tmp_path / "c.parquet"
+    pd.DataFrame({"comid": [5, 7, 9]}).to_parquet(p, index=False)
+    assert load_connected_comids(p) == {5, 7, 9}


### PR DESCRIPTION
Closes #138.

## What

Replaces the depstor pipeline's 60 m stream-buffer waterbody-connectivity heuristic with NHD's authoritative `WBAREACOMI` artificial-path topology.

- **`download/nhd_flowlines.py`** (+ `slurm_batch/download_nhd_flowlines.batch`): downloads per-VPU NHDPlusV2 NHDSnapshot flowline attributes and distills the distinct non-zero `WBAREACOMI` values into `input/nhd/connected_waterbody_comids.parquet` (the set of waterbodies an NHD artificial path flows through = on-stream).
- **`depstor.py` helpers**: `load_connected_comids` + `select_connected_waterbodies` (join on `COMID`/`member_comid`).
- **New `wbody_connectivity` builder** → `connected_wbody.tif` (connected waterbody polygons, rasterized + land-masked).
- **`dprst.py`** now consumes `connected_wbody` instead of `stream_buffer`; the impervious branch and region/clump algebra are byte-for-byte unchanged.
- **`streambuffer` step retired** (removed from STEP_ORDER/BUILDERS/config; module kept on disk as reference).
- Docs, `viz.py`, and `init_data_root`/profile comments updated.

## Why

The 60 m buffer was uncalibrated, a single overlapping pixel flipped an entire waterbody, and proximity ≠ connectivity. Our fabric `nsegment` layer is a subset/re-discretization of NHD, so it can't be reliably reconciled to NHD reaches. `WBAREACOMI` decides connectivity in NHD's own COMID space, so fabric segments play no role — and **no longer feed any depstor step**.

## Decisions (locked in design)

Medium-res NHDPlusV2 (matches our waterbody COMID namespace) · full-NHD connectivity scope · integration option A (drop-in mask; pure-attribute split deferred to a possible follow-up).

## Verification

- Per-builder unit tests added and run individually/serially (head-node pytest rule): `test_download_nhd_flowlines.py` (3), `test_wbody_connectivity.py` (5). Full suite runs in CI.
- `pre-commit` clean on all changed files (isort/ruff/yamllint/prettier).
- Multi-agent task reviews per commit + a final whole-branch review (verdict: ready to merge; DAG consistency, cross-task name/type seams, fail-fast guards, dprst behavior-preservation, and CONUS-scale memory all verified).

## Not yet done (follow-ups, see issue/spec)

- `download_nhd_flowlines.batch` has **not been run**, so `connected_waterbody_comids.parquet` is not staged yet — needed before a real depstor run. Confirm the exact NHDSnapshot S3 archive name against a live listing on first run.
- Validation: diff new `dprst_frac`/`onstream_storage_frac` vs. the old buffer-based outputs (bucketed by FTYPE) once staged.
- `gfv2_vpu01` lacks a COMID column, so the full depstor stack now fail-fasts there; validation uses the `gfv2` profile.

Design: `docs/superpowers/specs/2026-06-23-nhd-wbareacomi-connectivity-design.md`
Plan: `docs/superpowers/plans/2026-06-23-nhd-wbareacomi-connectivity.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)