### PR TITLE
fix(nhd): make download_nhd_flowlines robust to real NHD quirks (field casing + snapshot versions)

### DIFF
--- a/src/gfv2_params/download/nhd_flowlines.py
+++ b/src/gfv2_params/download/nhd_flowlines.py
@@ -66,14 +66,30 @@ def write_connected_comids(comids: set[int], out_path: Path) -> None:
 def read_flowline_attrs(flowline_path: Path) -> pd.DataFrame:
     """Read COMID/WBAREACOMI from an NHDFlowline source (no geometry).
 
+    NHD field-name casing is inconsistent across VPU snapshots (e.g. VPU 12
+    ships COMID/WBAREACOMI, VPU 13 ships ComID/WBAreaComI), so the columns are
+    resolved case-insensitively and normalised to canonical upper-case names.
+    Requesting the exact upper-case names would make pyogrio silently drop the
+    mismatched-case column, leaving the connectivity distiller to KeyError.
+
     Connectivity is keyed purely off non-zero WBAREACOMI (which NHD populates
     only on artificial paths), so FTYPE is not read.
     """
-    return pyogrio.read_dataframe(
-        flowline_path,
-        columns=["COMID", "WBAREACOMI"],
-        read_geometry=False,
+    available = list(pyogrio.read_info(flowline_path)["fields"])
+    by_upper = {name.upper(): name for name in available}
+    rename = {}
+    for canon in ("COMID", "WBAREACOMI"):
+        actual = by_upper.get(canon)
+        if actual is None:
+            raise KeyError(
+                f"{flowline_path}: NHDFlowline has no '{canon}' field "
+                f"(case-insensitive). Available fields: {available}"
+            )
+        rename[actual] = canon
+    df = pyogrio.read_dataframe(
+        flowline_path, columns=list(rename), read_geometry=False
     )
+    return df.rename(columns=rename)
 
 
 def _base_url(dd: str, vpu: str) -> str:

--- a/src/gfv2_params/download/nhd_flowlines.py
+++ b/src/gfv2_params/download/nhd_flowlines.py
@@ -10,6 +10,8 @@ writes a flat parquet of connected COMIDs consumed by the depstor
 
 from __future__ import annotations
 
+import re
+import xml.etree.ElementTree as ET
 from pathlib import Path
 
 import pandas as pd
@@ -33,7 +35,8 @@ vpu_index = {
     "13": "RG", "14": "CO", "15": "CO", "16": "GB", "17": "PN", "18": "CA",
 }
 
-_VERSION_CANDIDATES = ["05", "04", "03", "02", "01"]
+_S3_HOST = "https://dmap-data-commons-ow.s3.amazonaws.com"
+_S3_NS = "{http://s3.amazonaws.com/doc/2006-03-01/}"
 
 
 def connected_comids_from_flowlines(df: pd.DataFrame) -> set[int]:
@@ -95,32 +98,45 @@ def read_flowline_attrs(flowline_path: Path) -> pd.DataFrame:
 def _base_url(dd: str, vpu: str) -> str:
     nested = {"03", "10", "05", "06", "07", "08", "11", "14", "15"}
     if any(code in vpu for code in nested):
-        return f"https://dmap-data-commons-ow.s3.amazonaws.com/NHDPlusV21/Data/NHDPlus{dd}/NHDPlus{vpu}"
-    return f"https://dmap-data-commons-ow.s3.amazonaws.com/NHDPlusV21/Data/NHDPlus{dd}"
+        return f"{_S3_HOST}/NHDPlusV21/Data/NHDPlus{dd}/NHDPlus{vpu}"
+    return f"{_S3_HOST}/NHDPlusV21/Data/NHDPlus{dd}"
+
+
+def _pick_snapshot_key(keys: list[str], vpu: str) -> str | None:
+    """Highest-version NHDSnapshot (non-FGDB) S3 key for a VPU, or None.
+
+    NHDSnapshot version numbers are not uniform across VPUs (observed 04-09), so
+    the version is discovered from the bucket listing rather than probed from a
+    hardcoded list. The `NHDSnapshot_<digits>` shape excludes the parallel
+    `NHDSnapshotFGDB` archive and other components.
+    """
+    pat = re.compile(rf"_{re.escape(vpu)}_NHDSnapshot_(\d+)\.7z$")
+    matches = sorted((m.group(1), k) for k in keys for m in [pat.search(k)] if m)
+    return matches[-1][1] if matches else None
+
+
+def _snapshot_url(dd: str, vpu: str) -> str | None:
+    """Discover the NHDSnapshot archive URL for a VPU via the S3 listing."""
+    prefix = _base_url(dd, vpu).split(".amazonaws.com/", 1)[1]
+    r = requests.get(f"{_S3_HOST}/?list-type=2&prefix={prefix}/", timeout=60)
+    r.raise_for_status()
+    keys = [e.text for e in ET.fromstring(r.text).iter(f"{_S3_NS}Key")]
+    key = _pick_snapshot_key(keys, vpu)
+    return f"{_S3_HOST}/{key}" if key else None
 
 
 def download_snapshot(dd: str, vpu: str, download_dir: Path, extract_dir: Path) -> Path | None:
     """Download + extract a VPU's NHDSnapshot; return the NHDFlowline.shp path."""
-    base_url = _base_url(dd, vpu)
-    local_path = None
-    for version in _VERSION_CANDIDATES:
-        filename = f"NHDPlusV21_{dd}_{vpu}_NHDSnapshot_{version}.7z"
-        candidate = download_dir / filename
-        url = f"{base_url}/{filename}"
-        if candidate.exists():
-            local_path = candidate
-            break
-        logger.info(f"Checking: {url}")
-        status = requests.head(url, timeout=60, allow_redirects=True).status_code
-        if status != 200:
-            # Distinguish "archive absent" (404) from a transient/redirect issue
-            # that a GET might still satisfy — the latter shouldn't be read as
-            # "this version doesn't exist" without a trace.
-            if status != 404:
-                logger.warning(
-                    "HEAD %s returned %d (not 200/404) — treating as absent", url, status
-                )
-            continue
+    url = _snapshot_url(dd, vpu)
+    if url is None:
+        logger.error(f"NHDSnapshot not found in S3 listing for VPU {vpu}")
+        return None
+    filename = url.rsplit("/", 1)[1]
+    candidate = download_dir / filename
+
+    if candidate.exists():
+        logger.info(f"Already downloaded: {filename}")
+    else:
         logger.info(f"Downloading {filename} ...")
         # Download to a .part sidecar and atomically rename only after a
         # size-verified, complete write, so an interrupted download (node
@@ -138,16 +154,10 @@ def download_snapshot(dd: str, vpu: str, download_dir: Path, extract_dir: Path) 
             tmp.unlink(missing_ok=True)
             raise OSError(f"{filename}: downloaded {got} bytes, expected {expected}")
         tmp.rename(candidate)
-        local_path = candidate
-        break
-
-    if local_path is None:
-        logger.error(f"NHDSnapshot not found for VPU {vpu}")
-        return None
 
     out_dir = extract_dir / vpu / "NHDSnapshot"
     out_dir.mkdir(parents=True, exist_ok=True)
-    with py7zr.SevenZipFile(local_path, mode="r") as archive:
+    with py7zr.SevenZipFile(candidate, mode="r") as archive:
         archive.extractall(path=out_dir)
 
     shps = list(out_dir.glob("**/NHDFlowline.shp"))

--- a/tests/test_download_nhd_flowlines.py
+++ b/tests/test_download_nhd_flowlines.py
@@ -5,10 +5,30 @@ import pytest
 
 from gfv2_params.download.nhd_flowlines import (
     _base_url,
+    _pick_snapshot_key,
     connected_comids_from_flowlines,
     read_flowline_attrs,
     write_connected_comids,
 )
+
+
+def test_pick_snapshot_key_highest_version_excludes_fgdb():
+    # NHD snapshot version numbers vary per VPU (observed 04-09); pick the
+    # highest NHDSnapshot_<NN>.7z and never the parallel NHDSnapshotFGDB archive
+    # or other components.
+    pre = "NHDPlusV21/Data/NHDPlusMS/NHDPlus11/NHDPlusV21_MS_11_"
+    keys = [
+        f"{pre}NHDSnapshotFGDB_06.7z",   # FGDB variant — must be ignored
+        f"{pre}NHDSnapshot_05.7z",
+        f"{pre}NHDSnapshot_06.7z",       # highest non-FGDB -> winner
+        f"{pre}FdrFac_01.7z",            # other component — must be ignored
+    ]
+    assert _pick_snapshot_key(keys, "11") == f"{pre}NHDSnapshot_06.7z"
+
+
+def test_pick_snapshot_key_none_when_absent():
+    assert _pick_snapshot_key([], "11") is None
+    assert _pick_snapshot_key(["x/NHDPlusV21_MS_10L_NHDSnapshot_06.7z"], "11") is None
 
 
 def test_read_flowline_attrs_normalises_nhd_field_casing(tmp_path):

--- a/tests/test_download_nhd_flowlines.py
+++ b/tests/test_download_nhd_flowlines.py
@@ -6,8 +6,30 @@ import pytest
 from gfv2_params.download.nhd_flowlines import (
     _base_url,
     connected_comids_from_flowlines,
+    read_flowline_attrs,
     write_connected_comids,
 )
+
+
+def test_read_flowline_attrs_normalises_nhd_field_casing(tmp_path):
+    import geopandas as gpd
+    from shapely.geometry import LineString
+
+    # NHD field-name casing varies across VPU snapshots: VPU 12 ships
+    # COMID/WBAREACOMI, VPU 13 ships ComID/WBAreaComI. read_flowline_attrs must
+    # resolve them case-insensitively and normalise to canonical names so the
+    # per-VPU loop doesn't crash on the lower-cased VPUs.
+    gdf = gpd.GeoDataFrame(
+        {"ComID": [1, 2], "WBAreaComI": [100, 0]},
+        geometry=[LineString([(0, 0), (1, 1)]), LineString([(1, 1), (2, 2)])],
+        crs="EPSG:4269",
+    )
+    src = tmp_path / "NHDFlowline.gpkg"
+    gdf.to_file(src, driver="GPKG")
+
+    df = read_flowline_attrs(src)
+    assert set(df.columns) == {"COMID", "WBAREACOMI"}
+    assert connected_comids_from_flowlines(df) == {100}
 
 
 def test_base_url_nested_vs_flat():


### PR DESCRIPTION
## Problem

A CONUS `download_nhd_flowlines` run (job 202157) failed on **two** independent NHD inconsistencies. This PR fixes both.

### 1. Field-name casing varies per VPU
The run crashed at **VPU 13 (Rio Grande)** with `KeyError: 'WBAREACOMI'`:

| VPU | COMID field | WBAREACOMI field |
|-----|-------------|------------------|
| 12 (TX) | `COMID` | `WBAREACOMI` |
| 13 (RG) | `ComID` | `WBAreaComI` |

`read_flowline_attrs` requested the exact upper-case names; pyogrio silently dropped the mismatched column and the distiller `KeyError`'d. **Fix:** resolve `COMID`/`WBAREACOMI` case-insensitively, normalise to canonical names, and raise a clear field-listing error if either is truly absent.

### 2. Snapshot version numbers are not uniform
The same run logged `NHDSnapshot not found for VPU 11`. Investigation showed the hardcoded `_VERSION_CANDIDATES = [05..01]` misses **13 of 21 VPUs** — snapshot versions actually span **04–09** (VPU 11 is at 06, VPU 06 at 09). Those VPUs were silently logged 'not found' and collected into the fail-loud failures list, so a CONUS run could never complete. **Fix:** `download_snapshot` now lists the S3 bucket prefix and selects the highest-version `NHDSnapshot_<NN>.7z` (excluding the parallel `NHDSnapshotFGDB`), removing the version guesswork and the HEAD-probe loop.

## Verification

- Unit tests: case-insensitive `read_flowline_attrs` (GPKG with `ComID`/`WBAreaComI`); `_pick_snapshot_key` highest-version/FGDB-exclusion. 9 passed in `tests/test_download_nhd_flowlines.py`.
- Real data: **VPU 13 → 1668 connected COMIDs** (was a crash); **VPU 12 → 6540, unchanged**.
- Real S3: **all 21 VPUs resolve** to an actual archive via the listing (versions 04–09).

🤖 Generated with [Claude Code](https://claude.com/claude-code)