### PR TITLE
fix(depstor): carve impervious out of dprst per-cell (not whole-region)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,17 @@ These are hard-won; violating them silently corrupts outputs.
 - **Land masking.** Every depstor raster is masked against `land_mask.tif` (HRU
   fabric rasterised by the `landmask` step). Never use hydro-DEM nodata or FDR
   as a land mask.
+- **Impervious is carved from dprst per-cell, never whole-region.** A waterbody
+  clump is depression storage unless it is *on-stream* (touches the NHD-connected
+  mask); impervious cells are masked out of `dprst` cell-by-cell in
+  `depstor_builders/dprst.py` (restoring the ArcPy `getDprst` "outside of
+  impervious zones" behavior). Do NOT restore an imperv `regions_touching_mask`
+  exclusion — one impervious pixel would then drop a whole multi-km² waterbody
+  (a regression that falsely excluded ~16,800 km² CONUS-wide). The
+  imperv/dprst/perv cell partition must stay disjoint (no double-count). The
+  `imperv` 50% threshold (`VALUE > 50`) is a land-classification lever (which
+  NLCD cells are impervious), decoupled from dprst exclusion by the per-cell
+  carve — it is **not** a knob for limiting over-exclusion.
 - **WhiteboxTools cannot read LZW + `predictor=2` GeoTIFFs** — it silently
   corrupts them. Never pass `predictor=2` rasters to WBT subprocesses.
 - **CONUS-scale memory: stream/window, never hold a full-grid array.** The CONUS

--- a/docs/superpowers/plans/2026-06-25-dprst-imperv-percell-carveout.md
+++ b/docs/superpowers/plans/2026-06-25-dprst-imperv-percell-carveout.md
@@ -203,10 +203,14 @@ In `CLAUDE.md`, under the depstor "Non-obvious conventions & gotchas" section, a
 - **Impervious is carved from dprst per-cell, never whole-region.** A waterbody
   clump is depression storage unless it is *on-stream* (touches the NHD-connected
   mask); impervious cells are masked out of `dprst` cell-by-cell in
-  `depstor_builders/dprst.py`. Do NOT restore an imperv `regions_touching_mask`
+  `depstor_builders/dprst.py` (restoring the ArcPy `getDprst` "outside of
+  impervious zones" behavior). Do NOT restore an imperv `regions_touching_mask`
   exclusion — one impervious pixel would then drop a whole multi-km² waterbody
   (a regression that falsely excluded ~16,800 km² CONUS-wide). The
-  imperv/dprst/perv cell partition must stay disjoint (no double-count).
+  imperv/dprst/perv cell partition must stay disjoint (no double-count). The
+  `imperv` 50% threshold (`VALUE > 50`) is a land-classification lever (which
+  NLCD cells are impervious), decoupled from dprst exclusion by the per-cell
+  carve — it is **not** a knob for limiting over-exclusion.
 ```
 
 - [ ] **Step 2: Note the rebuild cascade in HPC_REFERENCE.md**

--- a/docs/superpowers/plans/2026-06-25-dprst-imperv-percell-carveout.md
+++ b/docs/superpowers/plans/2026-06-25-dprst-imperv-percell-carveout.md
@@ -1,0 +1,315 @@
+# dprst per-cell impervious carve-out — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop a single impervious pixel from removing a whole waterbody clump from depression storage; carve impervious cells out of `dprst` per-cell instead.
+
+**Architecture:** In `dprst.py`'s `build()`, impervious is removed from the region-level exclusion set (connectivity stays the only region-level exclusion) and instead masked out of `dprst_binary` cell-by-cell. `onstream` gains an impervious guard so carved cells aren't reclassified as on-stream. The `imperv`/`dprst`/`perv` cell partition stays disjoint, satisfying the double-counting intent.
+
+**Tech Stack:** Python, NumPy, rasterio; pixi-managed env; pytest. Builder lives in `src/gfv2_params/depstor_builders/dprst.py`.
+
+**Spec:** `docs/superpowers/specs/2026-06-25-dprst-imperv-percell-carveout-design.md`
+
+## Global Constraints
+
+- Environment is **pixi**. Run tests with `pixi run -e dev pytest ...`. **Do NOT run pytest on the HPC head node** — CI (`.github/workflows/ci.yml`) is the authoritative test gate; `py_compile`/import checks are fine locally.
+- **Builder + test together** — a builder change ships with its test in the same commit.
+- **Atomic commits** — one logical change per commit.
+- **Run `pixi run -e dev pre-commit run --all-files` before pushing.**
+- Memory ceiling unchanged: `dprst` remains a full-grid step (~384 GB peak, run at `--mem=384G`). This change adds no new full-grid array — `imperv_binary` is already read by the builder.
+
+---
+
+### Task 1: Per-cell impervious carve-out in `dprst` (code + test)
+
+**Files:**
+- Modify: `src/gfv2_params/depstor_builders/dprst.py` (module docstring; `build()` lines ~1, 46-68)
+- Test: `tests/test_build_depstor_dprst.py` (add one test; existing test unchanged)
+
+**Interfaces:**
+- Consumes (unchanged helpers from `gfv2_params.depstor`): `RasterInfo`, `read_aligned_uint8(path, info) -> np.ndarray`, `read_land_mask(path) -> np.ndarray[bool]`, `regions_to_binary(regions, keep_ids) -> np.ndarray[uint8]`, `regions_touching_mask(regions, mask) -> set[int]`, `write_uint8_binary(arr, info, path)`.
+- Produces (unchanged): `build(step_cfg, ctx, logger) -> {"dprst": Path, "onstream": Path}`. Output rasters `dprst_binary.tif` and `onstream_binary.tif` are uint8 (1 = present, 255 = nodata). Behavioural change only: a region touching imperv is now kept (minus its impervious cells) rather than wholly excluded.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_build_depstor_dprst.py` (keep the existing test; reuse the module-level `_N`, `_TRANSFORM`, `_write`):
+
+```python
+def test_dprst_carves_imperv_cells_but_keeps_region(tmp_path):
+    template = tmp_path / "template.tif"
+    _write(template, np.full((_N, _N), 100.0), "float32", -9999.0)
+
+    # One isolated waterbody region: rows 0-1, cols 0-3 (8 cells), not connected.
+    regions = np.zeros((_N, _N), dtype=np.int32)
+    regions[0:2, 0:4] = 1
+    _write(tmp_path / "wbody_regions.tif", regions, "int32", 0)
+
+    wbody_binary = np.where(regions > 0, np.uint8(1), np.uint8(255))
+    _write(tmp_path / "wbody_binary.tif", wbody_binary, "uint8", 255)
+
+    # Connected mask touches nothing -> nothing excluded for connectivity.
+    _write(tmp_path / "connected_wbody.tif",
+           np.full((_N, _N), 255, dtype=np.uint8), "uint8", 255)
+
+    # Two impervious cells fall inside the region (e.g. a road across a playa).
+    imperv = np.full((_N, _N), 255, dtype=np.uint8)
+    imperv[0, 0] = 1
+    imperv[0, 1] = 1
+    _write(tmp_path / "imperv.tif", imperv, "uint8", 255)
+    _write(tmp_path / "land_mask.tif", np.ones((_N, _N), dtype=np.uint8), "uint8", 255)
+
+    ctx = BuildContext(
+        fabric="t", template_path=template, output_dir=tmp_path,
+        hru_gpkg=tmp_path / "x.gpkg", hru_layer="nhru",
+    )
+    ctx.paths.update({
+        "landmask": tmp_path / "land_mask.tif",
+        "wbody_binary": tmp_path / "wbody_binary.tif",
+        "wbody_regions": tmp_path / "wbody_regions.tif",
+        "connected_wbody": tmp_path / "connected_wbody.tif",
+        "imperv": tmp_path / "imperv.tif",
+    })
+
+    produced = dprst.build(
+        {"outputs": {"dprst": "dprst_binary.tif", "onstream": "onstream_binary.tif"}},
+        ctx, logging.getLogger("test"),
+    )
+
+    with rasterio.open(produced["dprst"]) as src:
+        dprst_arr = src.read(1)
+    with rasterio.open(produced["onstream"]) as src:
+        onstream_arr = src.read(1)
+
+    # The region is kept as depression storage at its non-impervious cells ...
+    assert dprst_arr[1, 0] == 1
+    assert dprst_arr[1, 3] == 1
+    # ... the two impervious cells are carved out of dprst ...
+    assert dprst_arr[0, 0] != 1
+    assert dprst_arr[0, 1] != 1
+    # ... and are NOT swept into on-stream storage.
+    assert onstream_arr[0, 0] != 1
+    assert onstream_arr[0, 1] != 1
+    # Invariant: dprst and imperv never coincide (no double-count).
+    assert int(((dprst_arr == 1) & (imperv == 1)).sum()) == 0
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pixi run -e dev pytest tests/test_build_depstor_dprst.py::test_dprst_carves_imperv_cells_but_keeps_region -v`
+Expected: **FAIL** — current code excludes the whole region on imperv touch, so `assert dprst_arr[1, 0] == 1` fails (the cell is nodata 255, not 1).
+
+- [ ] **Step 3: Update the module docstring**
+
+In `src/gfv2_params/depstor_builders/dprst.py`, replace line 1:
+
+```python
+"""Combine wbody regions + connected-wbody mask + imperv into dprst + onstream."""
+```
+
+with:
+
+```python
+"""Classify waterbody regions into dprst + onstream.
+
+A waterbody region is depression storage unless it is on-stream (touches the
+NHD-connected mask). Impervious is NOT a region-level exclusion: a single
+impervious cell must not remove a whole clump. Impervious cells are carved out
+of dprst per-cell so imperv/dprst/perv stay a disjoint partition (no cell is
+counted as both impervious and depression storage).
+"""
+```
+
+- [ ] **Step 4: Implement the per-cell carve-out**
+
+In `build()`, replace the block currently at lines 46-68 (from `onstream_regions = ...` through the `onstream = np.where(...)` / `onstream[~land_valid] = 255` lines) with:
+
+```python
+    onstream_regions = regions_touching_mask(regions, connected_binary)
+    excluded = onstream_regions
+    # Impervious is carved per-cell (below), NOT used to exclude whole regions:
+    # a single impervious pixel must not drop an entire waterbody clump from
+    # depression storage. regions_touching_mask is kept only for logging.
+    imperv_regions = regions_touching_mask(regions, imperv_binary)
+    n_total = int(regions.max())
+    logger.info(
+        "  %d total wbody regions; %d touch connected wbody (excluded), "
+        "%d touch imperv (kept; cells carved per-cell)",
+        n_total, len(onstream_regions), len(imperv_regions),
+    )
+
+    all_ids = set(int(v) for v in np.unique(regions) if v != 0)
+    kept_ids = all_ids - excluded
+    dprst_binary = regions_to_binary(regions, kept_ids)
+    n_carved = int(((dprst_binary == 1) & (imperv_binary == 1)).sum())
+    dprst_binary[imperv_binary == 1] = 255  # carve impervious cells (no imperv/dprst double-count)
+    dprst_binary[~land_valid] = 255  # drop off-land (ocean) cells
+    write_uint8_binary(dprst_binary, info, dprst_path)
+    n_dprst = int((dprst_binary == 1).sum())
+    logger.info(
+        "  %d regions kept; %d impervious cells carved; %d cells in dprst (%.4f%% of grid)",
+        len(kept_ids), n_carved, n_dprst, 100 * n_dprst / dprst_binary.size,
+    )
+
+    onstream = np.where(
+        (wbody_binary == 1) & (dprst_binary != 1) & (imperv_binary != 1),
+        np.uint8(1), np.uint8(255),
+    )
+    onstream[~land_valid] = 255  # drop off-land (ocean) cells
+```
+
+(Everything below — `write_uint8_binary(onstream, ...)`, the on-stream log line, and the `return` — is unchanged.)
+
+- [ ] **Step 5: Run both dprst tests to verify they pass**
+
+Run: `pixi run -e dev pytest tests/test_build_depstor_dprst.py -v`
+Expected: **PASS** — both `test_dprst_excludes_connected_region_keeps_isolated` (imperv all-nodata → unchanged) and the new `test_dprst_carves_imperv_cells_but_keeps_region`.
+
+- [ ] **Step 6: Lint**
+
+Run: `pixi run -e dev pre-commit run --files src/gfv2_params/depstor_builders/dprst.py tests/test_build_depstor_dprst.py`
+Expected: PASS (ruff/format clean).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/gfv2_params/depstor_builders/dprst.py tests/test_build_depstor_dprst.py
+git commit -m "fix(depstor): carve impervious out of dprst per-cell, not whole-region
+
+A single impervious pixel was excluding an entire waterbody clump from
+depression storage (~16,800 km2 / 14,898 regions falsely excluded CONUS-wide).
+Impervious is now removed from dprst per-cell; connectivity stays the only
+region-level exclusion. Keeps imperv/dprst/perv a disjoint partition.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Documentation
+
+**Files:**
+- Modify: `CLAUDE.md` (depstor gotchas list)
+- Modify: `slurm_batch/HPC_REFERENCE.md` (DAG-order / cascade note near line 305)
+
+**Interfaces:** none (docs only).
+
+> Note: `docs/depstor_workflow.md` already describes the original ArcPy behavior as "depressions are only areas outside of impervious area" (per-cell) — this change *restores* that intent, so that file needs no edit. `docs/ARCHITECTURE.md` does not describe the imperv-exclusion mechanism, so it needs no edit. Verify both in Step 3 below rather than assuming.
+
+- [ ] **Step 1: Add a CLAUDE.md gotcha**
+
+In `CLAUDE.md`, under the depstor "Non-obvious conventions & gotchas" section, add a bullet adjacent to the **Land masking** bullet:
+
+```markdown
+- **Impervious is carved from dprst per-cell, never whole-region.** A waterbody
+  clump is depression storage unless it is *on-stream* (touches the NHD-connected
+  mask); impervious cells are masked out of `dprst` cell-by-cell in
+  `depstor_builders/dprst.py`. Do NOT restore an imperv `regions_touching_mask`
+  exclusion — one impervious pixel would then drop a whole multi-km² waterbody
+  (a regression that falsely excluded ~16,800 km² CONUS-wide). The
+  imperv/dprst/perv cell partition must stay disjoint (no double-count).
+```
+
+- [ ] **Step 2: Note the rebuild cascade in HPC_REFERENCE.md**
+
+In `slurm_batch/HPC_REFERENCE.md`, immediately after the **DAG order** paragraph (currently ending "... passed through to the Python script." around line 307), add:
+
+```markdown
+**dprst rebuild cascade.** Changing `dprst` membership (e.g. the per-cell
+impervious carve-out) invalidates everything downstream of it in the DAG:
+`perv`, `routing` → `drains_perv`/`drains_imperv`, and `carea_map` (it consumes
+`onstream` + `perv`). Rebuild with `--from dprst` and `FORCE=1`, then re-run the
+depstor zonal + merge for the affected fractions (`dprst_frac`, `perv_frac`,
+`drains_*_frac`, `onstream_storage_frac`, `carea_*`, `sro_to_dprst_*`).
+`waterbody`, `wbody_connectivity`, `vpu_id`, and `landmask` are upstream and
+unaffected.
+```
+
+- [ ] **Step 3: Verify no other doc asserts whole-region imperv exclusion**
+
+Run: `grep -rni "imperv" docs/ARCHITECTURE.md docs/depstor_workflow.md README.md | grep -i "region\|exclud\|touch\|dprst"`
+Expected: no line claims impervious *excludes a whole region/clump*. (`depstor_workflow.md` saying depressions are "outside of impervious area" is per-cell and correct.) If any line does assert whole-region exclusion, fix it to per-cell carve-out wording matching the CLAUDE.md bullet.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md slurm_batch/HPC_REFERENCE.md
+git commit -m "docs(depstor): document per-cell imperv carve-out + dprst rebuild cascade
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Open PR and let CI gate it
+
+**Files:** none (process).
+
+- [ ] **Step 1: Push the branch and open a PR**
+
+```bash
+git push -u origin dprst-imperv-percell-carveout
+gh pr create --title "fix(depstor): carve impervious out of dprst per-cell" \
+  --body "$(cat <<'EOF'
+Replaces the impervious region-level any-touch exclusion in the dprst builder
+with a per-cell carve-out. Previously one >=50%-impervious pixel removed an
+entire waterbody clump from depression storage; a CONUS scan found ~16,800 km2
+across 14,898 regions falsely excluded (89% of that area in >=1 km2 waterbodies;
+3,538 regions flipped by a single pixel). Connectivity stays the only
+region-level exclusion. imperv/dprst/perv remain a disjoint cell partition, so
+the double-counting intent is preserved.
+
+Spec: docs/superpowers/specs/2026-06-25-dprst-imperv-percell-carveout-design.md
+
+Note: this changes dprst membership and so requires a CONUS depstor rebuild
+`--from dprst` (perv, routing, drains_*, carea_map) before the params are
+regenerated — see slurm_batch/HPC_REFERENCE.md.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 2: Confirm CI passes**
+
+Wait for `.github/workflows/ci.yml` (runs `pytest tests/`) to go green on the PR. Do not run the suite on the head node.
+
+---
+
+### Task 4 (operational, run on HPC after merge): CONUS rebuild
+
+**Not a code task — run by the maintainer on the cluster after the PR merges.** Documented here so the cascade isn't missed.
+
+- [ ] **Step 1: Rebuild depstor rasters from `dprst` onward**
+
+From a shell with `~/.pixi/bin` on `PATH`:
+
+```bash
+FABRIC=gfv2 FORCE=1 sbatch --mem=384G slurm_batch/build_depstor_rasters.batch --from dprst
+```
+
+This re-runs `dprst → perv → routing → drains_perv/drains_imperv → carea_map` (per the DAG order in HPC_REFERENCE.md).
+
+- [ ] **Step 2: Regenerate the affected depstor fractions**
+
+Re-run the Stage 4 depstor zonal + merge jobs (per `slurm_batch/RUNME.md` §"Depstor fractions") for the affected fractions: `dprst_frac`, `perv_frac`, `drains_perv_frac`, `drains_imperv_frac`, `onstream_storage_frac`, `carea_t8_frac`, `sro_to_dprst_perv`, `sro_to_dprst_imperv`.
+
+- [ ] **Step 3: Spot-check the recovered features**
+
+Confirm the probe features are now depression storage (sample `gfv2/depstor_rasters/dprst_binary.tif` over their polygons): COMID 24068219 (Playa) and COMID 24152941 (SwampMarsh) should read `dprst==1` at their non-impervious cells; COMID 24079189 (Catlow) stays dprst. Verify `dprst_binary == 1` and `imperv_binary == 1` never coincide.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Core per-cell change (spec §"Detailed change") → Task 1. ✓
+- onstream impervious guard (spec §"Detailed change") → Task 1, Step 4. ✓
+- Disjoint-partition invariant (spec §"Resulting cell partition") → Task 1 test assertion. ✓
+- Downstream/cascade (spec §"Downstream effects") → Task 2 Step 2 + Task 4. ✓
+- Tests (spec §"Testing"): keeps-region, carved cells, not-onstream, dprst∩imperv=∅ → Task 1 test. ✓
+- Docs (spec §"Documentation") → Task 2 (refined: CLAUDE.md + HPC_REFERENCE; ARCHITECTURE/workflow verified rather than blindly edited). ✓
+- Deferred Approach C (spec §"Deferred") → no task, by design. ✓
+
+**Placeholder scan:** none — all steps carry exact code, commands, and expected output.
+
+**Type consistency:** `build(step_cfg, ctx, logger) -> dict` and the `dprst`/`onstream` uint8 (1/255) semantics match the existing builder and test; helper signatures (`regions_to_binary`, `regions_touching_mask`, `read_aligned_uint8`, `write_uint8_binary`) are unchanged and used as in the current file.

--- a/docs/superpowers/specs/2026-06-25-dprst-imperv-percell-carveout-design.md
+++ b/docs/superpowers/specs/2026-06-25-dprst-imperv-percell-carveout-design.md
@@ -1,0 +1,135 @@
+# Design: per-cell impervious carve-out in dprst
+
+**Date:** 2026-06-25
+**Status:** Approved (design), pending implementation plan
+**Component:** `src/gfv2_params/depstor_builders/dprst.py` (depression-storage classification)
+
+## Problem
+
+The `dprst` builder classifies waterbody clumps as depression storage. A clump is
+currently **excluded** from dprst if its region touches **either** the
+NHD-connected (WBAREACOMI) mask **or** the impervious mask, via
+`regions_touching_mask` — a region is flagged if it shares **≥1 cell** with the
+mask ([depstor.py](../../../src/gfv2_params/depstor.py) `regions_touching_mask`;
+[dprst.py:46-48](../../../src/gfv2_params/depstor_builders/dprst.py)).
+
+For the impervious mask this any-touch rule is far too aggressive: a **single**
+≥50%-impervious 30 m pixel (a dirt road across a dry lakebed, an outbuilding, or
+NLCD misclassifying a bright playa/water surface) removes an **entire** multi-km²
+natural waterbody from depression storage.
+
+### Evidence (verified)
+
+Three SE-Oregon (Great Basin) features, sampled from the on-disk
+`gfv2/depstor_rasters` outputs:
+
+| COMID | FTYPE | area | actual label | cause |
+|---|---|---|---|---|
+| 24079189 (Catlow) | Playa | 1.6 km² | **dprst** ✓ | touches no imperv / connected |
+| 24068219 | Playa | 2.54 km² | on-stream | **3 imperv cells of 2813** |
+| 24152941 | SwampMarsh | 3.9 km² | on-stream | **1 imperv cell of 4334** |
+
+### Blast radius (CONUS scan, `scratchpad/blast_radius.py`, streaming row-strips over the int32 regions grid)
+
+- 418,915 waterbody regions / 255,392 km²; current dprst = 268,432 regions / 60,141 km².
+- **Excluded by imperv *only* (touch imperv, not connected): 14,898 regions / 16,800 km² ≈ +28% potential dprst area.**
+- Of that, ≈16,600 km² is false exclusion (regions ≤5% impervious; 9,982 km² at
+  ≤0.1%; 3,538 regions / 3,289 km² flipped by a **single** pixel; 89% of flipped
+  area sits in ≥1 km² waterbodies).
+- Only 3,405 regions / 222 km² are >25% impervious (legitimately impervious-laced).
+
+## Intent and chosen approach
+
+The impervious exclusion exists to **avoid double-counting** the same cells as
+both impervious and depression storage. The pipeline treats `imperv` / `dprst` /
+`perv` as a **disjoint cell-level partition**
+(`perv = land ∧ ¬imperv ∧ ¬dprst`, [perv.py:19-32](../../../src/gfv2_params/depstor_builders/perv.py)).
+
+A region-level **fraction threshold** was considered (exclude a clump only if it
+is >X% impervious) but rejected: for sub-threshold regions it either keeps the
+impervious cells inside dprst — reintroducing the very double-count the rule
+exists to prevent — or it still needs per-cell subtraction, making the threshold
+redundant.
+
+**Chosen: Approach A — per-cell carve-out.** Impervious stops being a
+region-level exclusion and becomes a cell-level removal. A waterbody region is
+depression storage **unless it is on-stream (connectivity)**; impervious cells
+inside it are simply excised. This satisfies the double-counting intent exactly,
+keeps the imperv/dprst/perv partition disjoint, recovers ~16,800 km² of false
+exclusions, and needs no calibrated threshold.
+
+## Detailed change — `dprst.py` `build()`
+
+```python
+# region-level exclusion is connectivity ONLY (imperv removed):
+onstream_regions = regions_touching_mask(regions, connected_binary)
+excluded = onstream_regions
+
+all_ids = set(int(v) for v in np.unique(regions) if v != 0)
+kept_ids = all_ids - excluded
+dprst_binary = regions_to_binary(regions, kept_ids)
+dprst_binary[imperv_binary == 1] = 255   # NEW: carve impervious cells out of dprst
+dprst_binary[~land_valid] = 255
+
+# onstream must not absorb the carved impervious cells:
+onstream = np.where(
+    (wbody_binary == 1) & (dprst_binary != 1) & (imperv_binary != 1),
+    np.uint8(1), np.uint8(255))
+onstream[~land_valid] = 255
+```
+
+- `regions_touching_mask(regions, imperv_binary)` is dropped from `excluded`. It
+  may be retained purely as an informational log count (regions touching imperv,
+  cells carved). Update the existing log lines accordingly.
+- The `imperv` input is already read in `build()`; no new inputs.
+
+### Resulting cell partition
+
+Every land cell is at most one of `{imperv, dprst, onstream}`, with
+`perv = ¬imperv ∧ ¬dprst` (so `onstream ⊆ perv`, which is existing intended
+behavior — carea_map wants on-stream cells pervious). No cell is both `imperv`
+and `dprst`.
+
+## Downstream effects & rebuild cascade
+
+`dprst` membership changes, and `perv` / `onstream` sit directly downstream, so
+the cascade is fuller than the connectivity-only change:
+
+- **perv** ← dprst: recovered cells move perv→dprst; `perv` shrinks by exactly those cells. Correct.
+- **carea_map** ← onstream + perv: recovered cells leave carea_map (no longer
+  pervious/on-stream). `compute_carea_map_binary` gates on `is_perv`
+  (`keep = land_valid & is_perv & (above_thresh | is_onstream)`,
+  [depstor.py:168](../../../src/gfv2_params/depstor.py)), so impervious cells
+  never entered carea_map — no imperv leakage.
+- **routing → drains_to_dprst → drains_perv / drains_imperv** ← dprst: rebuild.
+- **Params re-derived:** `dprst_frac` (+~16,800 km², minus literal imperv cells),
+  `sro_to_dprst_perv` / `sro_to_dprst_imperv` ratios, `carea_max` / `smidx_coef`.
+
+Rebuild order: `dprst → {perv, carea_map, routing} → {drains_perv, drains_imperv}`
+then merged ratios. Memory peak remains the dprst step (~384 G ceiling; see
+HPC_REFERENCE).
+
+## Testing
+
+Update [test_build_depstor_dprst.py](../../../tests/test_build_depstor_dprst.py):
+
+- Existing connected-vs-isolated test stays valid (imperv all-nodata → unchanged).
+- **New case:** an isolated region touching a few impervious cells **stays
+  dprst**, with only those impervious cells removed (`dprst==255` there), and
+  those cells are **not** in `onstream`.
+- **Invariant assertion:** `dprst_binary == 1` and `imperv == 1` never coincide
+  (`dprst ∩ imperv = ∅`).
+
+## Documentation
+
+- [CLAUDE.md](../../../CLAUDE.md): depstor gotchas describe imperv as a region
+  exclusion — update to per-cell carve-out.
+- [docs/ARCHITECTURE.md](../../ARCHITECTURE.md) and depstor docs: same.
+- `slurm_batch/HPC_REFERENCE.md`: note the dprst→perv/carea_map/routing rebuild cascade.
+
+## Deferred (not in scope)
+
+**Approach C** — in addition to the per-cell carve-out, drop a whole region from
+dprst if it is >~50% impervious, to delete genuinely urban/concrete water
+features as a unit. Only warranted if the "urban-feature" intent (distinct from
+double-counting) becomes a goal. Recorded here for future revisit; not implemented.

--- a/docs/superpowers/specs/2026-06-25-dprst-imperv-percell-carveout-design.md
+++ b/docs/superpowers/specs/2026-06-25-dprst-imperv-percell-carveout-design.md
@@ -58,6 +58,29 @@ inside it are simply excised. This satisfies the double-counting intent exactly,
 keeps the imperv/dprst/perv partition disjoint, recovers ~16,800 km² of false
 exclusions, and needs no calibrated threshold.
 
+This is a restoration, not a new behavior: the ArcPy reference already carved
+impervious per-cell — `getDprst` defines depressions as "areas outside of
+impervious zones" and `getImpervBin` thresholds at `VALUE > 50`
+([docs/0b_TB_depr_stor.py](../../0b_TB_depr_stor.py)). The region-level any-touch
+exclusion was a regression introduced in the open-source port.
+
+### Impervious threshold (unchanged, kept at 50%)
+
+The `imperv` step thresholds NLCD fractional-impervious at **≥50%** to mark a
+cell impervious ([imperv.py](../../../src/gfv2_params/depstor_builders/imperv.py),
+[depstor_rasters.yml](../../../configs/depstor/depstor_rasters.yml) `threshold: 50`),
+matching the ArcPy `VALUE > 50`. This threshold is a **land-classification**
+lever (which NLCD cells count as impervious), not a dprst-exclusion control.
+Under the broken region-level any-touch rule the high threshold *incidentally*
+limited the blast radius (fewer impervious cells → fewer whole waterbodies
+nuked); the per-cell carve **decouples** the two, so the threshold reverts to its
+proper narrow role: it determines which cells are carved from `dprst` and counted
+in `hru_percent_imperv`, scaling dprst area smoothly and proportionally rather
+than all-or-nothing. Because `imperv_binary` is binary at 50%, there is no
+fractional double-count (a 40% cell is fully dprst/pervious; a 60% cell is fully
+impervious). **The value stays 50%** — changing it shifts `hru_percent_imperv`
+CONUS-wide and is a separate concern (see Deferred).
+
 ## Detailed change — `dprst.py` `build()`
 
 ```python
@@ -133,3 +156,8 @@ Update [test_build_depstor_dprst.py](../../../tests/test_build_depstor_dprst.py)
 dprst if it is >~50% impervious, to delete genuinely urban/concrete water
 features as a unit. Only warranted if the "urban-feature" intent (distinct from
 double-counting) becomes a goal. Recorded here for future revisit; not implemented.
+
+**Impervious threshold value** — the 50% cut (`VALUE > 50`) is kept as-is here.
+Revisiting it (e.g. 30/40/60%) is a separate land-classification decision that
+shifts `hru_percent_imperv` CONUS-wide; defer to its own change with a
+sensitivity scan if needed.

--- a/slurm_batch/HPC_REFERENCE.md
+++ b/slurm_batch/HPC_REFERENCE.md
@@ -306,6 +306,15 @@ rejected; never substitute it.
 vpu_id → routing → drains_perv / drains_imperv → carea_map. Selective re-runs
 via `--step <name>` or `--from <name>` passed through to the Python script.
 
+**dprst rebuild cascade.** Changing `dprst` membership (e.g. the per-cell
+impervious carve-out) invalidates everything downstream of it in the DAG:
+`perv`, `routing` → `drains_perv`/`drains_imperv`, and `carea_map` (it consumes
+`onstream` + `perv`). Rebuild with `--from dprst` and `FORCE=1`, then re-run the
+depstor zonal + merge for the affected fractions (`dprst_frac`, `perv_frac`,
+`drains_*_frac`, `onstream_storage_frac`, `carea_*`, `sro_to_dprst_*`).
+`waterbody`, `wbody_connectivity`, `vpu_id`, and `landmask` are upstream and
+unaffected.
+
 **`vpu_id` step.** Rasterises the HRU fabric's `vpu` attribute onto the template
 grid. Required by `carea_map` when `threshold_mode: percentile` and the fabric
 spans multiple VPUs. Single-VPU fabrics set `vpu: "<id>"` in their profile and

--- a/src/gfv2_params/depstor_builders/dprst.py
+++ b/src/gfv2_params/depstor_builders/dprst.py
@@ -1,4 +1,11 @@
-"""Combine wbody regions + connected-wbody mask + imperv into dprst + onstream."""
+"""Classify waterbody regions into dprst + onstream.
+
+A waterbody region is depression storage unless it is on-stream (touches the
+NHD-connected mask). Impervious is NOT a region-level exclusion: a single
+impervious cell must not remove a whole clump. Impervious cells are carved out
+of dprst per-cell so imperv/dprst/perv stay a disjoint partition (no cell is
+counted as both impervious and depression storage).
+"""
 
 from __future__ import annotations
 
@@ -44,26 +51,35 @@ def build(step_cfg: dict, ctx: BuildContext, logger) -> dict:
     land_valid = read_land_mask(landmask_path)
 
     onstream_regions = regions_touching_mask(regions, connected_binary)
+    excluded = onstream_regions
+    # Impervious is carved per-cell (below), NOT used to exclude whole regions:
+    # a single impervious pixel must not drop an entire waterbody clump from
+    # depression storage. regions_touching_mask is kept only for logging.
     imperv_regions = regions_touching_mask(regions, imperv_binary)
-    excluded = onstream_regions | imperv_regions
     n_total = int(regions.max())
     logger.info(
-        "  %d total wbody regions; %d touch connected wbody, %d touch imperv, %d excluded",
-        n_total, len(onstream_regions), len(imperv_regions), len(excluded),
+        "  %d total wbody regions; %d touch connected wbody (excluded), "
+        "%d touch imperv (kept; cells carved per-cell)",
+        n_total, len(onstream_regions), len(imperv_regions),
     )
 
     all_ids = set(int(v) for v in np.unique(regions) if v != 0)
     kept_ids = all_ids - excluded
     dprst_binary = regions_to_binary(regions, kept_ids)
+    n_carved = int(((dprst_binary == 1) & (imperv_binary == 1)).sum())
+    dprst_binary[imperv_binary == 1] = 255  # carve impervious cells (no imperv/dprst double-count)
     dprst_binary[~land_valid] = 255  # drop off-land (ocean) cells
     write_uint8_binary(dprst_binary, info, dprst_path)
     n_dprst = int((dprst_binary == 1).sum())
     logger.info(
-        "  %d regions kept; %d cells in dprst (%.4f%% of grid)",
-        len(kept_ids), n_dprst, 100 * n_dprst / dprst_binary.size,
+        "  %d regions kept; %d impervious cells carved; %d cells in dprst (%.4f%% of grid)",
+        len(kept_ids), n_carved, n_dprst, 100 * n_dprst / dprst_binary.size,
     )
 
-    onstream = np.where((wbody_binary == 1) & (dprst_binary != 1), np.uint8(1), np.uint8(255))
+    onstream = np.where(
+        (wbody_binary == 1) & (dprst_binary != 1) & (imperv_binary != 1),
+        np.uint8(1), np.uint8(255),
+    )
     onstream[~land_valid] = 255  # drop off-land (ocean) cells
     write_uint8_binary(onstream, info, onstream_path)
     n_on = int((onstream == 1).sum())

--- a/tests/test_build_depstor_dprst.py
+++ b/tests/test_build_depstor_dprst.py
@@ -79,3 +79,61 @@ def test_dprst_excludes_connected_region_keeps_isolated(tmp_path):
     # Region 1 lands in on-stream storage; region 2 does not.
     assert onstream_arr[0, 0] == 1
     assert onstream_arr[9, 9] != 1
+
+
+def test_dprst_carves_imperv_cells_but_keeps_region(tmp_path):
+    template = tmp_path / "template.tif"
+    _write(template, np.full((_N, _N), 100.0), "float32", -9999.0)
+
+    # One isolated waterbody region: rows 0-1, cols 0-3 (8 cells), not connected.
+    regions = np.zeros((_N, _N), dtype=np.int32)
+    regions[0:2, 0:4] = 1
+    _write(tmp_path / "wbody_regions.tif", regions, "int32", 0)
+
+    wbody_binary = np.where(regions > 0, np.uint8(1), np.uint8(255))
+    _write(tmp_path / "wbody_binary.tif", wbody_binary, "uint8", 255)
+
+    # Connected mask touches nothing -> nothing excluded for connectivity.
+    _write(tmp_path / "connected_wbody.tif",
+           np.full((_N, _N), 255, dtype=np.uint8), "uint8", 255)
+
+    # Two impervious cells fall inside the region (e.g. a road across a playa).
+    imperv = np.full((_N, _N), 255, dtype=np.uint8)
+    imperv[0, 0] = 1
+    imperv[0, 1] = 1
+    _write(tmp_path / "imperv.tif", imperv, "uint8", 255)
+    _write(tmp_path / "land_mask.tif", np.ones((_N, _N), dtype=np.uint8), "uint8", 255)
+
+    ctx = BuildContext(
+        fabric="t", template_path=template, output_dir=tmp_path,
+        hru_gpkg=tmp_path / "x.gpkg", hru_layer="nhru",
+    )
+    ctx.paths.update({
+        "landmask": tmp_path / "land_mask.tif",
+        "wbody_binary": tmp_path / "wbody_binary.tif",
+        "wbody_regions": tmp_path / "wbody_regions.tif",
+        "connected_wbody": tmp_path / "connected_wbody.tif",
+        "imperv": tmp_path / "imperv.tif",
+    })
+
+    produced = dprst.build(
+        {"outputs": {"dprst": "dprst_binary.tif", "onstream": "onstream_binary.tif"}},
+        ctx, logging.getLogger("test"),
+    )
+
+    with rasterio.open(produced["dprst"]) as src:
+        dprst_arr = src.read(1)
+    with rasterio.open(produced["onstream"]) as src:
+        onstream_arr = src.read(1)
+
+    # The region is kept as depression storage at its non-impervious cells ...
+    assert dprst_arr[1, 0] == 1
+    assert dprst_arr[1, 3] == 1
+    # ... the two impervious cells are carved out of dprst ...
+    assert dprst_arr[0, 0] != 1
+    assert dprst_arr[0, 1] != 1
+    # ... and are NOT swept into on-stream storage.
+    assert onstream_arr[0, 0] != 1
+    assert onstream_arr[0, 1] != 1
+    # Invariant: dprst and imperv never coincide (no double-count).
+    assert int(((dprst_arr == 1) & (imperv == 1)).sum()) == 0


### PR DESCRIPTION
Closes #143.

Replaces the impervious **region-level any-touch** exclusion in the `dprst` builder with a **per-cell carve-out**. Previously one ≥50%-impervious pixel removed an entire waterbody clump from depression storage; a CONUS scan found ~16,800 km² across 14,898 regions falsely excluded (89% of that area in ≥1 km² waterbodies; 3,538 regions flipped by a single pixel). Connectivity stays the only region-level exclusion. `imperv`/`dprst`/`perv` remain a disjoint cell partition, so the double-counting intent is preserved. This restores the original ArcPy `getDprst` per-cell behavior; the any-touch rule was a port regression.

## Changes
- `src/gfv2_params/depstor_builders/dprst.py` — impervious removed from region-level `excluded`; carved from `dprst` per-cell (`dprst_binary[imperv_binary == 1] = 255`); `onstream` guarded with `& (imperv_binary != 1)`; logging updated (`n_carved`).
- `tests/test_build_depstor_dprst.py` — new test pins: region kept, imperv cells carved, carved cells not on-stream, `dprst ∩ imperv = ∅`. Existing test unchanged.
- `CLAUDE.md`, `slurm_batch/HPC_REFERENCE.md` — per-cell carve-out gotcha (anti-regression) + dprst rebuild-cascade note.
- `docs/superpowers/{specs,plans}/2026-06-25-dprst-imperv-percell-carveout*` — design spec + implementation plan.

## Testing
`pixi run -e dev pytest tests/test_build_depstor_dprst.py -v` → 2 passed. Full suite runs in CI (not on the HPC head node).

## Operational follow-up (post-merge, on HPC)
Changing `dprst` membership requires a CONUS rebuild `--from dprst` (perv, routing, drains_*, carea_map) and re-derivation of the affected fractions (`dprst_frac`, `perv_frac`, `drains_*_frac`, `onstream_storage_frac`, `carea_*`, `sro_to_dprst_*`) before regenerated params are valid. See `slurm_batch/HPC_REFERENCE.md`.

## Deferred (not in this PR)
- Approach C (drop whole regions that are >~50% impervious, for genuinely urban water features).
- Revisiting the 50% impervious threshold value (separate `hru_percent_imperv` concern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
