### PR TITLE
fix(shared_rasters): scope vpus to consolidated 01-18 (not RPU-split units)

### DIFF
--- a/configs/shared_rasters/shared_rasters.yml
+++ b/configs/shared_rasters/shared_rasters.yml
@@ -18,20 +18,25 @@
 # Per-VPU loop scope. Per-VPU steps iterate this list internally rather
 # than being launched once per VPU. Override at the CLI with --vpus to
 # scope a partial run (e.g., --vpus 01 for VPU01 validation only).
+#
+# These are the CONSOLIDATED VPU ids (01-18), matching the per-VPU merged
+# tiles on disk (shared/per_vpu/<vpu>/) and the keys of the merge manifests
+# (merge_rpu_by_vpu*.yml). Do NOT list the RPU-split units (03N/03S/03W,
+# 10L/10U) here: the merge step consolidates those RPUs into single 03/10
+# tiles, so a per-VPU step iterating split units FileNotFounds on the missing
+# NEDSnapshot_merged_03N.tif. test_default_vpus_scope_matches_merge_manifests
+# pins this list to the manifests.
 vpus:
   - "01"
   - "02"
-  - "03N"
-  - "03S"
-  - "03W"
+  - "03"
   - "04"
   - "05"
   - "06"
   - "07"
   - "08"
   - "09"
-  - "10L"
-  - "10U"
+  - "10"
   - "11"
   - "12"
   - "13"

--- a/tests/test_shared_rasters_orchestrator.py
+++ b/tests/test_shared_rasters_orchestrator.py
@@ -6,7 +6,6 @@ must still parse its config, walk zero steps, and exit cleanly.
 
 import subprocess
 import sys
-import tempfile
 from pathlib import Path
 
 import pytest
@@ -25,6 +24,24 @@ ORCHESTRATOR = REPO_ROOT / "scripts" / "build_shared_rasters.py"
 
 def test_every_registered_step_has_a_builder():
     assert set(STEP_ORDER) == set(BUILDERS.keys())
+
+
+def test_default_vpus_scope_matches_merge_manifests():
+    """The per-VPU loop scope (`vpus:` in shared_rasters.yml) must match the
+    consolidated VPU keys of the merge manifests (01-18), NOT the RPU-split
+    units (03N/03S/03W, 10L/10U).
+
+    If they drift, a per-VPU `--step` run with no `--vpus` override walks the
+    21-unit list and raises FileNotFoundError on the missing
+    NEDSnapshot_merged_03N.tif (the merged tiles are named `03`/`10`). This
+    test pins the two together so the config can't go stale again.
+    """
+    cfg_dir = REPO_ROOT / "configs" / "shared_rasters"
+    vpus = set(yaml.safe_load((cfg_dir / "shared_rasters.yml").read_text())["vpus"])
+    std = set(yaml.safe_load((cfg_dir / "merge_rpu_by_vpu.yml").read_text()))
+    twi = set(yaml.safe_load((cfg_dir / "merge_rpu_by_vpu_twi.yml").read_text()))
+    assert vpus == std, f"vpus scope != merge_rpu_by_vpu manifest: {vpus ^ std}"
+    assert vpus == twi, f"vpus scope != merge_rpu_by_vpu_twi manifest: {vpus ^ twi}"
 
 
 def test_every_registered_step_is_in_planned_or_documented_aliases():


### PR DESCRIPTION
## Summary

The default per-VPU loop scope (`vpus:` in `configs/shared_rasters/shared_rasters.yml`) listed the **21 RPU-split units** (`03N/03S/03W`, `10L/10U`), but the merge step consolidates those RPUs into single `03`/`10` tiles, and both `merge_rpu_by_vpu*.yml` manifests are keyed `01–18`. The on-disk per-VPU tiles are named `03`/`10`.

## Impact (hit during the COG-mosaic rebuild, 2026-06-30)

A per-VPU `--step` run with **no `--vpus` override** walks the 21-unit list and:
- `compute_slope_aspect` / `compute_dem_derivatives` → `FileNotFoundError: DEM not found .../NEDSnapshot_merged_03N.tif` (the dir `03N` doesn't exist) after processing 01/02.
- `merge_rpu_by_vpu_twi` → silently **skips `03`/`10`** (not in the 21-scope), so those tiles never rebuild.

The existence check in `_process_vpu` fires regardless of `--force`, so even a normal full Part-1 run trips it.

## Fix

- Set `vpus:` to the consolidated `01–18`, matching the merge manifests and the on-disk tiles, with a comment explaining why the RPU-split units must not be listed.
- Add `test_default_vpus_scope_matches_merge_manifests` pinning the scope list to **both** merge manifests, so the config can't drift from the manifests again (this test would have caught the bug).
- Drop a pre-existing unused `tempfile` import in the touched test module (ruff F401).

## Validation

`vpus` now equals both manifest keysets (18 entries, no RPU-split units). Verified locally; CI runs the new test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
