### PR TITLE
fix(border_dem): relax download guard (20→30%) + stream fill-mask (fix CONUS OOM)

### DIFF
--- a/src/gfv2_params/download/copernicus_dem.py
+++ b/src/gfv2_params/download/copernicus_dem.py
@@ -57,16 +57,27 @@ def download_tiles(
     tile_labels: list[str],
     out_dir: Path,
     timeout: int = 120,
-) -> list[Path]:
+) -> tuple[list[Path], list[str]]:
     """Download Copernicus GLO-30 tiles to *out_dir*.
 
-    Idempotent: skips files that already exist.  Tiles that return 404
-    (ocean, polar) are logged as warnings and skipped.
+    Idempotent: skips files that already exist. Tiles that return HTTP 404 are
+    the *expected* open-ocean/polar case (the border bbox is deliberately
+    generous, see BORDER_ZONES) and are silently skipped. Tiles that fail for
+    any *other* reason (timeout, 5xx, connection reset, DNS) are real download
+    failures and are collected separately so the caller can distinguish
+    "no land here" from "the download broke" — a count-based shortfall check
+    cannot tell them apart.
 
-    Returns list of paths to successfully downloaded .tif files.
+    Returns
+    -------
+    (paths, failed) : tuple[list[Path], list[str]]
+        ``paths`` — .tif files now available (freshly downloaded or pre-existing).
+        ``failed`` — labels that failed for a non-404 reason (empty on a clean
+        run); the caller should treat any entries as a hard error.
     """
     out_dir.mkdir(parents=True, exist_ok=True)
     paths = []
+    failed = []
     skipped = 0
 
     for i, label in enumerate(tile_labels, start=1):
@@ -100,10 +111,12 @@ def download_tiles(
                 )
         except requests.RequestException as e:
             partial.unlink(missing_ok=True)
+            failed.append(label)
             logger.warning("Failed to download %s: %s", label, e)
 
     logger.info(
-        "Download complete: %d tiles available, %d skipped (existing), %d total requested",
-        len(paths), skipped, len(tile_labels),
+        "Download complete: %d tiles available, %d skipped (existing), "
+        "%d failed (non-404), %d total requested",
+        len(paths), skipped, len(failed), len(tile_labels),
     )
-    return paths
+    return paths, failed

--- a/src/gfv2_params/shared_rasters/build_border_dem.py
+++ b/src/gfv2_params/shared_rasters/build_border_dem.py
@@ -291,7 +291,12 @@ def build(step_cfg: dict, ctx: SharedRastersContext, logger) -> dict:
             f"Only {n_downloaded}/{n_requested} tiles downloaded "
             f"({shortfall_pct:.0f}% shortfall) — border DEM may have coverage gaps"
         )
-        if shortfall_pct > 20:
+        # The border bbox is deliberately generous (BORDER_ZONES), so a baseline
+        # ~20% of requested tiles are open-ocean / no-land and 404 *deterministically*
+        # — 1238/1557 (20.5% shortfall) for the current Canada+Mexico zones. Only
+        # abort on a gross shortfall that implies a real network/coverage failure,
+        # not this expected ocean baseline; lesser shortfalls log a warning.
+        if shortfall_pct > 30:
             raise RuntimeError(msg)
         logger.warning(msg)
 

--- a/src/gfv2_params/shared_rasters/build_border_dem.py
+++ b/src/gfv2_params/shared_rasters/build_border_dem.py
@@ -100,86 +100,139 @@ def _build_composite_vrt(
     return output_vrt
 
 
-def _compute_fill_mask(
+# Windowed-strip height for the fill-mask computation and mask application.
+# The fill zone spans the full Copernicus extent (~29.6 B cells at CONUS 30m).
+# The previous approach loaded it whole — two gdal.Warp(format="MEM") full-extent
+# readbacks plus their float32 copies (~4x139 GiB) — which exceeded the 503 GiB
+# node and OOM'd (numpy _ArrayMemoryError). Both _write_fill_mask and
+# _apply_fill_mask now process STRIP_ROWS rows at a time, holding only
+# strip-sized arrays. Mirrors carea_map's windowed-strip pattern (see the
+# CONUS-scale memory note in docs/ARCHITECTURE.md).
+STRIP_ROWS = 4096
+
+
+def _write_fill_mask(
     copernicus_elev: Path,
     nhdplus_vrt: Path,
-    geotransform: tuple,
-    rows: int,
-    cols: int,
-) -> np.ndarray:
-    """Fill zone = pixels where Copernicus has valid data AND NHDPlus has nodata."""
-    output_bounds = [
-        geotransform[0],
-        geotransform[3] + rows * geotransform[5],
-        geotransform[0] + cols * geotransform[1],
-        geotransform[3],
-    ]
-    warp_kwargs = dict(
-        format="MEM",
-        outputBounds=output_bounds,
-        xRes=abs(geotransform[1]),
-        yRes=abs(geotransform[5]),
-        dstNodata=OUTPUT_NODATA,
-        srcNodata=OUTPUT_NODATA,
+    ref_raster: Path,
+    mask_out: Path,
+) -> None:
+    """Stream a UInt8 fill-zone mask onto ``ref_raster``'s grid.
+
+    Fill zone = 1 where Copernicus has valid data AND NHDPlus is nodata, else 0.
+    Warps Copernicus and NHDPlus into each horizontal strip's window in memory
+    (strip-sized, never full-extent) and writes the mask strip-by-strip.
+    """
+    ref_ds = gdal.Open(str(ref_raster))
+    if ref_ds is None:
+        raise RuntimeError(
+            f"gdal.Open failed for ref raster: {ref_raster} — {gdal.GetLastErrorMsg()}"
+        )
+    gt = ref_ds.GetGeoTransform()
+    proj = ref_ds.GetProjection()
+    cols = ref_ds.RasterXSize
+    rows = ref_ds.RasterYSize
+    del ref_ds
+
+    driver = gdal.GetDriverByName("GTiff")
+    if driver is None:
+        raise RuntimeError("GTiff driver not available — check GDAL installation")
+    mask_ds = driver.Create(
+        str(mask_out), cols, rows, 1, gdal.GDT_Byte,
+        options=["COMPRESS=LZW", "TILED=YES", "BLOCKXSIZE=512", "BLOCKYSIZE=512", "BIGTIFF=YES"],
     )
-
-    cop_ds = gdal.Warp("", str(copernicus_elev), **warp_kwargs)
-    if cop_ds is None:
+    if mask_ds is None:
         raise RuntimeError(
-            f"gdal.Warp to MEM failed for Copernicus readback: "
-            f"{copernicus_elev} — {gdal.GetLastErrorMsg()}"
+            f"gdal driver.Create failed for mask: {mask_out} — {gdal.GetLastErrorMsg()}"
         )
-    cop_data = cop_ds.GetRasterBand(1).ReadAsArray().astype(np.float32)
-    del cop_ds
+    mask_ds.SetGeoTransform(gt)
+    mask_ds.SetProjection(proj)
+    mask_band = mask_ds.GetRasterBand(1)
 
-    nhd_ds = gdal.Warp("", str(nhdplus_vrt), **warp_kwargs)
-    if nhd_ds is None:
-        raise RuntimeError(
-            f"gdal.Warp to MEM failed for NHDPlus VRT readback: "
-            f"{nhdplus_vrt} — {gdal.GetLastErrorMsg()}"
+    for r0 in range(0, rows, STRIP_ROWS):
+        strip_h = min(STRIP_ROWS, rows - r0)
+        # Strip bounds in the ref CRS (gt[5] is negative for a north-up grid).
+        strip_bounds = [
+            gt[0],
+            gt[3] + (r0 + strip_h) * gt[5],
+            gt[0] + cols * gt[1],
+            gt[3] + r0 * gt[5],
+        ]
+        warp_kwargs = dict(
+            format="MEM",
+            outputBounds=strip_bounds,
+            width=cols,
+            height=strip_h,
+            dstNodata=OUTPUT_NODATA,
+            srcNodata=OUTPUT_NODATA,
         )
-    nhd_data = nhd_ds.GetRasterBand(1).ReadAsArray().astype(np.float32)
-    del nhd_ds
+        cop_ds = gdal.Warp("", str(copernicus_elev), **warp_kwargs)
+        if cop_ds is None:
+            raise RuntimeError(
+                f"gdal.Warp to MEM failed for Copernicus strip (row {r0}): "
+                f"{copernicus_elev} — {gdal.GetLastErrorMsg()}"
+            )
+        cop = cop_ds.GetRasterBand(1).ReadAsArray()
+        del cop_ds
+        nhd_ds = gdal.Warp("", str(nhdplus_vrt), **warp_kwargs)
+        if nhd_ds is None:
+            raise RuntimeError(
+                f"gdal.Warp to MEM failed for NHDPlus strip (row {r0}): "
+                f"{nhdplus_vrt} — {gdal.GetLastErrorMsg()}"
+            )
+        nhd = nhd_ds.GetRasterBand(1).ReadAsArray()
+        del nhd_ds
 
-    if cop_data.shape != (rows, cols) or nhd_data.shape != (rows, cols):
-        raise RuntimeError(
-            f"Shape mismatch after warp: expected ({rows}, {cols}), "
-            f"got cop={cop_data.shape}, nhd={nhd_data.shape}"
-        )
+        # -9999 is exactly representable in float32, so equality is safe.
+        strip_mask = ((cop != OUTPUT_NODATA) & (nhd == OUTPUT_NODATA)).astype(np.uint8)
+        err = mask_band.WriteArray(strip_mask, 0, r0)
+        if err != gdal.CE_None:
+            raise RuntimeError(
+                f"WriteArray failed for mask strip (row {r0}) — code {err}: "
+                f"{gdal.GetLastErrorMsg()}"
+            )
 
-    # -9999 is exactly representable in float32, so equality is safe.
-    return (cop_data != OUTPUT_NODATA) & (nhd_data == OUTPUT_NODATA)
+    mask_ds.FlushCache()
+    del mask_ds
 
 
 def _apply_fill_mask(
     raw_raster: Path,
-    fill_mask: np.ndarray,
+    mask_raster: Path,
     output: Path,
     overview_resampling: str,
 ) -> None:
+    """Stream-apply ``mask_raster`` to ``raw_raster``, writing ``output`` as a COG.
+
+    Keeps raw values where the mask is 1, writes nodata elsewhere, one
+    STRIP_ROWS-tall window at a time (never the full-extent array). The plain
+    windowed write goes to a temp, then to_cog reorganizes it into a COG (tiled
+    512 + overviews + ZSTD/pred3) — border slope/aspect fill feed the same VRTs
+    as the per-VPU tiles and are GDAL/QGIS-consumed (never WBT). Aspect passes
+    overview_resampling="NEAREST" (circular 0/360 field).
+    """
     raw_ds = gdal.Open(str(raw_raster))
     if raw_ds is None:
         raise RuntimeError(
             f"gdal.Open failed for raw raster: {raw_raster} — {gdal.GetLastErrorMsg()}"
         )
-    raw_data = raw_ds.GetRasterBand(1).ReadAsArray().astype(np.float32)
-    geotransform = raw_ds.GetGeoTransform()
-    projection = raw_ds.GetProjection()
-    rows, cols = raw_data.shape
-    del raw_ds
-
-    if fill_mask.shape != (rows, cols):
+    mask_ds = gdal.Open(str(mask_raster))
+    if mask_ds is None:
+        raise RuntimeError(
+            f"gdal.Open failed for mask raster: {mask_raster} — {gdal.GetLastErrorMsg()}"
+        )
+    gt = raw_ds.GetGeoTransform()
+    proj = raw_ds.GetProjection()
+    cols = raw_ds.RasterXSize
+    rows = raw_ds.RasterYSize
+    if (mask_ds.RasterXSize, mask_ds.RasterYSize) != (cols, rows):
         raise RuntimeError(
             f"Shape mismatch in _apply_fill_mask for {output.name}: "
-            f"raw=({rows}, {cols}), mask={fill_mask.shape}"
+            f"raw=({rows}, {cols}), mask=({mask_ds.RasterYSize}, {mask_ds.RasterXSize})"
         )
+    raw_band = raw_ds.GetRasterBand(1)
+    mask_band = mask_ds.GetRasterBand(1)
 
-    masked = np.where(fill_mask, raw_data, np.float32(OUTPUT_NODATA))
-
-    # Write a plain temp, then reorganize into a COG (tiled 512 + overviews +
-    # ZSTD/pred3) matching the per-VPU slope/aspect tiles — these border fill
-    # tiles feed the same slope/aspect VRTs and are GDAL/QGIS-consumed (never
-    # WBT). Aspect passes overview_resampling="NEAREST" (circular 0/360 field).
     driver = gdal.GetDriverByName("GTiff")
     if driver is None:
         raise RuntimeError("GTiff driver not available — check GDAL installation")
@@ -192,18 +245,26 @@ def _apply_fill_mask(
             raise RuntimeError(
                 f"gdal driver.Create failed for output: {tmp} — {gdal.GetLastErrorMsg()}"
             )
-        out_ds.SetGeoTransform(geotransform)
-        out_ds.SetProjection(projection)
+        out_ds.SetGeoTransform(gt)
+        out_ds.SetProjection(proj)
         out_band = out_ds.GetRasterBand(1)
         out_band.SetNoDataValue(OUTPUT_NODATA)
-        err = out_band.WriteArray(masked)
-        if err != gdal.CE_None:
-            raise RuntimeError(
-                f"WriteArray failed for {tmp} — GDAL error code {err}: "
-                f"{gdal.GetLastErrorMsg()}"
-            )
+
+        for r0 in range(0, rows, STRIP_ROWS):
+            strip_h = min(STRIP_ROWS, rows - r0)
+            raw = raw_band.ReadAsArray(0, r0, cols, strip_h).astype(np.float32)
+            mask = mask_band.ReadAsArray(0, r0, cols, strip_h)
+            masked = np.where(mask.astype(bool), raw, np.float32(OUTPUT_NODATA))
+            err = out_band.WriteArray(masked, 0, r0)
+            if err != gdal.CE_None:
+                raise RuntimeError(
+                    f"WriteArray failed for {tmp} strip (row {r0}) — code {err}: "
+                    f"{gdal.GetLastErrorMsg()}"
+                )
+
         out_ds.FlushCache()
         del out_ds
+        del raw_ds, mask_ds
         to_cog(tmp, output, overview_resampling=overview_resampling, predictor=3)
 
 
@@ -349,7 +410,11 @@ def build(step_cfg: dict, ctx: SharedRastersContext, logger) -> dict:
     composite_clipped = fill_dir / "composite_elevation_clipped.tif"
     slope_raw = fill_dir / "slope_raw.tif"
     aspect_raw = fill_dir / "aspect_raw.tif"
-    intermediates = [slope_raw, aspect_raw, nhdplus_vrt, composite_vrt, composite_clipped]
+    fill_mask_raster = fill_dir / "fill_mask.tif"
+    intermediates = [
+        slope_raw, aspect_raw, nhdplus_vrt, composite_vrt, composite_clipped,
+        fill_mask_raster,
+    ]
 
     if not slope_out.exists() or not aspect_out.exists() or ctx.force:
         try:
@@ -427,27 +492,19 @@ def build(step_cfg: dict, ctx: SharedRastersContext, logger) -> dict:
             logger.info("=== Step 5/5: Mask slope/aspect to fill zone ===")
             t4 = time.time()
 
-            ref_ds = gdal.Open(str(slope_raw))
-            if ref_ds is None:
-                raise RuntimeError(
-                    f"gdal.Open failed for slope raw raster: {slope_raw} "
-                    f"— {gdal.GetLastErrorMsg()}"
-                )
-            ref_gt = ref_ds.GetGeoTransform()
-            ref_rows = ref_ds.RasterYSize
-            ref_cols = ref_ds.RasterXSize
-            del ref_ds
-
-            fill_mask = _compute_fill_mask(
-                elev_out, nhdplus_vrt, ref_gt, ref_rows, ref_cols,
-            )
+            # Compute the fill-zone mask once (streamed to disk on slope_raw's
+            # grid), then stream-apply it to both slope and aspect. Windowed
+            # throughout so peak memory is strip-sized, not full-extent (the
+            # old full-array _compute_fill_mask OOM'd on CONUS — see STRIP_ROWS).
+            logger.info("  Computing fill-zone mask (streaming)...")
+            _write_fill_mask(elev_out, nhdplus_vrt, slope_raw, fill_mask_raster)
 
             logger.info("  Masking slope to fill zone...")
-            _apply_fill_mask(slope_raw, fill_mask, slope_out, "BILINEAR")
+            _apply_fill_mask(slope_raw, fill_mask_raster, slope_out, "BILINEAR")
             logger.info("  Masked slope saved: %s", slope_out)
 
             logger.info("  Masking aspect to fill zone...")
-            _apply_fill_mask(aspect_raw, fill_mask, aspect_out, "NEAREST")
+            _apply_fill_mask(aspect_raw, fill_mask_raster, aspect_out, "NEAREST")
             logger.info("  Masked aspect saved: %s", aspect_out)
 
             logger.info("  Masking complete in %s", _elapsed(t4))

--- a/src/gfv2_params/shared_rasters/build_border_dem.py
+++ b/src/gfv2_params/shared_rasters/build_border_dem.py
@@ -101,13 +101,15 @@ def _build_composite_vrt(
 
 
 # Windowed-strip height for the fill-mask computation and mask application.
-# The fill zone spans the full Copernicus extent (~29.6 B cells at CONUS 30m).
-# The previous approach loaded it whole — two gdal.Warp(format="MEM") full-extent
-# readbacks plus their float32 copies (~4x139 GiB) — which exceeded the 503 GiB
-# node and OOM'd (numpy _ArrayMemoryError). Both _write_fill_mask and
-# _apply_fill_mask now process STRIP_ROWS rows at a time, holding only
-# strip-sized arrays. Mirrors carea_map's windowed-strip pattern (see the
-# CONUS-scale memory note in docs/ARCHITECTURE.md).
+# The fill zone spans the full continental Copernicus extent at 30 m. The
+# previous approach loaded it whole — two gdal.Warp(format="MEM") full-extent
+# float32 readbacks plus their .astype copies (~4 full-extent arrays,
+# ~560 GB combined) — which exceeded the 503 GB node and OOM'd (numpy
+# _ArrayMemoryError). Both _write_fill_mask and _apply_fill_mask now process
+# STRIP_ROWS rows at a time, holding only strip-sized arrays. Mirrors
+# carea_map's windowed-strip pattern (see the CONUS-scale memory note in
+# docs/ARCHITECTURE.md). Larger STRIP_ROWS = fewer warp calls (less I/O
+# overhead) but proportionally more resident memory per strip.
 STRIP_ROWS = 4096
 
 
@@ -174,6 +176,11 @@ def _write_fill_mask(
             )
         cop = cop_ds.GetRasterBand(1).ReadAsArray()
         del cop_ds
+        if cop is None:
+            raise RuntimeError(
+                f"ReadAsArray returned None for Copernicus strip (row {r0}): "
+                f"{copernicus_elev} — {gdal.GetLastErrorMsg()}"
+            )
         nhd_ds = gdal.Warp("", str(nhdplus_vrt), **warp_kwargs)
         if nhd_ds is None:
             raise RuntimeError(
@@ -182,6 +189,11 @@ def _write_fill_mask(
             )
         nhd = nhd_ds.GetRasterBand(1).ReadAsArray()
         del nhd_ds
+        if nhd is None:
+            raise RuntimeError(
+                f"ReadAsArray returned None for NHDPlus strip (row {r0}): "
+                f"{nhdplus_vrt} — {gdal.GetLastErrorMsg()}"
+            )
 
         # -9999 is exactly representable in float32, so equality is safe.
         strip_mask = ((cop != OUTPUT_NODATA) & (nhd == OUTPUT_NODATA)).astype(np.uint8)
@@ -252,9 +264,21 @@ def _apply_fill_mask(
 
         for r0 in range(0, rows, STRIP_ROWS):
             strip_h = min(STRIP_ROWS, rows - r0)
-            raw = raw_band.ReadAsArray(0, r0, cols, strip_h).astype(np.float32)
+            raw = raw_band.ReadAsArray(0, r0, cols, strip_h)
+            if raw is None:
+                raise RuntimeError(
+                    f"ReadAsArray returned None for raw strip (row {r0}): "
+                    f"{raw_raster} — {gdal.GetLastErrorMsg()}"
+                )
             mask = mask_band.ReadAsArray(0, r0, cols, strip_h)
-            masked = np.where(mask.astype(bool), raw, np.float32(OUTPUT_NODATA))
+            if mask is None:
+                raise RuntimeError(
+                    f"ReadAsArray returned None for mask strip (row {r0}): "
+                    f"{mask_raster} — {gdal.GetLastErrorMsg()}"
+                )
+            masked = np.where(
+                mask.astype(bool), raw.astype(np.float32), np.float32(OUTPUT_NODATA)
+            )
             err = out_band.WriteArray(masked, 0, r0)
             if err != gdal.CE_None:
                 raise RuntimeError(
@@ -266,6 +290,37 @@ def _apply_fill_mask(
         del out_ds
         del raw_ds, mask_ds
         to_cog(tmp, output, overview_resampling=overview_resampling, predictor=3)
+
+
+# Baseline fraction of requested border tiles that 404 deterministically. The
+# BORDER_ZONES bbox is deliberately generous, so a large share cover open ocean
+# / no land and 404 every run (1238/1557 downloaded = 20.5% shortfall for the
+# current Canada+Mexico zones). Abort only *above* this, where a count-based
+# shortfall implies a real coverage failure rather than the expected ocean
+# baseline. This threshold cannot see non-404 download errors — those are
+# treated as a hard error separately (see download_tiles' `failed` list).
+OCEAN_SHORTFALL_PCT = 30
+
+
+def _check_shortfall(n_requested: int, n_downloaded: int) -> str | None:
+    """Classify a tile-count shortfall against the ocean baseline.
+
+    Returns None when every requested tile is present, a warning message for a
+    shortfall within the expected open-ocean 404 baseline (<= OCEAN_SHORTFALL_PCT,
+    strict), and raises RuntimeError for a gross shortfall above it (a likely
+    real coverage failure). Non-404 download failures are NOT visible here and
+    must be gated by the caller before calling this.
+    """
+    if n_downloaded >= n_requested:
+        return None
+    shortfall_pct = 100 * (n_requested - n_downloaded) / n_requested
+    msg = (
+        f"Only {n_downloaded}/{n_requested} tiles downloaded "
+        f"({shortfall_pct:.0f}% shortfall) — border DEM may have coverage gaps"
+    )
+    if shortfall_pct > OCEAN_SHORTFALL_PCT:
+        raise RuntimeError(msg)
+    return msg
 
 
 def build(step_cfg: dict, ctx: SharedRastersContext, logger) -> dict:
@@ -301,8 +356,8 @@ def build(step_cfg: dict, ctx: SharedRastersContext, logger) -> dict:
     # Early-exit if every output is already on disk. Without this the
     # orchestrator re-runs the Copernicus download on every walk, even
     # when the three output tiles are cached — slow (network-bound) and
-    # fragile (the >20% shortfall guard at line ~259 trips intermittently
-    # on transient 404s from the deliberately-generous border bbox).
+    # fragile (the shortfall guard, _check_shortfall, trips intermittently
+    # on transient failures from the deliberately-generous border bbox).
     # Mirrors the skip-if-exists pattern every per-VPU builder uses.
     if (
         not ctx.force
@@ -336,7 +391,7 @@ def build(step_cfg: dict, ctx: SharedRastersContext, logger) -> dict:
     logger.info("  Total unique tiles: %d", len(all_labels))
 
     t1 = time.time()
-    tile_paths = download_tiles(all_labels, raw_dir)
+    tile_paths, failed = download_tiles(all_labels, raw_dir)
     logger.info("  Download complete in %s: %d tiles available", _elapsed(t1), len(tile_paths))
 
     if not tile_paths:
@@ -344,22 +399,22 @@ def build(step_cfg: dict, ctx: SharedRastersContext, logger) -> dict:
             "No Copernicus tiles downloaded — check network access and tile labels"
         )
 
-    n_requested = len(all_labels)
-    n_downloaded = len(tile_paths)
-    if n_downloaded < n_requested:
-        shortfall_pct = 100 * (n_requested - n_downloaded) / n_requested
-        msg = (
-            f"Only {n_downloaded}/{n_requested} tiles downloaded "
-            f"({shortfall_pct:.0f}% shortfall) — border DEM may have coverage gaps"
+    # Non-404 failures (timeout / 5xx / DNS) are real download errors, not the
+    # expected open-ocean baseline. Abort regardless of the overall shortfall so
+    # a partial network outage can't silently drop land tiles from the border
+    # fill — the count-based ocean-baseline check below cannot distinguish them.
+    if failed:
+        preview = ", ".join(failed[:10]) + (" ..." if len(failed) > 10 else "")
+        raise RuntimeError(
+            f"{len(failed)} Copernicus tile(s) failed to download for a non-404 "
+            f"reason (network/HTTP error, not open-ocean): {preview} — this is a "
+            f"real download failure, not the expected ocean baseline; rerun once "
+            f"resolved"
         )
-        # The border bbox is deliberately generous (BORDER_ZONES), so a baseline
-        # ~20% of requested tiles are open-ocean / no-land and 404 *deterministically*
-        # — 1238/1557 (20.5% shortfall) for the current Canada+Mexico zones. Only
-        # abort on a gross shortfall that implies a real network/coverage failure,
-        # not this expected ocean baseline; lesser shortfalls log a warning.
-        if shortfall_pct > 30:
-            raise RuntimeError(msg)
-        logger.warning(msg)
+
+    warning = _check_shortfall(len(all_labels), len(tile_paths))
+    if warning:
+        logger.warning(warning)
 
     # --- Step 2: Mosaic raw tiles and reproject ---
     logger.info("=== Step 2/5: Mosaic -> reproject to EPSG:5070 ===")

--- a/tests/test_build_border_dem.py
+++ b/tests/test_build_border_dem.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 
 import numpy as np
+import pytest
 from osgeo import gdal, osr
 
 
@@ -49,8 +50,8 @@ def _read(path: Path) -> np.ndarray:
 class TestWriteFillMask:
     """_write_fill_mask streams a UInt8 fill-zone raster (1 where Copernicus has
     data AND NHDPlus is nodata) instead of holding full-extent arrays in memory
-    (the previous _compute_fill_mask OOM'd at CONUS scale). See issue: the
-    2x full-extent gdal.Warp-to-MEM needed ~560 GB > the 503 GB node."""
+    (the previous _compute_fill_mask OOM'd at CONUS scale — the full-extent warp
+    readbacks plus their copies exceeded the 503 GB node)."""
 
     def test_fill_zone_values(self, tmp_path):
         from gfv2_params.shared_rasters import build_border_dem as bbd
@@ -94,6 +95,36 @@ class TestWriteFillMask:
         orig = bbd.STRIP_ROWS
         try:
             bbd.STRIP_ROWS = 2  # 3 strips over 6 rows
+            bbd._write_fill_mask(
+                tmp_path / "cop.tif", tmp_path / "nhd.tif", tmp_path / "ref.tif", mask_out,
+            )
+        finally:
+            bbd.STRIP_ROWS = orig
+
+        np.testing.assert_array_equal(_read(mask_out), expected)
+
+    def test_streaming_partial_last_strip(self, tmp_path):
+        """A raster height not divisible by STRIP_ROWS must still tile fully:
+        5 rows / STRIP_ROWS=2 -> strips of 2, 2, 1 (the trailing partial strip
+        is where an off-by-one in the min() clamp / row offset would hide)."""
+        from gfv2_params.shared_rasters import build_border_dem as bbd
+
+        nd = -9999.0
+        cop = np.full((5, 3), 100.0, dtype=np.float32)
+        cop[0, :] = nd
+        nhd = np.full((5, 3), nd, dtype=np.float32)
+        nhd[2, 1] = 5.0
+        nhd[4, 2] = 7.0  # a toggle in the final 1-row strip
+        expected = ((cop != nd) & (nhd == nd)).astype(np.uint8)
+
+        _make_tif(tmp_path / "cop.tif", cop)
+        _make_tif(tmp_path / "nhd.tif", nhd)
+        _make_tif(tmp_path / "ref.tif", np.zeros((5, 3), dtype=np.float32))
+        mask_out = tmp_path / "mask.tif"
+
+        orig = bbd.STRIP_ROWS
+        try:
+            bbd.STRIP_ROWS = 2  # 3 strips over 5 rows: 2, 2, 1
             bbd._write_fill_mask(
                 tmp_path / "cop.tif", tmp_path / "nhd.tif", tmp_path / "ref.tif", mask_out,
             )
@@ -181,6 +212,125 @@ class TestApplyFillMaskCog:
         result = _read(out)
         expected = np.where(mask.astype(bool), raw, np.float32(-9999.0))
         np.testing.assert_array_equal(result, expected)
+
+    def test_masked_values_partial_last_strip(self, tmp_path):
+        """Windowed apply over a height not divisible by STRIP_ROWS: 5 rows /
+        STRIP_ROWS=2 -> 2, 2, 1, with a fill pixel in the trailing 1-row strip."""
+        from gfv2_params.shared_rasters import build_border_dem as bbd
+
+        raw = np.arange(15, dtype=np.float32).reshape(5, 3)
+        mask = np.zeros((5, 3), dtype=np.uint8)
+        mask[1, 0] = 1
+        mask[4, 2] = 1  # trailing 1-row strip
+        _make_tif(tmp_path / "raw.tif", raw)
+        _make_mask_tif(tmp_path / "mask.tif", mask)
+        out = tmp_path / "out.tif"
+
+        orig = bbd.STRIP_ROWS
+        try:
+            bbd.STRIP_ROWS = 2
+            bbd._apply_fill_mask(
+                tmp_path / "raw.tif", tmp_path / "mask.tif", out,
+                overview_resampling="BILINEAR",
+            )
+        finally:
+            bbd.STRIP_ROWS = orig
+
+        result = _read(out)
+        expected = np.where(mask.astype(bool), raw, np.float32(-9999.0))
+        np.testing.assert_array_equal(result, expected)
+
+    def test_shape_mismatch_raises(self, tmp_path):
+        """A raw/mask dimension mismatch must fail loudly, not misalign cells."""
+        from gfv2_params.shared_rasters.build_border_dem import _apply_fill_mask
+
+        raw = tmp_path / "raw.tif"
+        mask = tmp_path / "mask.tif"
+        _make_tif(raw, np.zeros((6, 4), dtype=np.float32))
+        _make_mask_tif(mask, np.ones((6, 5), dtype=np.uint8))
+
+        with pytest.raises(RuntimeError, match="Shape mismatch"):
+            _apply_fill_mask(raw, mask, tmp_path / "out.tif", overview_resampling="BILINEAR")
+
+
+class TestCheckShortfall:
+    """_check_shortfall classifies a tile-count shortfall against the ocean
+    baseline: None when complete, a warning within OCEAN_SHORTFALL_PCT (strict),
+    RuntimeError above it."""
+
+    def test_no_shortfall_returns_none(self):
+        from gfv2_params.shared_rasters.build_border_dem import _check_shortfall
+
+        assert _check_shortfall(100, 100) is None
+
+    def test_ocean_baseline_warns(self):
+        from gfv2_params.shared_rasters.build_border_dem import _check_shortfall
+
+        # ~20% — the deterministic open-ocean 404 baseline: warn, don't raise.
+        msg = _check_shortfall(100, 80)
+        assert msg is not None
+        assert "shortfall" in msg
+
+    def test_at_threshold_warns_not_raises(self):
+        from gfv2_params.shared_rasters.build_border_dem import _check_shortfall
+
+        # Exactly 30% — the guard is strict (> 30), so this warns.
+        assert _check_shortfall(100, 70) is not None
+
+    def test_above_threshold_raises(self):
+        from gfv2_params.shared_rasters.build_border_dem import _check_shortfall
+
+        # 31% — a gross shortfall implying a real coverage failure.
+        with pytest.raises(RuntimeError, match="shortfall"):
+            _check_shortfall(100, 69)
+
+
+class _FakeResp:
+    """Minimal stand-in for a streaming requests.Response context manager."""
+
+    def __init__(self, status_code: int, body: bytes = b""):
+        self.status_code = status_code
+        self._body = body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            import requests
+
+            raise requests.HTTPError(f"HTTP {self.status_code}")
+
+    def iter_content(self, chunk_size=65536):
+        yield self._body
+
+
+class TestDownloadTilesClassification:
+    """download_tiles must separate expected open-ocean 404s (silently skipped)
+    from real non-404 failures (returned in `failed` for the caller to abort)."""
+
+    def test_404_vs_error_vs_ok(self, tmp_path, monkeypatch):
+        from gfv2_params.download import copernicus_dem
+
+        labels = ["TILE_OK", "TILE_OCEAN", "TILE_BROKEN"]
+
+        def fake_get(url, stream=False, timeout=None):
+            if "TILE_OK" in url:
+                return _FakeResp(200, b"elevation-bytes")
+            if "TILE_OCEAN" in url:
+                return _FakeResp(404)
+            return _FakeResp(500)  # server error -> real failure
+
+        monkeypatch.setattr(copernicus_dem.requests, "get", fake_get)
+
+        paths, failed = copernicus_dem.download_tiles(labels, tmp_path)
+
+        assert [p.name for p in paths] == ["TILE_OK.tif"]
+        assert failed == ["TILE_BROKEN"]  # 404 is NOT a failure
+        assert (tmp_path / "TILE_OK.tif").exists()
 
 
 class TestCompositeVrtOrdering:

--- a/tests/test_build_border_dem.py
+++ b/tests/test_build_border_dem.py
@@ -25,41 +25,88 @@ def _make_tif(path: Path, data: np.ndarray, nodata: float = -9999.0) -> None:
     del ds
 
 
-class TestFillMask:
-    """Verify fill_mask = (copernicus != nodata) & (nhdplus == nodata)."""
+def _make_mask_tif(path: Path, mask: np.ndarray) -> None:
+    """Create a UInt8 mask GeoTIFF (1 = fill zone) on the standard test grid."""
+    rows, cols = mask.shape
+    driver = gdal.GetDriverByName("GTiff")
+    ds = driver.Create(str(path), cols, rows, 1, gdal.GDT_Byte)
+    ds.SetGeoTransform([0, 30, 0, 0, 0, -30])
+    srs = osr.SpatialReference()
+    srs.ImportFromEPSG(5070)
+    ds.SetProjection(srs.ExportToWkt())
+    ds.GetRasterBand(1).WriteArray(mask.astype(np.uint8))
+    ds.FlushCache()
+    del ds
 
-    def test_fill_mask_basic(self):
-        """Fill mask should be True only where Copernicus has data and NHDPlus does not."""
-        nodata = -9999.0
-        copernicus = np.array([[nodata, 500.0], [600.0, 700.0]])
-        nhdplus = np.array([[100.0, 200.0], [nodata, nodata]])
 
-        fill_mask = (copernicus != nodata) & (nhdplus == nodata)
+def _read(path: Path) -> np.ndarray:
+    ds = gdal.Open(str(path))
+    arr = ds.GetRasterBand(1).ReadAsArray()
+    del ds
+    return arr
 
-        assert not fill_mask[0, 0]
-        assert not fill_mask[0, 1]
-        assert fill_mask[1, 0]
-        assert fill_mask[1, 1]
 
-    def test_masked_slope_retains_only_fill_zone(self):
-        """After masking, slope values should only exist in the fill zone."""
-        nodata = -9999.0
-        copernicus = np.array([[nodata, 500.0], [600.0, 700.0]])
-        nhdplus = np.array([[100.0, 200.0], [nodata, nodata]])
-        raw_slope = np.array([[5.0, 10.0], [15.0, 20.0]])
+class TestWriteFillMask:
+    """_write_fill_mask streams a UInt8 fill-zone raster (1 where Copernicus has
+    data AND NHDPlus is nodata) instead of holding full-extent arrays in memory
+    (the previous _compute_fill_mask OOM'd at CONUS scale). See issue: the
+    2x full-extent gdal.Warp-to-MEM needed ~560 GB > the 503 GB node."""
 
-        fill_mask = (copernicus != nodata) & (nhdplus == nodata)
-        masked_slope = np.where(fill_mask, raw_slope, nodata)
+    def test_fill_zone_values(self, tmp_path):
+        from gfv2_params.shared_rasters import build_border_dem as bbd
 
-        assert masked_slope[0, 0] == nodata
-        assert masked_slope[0, 1] == nodata
-        assert masked_slope[1, 0] == 15.0
-        assert masked_slope[1, 1] == 20.0
+        nd = -9999.0
+        cop = np.array([[nd, 500.0], [600.0, 700.0]], dtype=np.float32)
+        nhd = np.array([[100.0, 200.0], [nd, nd]], dtype=np.float32)
+        _make_tif(tmp_path / "cop.tif", cop)
+        _make_tif(tmp_path / "nhd.tif", nhd)
+        _make_tif(tmp_path / "ref.tif", np.zeros((2, 2), dtype=np.float32))
+        mask_out = tmp_path / "mask.tif"
+
+        bbd._write_fill_mask(
+            tmp_path / "cop.tif", tmp_path / "nhd.tif", tmp_path / "ref.tif", mask_out,
+        )
+
+        # fill zone = Copernicus has data AND NHDPlus is nodata -> row 1 only
+        np.testing.assert_array_equal(
+            _read(mask_out), np.array([[0, 0], [1, 1]], dtype=np.uint8),
+        )
+
+    def test_streaming_multi_strip_matches_naive(self, tmp_path):
+        """With STRIP_ROWS forced small, the streamed mask must equal the naive
+        full-array computation across strip boundaries."""
+        from gfv2_params.shared_rasters import build_border_dem as bbd
+
+        nd = -9999.0
+        cop = np.full((6, 4), 100.0, dtype=np.float32)
+        cop[0, :] = nd
+        cop[3, 1] = nd
+        nhd = np.full((6, 4), nd, dtype=np.float32)
+        nhd[4, :] = 5.0
+        nhd[0, 0] = 5.0
+        expected = ((cop != nd) & (nhd == nd)).astype(np.uint8)
+
+        _make_tif(tmp_path / "cop.tif", cop)
+        _make_tif(tmp_path / "nhd.tif", nhd)
+        _make_tif(tmp_path / "ref.tif", np.zeros((6, 4), dtype=np.float32))
+        mask_out = tmp_path / "mask.tif"
+
+        orig = bbd.STRIP_ROWS
+        try:
+            bbd.STRIP_ROWS = 2  # 3 strips over 6 rows
+            bbd._write_fill_mask(
+                tmp_path / "cop.tif", tmp_path / "nhd.tif", tmp_path / "ref.tif", mask_out,
+            )
+        finally:
+            bbd.STRIP_ROWS = orig
+
+        np.testing.assert_array_equal(_read(mask_out), expected)
 
 
 class TestApplyFillMaskCog:
-    """The masked slope/aspect fill tiles feed the slope/aspect VRTs and must
-    be COGs (tiled 512 + overviews + ZSTD/pred3), like the per-VPU outputs."""
+    """_apply_fill_mask stream-applies a mask RASTER to a raw slope/aspect tile
+    and writes a COG (tiled 512 + overviews + ZSTD/pred3), windowed to avoid
+    loading the full-extent raw into memory."""
 
     def _meta(self, path):
         ds = gdal.Open(str(path))
@@ -80,9 +127,10 @@ class TestApplyFillMaskCog:
         from gfv2_params.shared_rasters.build_border_dem import _apply_fill_mask
 
         raw = tmp_path / "slope_raw.tif"
+        mask = tmp_path / "mask.tif"
         out = tmp_path / "slope.tif"
         _make_tif(raw, np.full((1024, 1024), 7.5, dtype=np.float32))
-        mask = np.ones((1024, 1024), dtype=bool)
+        _make_mask_tif(mask, np.ones((1024, 1024), dtype=np.uint8))
 
         _apply_fill_mask(raw, mask, out, overview_resampling="BILINEAR")
 
@@ -98,13 +146,41 @@ class TestApplyFillMaskCog:
         from gfv2_params.shared_rasters.build_border_dem import _apply_fill_mask
 
         raw = tmp_path / "aspect_raw.tif"
+        mask = tmp_path / "mask.tif"
         out = tmp_path / "aspect.tif"
         _make_tif(raw, np.full((1024, 1024), 180.0, dtype=np.float32))
-        mask = np.ones((1024, 1024), dtype=bool)
+        _make_mask_tif(mask, np.ones((1024, 1024), dtype=np.uint8))
 
         _apply_fill_mask(raw, mask, out, overview_resampling="NEAREST")
 
         assert self._meta(out)["overview_resampling"] == "NEAREST"
+
+    def test_masked_values_multi_strip(self, tmp_path):
+        """Windowed apply must keep raw values in the fill zone and write nodata
+        elsewhere, correctly across strip boundaries."""
+        from gfv2_params.shared_rasters import build_border_dem as bbd
+
+        raw = np.arange(24, dtype=np.float32).reshape(6, 4)
+        mask = np.zeros((6, 4), dtype=np.uint8)
+        mask[1, 1] = 1
+        mask[4, 3] = 1  # in different strips (STRIP_ROWS=2)
+        _make_tif(tmp_path / "raw.tif", raw)
+        _make_mask_tif(tmp_path / "mask.tif", mask)
+        out = tmp_path / "out.tif"
+
+        orig = bbd.STRIP_ROWS
+        try:
+            bbd.STRIP_ROWS = 2
+            bbd._apply_fill_mask(
+                tmp_path / "raw.tif", tmp_path / "mask.tif", out,
+                overview_resampling="BILINEAR",
+            )
+        finally:
+            bbd.STRIP_ROWS = orig
+
+        result = _read(out)
+        expected = np.where(mask.astype(bool), raw, np.float32(-9999.0))
+        np.testing.assert_array_equal(result, expected)
 
 
 class TestCompositeVrtOrdering:


### PR DESCRIPTION
Two `build_border_dem` fixes found while running the CONUS COG rebuild (the border DEM step failed twice, for two independent reasons).

## 1. Relax the Copernicus download-shortfall guard (20% → 30%)

`build_border_dem` aborts when the GLO-30 tile shortfall exceeds 20%. But the border bbox (`BORDER_ZONES`) is deliberately generous, so a baseline ~20% of requested tiles are open-ocean / no-land and **404 deterministically** — `1238/1557` (20.5%) for the current Canada+Mexico zones. The guard tripped on every run. Raised to `>30%` (still catches a gross/real download failure; lesser shortfalls log a warning). Comment documents the deterministic 20.5% figure.

## 2. Stream `_compute_fill_mask` / `_apply_fill_mask` (fix CONUS OOM)

Step 5 held the full Copernicus fill extent (~29.6 B cells) in memory:
- `_compute_fill_mask` did **two** `gdal.Warp(format="MEM")` full-extent readbacks + their float32 copies (~4×139 GiB), and
- `_apply_fill_mask` loaded the full 149 GB raw slope/aspect.

Together that's well over the 503 GiB node, so after ~1h of single-threaded full-extent warping it OOM'd (`numpy _ArrayMemoryError: Unable to allocate 139 GiB`). This blocked the border slope/aspect fill tiles from being rebuilt as COGs during the rebuild (the run finished on the pre-existing fill).

Reworked both as **windowed strips** (`STRIP_ROWS=4096`, mirroring `carea_map`'s pattern):
- `_write_fill_mask` streams a UInt8 fill-zone mask (1 = Copernicus-has-data AND NHDPlus-nodata) onto the raw grid, warping each strip's window to MEM.
- `_apply_fill_mask` stream-applies that mask raster to the raw slope/aspect strip-by-strip, then `to_cog` (COG output unchanged).
- `build()` computes the mask once (to disk) and applies it to both slope and aspect; `fill_mask.tif` is registered as an intermediate for cleanup.

**Peak memory drops from ~560 GB to ~10 GB** (strip-sized), and it avoids the single giant in-memory warp. This unblocks rebuilding the border slope/aspect tiles as COGs.

## Tests

`tests/test_build_border_dem.py` rewritten for the streaming API: `_write_fill_mask` fill-zone values, `_apply_fill_mask` COG format (bilinear/nearest), and **multi-strip correctness** (mask + masked output equal the naive full-array result across strip seams, with `STRIP_ROWS` forced small).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
