### PR TITLE
fix(depstor): on-stream waterbodies as drains_to_dprst barriers (closes #158)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,13 @@ These are hard-won; violating them silently corrupts outputs.
   on a fully drainage-enforced FDR with interior sinks removed — *not* the opt-in
   richdem `Fdr_hydrodem` from `compute_dem_derivatives.py`. See `docs/ARCHITECTURE.md`
   and issue #147 (depression-respecting FDR investigation) for the provenance/tradeoff.
+- **On-stream waterbodies are traversal barriers in `routing`.** Land upslope
+  of an on-stream (non-dprst) waterbody is captured by that waterbody's
+  stream/lake routing and must not be attributed to a downstream depression —
+  `routing` stops a cell's D8 trace at the first on-stream waterbody cell it
+  hits, before it can reach a dprst pour-point. The barrier set is the full
+  `onstream` mask (no size filtering); the fix is a strict subtraction that
+  can only reduce `drains_to_dprst` coverage, never increase it.
 - **Land masking.** Every depstor raster is masked against `land_mask.tif` (HRU
   fabric rasterised by the `landmask` step). Never use hydro-DEM nodata or FDR
   as a land mask.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -192,6 +192,16 @@ These are hard-won; violating them silently corrupts outputs.
   [`docs/superpowers/specs/2026-06-29-depression-respecting-fdr-design.md`](superpowers/specs/2026-06-29-depression-respecting-fdr-design.md)
   and the A/B runbook in `slurm_batch/HPC_REFERENCE.md`
   ("§ #147 depression-respecting FDR A/B").
+- **On-stream waterbodies are traversal barriers in `routing`.** The `routing`
+  step also consumes `onstream_binary.tif` (emitted by the `dprst` step): a
+  cell is `drains_to_dprst` only if its D8 flow path reaches a
+  depression-storage pour-point **before** it reaches any on-stream waterbody
+  cell — traversal stops at the first waterbody on the path. This makes
+  `drains_to_dprst` a strict subtraction from the pre-barrier behavior
+  (coverage can only decrease, never increase): land upslope of an on-stream
+  lake or reservoir is captured by that waterbody's stream/lake routing, not
+  a downstream depression. Playas need no special handling — they are
+  classified `dprst`, never `onstream`, so they are never barriers.
 - **Land masking.** Every depstor raster is masked against `land_mask.tif`
   (the HRU fabric rasterised by the `landmask` step). Never use hydro-DEM
   nodata or FDR as a land mask.

--- a/docs/superpowers/plans/2026-07-01-drains-to-dprst-onstream-barrier.md
+++ b/docs/superpowers/plans/2026-07-01-drains-to-dprst-onstream-barrier.md
@@ -1,0 +1,299 @@
+# drains_to_dprst On-Stream Waterbody Barrier — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make on-stream (non-dprst) waterbodies act as barriers in the D8 routing traversal, so land upslope of an on-stream lake is no longer wrongly attributed to a downstream depression-storage waterbody.
+
+**Architecture:** Add an explicit `barrier` mask to the in-process D8 kernel (`d8_routing.py`): barrier cells are seeded non-draining and terminate any flow path that reaches them, giving "first waterbody on the path wins" semantics. The `routing` builder reads the `onstream_binary.tif` the `dprst` step already emits, scopes it per-VPU with the existing `vpu_pour_points` helper, and passes it as the barrier. The result is a strict subtraction from today's `drains_to_dprst` raster.
+
+**Tech Stack:** Python, NumPy, numba (`@njit`), rasterio, GDAL; pytest; pixi-managed env.
+
+## Global Constraints
+
+- Env is pixi-managed; run tests with `pixi run -e dev pytest ...`. Do **not** run pytest on the HPC head node — CI is the gate, but local single-file pytest runs here are done in the pixi dev env, not the login node.
+- The kernel is the only numba user; keep it numba-compatible (typed scalars, no Python objects inside `@njit`).
+- `barrier_win` is a **required positional** argument (non-backward-compatible change, approved). Every caller must pass a barrier.
+- ESRI-D8 encoding: `1=E 2=SE 4=S 8=SW 16=W 32=NW 64=N 128=NE`; `255` (and any other value) = nodata/sink.
+- dprst and on-stream masks are disjoint by construction; when both seed the same cell, dprst (`_DRAINS`) wins.
+- Run `pixi run -e dev pre-commit run --all-files` before the final commit.
+
+---
+
+### Task 1: Kernel barrier support
+
+**Files:**
+- Modify: `src/gfv2_params/d8_routing.py` (the `_resolve` `@njit` function, the `drains_to_dprst_kernel` wrapper, and the module docstring)
+- Test: `tests/test_drains_kernel.py`
+
+**Interfaces:**
+- Produces: `drains_to_dprst_kernel(fdr_win, pour_win, barrier_win, fdr_nodata=255) -> (out: uint8 ndarray, n_cycles: int)`. `barrier_win` is uint8, `1` = barrier cell (on-stream waterbody), `0` = background, same shape as `fdr_win`/`pour_win`. A cell whose D8 path reaches a barrier cell before a pour cell is `0` in `out`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_drains_kernel.py`:
+
+```python
+def test_barrier_blocks_upslope_from_pour():
+    # Row flowing East into a pour point at the right end, with a barrier in
+    # the middle:  cell0 ->  cell1 -> [barrier] -> [pour]
+    # cell0/cell1 hit the barrier before the pour => not draining.
+    fdr = np.array([[1, 1, 1, 255]], dtype=np.uint8)
+    pour = np.array([[0, 0, 0, 1]], dtype=np.uint8)
+    barrier = np.array([[0, 0, 1, 0]], dtype=np.uint8)
+    out, n_cycles = drains_to_dprst_kernel(fdr, pour, barrier)
+    # cell0, cell1 blocked; barrier itself non-draining; pour drains itself.
+    assert out.tolist() == [[0, 0, 0, 1]]
+    assert n_cycles == 0
+
+
+def test_barrier_downstream_of_pour_does_not_unmark():
+    # Path reaches the pour BEFORE the barrier: first-waterbody-wins => drains.
+    # cell0 -> [pour] -> [barrier]
+    fdr = np.array([[1, 1, 255]], dtype=np.uint8)
+    pour = np.array([[0, 1, 0]], dtype=np.uint8)
+    barrier = np.array([[0, 0, 1]], dtype=np.uint8)
+    out, n_cycles = drains_to_dprst_kernel(fdr, pour, barrier)
+    assert out.tolist() == [[1, 1, 0]]
+    assert n_cycles == 0
+
+
+def test_no_barrier_is_equivalent_to_old_behavior():
+    # An all-zero barrier reproduces the pre-barrier straight-chain result.
+    fdr = np.array([[1, 1, 1, 255]], dtype=np.uint8)
+    pour = np.array([[0, 0, 0, 1]], dtype=np.uint8)
+    barrier = np.zeros_like(pour)
+    out, n_cycles = drains_to_dprst_kernel(fdr, pour, barrier)
+    assert out.tolist() == [[1, 1, 1, 1]]
+    assert n_cycles == 0
+
+
+def test_pour_wins_when_cell_is_both_pour_and_barrier():
+    # Defensive: overlap is impossible by construction, but if a cell is both,
+    # dprst (_DRAINS) must win over the barrier seed.
+    fdr = np.array([[1, 255]], dtype=np.uint8)
+    pour = np.array([[0, 1]], dtype=np.uint8)
+    barrier = np.array([[0, 1]], dtype=np.uint8)
+    out, n_cycles = drains_to_dprst_kernel(fdr, pour, barrier)
+    assert out.tolist() == [[1, 1]]
+    assert n_cycles == 0
+```
+
+Then migrate every **existing** call in this file to pass a barrier. Mechanical rule: insert `np.zeros_like(pour)` (or `np.zeros((H, W), dtype=np.uint8)` where the fixture uses a fresh pour array) as the **third positional argument**, before any `fdr_nodata=` keyword. Representative before/after:
+
+```python
+# before
+out, n_cycles = drains_to_dprst_kernel(fdr, pour)
+# after
+out, n_cycles = drains_to_dprst_kernel(fdr, pour, np.zeros_like(pour))
+
+# before (custom nodata)
+out, n_cycles = drains_to_dprst_kernel(fdr, pour, fdr_nodata=0)
+# after
+out, n_cycles = drains_to_dprst_kernel(fdr, pour, np.zeros_like(pour), fdr_nodata=0)
+```
+
+Apply to all pre-existing tests: `test_pour_point_itself_drains`, `test_straight_chain_into_pour_point`, `test_chain_draining_away_is_not_marked`, `test_two_cell_cycle_with_no_pour_terminates_and_marks_zero`, `test_four_cell_cycle_with_no_pour_terminates_and_marks_zero`, `test_cell_upstream_of_cycle_not_marked`, `test_cycle_containing_pour_point_marks_drains`, `test_nodata_sink_does_not_drain`, `test_branching_tributaries_all_reach_pour`, `test_all_eight_directions_decode_into_a_central_pour`, `test_off_window_flow_does_not_drain`, `test_custom_nodata_value_terminates`.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pixi run -e dev pytest tests/test_drains_kernel.py -q`
+Expected: FAIL — `drains_to_dprst_kernel()` / `_resolve()` got an unexpected positional argument (the new `barrier` param does not exist yet).
+
+- [ ] **Step 3: Implement the kernel change**
+
+In `src/gfv2_params/d8_routing.py`, change the `@njit` signature and add barrier seeding after the pour seeding:
+
+```python
+@njit(cache=True)
+def _resolve(fdr, pour, barrier, fdr_nodata):
+    ny, nx = fdr.shape
+    st = np.zeros((ny, nx), dtype=np.uint8)
+
+    # Seed: every pour-point cell drains (to itself / the depression).
+    for r in range(ny):
+        for c in range(nx):
+            if pour[r, c] == 1:
+                st[r, c] = _DRAINS
+
+    # Seed barriers as non-draining termini (on-stream waterbodies). A flow
+    # path that reaches a barrier before a pour resolves _NOT and stops there,
+    # so its upslope land is not attributed to a downstream depression. dprst
+    # wins any overlap (disjoint by construction; only seed still-_UNKNOWN cells).
+    for r in range(ny):
+        for c in range(nx):
+            if barrier[r, c] == 1 and st[r, c] == _UNKNOWN:
+                st[r, c] = _NOT
+```
+
+Update the wrapper to accept and forward `barrier_win`:
+
+```python
+def drains_to_dprst_kernel(fdr_win, pour_win, barrier_win, fdr_nodata=255):
+    ...
+    fdr = np.ascontiguousarray(fdr_win, dtype=np.uint8)
+    pour = np.ascontiguousarray(pour_win, dtype=np.uint8)
+    barrier = np.ascontiguousarray(barrier_win, dtype=np.uint8)
+    return _resolve(fdr, pour, barrier, np.uint8(fdr_nodata))
+```
+
+Also update the module docstring and the `drains_to_dprst_kernel` docstring: note that pour-points (dprst) seed `_DRAINS`, barrier cells (on-stream waterbodies) seed `_NOT`, and semantics are "first waterbody on the flow path wins"; document the new `barrier_win` parameter.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pixi run -e dev pytest tests/test_drains_kernel.py -q`
+Expected: PASS (all migrated + 4 new tests green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/gfv2_params/d8_routing.py tests/test_drains_kernel.py
+git commit -m "feat(routing): add barrier mask to D8 drains_to_dprst kernel"
+```
+
+---
+
+### Task 2: Wire the on-stream barrier through the routing builder
+
+**Files:**
+- Modify: `src/gfv2_params/depstor_builders/routing.py` (require `onstream`, read per-VPU window, pass barrier to the kernel, module docstring)
+- Test: `tests/test_routing_tiling.py`
+
+**Interfaces:**
+- Consumes: `drains_to_dprst_kernel(fdr_masked, pour, barrier, fdr_nodata=255)` from Task 1; `vpu_pour_points(mask_win, vpu_win, code) -> uint8 ndarray` (reused for the on-stream barrier — it is the generic "this VPU's cells where mask==1" op); `ctx.require("onstream")` returning the `onstream_binary.tif` path emitted by the `dprst` step.
+- Produces: unchanged output contract — `{"drains_to_dprst": output_path}`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_routing_tiling.py` (it already imports `vpu_pour_points` and NumPy; add `from gfv2_params.d8_routing import drains_to_dprst_kernel` at the top if not present). This pins the tiled-helper behavior the builder relies on, without file I/O:
+
+```python
+def test_onstream_barrier_blocks_drainage_at_helper_level():
+    # Single VPU (code 1). Row flows East into a dprst pour at the right end,
+    # with an on-stream waterbody cell in the middle acting as a barrier.
+    #   land -> land -> [onstream] -> [dprst]
+    from gfv2_params.d8_routing import drains_to_dprst_kernel
+
+    vpu = np.ones((1, 4), dtype=np.uint8)
+    fdr = np.array([[1, 1, 1, 255]], dtype=np.uint8)
+    dprst = np.array([[0, 0, 0, 1]], dtype=np.uint8)
+    onstream = np.array([[0, 0, 1, 0]], dtype=np.uint8)
+
+    pour = vpu_pour_points(dprst, vpu, code=1)
+    barrier = vpu_pour_points(onstream, vpu, code=1)  # reused: mask ∩ VPU
+    out, _ = drains_to_dprst_kernel(fdr, pour, barrier)
+
+    assert out.tolist() == [[0, 0, 0, 1]]  # upslope land blocked by on-stream cell
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pixi run -e dev pytest tests/test_routing_tiling.py::test_onstream_barrier_blocks_drainage_at_helper_level -q`
+Expected: FAIL — `drains_to_dprst_kernel()` missing the `barrier` positional (only if Task 1 not yet merged) OR, once Task 1 is in, the test is the new spec and passes only after confirming the helper wiring. (If Task 1 is already committed, this test passes immediately; that is acceptable — it documents the builder's intended composition and guards against regressions in the reused helper.)
+
+- [ ] **Step 3: Implement the builder change**
+
+In `src/gfv2_params/depstor_builders/routing.py`:
+
+Add the require next to the other requires (after `dprst_path = ctx.require("dprst")`):
+
+```python
+    onstream_path = ctx.require("onstream")
+```
+
+Open the on-stream raster alongside FDR and dprst in the `with` block:
+
+```python
+        with rasterio.open(fdr_aligned) as fdr_src, \
+                rasterio.open(dprst_path) as dprst_src, \
+                rasterio.open(onstream_path) as onstream_src:
+            for code in codes:
+                bbox = vpu_bbox(vpu_id, code)
+                r0, r1, c0, c1 = bbox
+                window = Window(c0, r0, c1 - c0, r1 - r0)
+                vpu_win = vpu_id[r0:r1, c0:c1]
+                fdr_win = fdr_src.read(1, window=window)
+                dprst_win = dprst_src.read(1, window=window)
+                onstream_win = onstream_src.read(1, window=window)
+
+                fdr_masked = mask_fdr_to_vpu(fdr_win, vpu_win, code, nodata=255)
+                pour = vpu_pour_points(dprst_win, vpu_win, code)
+                # On-stream waterbodies of THIS vpu are traversal barriers, so
+                # land captured by an on-stream lake is not attributed to a
+                # downstream dprst. vpu_pour_points is the generic mask∩VPU op.
+                barrier = vpu_pour_points(onstream_win, vpu_win, code)
+```
+
+Pass the barrier to the kernel (replace the existing call):
+
+```python
+                ws_win, n_cycles = drains_to_dprst_kernel(
+                    fdr_masked, pour, barrier, fdr_nodata=255
+                )
+```
+
+Add a barrier-cell count to the per-VPU logging (place next to the existing `n_vpu` log, in the `else` branch or just before it):
+
+```python
+                n_barrier = int((barrier == 1).sum())
+                if n_barrier:
+                    logger.info("  VPU %d: %d on-stream barrier cell(s)", code, n_barrier)
+```
+
+Update the module docstring: state that on-stream waterbody cells (`onstream_binary.tif`) are passed as barriers so the traversal stops at the first waterbody on each flow path (dprst → drains, on-stream → not), and that `drains_to_dprst` is therefore a strict subtraction from the pre-barrier raster.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pixi run -e dev pytest tests/test_routing_tiling.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/gfv2_params/depstor_builders/routing.py tests/test_routing_tiling.py
+git commit -m "feat(routing): treat on-stream waterbodies as drains_to_dprst barriers"
+```
+
+---
+
+### Task 3: Repo-level docs
+
+**Files:**
+- Modify: `docs/ARCHITECTURE.md` (depstor / routing section)
+- Modify: `CLAUDE.md` (the `drains_to_dprst` / depstor gotchas region)
+
+**Interfaces:** none (documentation only).
+
+- [ ] **Step 1: Update ARCHITECTURE.md**
+
+In the depstor routing description, add that the `routing` step consumes `onstream_binary.tif` (from the `dprst` step) as a **barrier**: a cell is `drains_to_dprst` only if its D8 flow path reaches a depression-storage cell **before** any on-stream waterbody cell. State that this makes `drains_to_dprst` a strict subtraction from the pre-barrier behavior (coverage can only decrease) and that playas need no special handling (classified dprst, never on-stream).
+
+- [ ] **Step 2: Update CLAUDE.md**
+
+In the depstor conventions, add a bullet: on-stream (non-dprst) waterbodies act as traversal barriers in `routing`; land upslope of an on-stream waterbody is captured by that waterbody's stream/lake routing and must not be attributed to a downstream depression. The barrier set is the full `onstream` mask (no size filtering); the fix is a strict subtraction that can only reduce `drains_to_dprst` coverage.
+
+- [ ] **Step 3: Run pre-commit and commit**
+
+Run: `pixi run -e dev pre-commit run --all-files`
+Expected: PASS (or auto-fix, then re-stage).
+
+```bash
+git add docs/ARCHITECTURE.md CLAUDE.md
+git commit -m "docs(depstor): document on-stream waterbody barrier in drains_to_dprst"
+```
+
+---
+
+## Validation (post-implementation, on HPC — not part of the unit-test cycle)
+
+This is the runtime check folded in from the spec. It is **not** a pytest step; it runs the pipeline on real data.
+
+1. Rebuild `dprst` first so the current classifier output (and `onstream_binary.tif`) is on disk. Per the depstor rebuild cascade, changing/regenerating dprst cascades into `routing`.
+2. Run the `routing` step; confirm the new per-VPU "on-stream barrier cell(s)" log lines appear.
+3. On VPU 15: compare `drains_to_dprst` area before vs. after — expect a decrease concentrated below on-stream lakes/reservoirs; coverage must not increase anywhere.
+4. Spot-check that no legitimate terminal-basin land was dropped by a mislabeled on-stream cell (a data-quality check on the on-stream mask, not the logic).
+
+## Self-Review notes
+
+- **Spec coverage:** kernel barrier (Task 1), builder wiring + onstream require + per-VPU scoping + logging (Task 2), docstrings (Tasks 1–2), ARCHITECTURE.md + CLAUDE.md (Task 3), validation (runtime section). Playa handling requires no code (classifier already excludes them from `onstream`) — documented, not implemented.
+- **Non-backward-compatible kernel signature:** all 12 existing kernel tests migrated in Task 1 Step 1; the builder is the only production caller and is updated in Task 2.
+- **DRY:** the on-stream barrier reuses `vpu_pour_points` rather than adding a duplicate helper.

--- a/docs/superpowers/specs/2026-07-01-drains-to-dprst-onstream-barrier-design.md
+++ b/docs/superpowers/specs/2026-07-01-drains-to-dprst-onstream-barrier-design.md
@@ -1,0 +1,120 @@
+# drains_to_dprst on-stream waterbody barrier — design
+
+Date: 2026-07-01
+Status: approved (brainstorming)
+Branch: TBD (feature branch off `main`)
+
+## Problem
+
+`drains_to_dprst.tif` (built by the `routing` step,
+`src/gfv2_params/depstor_builders/routing.py`, via the in-process D8 kernel in
+`src/gfv2_params/d8_routing.py`) marks, for each cell, whether its ESRI-D8 flow
+path eventually reaches a **depression-storage (dprst) pour-point cell**. The
+pour-point set is exactly the dprst waterbody cells.
+
+The FDR the traversal walks is the fully depression-filled NHDPlus HydroDEM, so
+the traversal passes **straight through** any on-stream (non-dprst) waterbody as
+if it were not there. As a result, a cell that first drains into an on-stream
+waterbody — whose outflow then continues downstream and eventually reaches a
+dprst waterbody — is incorrectly counted as draining to depression storage.
+Observed in VPU 15.
+
+`drains_to_dprst` feeds `drains_perv` (× `perv`) and `drains_imperv`
+(× `imperv`) via `depstor_builders/intersect.py`, i.e. the fractions of an HRU's
+pervious/impervious area that drain to depression storage. Over-attribution here
+inflates those fractions.
+
+## Hydrologic principle
+
+By the classifier's definition, a depression-storage waterbody is an
+**off-network / terminal** feature (inflow-only sink, outflow-only pothole, or
+isolated depression) **plus playas** (force-classified dprst regardless of
+apparent connectivity). Surface runoff captured by an on-stream waterbody has
+entered the stream/lake routing network; its outflow is streamflow, not inflow
+to a downstream depression's storage. So land upslope of an on-stream waterbody
+must not be attributed to a downstream dprst.
+
+An on-stream waterbody should therefore act as a **barrier**: any cell whose flow
+path hits an on-stream waterbody *before* reaching a dprst is not
+`drains_to_dprst`.
+
+Notes settled during brainstorming:
+
+- **Playas need no special handling.** Playas are classified `dprst`, never
+  `onstream`, so they are never in the barrier set and their contributing area
+  always counts. The classifier already carves them out.
+- **Barrier set = all on-stream waterbodies**, including small on-stream ponds.
+  No size/name filtering — treat every on-stream waterbody like any other.
+- **Scope is on-stream waterbodies only, not the full stream-channel network.**
+  With a correct dprst classifier, open-drainage land only reaches a "dprst" by
+  routing through an on-network *waterbody*; barrier-ing those is minimal and
+  sufficient. A pure river channel threading a terminal depression is a rare
+  filled-FDR artifact and is out of scope (YAGNI).
+
+## Approach (selected)
+
+Add an explicit **barrier mask** to the D8 kernel rather than mutating the FDR.
+Rejected alternative: burning on-stream cells into the FDR as nodata/sinks —
+functionally similar but conflates classification with flow data and muddies the
+"unexpected FDR code" diagnostics.
+
+### Kernel — `src/gfv2_params/d8_routing.py`
+
+- New signature: `drains_to_dprst_kernel(fdr_win, pour_win, barrier_win, fdr_nodata=255)`.
+  `barrier_win` is uint8, `1` = on-stream waterbody cell, `0` = background.
+- In `_resolve`, after seeding pour cells to `_DRAINS`, seed cells that are
+  `barrier == 1` **and still `_UNKNOWN`** to `_NOT`. dprst wins any overlap
+  (disjoint by construction; precedence made explicit for determinism).
+- Traversal is otherwise unchanged. A path that reaches a barrier cell (state
+  `_NOT`) resolves non-draining and stops; a barrier cell's own downstream walk
+  is skipped because its state is no longer `_UNKNOWN`. Net semantics: **first
+  waterbody on the flow path wins.**
+
+### Builder — `src/gfv2_params/depstor_builders/routing.py`
+
+- `onstream_path = ctx.require("onstream")` — the `onstream_binary.tif` the
+  `dprst` step already emits. `routing` already depends on `dprst`, so it is on
+  disk; no DAG reorder needed.
+- Per VPU, read the on-stream window like `dprst_win`, mask it to the VPU code
+  (mirroring `vpu_pour_points`), and pass it as `barrier_win`.
+- Keep existing per-VPU "N cells drain to dprst" logging; optionally add a
+  barrier-cell count for visibility.
+
+### Semantics / invariants
+
+`drains_to_dprst` becomes a **strict subtraction** from today's raster: a cell is
+dropped iff its flow path hits an on-stream waterbody before any dprst. Coverage
+can only decrease. The existing all-nodata guard and the >50% coverage warning
+remain valid.
+
+## Tests
+
+- `tests/test_drains_kernel.py`:
+  - linear chain `upslope → barrier → pour` ⇒ upslope **not** marked, pour marked;
+  - `upslope → pour` (no barrier) ⇒ still marked (regression guard);
+  - barrier placed **downstream** of a pour ⇒ upslope still marked (first-hit-wins).
+- `tests/test_routing_tiling.py`: update kernel/builder call sites for the new
+  argument; add a small "barrier blocks drainage" tiling case.
+
+## Docs (same branch, per repo convention)
+
+- Module docstrings in `d8_routing.py` and `routing.py`.
+- The depstor section of `docs/ARCHITECTURE.md`.
+- The `drains_to_dprst` note in `CLAUDE.md`.
+
+## Validation
+
+1. Rebuild `dprst` first — picks up the recent classifier changes, yielding the
+   current set of depression-storage (and on-stream) waterbodies.
+2. Run `routing` with the barrier.
+3. On a test VPU (15): compare `drains_to_dprst` area before/after — expect a
+   decrease concentrated below on-stream lakes.
+4. Spot-check that no legitimate terminal-basin land was dropped by a mislabeled
+   on-stream cell (data-quality check on the on-stream mask, not the logic).
+
+## Out of scope
+
+- Full stream-channel-network barrier (channels, not just waterbodies).
+- Partial-capture / spill modeling for on-stream waterbodies — `drains_to_dprst`
+  is an a-priori binary land attribution; PRMS routes the lake/stream network
+  separately.

--- a/scripts/diagnose/ab_drains_to_dprst.py
+++ b/scripts/diagnose/ab_drains_to_dprst.py
@@ -81,7 +81,12 @@ def _run_one_vpu(fdr_path, dprst_path, vpu_id_path, template_path, vpu_code,
             dprst_win = dsrc.read(1, window=window)
         fdr_masked = mask_fdr_to_vpu(fdr_win, vpu_win, code, nodata=255)
         pour = vpu_pour_points(dprst_win, vpu_win, code)
-        drains, n_cycles = drains_to_dprst_kernel(fdr_masked, pour, fdr_nodata=255)
+        # This A/B diagnostic compares FDR variants only; it has no on-stream
+        # barrier concept, so pass an all-zero barrier (keeps the binary result
+        # comparable to the barrier-free labeled kernel below for the
+        # n_labeled == n_drain self-check).
+        no_barrier = np.zeros_like(pour)
+        drains, n_cycles = drains_to_dprst_kernel(fdr_masked, pour, no_barrier, fdr_nodata=255)
         n_land = int((vpu_win == code).sum())
         n_drain = int((drains[vpu_win == code] == 1).sum())
         logger.info("VPU %d [%s]: %d/%d land cells drain (%.4f); %d cycles",

--- a/src/gfv2_params/d8_routing.py
+++ b/src/gfv2_params/d8_routing.py
@@ -8,7 +8,12 @@ docs/superpowers/specs/2026-05-29-depstor-d8-routing-kernel-design.md).
 `drains_to_dprst_kernel` answers, for every cell: does following the ESRI-D8
 flow pointer downstream eventually reach a depression pour-point? It is the
 upslope contributing area of the pour-point set on a functional (out-degree-1)
-flow graph — a textbook O(N) traversal.
+flow graph — a textbook O(N) traversal. Pour-point (dprst) cells seed as
+draining; barrier cells (on-stream waterbodies) seed as non-draining termini,
+so a flow path that reaches a barrier before a pour stops there and its
+upslope land is not attributed to a downstream depression — the first
+waterbody on the flow path wins (dprst wins any impossible-by-construction
+overlap with a barrier).
 
 `drains_to_dprst_labeled_kernel` extends this to per-depression attribution:
 each cell receives the label of the specific depression its D8 path reaches,
@@ -32,6 +37,119 @@ _UNKNOWN = 0
 _DRAINS = 1
 _NOT = 2
 _ACTIVE = 3  # currently on the path being walked (detects cycles)
+
+
+@njit(cache=True)
+def _resolve(fdr, pour, barrier, fdr_nodata):
+    ny, nx = fdr.shape
+    st = np.zeros((ny, nx), dtype=np.uint8)
+
+    # Seed: every pour-point cell drains (to itself / the depression).
+    for r in range(ny):
+        for c in range(nx):
+            if pour[r, c] == 1:
+                st[r, c] = _DRAINS
+
+    # Seed barriers as non-draining termini (on-stream waterbodies). A flow
+    # path that reaches a barrier before a pour resolves _NOT and stops there,
+    # so its upslope land is not attributed to a downstream depression. dprst
+    # wins any overlap (disjoint by construction; only seed still-_UNKNOWN cells).
+    for r in range(ny):
+        for c in range(nx):
+            if barrier[r, c] == 1 and st[r, c] == _UNKNOWN:
+                st[r, c] = _NOT
+
+    cap = 1 << 20
+    stack_r = np.empty(cap, dtype=np.int64)
+    stack_c = np.empty(cap, dtype=np.int64)
+    n_cycles = 0
+
+    for sr in range(ny):
+        for sc in range(nx):
+            if st[sr, sc] != _UNKNOWN:
+                continue
+            n = 0
+            cr = sr
+            cc = sc
+            result = _NOT
+            while True:
+                s = st[cr, cc]
+                if s == _DRAINS:
+                    result = _DRAINS
+                    break
+                if s == _NOT:
+                    result = _NOT
+                    break
+                if s == _ACTIVE:
+                    n_cycles += 1
+                    result = _NOT
+                    break
+
+                st[cr, cc] = _ACTIVE
+                if n >= cap:
+                    new_cap = cap * 2
+                    nr_ = np.empty(new_cap, dtype=np.int64)
+                    nc_ = np.empty(new_cap, dtype=np.int64)
+                    nr_[:cap] = stack_r
+                    nc_[:cap] = stack_c
+                    stack_r = nr_
+                    stack_c = nc_
+                    cap = new_cap
+                stack_r[n] = cr
+                stack_c[n] = cc
+                n += 1
+
+                code = fdr[cr, cc]
+                if code == fdr_nodata:
+                    result = _NOT
+                    break
+                if code == 1:
+                    dr = 0
+                    dc = 1
+                elif code == 2:
+                    dr = 1
+                    dc = 1
+                elif code == 4:
+                    dr = 1
+                    dc = 0
+                elif code == 8:
+                    dr = 1
+                    dc = -1
+                elif code == 16:
+                    dr = 0
+                    dc = -1
+                elif code == 32:
+                    dr = -1
+                    dc = -1
+                elif code == 64:
+                    dr = -1
+                    dc = 0
+                elif code == 128:
+                    dr = -1
+                    dc = 1
+                else:
+                    result = _NOT
+                    break
+
+                nr2 = cr + dr
+                nc2 = cc + dc
+                if nr2 < 0 or nr2 >= ny or nc2 < 0 or nc2 >= nx:
+                    result = _NOT
+                    break
+                cr = nr2
+                cc = nc2
+
+            for i in range(n):
+                rr = stack_r[i]
+                ric = stack_c[i]
+                st[rr, ric] = result
+
+    out = np.zeros((ny, nx), dtype=np.uint8)
+    for r in range(ny):
+        for c in range(nx):
+            if st[r, c] == _DRAINS:
+                out[r, c] = 1
+    return out, n_cycles
 
 
 @njit(cache=True)
@@ -144,8 +262,16 @@ def _resolve_labeled(fdr, label, fdr_nodata):
     return out, n_cycles
 
 
-def drains_to_dprst_kernel(fdr_win, pour_win, fdr_nodata=255):
+def drains_to_dprst_kernel(fdr_win, pour_win, barrier_win, fdr_nodata=255):
     """Mark cells whose ESRI-D8 path reaches a depression pour-point.
+
+    Pour-point (dprst) cells seed as draining (`_DRAINS`); barrier cells
+    (on-stream waterbodies) seed as non-draining termini (`_NOT`). A flow path
+    that reaches a barrier before it reaches a pour stops there and is marked
+    non-draining, so land upslope of an on-stream waterbody is not attributed
+    to a downstream depression — the first waterbody on the flow path wins.
+    dprst wins on any (impossible-by-construction) overlap between the two
+    masks.
 
     Parameters
     ----------
@@ -154,6 +280,9 @@ def drains_to_dprst_kernel(fdr_win, pour_win, fdr_nodata=255):
         flow directions; `fdr_nodata` and any other value terminate as sinks.
     pour_win : ndarray[uint8]
         Pour-point mask: 1 = depression cell, 0 = background.
+    barrier_win : ndarray[uint8]
+        Barrier mask, same shape as `fdr_win`/`pour_win`: 1 = barrier cell
+        (on-stream waterbody), 0 = background. Required.
     fdr_nodata : int, default 255
         FDR nodata value (treated as a sink).
 
@@ -168,13 +297,10 @@ def drains_to_dprst_kernel(fdr_win, pour_win, fdr_nodata=255):
         its cells are resolved as non-draining. A non-zero count is worth a
         warning at the call site.
     """
-    # Delegate to the labeled kernel: every pour-point is one depression
-    # labeled 1, so "reaches any pour-point" is "reaches label 1".
     fdr = np.ascontiguousarray(fdr_win, dtype=np.uint8)
     pour = np.ascontiguousarray(pour_win, dtype=np.uint8)
-    label = (pour == 1).astype(np.int32)
-    labeled, n_cycles = _resolve_labeled(fdr, label, np.uint8(fdr_nodata))
-    return (labeled > 0).astype(np.uint8), n_cycles
+    barrier = np.ascontiguousarray(barrier_win, dtype=np.uint8)
+    return _resolve(fdr, pour, barrier, np.uint8(fdr_nodata))
 
 
 def drains_to_dprst_labeled_kernel(fdr_win, label_win, fdr_nodata=255):

--- a/src/gfv2_params/d8_routing.py
+++ b/src/gfv2_params/d8_routing.py
@@ -297,6 +297,13 @@ def drains_to_dprst_kernel(fdr_win, pour_win, barrier_win, fdr_nodata=255):
         its cells are resolved as non-draining. A non-zero count is worth a
         warning at the call site.
     """
+    # numba runs with bounds-checking off; a smaller pour/barrier than fdr would
+    # be silent out-of-bounds reads, not an error. Guard loudly in plain Python.
+    if not (fdr_win.shape == pour_win.shape == barrier_win.shape):
+        raise ValueError(
+            f"fdr/pour/barrier shapes must match: {fdr_win.shape}, "
+            f"{pour_win.shape}, {barrier_win.shape}"
+        )
     fdr = np.ascontiguousarray(fdr_win, dtype=np.uint8)
     pour = np.ascontiguousarray(pour_win, dtype=np.uint8)
     barrier = np.ascontiguousarray(barrier_win, dtype=np.uint8)

--- a/src/gfv2_params/depstor_builders/routing.py
+++ b/src/gfv2_params/depstor_builders/routing.py
@@ -7,6 +7,14 @@ WhiteboxTools `Watershed`, which hung on CONUS VPU 2 (a flow-cycle /
 pathological-trace stall, not OOM). See
 docs/superpowers/specs/2026-05-29-depstor-d8-routing-kernel-design.md.
 
+On-stream waterbody cells (`onstream_binary.tif`, emitted by the `dprst` step)
+are passed to the kernel as traversal barriers: a flow path that reaches an
+on-stream waterbody before it reaches a dprst pour-point stops there and is
+marked non-draining, so land captured by an on-stream lake is not attributed
+to a downstream depression — traversal stops at the first waterbody on each
+flow path. This makes `drains_to_dprst` a strict subtraction from the
+pre-barrier raster (coverage can only decrease).
+
 NHDPlus VPU boundaries follow drainage divides, so each VPU's contributing area
 is local: we route each VPU in isolation (FDR masked to the VPU via vpu_id) and
 mosaic the per-VPU results into the CONUS grid. Memory note: this keeps the
@@ -88,6 +96,7 @@ def build(step_cfg: dict, ctx: BuildContext, logger) -> dict:
     output_path = ctx.resolve_output(step_cfg["output"])
     landmask_path = ctx.require("landmask")
     dprst_path = ctx.require("dprst")
+    onstream_path = ctx.require("onstream")
     vpu_id_path = ctx.require("vpu_id")
     keep_intermediates = bool(step_cfg.get("keep_intermediates", False))
 
@@ -118,7 +127,9 @@ def build(step_cfg: dict, ctx: BuildContext, logger) -> dict:
 
         drains = np.full((info.height, info.width), np.uint8(255), dtype=np.uint8)
 
-        with rasterio.open(fdr_aligned) as fdr_src, rasterio.open(dprst_path) as dprst_src:
+        with rasterio.open(fdr_aligned) as fdr_src, \
+                rasterio.open(dprst_path) as dprst_src, \
+                rasterio.open(onstream_path) as onstream_src:
             for code in codes:
                 bbox = vpu_bbox(vpu_id, code)
                 r0, r1, c0, c1 = bbox
@@ -126,9 +137,14 @@ def build(step_cfg: dict, ctx: BuildContext, logger) -> dict:
                 vpu_win = vpu_id[r0:r1, c0:c1]
                 fdr_win = fdr_src.read(1, window=window)
                 dprst_win = dprst_src.read(1, window=window)
+                onstream_win = onstream_src.read(1, window=window)
 
                 fdr_masked = mask_fdr_to_vpu(fdr_win, vpu_win, code, nodata=255)
                 pour = vpu_pour_points(dprst_win, vpu_win, code)
+                # On-stream waterbodies of THIS vpu are traversal barriers, so
+                # land captured by an on-stream lake is not attributed to a
+                # downstream dprst. vpu_pour_points is the generic mask∩VPU op.
+                barrier = vpu_pour_points(onstream_win, vpu_win, code)
 
                 unexpected = set(np.unique(fdr_masked).tolist()) - _VALID_FDR_VALUES
                 if unexpected:
@@ -139,8 +155,11 @@ def build(step_cfg: dict, ctx: BuildContext, logger) -> dict:
 
                 # In-process D8 traversal (replaces WBT Watershed). Output is
                 # 1 where the cell drains to a pour-point, else 0, so
-                # assign_vpu_drains treats 0 as nodata.
-                ws_win, n_cycles = drains_to_dprst_kernel(fdr_masked, pour, fdr_nodata=255)
+                # assign_vpu_drains treats 0 as nodata. Barrier cells (on-stream
+                # waterbodies) stop the traversal before it reaches a pour.
+                ws_win, n_cycles = drains_to_dprst_kernel(
+                    fdr_masked, pour, barrier, fdr_nodata=255
+                )
                 if n_cycles:
                     logger.warning(
                         "  VPU %d: %d flow cycle(s) in FDR — those cells marked "
@@ -148,6 +167,9 @@ def build(step_cfg: dict, ctx: BuildContext, logger) -> dict:
                     )
                 assign_vpu_drains(drains, vpu_id, code, bbox, ws_win, ws_nodata=0)
                 n_vpu = int((drains[r0:r1, c0:c1][vpu_win == code] == 1).sum())
+                n_barrier = int((barrier == 1).sum())
+                if n_barrier:
+                    logger.info("  VPU %d: %d on-stream barrier cell(s)", code, n_barrier)
                 if n_vpu == 0:
                     logger.warning(
                         "  VPU %d: 0 cells drain to dprst — expected for a VPU with "

--- a/src/gfv2_params/depstor_builders/routing.py
+++ b/src/gfv2_params/depstor_builders/routing.py
@@ -32,6 +32,7 @@ from rasterio.windows import Window
 from ..d8_routing import drains_to_dprst_kernel
 from ..depstor import (
     RasterInfo,
+    assert_raster_aligned,
     assign_vpu_drains,
     mask_fdr_to_vpu,
     read_aligned_uint8,
@@ -130,6 +131,11 @@ def build(step_cfg: dict, ctx: BuildContext, logger) -> dict:
         with rasterio.open(fdr_aligned) as fdr_src, \
                 rasterio.open(dprst_path) as dprst_src, \
                 rasterio.open(onstream_path) as onstream_src:
+            # dprst/onstream are windowed by vpu_id's grid; a same-shape but
+            # differently-georeferenced raster would be read at the wrong origin
+            # silently. Assert both are on the template grid (as carea_map does).
+            assert_raster_aligned(dprst_src, info, "dprst")
+            assert_raster_aligned(onstream_src, info, "onstream")
             for code in codes:
                 bbox = vpu_bbox(vpu_id, code)
                 r0, r1, c0, c1 = bbox
@@ -172,8 +178,10 @@ def build(step_cfg: dict, ctx: BuildContext, logger) -> dict:
                     logger.info("  VPU %d: %d on-stream barrier cell(s)", code, n_barrier)
                 if n_vpu == 0:
                     logger.warning(
-                        "  VPU %d: 0 cells drain to dprst — expected for a VPU with "
-                        "no depressions, else check dprst/vpu_id alignment.", code,
+                        "  VPU %d: 0 cells drain to dprst (%d on-stream barrier "
+                        "cell(s)) — expected for a VPU with no depressions or where "
+                        "barriers intercept every path, else check "
+                        "dprst/vpu_id/onstream alignment.", code, n_barrier,
                     )
                 else:
                     logger.info("  VPU %d: %d cells drain to dprst", code, n_vpu)

--- a/tests/test_drains_kernel.py
+++ b/tests/test_drains_kernel.py
@@ -12,7 +12,7 @@ def test_pour_point_itself_drains():
     # A lone pour point with no inflow still counts as draining.
     fdr = np.array([[255]], dtype=np.uint8)
     pour = np.array([[1]], dtype=np.uint8)
-    out, n_cycles = drains_to_dprst_kernel(fdr, pour)
+    out, n_cycles = drains_to_dprst_kernel(fdr, pour, np.zeros_like(pour))
     assert out.tolist() == [[1]]
     assert n_cycles == 0
 
@@ -22,7 +22,7 @@ def test_straight_chain_into_pour_point():
     # cells:  ->  ->  ->  [pour]
     fdr = np.array([[1, 1, 1, 255]], dtype=np.uint8)
     pour = np.array([[0, 0, 0, 1]], dtype=np.uint8)
-    out, n_cycles = drains_to_dprst_kernel(fdr, pour)
+    out, n_cycles = drains_to_dprst_kernel(fdr, pour, np.zeros_like(pour))
     # every upstream cell reaches the pour point
     assert out.tolist() == [[1, 1, 1, 1]]
     assert n_cycles == 0
@@ -33,7 +33,7 @@ def test_chain_draining_away_is_not_marked():
     # The pour point drains (itself); nothing upstream of it exists.
     fdr = np.array([[16, 16, 16, 255]], dtype=np.uint8)
     pour = np.array([[0, 0, 0, 1]], dtype=np.uint8)
-    out, n_cycles = drains_to_dprst_kernel(fdr, pour)
+    out, n_cycles = drains_to_dprst_kernel(fdr, pour, np.zeros_like(pour))
     # cells 0..2 flow further West off-grid -> do not reach the pour point
     assert out.tolist() == [[0, 0, 0, 1]]
     assert n_cycles == 0
@@ -44,7 +44,7 @@ def test_two_cell_cycle_with_no_pour_terminates_and_marks_zero():
     # left flows East (1) into right; right flows West (16) into left.
     fdr = np.array([[1, 16]], dtype=np.uint8)
     pour = np.array([[0, 0]], dtype=np.uint8)
-    out, n_cycles = drains_to_dprst_kernel(fdr, pour)  # must return, not hang
+    out, n_cycles = drains_to_dprst_kernel(fdr, pour, np.zeros_like(pour))  # must return, not hang
     assert out.tolist() == [[0, 0]]
     assert n_cycles >= 1  # the cycle is detected and counted
 
@@ -54,7 +54,7 @@ def test_four_cell_cycle_with_no_pour_terminates_and_marks_zero():
     fdr = np.array([[1, 4],
                     [64, 16]], dtype=np.uint8)
     pour = np.zeros((2, 2), dtype=np.uint8)
-    out, n_cycles = drains_to_dprst_kernel(fdr, pour)  # must return, not hang
+    out, n_cycles = drains_to_dprst_kernel(fdr, pour, np.zeros_like(pour))  # must return, not hang
     assert out.tolist() == [[0, 0], [0, 0]]
     assert n_cycles >= 1
 
@@ -65,7 +65,7 @@ def test_cell_upstream_of_cycle_not_marked():
     #   col0 -> col1 -> col2, col2 -> col1  => cycle between col1 and col2
     fdr = np.array([[1, 1, 16]], dtype=np.uint8)
     pour = np.array([[0, 0, 0]], dtype=np.uint8)
-    out, n_cycles = drains_to_dprst_kernel(fdr, pour)  # must return, not hang
+    out, n_cycles = drains_to_dprst_kernel(fdr, pour, np.zeros_like(pour))  # must return, not hang
     assert out.tolist() == [[0, 0, 0]]
     assert n_cycles >= 1
 
@@ -78,7 +78,7 @@ def test_cycle_containing_pour_point_marks_drains():
     # left(E->right) and right(W->left) form a cycle; left is the pour point.
     fdr = np.array([[1, 16]], dtype=np.uint8)
     pour = np.array([[1, 0]], dtype=np.uint8)  # col 0 is the pour point
-    out, n_cycles = drains_to_dprst_kernel(fdr, pour)
+    out, n_cycles = drains_to_dprst_kernel(fdr, pour, np.zeros_like(pour))
     # col 0 is the pour point => drains; col 1 flows into it => drains too
     assert out.tolist() == [[1, 1]]
     assert n_cycles == 0  # the pour point breaks the cycle before it is entered
@@ -88,7 +88,7 @@ def test_nodata_sink_does_not_drain():
     # Single non-pour sink cell.
     fdr = np.array([[255]], dtype=np.uint8)
     pour = np.array([[0]], dtype=np.uint8)
-    out, n_cycles = drains_to_dprst_kernel(fdr, pour)
+    out, n_cycles = drains_to_dprst_kernel(fdr, pour, np.zeros_like(pour))
     assert out.tolist() == [[0]]
     assert n_cycles == 0
 
@@ -103,7 +103,7 @@ def test_branching_tributaries_all_reach_pour():
                     [255, 255, 255]], dtype=np.uint8)
     pour = np.zeros((3, 3), dtype=np.uint8)
     pour[2, 1] = 1
-    out, n_cycles = drains_to_dprst_kernel(fdr, pour)
+    out, n_cycles = drains_to_dprst_kernel(fdr, pour, np.zeros_like(pour))
     assert out[0, 0] == 1   # NW tributary
     assert out[0, 2] == 1   # NE tributary
     assert out[1, 1] == 1   # confluence
@@ -124,7 +124,7 @@ def test_all_eight_directions_decode_into_a_central_pour():
                     [128, 64, 32]], dtype=np.uint8)
     pour = np.zeros((3, 3), dtype=np.uint8)
     pour[1, 1] = 1
-    out, n_cycles = drains_to_dprst_kernel(fdr, pour)
+    out, n_cycles = drains_to_dprst_kernel(fdr, pour, np.zeros_like(pour))
     assert out.tolist() == [[1, 1, 1], [1, 1, 1], [1, 1, 1]]
     assert n_cycles == 0
 
@@ -133,7 +133,7 @@ def test_off_window_flow_does_not_drain():
     # A cell flowing North off the top edge terminates as does-not-drain.
     fdr = np.array([[64]], dtype=np.uint8)
     pour = np.array([[0]], dtype=np.uint8)
-    out, n_cycles = drains_to_dprst_kernel(fdr, pour)
+    out, n_cycles = drains_to_dprst_kernel(fdr, pour, np.zeros_like(pour))
     assert out.tolist() == [[0]]
     assert n_cycles == 0
 
@@ -142,6 +142,51 @@ def test_custom_nodata_value_terminates():
     # fdr_nodata is configurable; 0 here marks the sink.
     fdr = np.array([[1, 0]], dtype=np.uint8)
     pour = np.array([[0, 0]], dtype=np.uint8)
-    out, n_cycles = drains_to_dprst_kernel(fdr, pour, fdr_nodata=0)
+    out, n_cycles = drains_to_dprst_kernel(fdr, pour, np.zeros_like(pour), fdr_nodata=0)
     assert out.tolist() == [[0, 0]]
+    assert n_cycles == 0
+
+
+def test_barrier_blocks_upslope_from_pour():
+    # Row flowing East into a pour point at the right end, with a barrier in
+    # the middle:  cell0 ->  cell1 -> [barrier] -> [pour]
+    # cell0/cell1 hit the barrier before the pour => not draining.
+    fdr = np.array([[1, 1, 1, 255]], dtype=np.uint8)
+    pour = np.array([[0, 0, 0, 1]], dtype=np.uint8)
+    barrier = np.array([[0, 0, 1, 0]], dtype=np.uint8)
+    out, n_cycles = drains_to_dprst_kernel(fdr, pour, barrier)
+    # cell0, cell1 blocked; barrier itself non-draining; pour drains itself.
+    assert out.tolist() == [[0, 0, 0, 1]]
+    assert n_cycles == 0
+
+
+def test_barrier_downstream_of_pour_does_not_unmark():
+    # Path reaches the pour BEFORE the barrier: first-waterbody-wins => drains.
+    # cell0 -> [pour] -> [barrier]
+    fdr = np.array([[1, 1, 255]], dtype=np.uint8)
+    pour = np.array([[0, 1, 0]], dtype=np.uint8)
+    barrier = np.array([[0, 0, 1]], dtype=np.uint8)
+    out, n_cycles = drains_to_dprst_kernel(fdr, pour, barrier)
+    assert out.tolist() == [[1, 1, 0]]
+    assert n_cycles == 0
+
+
+def test_no_barrier_is_equivalent_to_old_behavior():
+    # An all-zero barrier reproduces the pre-barrier straight-chain result.
+    fdr = np.array([[1, 1, 1, 255]], dtype=np.uint8)
+    pour = np.array([[0, 0, 0, 1]], dtype=np.uint8)
+    barrier = np.zeros_like(pour)
+    out, n_cycles = drains_to_dprst_kernel(fdr, pour, barrier)
+    assert out.tolist() == [[1, 1, 1, 1]]
+    assert n_cycles == 0
+
+
+def test_pour_wins_when_cell_is_both_pour_and_barrier():
+    # Defensive: overlap is impossible by construction, but if a cell is both,
+    # dprst (_DRAINS) must win over the barrier seed.
+    fdr = np.array([[1, 255]], dtype=np.uint8)
+    pour = np.array([[0, 1]], dtype=np.uint8)
+    barrier = np.array([[0, 1]], dtype=np.uint8)
+    out, n_cycles = drains_to_dprst_kernel(fdr, pour, barrier)
+    assert out.tolist() == [[1, 1]]
     assert n_cycles == 0

--- a/tests/test_drains_kernel.py
+++ b/tests/test_drains_kernel.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from gfv2_params.d8_routing import drains_to_dprst_kernel
 
@@ -190,3 +191,49 @@ def test_pour_wins_when_cell_is_both_pour_and_barrier():
     out, n_cycles = drains_to_dprst_kernel(fdr, pour, barrier)
     assert out.tolist() == [[1, 1]]
     assert n_cycles == 0
+
+
+def test_barrier_on_two_cell_cycle_breaks_it_without_counting_a_cycle():
+    # Mirror of test_cycle_containing_pour_point_marks_drains, but the seeded
+    # cell is a BARRIER, not a pour. left(E->right) and right(W->left) would
+    # form a cycle; right is a barrier. Barriers are seeded _NOT before the
+    # walk, so the barrier cell exits via the _NOT branch (not the cycle guard):
+    # left resolves _NOT and no cycle is counted. Pins the seeding-order
+    # invariant for barriers.
+    fdr = np.array([[1, 16]], dtype=np.uint8)
+    pour = np.array([[0, 0]], dtype=np.uint8)
+    barrier = np.array([[0, 1]], dtype=np.uint8)  # col 1 is the barrier
+    out, n_cycles = drains_to_dprst_kernel(fdr, pour, barrier)
+    assert out.tolist() == [[0, 0]]
+    assert n_cycles == 0  # barrier breaks the cycle before it is entered
+
+
+def test_confluence_into_single_barrier_blocks_both_tributaries():
+    # Two tributaries merge at a barrier cell that sits directly upstream of a
+    # pour. Both branches must be blocked at the shared barrier, the barrier
+    # itself is non-draining, and the barrier must NOT let the downstream pour
+    # propagate draining back up.
+    #   (0,0) SE(2) ->(1,1)=barrier   (0,2) SW(8) ->(1,1)=barrier
+    #   (1,1) S(4)  ->(2,1)=pour
+    fdr = np.array([[2, 255, 8],
+                    [255, 4, 255],
+                    [255, 255, 255]], dtype=np.uint8)
+    pour = np.zeros((3, 3), dtype=np.uint8)
+    pour[2, 1] = 1
+    barrier = np.zeros((3, 3), dtype=np.uint8)
+    barrier[1, 1] = 1
+    out, n_cycles = drains_to_dprst_kernel(fdr, pour, barrier)
+    assert out.tolist() == [[0, 0, 0],
+                            [0, 0, 0],
+                            [0, 1, 0]]  # only the pour drains itself
+    assert n_cycles == 0
+
+
+def test_mismatched_barrier_shape_raises():
+    # numba has no bounds-checking; the plain-Python wrapper must reject a
+    # barrier/pour that is not the same shape as fdr (loud, not silent OOB).
+    fdr = np.zeros((2, 2), dtype=np.uint8)
+    pour = np.zeros((2, 2), dtype=np.uint8)
+    barrier = np.zeros((2, 1), dtype=np.uint8)
+    with pytest.raises(ValueError):
+        drains_to_dprst_kernel(fdr, pour, barrier)

--- a/tests/test_routing_tiling.py
+++ b/tests/test_routing_tiling.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+from gfv2_params.d8_routing import drains_to_dprst_kernel
 from gfv2_params.depstor import (
     assign_vpu_drains,
     mask_fdr_to_vpu,
@@ -77,3 +78,19 @@ def test_assign_vpu_drains_all_nodata_marks_nothing():
     ws = np.full((2, 2), -32768, dtype=np.int32)
     assign_vpu_drains(drains, vpu, 1, (0, 2, 0, 2), ws, ws_nodata=-32768)
     assert (drains == 255).all()
+
+
+def test_onstream_barrier_blocks_drainage_at_helper_level():
+    # Single VPU (code 1). Row flows East into a dprst pour at the right end,
+    # with an on-stream waterbody cell in the middle acting as a barrier.
+    #   land -> land -> [onstream] -> [dprst]
+    vpu = np.ones((1, 4), dtype=np.uint8)
+    fdr = np.array([[1, 1, 1, 255]], dtype=np.uint8)
+    dprst = np.array([[0, 0, 0, 1]], dtype=np.uint8)
+    onstream = np.array([[0, 0, 1, 0]], dtype=np.uint8)
+
+    pour = vpu_pour_points(dprst, vpu, code=1)
+    barrier = vpu_pour_points(onstream, vpu, code=1)  # reused: mask ∩ VPU
+    out, _ = drains_to_dprst_kernel(fdr, pour, barrier)
+
+    assert out.tolist() == [[0, 0, 0, 1]]  # upslope land blocked by on-stream cell


### PR DESCRIPTION
## Scope expansion callout

The original plan touched three areas (D8 kernel, `routing` builder, docs). Making `barrier_win` a **required** positional on `drains_to_dprst_kernel` (an approved, deliberate non-backward-compatible change) left one **pre-existing** caller stale: the #147/#148 A/B diagnostic `scripts/diagnose/ab_drains_to_dprst.py`. CI does not exercise that call path, so it would have failed only at runtime on the next HPC A/B run. The whole-branch review caught it; commit `1ab0fbb` fixes it by passing an all-zero barrier (keeping the diagnostic barrier-free so its binary-vs-labeled self-check stays valid). This is the only change beyond the original plan.

## What & why

Closes #158. The `routing` step's D8 traversal treated only depression-storage (dprst) waterbodies as flow termini and walked straight through **on-stream** (non-dprst) waterbodies on the depression-filled FDR. Land that first drains into an on-stream lake — whose outflow then reaches a downstream dprst — was wrongly counted as `drains_to_dprst` (seen in VPU 15).

An on-stream waterbody captures its upslope runoff into the stream/lake routing network (streamflow), not into a downstream depression's storage. So on-stream waterbody cells now act as **barriers**: a cell is `drains_to_dprst` only if its flow path reaches a dprst cell **before** any on-stream waterbody cell ("first waterbody on the path wins").

**Net effect is a strict subtraction** from the prior raster — `drains_to_dprst` coverage can only decrease, never increase. Playas need no special handling (classified `dprst`, never `onstream`, so never barriers). Barrier set is the full `onstream` mask (no size filtering).

## Changes

- **Kernel** (`d8_routing.py`): `drains_to_dprst_kernel(fdr_win, pour_win, barrier_win, fdr_nodata=255)` — new required `barrier_win`; barrier cells seeded `_NOT`; dprst wins any overlap. +4 tests; 12 existing calls migrated.
- **Builder** (`depstor_builders/routing.py`): `ctx.require("onstream")`, read per-VPU with the same window as fdr/dprst, scope via the existing `vpu_pour_points` helper (no new helper), pass as the kernel barrier, log per-VPU barrier-cell counts.
- **Diagnostic** (`scripts/diagnose/ab_drains_to_dprst.py`): pass a no-op barrier (see scope callout).
- **Docs**: `docs/ARCHITECTURE.md`, `CLAUDE.md`, module docstrings; design spec + implementation plan under `docs/superpowers/`.

## Testing

`tests/test_drains_kernel.py`, `tests/test_routing_tiling.py`, `tests/test_ab_drains_to_dprst.py` → **29 passed** locally in the pixi dev env. CI (`pytest tests/`) is the authoritative gate.

## Not done here (runtime validation — needs HPC)

Code-only. Validation on real data still required: rebuild `dprst` (picks up the recent classifier changes / current `onstream` mask) → run `routing` → compare `drains_to_dprst` area on VPU 15 before/after (expect a decrease concentrated below on-stream lakes; coverage must not increase). Spot-check that no legitimate terminal-basin land was dropped by a mislabeled on-stream cell.

## Follow-ups (non-blocking, from the whole-branch review)

- Add a `_run_one_vpu` smoke/call-site test for `ab_drains_to_dprst.py` so a future kernel-signature change can't break the A/B tool with green CI.
- Optional barrier parity for the diagnostic `drains_to_dprst_labeled_kernel` if the #147 A/B tool ever needs to mirror production semantics.
- Optional cycle-containing-barrier unit test (belt-and-suspenders; behavior is correct by construction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)