### PR TITLE
feat(depstor): same-HRU restriction for sro_to_dprst_* (closes #160)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,16 @@ These are hard-won; violating them silently corrupts outputs.
   hits, before it can reach a dprst pour-point. The barrier set is the full
   `onstream` mask (no size filtering); the fix is a strict subtraction that
   can only reduce `drains_to_dprst` coverage, never increase it.
+- **`sro_to_dprst_perv`/`sro_to_dprst_imperv` are same-HRU-restricted via a
+  raster intersection, not gdptools.** `same_hru_drains` computes
+  `drains_to_dprst_hru == hru_id` (both int32, per-cell) to build
+  `drains_perv_binary.tif`/`drains_imperv_binary.tif`, replacing the old plain
+  `intersect` — because it's a per-cell reached-HRU-vs-own-HRU test that
+  gdptools' partial-pixel zonal weighting cannot express. The per-HRU COUNT
+  aggregation downstream still uses gdptools as normal. This reproduces the
+  legacy `Con(rSro == hru)` (`docs/0b_TB_depr_stor.py:214`). `drains_to_dprst`
+  itself (from `routing`) stays HRU-agnostic — only the `sro_to_dprst_*`
+  ratios get the same-HRU restriction.
 - **Land masking.** Every depstor raster is masked against `land_mask.tif` (HRU
   fabric rasterised by the `landmask` step). Never use hydro-DEM nodata or FDR
   as a land mask.

--- a/configs/depstor/depstor_rasters.yml
+++ b/configs/depstor/depstor_rasters.yml
@@ -44,6 +44,9 @@ steps:
   - name: perv
     output: perv_binary.tif
 
+  - name: hru_id
+    output: hru_id.tif
+
   - name: vpu_id
     output: vpu_id.tif
 

--- a/configs/depstor/depstor_rasters.yml
+++ b/configs/depstor/depstor_rasters.yml
@@ -54,6 +54,9 @@ steps:
     keep_intermediates: false
     output: drains_to_dprst.tif
 
+  - name: routing_hru
+    output: drains_to_dprst_hru.tif
+
   - name: drains_perv
     inputs: [drains_to_dprst, perv]
     output_key: drains_perv

--- a/configs/depstor/depstor_rasters.yml
+++ b/configs/depstor/depstor_rasters.yml
@@ -58,12 +58,12 @@ steps:
     output: drains_to_dprst_hru.tif
 
   - name: drains_perv
-    inputs: [drains_to_dprst, perv]
+    inputs: [drains_to_dprst_hru, hru_id, perv]
     output_key: drains_perv
     output: drains_perv_binary.tif
 
   - name: drains_imperv
-    inputs: [drains_to_dprst, imperv]
+    inputs: [drains_to_dprst_hru, hru_id, imperv]
     output_key: drains_imperv
     output: drains_imperv_binary.tif
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -204,8 +204,8 @@ These are hard-won; violating them silently corrupts outputs.
   classified `dprst`, never `onstream`, so they are never barriers.
 - **Same-HRU restriction on `sro_to_dprst_perv`/`sro_to_dprst_imperv` is a
   raster-space intersection, not a gdptools operation.** The chain is
-  `hru_id` (rasterises `nat_hru_id` onto the template via `rasterize_ids` →
-  `hru_id.tif`, int32) → `routing_hru` (a labeled, barrier-aware D8 trace —
+  `hru_id` (rasterises `nat_hru_id` onto the template via `rasterize_ids`,
+  `all_touched=True` → `hru_id.tif`, int32) → `routing_hru` (a labeled, barrier-aware D8 trace —
   same per-VPU tiling and on-stream barriers as `routing`, but each depression
   cell is labelled with its own HRU id and the kernel propagates that label to
   every cell that drains to it → `drains_to_dprst_hru.tif`, int32, per-cell
@@ -218,7 +218,12 @@ These are hard-won; violating them silently corrupts outputs.
   partial-pixel weighting cannot express; a fractional-overlap weight has no
   way to encode "same HRU or not." The per-HRU **count** aggregation
   downstream is unaffected and still uses gdptools as normal. This reproduces
-  the legacy `Con(rSro == hru)` (`docs/0b_TB_depr_stor.py:214`). The tradeoff
+  the legacy `Con(rSro == hru)` (`docs/0b_TB_depr_stor.py:214`). `hru_id.tif`
+  is rasterised `all_touched=True` to match `land_mask.tif`/`perv_binary.tif`'s
+  footprint (`landmask.py`); a stricter (default) footprint would leave
+  HRU-boundary land cells at `hru_id==0`, and `same_hru_intersect` (which
+  requires `labeled==hru_id & labeled>0`) would silently drop them —
+  undercounting `drains_perv`/`drains_imperv` at every HRU edge. The tradeoff
   is a 1-pixel HRU-boundary approximation (a cell rasterised into HRU A that
   geometrically straddles into HRU B), which is immaterial against the
   basin-scale `sro_to_dprst_*` signal. `drains_to_dprst.tif` (from `routing`)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -202,6 +202,29 @@ These are hard-won; violating them silently corrupts outputs.
   lake or reservoir is captured by that waterbody's stream/lake routing, not
   a downstream depression. Playas need no special handling — they are
   classified `dprst`, never `onstream`, so they are never barriers.
+- **Same-HRU restriction on `sro_to_dprst_perv`/`sro_to_dprst_imperv` is a
+  raster-space intersection, not a gdptools operation.** The chain is
+  `hru_id` (rasterises `nat_hru_id` onto the template via `rasterize_ids` →
+  `hru_id.tif`, int32) → `routing_hru` (a labeled, barrier-aware D8 trace —
+  same per-VPU tiling and on-stream barriers as `routing`, but each depression
+  cell is labelled with its own HRU id and the kernel propagates that label to
+  every cell that drains to it → `drains_to_dprst_hru.tif`, int32, per-cell
+  reached-HRU) → `same_hru_drains` (replaces the old plain `intersect` step
+  for `drains_perv`/`drains_imperv`, same output filenames/keys). It computes
+  `drains_to_dprst_hru == hru_id` cell-by-cell (`same_hru_intersect` in
+  `depstor.py`) **before** aggregation — deliberately **not** expressed as a
+  gdptools zonal operation, because it is a per-cell test (does this cell's
+  reached depression belong to *this same cell's* HRU?) that gdptools'
+  partial-pixel weighting cannot express; a fractional-overlap weight has no
+  way to encode "same HRU or not." The per-HRU **count** aggregation
+  downstream is unaffected and still uses gdptools as normal. This reproduces
+  the legacy `Con(rSro == hru)` (`docs/0b_TB_depr_stor.py:214`). The tradeoff
+  is a 1-pixel HRU-boundary approximation (a cell rasterised into HRU A that
+  geometrically straddles into HRU B), which is immaterial against the
+  basin-scale `sro_to_dprst_*` signal. `drains_to_dprst.tif` (from `routing`)
+  and the `drains_to_dprst_frac` param stay HRU-agnostic — only the
+  `sro_to_dprst_*` ratios get the same-HRU restriction; `depstor_params.yml`
+  is unchanged.
 - **Land masking.** Every depstor raster is masked against `land_mask.tif`
   (the HRU fabric rasterised by the `landmask` step). Never use hydro-DEM
   nodata or FDR as a land mask.

--- a/docs/superpowers/plans/2026-07-02-same-hru-drains.md
+++ b/docs/superpowers/plans/2026-07-02-same-hru-drains.md
@@ -1,0 +1,623 @@
+# Same-HRU restriction for `sro_to_dprst_*` — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore the legacy same-HRU restriction on `sro_to_dprst_perv/imperv` — a pervious/impervious cell counts only if it drains to a depression in its **own** HRU — additively, without changing the merged binary `drains_to_dprst` path.
+
+**Architecture:** Three new depstor raster builders upstream of the unchanged parameter aggregation: `hru_id` (rasterize `nat_hru_id`), `routing_hru` (a barrier-aware **labeled** D8 trace → per-cell reached-HRU), and `same_hru_drains` (raster-space `(labeled == hru_id) & perv/imperv`, replacing the two `intersect` steps and writing the same filenames). `depstor_params.yml` is untouched, so `sro_to_dprst_*` are corrected transparently.
+
+**Tech Stack:** Python, NumPy, numba (`@njit`), rasterio, GDAL/`rasterio.features`, GeoPandas; pytest; pixi.
+
+## Global Constraints
+
+- Env is pixi-managed; run tests as `pixi run -e dev --as-is pytest <path>` with `~/.pixi/bin` on PATH. Do NOT run the full suite or pytest generally on the HPC head node; run only the specific new/changed test files.
+- The kernel is the only numba user; `_resolve_labeled` must stay numba-compatible (typed scalars, no Python objects inside `@njit`).
+- Paths/inputs come from the active fabric profile via `require_config_key` / `BuildContext`, never hardcoded. Use `{data_root}`/`{fabric}` placeholders in YAML.
+- ESRI-D8 encoding: `1=E 2=SE 4=S 8=SW 16=W 32=NW 64=N 128=NE`; `255`/other = sink.
+- New builders must not materialize a full-CONUS in-memory array except the one already-established full-CONUS `vpu_id` load; the int32 labeled output is written per-VPU windowed (it is 4× the uint8 binary — a full-grid int32 is ~68 GB).
+- `same_hru_drains` writes the SAME output filenames/keys as the `intersect` step it replaces (`drains_perv_binary.tif`/`drains_imperv_binary.tif`, keys `drains_perv`/`drains_imperv`), so `depstor_params.yml` needs zero changes.
+- Add a builder + a test together; register every new step in `BUILDERS` and `STEP_ORDER` (`src/gfv2_params/depstor_builders/__init__.py`) and in `configs/depstor/depstor_rasters.yml`.
+- Run `pixi run -e dev pre-commit run --files <changed>` before the docs commit.
+
+---
+
+### Task 1: Barrier support in the labeled D8 kernel
+
+**Files:**
+- Modify: `src/gfv2_params/d8_routing.py` (`_resolve_labeled`, `drains_to_dprst_labeled_kernel`, module/function docstrings)
+- Modify: `scripts/diagnose/ab_drains_to_dprst.py` (the labeled call — migrate to the new required arg)
+- Test: `tests/test_drains_kernel.py` (labeled-kernel barrier cases) and migrate `tests/test_d8_routing_labeled.py`
+
+**Interfaces:**
+- Produces: `drains_to_dprst_labeled_kernel(fdr_win, label_win, barrier_win, fdr_nodata=255) -> (out_int32, n_cycles)`. `barrier_win` is a REQUIRED 3rd positional uint8 array (1 = barrier). A cell whose path reaches a barrier before a labeled depression is `0` in `out`. Labels (dprst) win over barriers on overlap (disjoint by construction).
+
+- [ ] **Step 1: Write the failing tests** — append to `tests/test_drains_kernel.py`:
+
+```python
+from gfv2_params.d8_routing import drains_to_dprst_labeled_kernel
+
+
+def test_labeled_barrier_blocks_upslope():
+    # cell0 -> cell1 -> [barrier] -> [dprst label 7]
+    fdr = np.array([[1, 1, 1, 255]], dtype=np.uint8)
+    label = np.array([[0, 0, 0, 7]], dtype=np.int32)
+    barrier = np.array([[0, 0, 1, 0]], dtype=np.uint8)
+    out, n = drains_to_dprst_labeled_kernel(fdr, label, barrier)
+    assert out.tolist() == [[0, 0, 0, 7]]
+    assert n == 0
+
+
+def test_labeled_no_barrier_matches_unbarriered():
+    # all-zero barrier reproduces the straight-chain label fill
+    fdr = np.array([[1, 1, 1, 255]], dtype=np.uint8)
+    label = np.array([[0, 0, 0, 7]], dtype=np.int32)
+    barrier = np.zeros_like(label, dtype=np.uint8)
+    out, n = drains_to_dprst_labeled_kernel(fdr, label, barrier)
+    assert out.tolist() == [[7, 7, 7, 7]]
+    assert n == 0
+
+
+def test_labeled_first_waterbody_wins():
+    # cell0 -> [dprst 5] -> [barrier]: label reached before barrier
+    fdr = np.array([[1, 1, 255]], dtype=np.uint8)
+    label = np.array([[0, 5, 0]], dtype=np.int32)
+    barrier = np.array([[0, 0, 1]], dtype=np.uint8)
+    out, n = drains_to_dprst_labeled_kernel(fdr, label, barrier)
+    assert out.tolist() == [[5, 5, 0]]
+    assert n == 0
+```
+
+Also migrate every existing `drains_to_dprst_labeled_kernel(fdr, label)` call (in `tests/test_d8_routing_labeled.py`) to pass `np.zeros_like(label, dtype=np.uint8)` as the 3rd positional arg.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pixi run -e dev --as-is pytest tests/test_drains_kernel.py tests/test_d8_routing_labeled.py -q`
+Expected: FAIL — `_resolve_labeled()` / `drains_to_dprst_labeled_kernel()` got an unexpected positional argument.
+
+- [ ] **Step 3: Implement the barrier** — in `src/gfv2_params/d8_routing.py`, change the signature and seed barriers after the label seeding:
+
+```python
+@njit(cache=True)
+def _resolve_labeled(fdr, label, barrier, fdr_nodata):
+    ny, nx = fdr.shape
+    st = np.zeros((ny, nx), dtype=np.uint8)
+    lab = np.zeros((ny, nx), dtype=np.int32)
+
+    # Seed: each depression cell drains to its own label.
+    for r in range(ny):
+        for c in range(nx):
+            if label[r, c] > 0:
+                st[r, c] = _DRAINS
+                lab[r, c] = label[r, c]
+
+    # Seed barriers (on-stream waterbodies) as non-draining termini, but only
+    # where not already a label cell — labels win any overlap.
+    for r in range(ny):
+        for c in range(nx):
+            if barrier[r, c] == 1 and st[r, c] == _UNKNOWN:
+                st[r, c] = _NOT
+```
+
+(The rest of `_resolve_labeled` is unchanged.) Update the wrapper:
+
+```python
+def drains_to_dprst_labeled_kernel(fdr_win, label_win, barrier_win, fdr_nodata=255):
+    ...
+    fdr = np.ascontiguousarray(fdr_win, dtype=np.uint8)
+    label = np.ascontiguousarray(label_win, dtype=np.int32)
+    barrier = np.ascontiguousarray(barrier_win, dtype=np.uint8)
+    return _resolve_labeled(fdr, label, barrier, np.uint8(fdr_nodata))
+```
+
+Update the docstrings to document `barrier_win` and the "first waterbody wins / labels win overlap" semantics. Then in `scripts/diagnose/ab_drains_to_dprst.py`, change the labeled call to pass a no-op barrier:
+
+```python
+labeled, _ = drains_to_dprst_labeled_kernel(fdr_masked, label_win, np.zeros_like(label_win, dtype=np.uint8), fdr_nodata=255)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pixi run -e dev --as-is pytest tests/test_drains_kernel.py tests/test_d8_routing_labeled.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/gfv2_params/d8_routing.py scripts/diagnose/ab_drains_to_dprst.py tests/test_drains_kernel.py tests/test_d8_routing_labeled.py
+git commit -m "feat(routing): add barrier mask to labeled D8 kernel"
+```
+
+---
+
+### Task 2: `hru_id` raster builder
+
+**Files:**
+- Modify: `src/gfv2_params/depstor.py` (add `rasterize_ids` helper)
+- Modify: `src/gfv2_params/depstor_builders/context.py` (add `id_feature` field)
+- Modify: `scripts/build_depstor_rasters.py` (read `id_feature`, pass to `BuildContext`)
+- Create: `src/gfv2_params/depstor_builders/hru_id.py`
+- Modify: `src/gfv2_params/depstor_builders/__init__.py` (register), `configs/depstor/depstor_rasters.yml` (add step)
+- Test: `tests/test_hru_id.py`
+
+**Interfaces:**
+- Consumes: `RasterInfo.from_path`, `write_int32_regions(arr, info, out_path)` (existing).
+- Produces: `rasterize_ids(gdf, id_field, info) -> np.ndarray[int32]` (0 = no polygon); `hru_id` builder writing `hru_id.tif` (int32) and registering key `"hru_id"`. `BuildContext.id_feature: str`.
+
+- [ ] **Step 1: Write the failing test** — `tests/test_hru_id.py`:
+
+```python
+import geopandas as gpd
+import numpy as np
+from shapely.geometry import box
+
+from gfv2_params.depstor import RasterInfo, rasterize_ids
+
+
+def test_rasterize_ids_burns_attribute(tmp_path):
+    # 4x4 grid, 1.0 cell size, origin (0, 4) north-up
+    import rasterio
+    from rasterio.transform import from_origin
+    tpl = tmp_path / "tpl.tif"
+    transform = from_origin(0, 4, 1, 1)
+    with rasterio.open(tpl, "w", driver="GTiff", height=4, width=4, count=1,
+                       dtype="uint8", crs="EPSG:5070", transform=transform) as d:
+        d.write(np.zeros((4, 4), np.uint8), 1)
+    info = RasterInfo.from_path(tpl)
+    gdf = gpd.GeoDataFrame(
+        {"nat_hru_id": [11, 22]},
+        geometry=[box(0, 0, 2, 4), box(2, 0, 4, 4)], crs="EPSG:5070",
+    )
+    out = rasterize_ids(gdf, "nat_hru_id", info)
+    assert out.dtype == np.int32
+    assert out[0, 0] == 11 and out[0, 3] == 22   # left half 11, right half 22
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pixi run -e dev --as-is pytest tests/test_hru_id.py -q`
+Expected: FAIL — `cannot import name 'rasterize_ids'`.
+
+- [ ] **Step 3: Implement `rasterize_ids`** — in `src/gfv2_params/depstor.py` (near `rasterize_binary`):
+
+```python
+def rasterize_ids(gdf, id_field: str, info: "RasterInfo") -> np.ndarray:
+    """Burn an integer id attribute onto the template grid (0 = no polygon)."""
+    from rasterio.features import rasterize
+    shapes = ((geom, int(val)) for geom, val in zip(gdf.geometry, gdf[id_field]))
+    return rasterize(
+        shapes, out_shape=(info.height, info.width), transform=info.transform,
+        fill=0, dtype="int32",
+    ).astype(np.int32, copy=False)
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pixi run -e dev --as-is pytest tests/test_hru_id.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Thread `id_feature` + add the builder + register + config**
+
+In `src/gfv2_params/depstor_builders/context.py`, add after `hru_layer: str`:
+
+```python
+    id_feature: str = "nat_hru_id"
+```
+
+In `scripts/build_depstor_rasters.py`, alongside the `hru_layer` read (~line 70):
+
+```python
+    id_feature = require_config_key(config, "id_feature", "build_depstor_rasters")
+```
+
+and pass `id_feature=id_feature,` into the `BuildContext(...)` call.
+
+Create `src/gfv2_params/depstor_builders/hru_id.py`:
+
+```python
+"""Build hru_id.tif: per-cell HRU id (nat_hru_id) rasterised onto the template.
+
+The open-source equivalent of the legacy `nhrug`. Consumed by `routing_hru`
+(to label depressions by HRU) and `same_hru_drains` (the same-HRU test). This
+is a raster-space HRU identity used only for the same-HRU restriction; per-HRU
+parameter COUNTS still use gdptools zonal weights downstream.
+"""
+from __future__ import annotations
+
+import geopandas as gpd
+
+from ..depstor import RasterInfo, rasterize_ids, write_int32_regions
+from .context import BuildContext
+
+
+def build(step_cfg: dict, ctx: BuildContext, logger) -> dict:
+    output_path = ctx.resolve_output(step_cfg["output"])
+    if not ctx.template_path.exists():
+        raise FileNotFoundError(f"Template raster not found: {ctx.template_path}")
+    if not ctx.hru_gpkg.exists():
+        raise FileNotFoundError(f"HRU fabric gpkg not found: {ctx.hru_gpkg}")
+
+    logger.info("--- hru_id ---")
+    logger.info("  HRU fabric: %s (layer=%s, id=%s)", ctx.hru_gpkg, ctx.hru_layer, ctx.id_feature)
+    logger.info("  Output    : %s", output_path)
+    if output_path.exists() and not ctx.force:
+        logger.info("  Output exists — skipping (pass --force to rebuild)")
+        return {"hru_id": output_path}
+
+    info = RasterInfo.from_path(ctx.template_path)
+    gdf = gpd.read_file(ctx.hru_gpkg, layer=ctx.hru_layer)
+    gdf = gdf[gdf.geometry.notna() & ~gdf.geometry.is_empty]
+    if (gdf[ctx.id_feature] <= 0).any():
+        raise ValueError(f"{ctx.id_feature} must be positive (0 is the no-HRU sentinel).")
+    ids = rasterize_ids(gdf, ctx.id_feature, info)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    write_int32_regions(ids, info, output_path)
+    n = int((ids > 0).sum())
+    logger.info("  Rasterised %d HRUs | %d labelled cells (%.2f%%)", len(gdf), n, 100 * n / ids.size)
+    return {"hru_id": output_path}
+```
+
+In `src/gfv2_params/depstor_builders/__init__.py`: import `hru_id`, add `"hru_id": hru_id.build` to `BUILDERS`, and insert `"hru_id"` into `STEP_ORDER` right after `"perv"`.
+
+In `configs/depstor/depstor_rasters.yml`, add after the `perv` step:
+
+```yaml
+  - name: hru_id
+    output: hru_id.tif
+```
+
+- [ ] **Step 6: Verify + commit**
+
+Run: `pixi run -e dev --as-is pytest tests/test_hru_id.py -q`
+Expected: PASS.
+
+```bash
+git add src/gfv2_params/depstor.py src/gfv2_params/depstor_builders/context.py \
+  scripts/build_depstor_rasters.py src/gfv2_params/depstor_builders/hru_id.py \
+  src/gfv2_params/depstor_builders/__init__.py configs/depstor/depstor_rasters.yml \
+  tests/test_hru_id.py
+git commit -m "feat(depstor): hru_id raster (rasterised nat_hru_id) builder"
+```
+
+---
+
+### Task 3: Promote the FDR-alignment helper to shared `depstor.py`
+
+**Files:**
+- Modify: `src/gfv2_params/depstor.py` (add public `align_fdr_to_dprst_grid`)
+- Modify: `src/gfv2_params/depstor_builders/routing.py` (import it; delete the local `_align_fdr_to_dprst_grid`)
+- Test: existing `tests/test_routing_tiling.py` (regression — routing unchanged)
+
+**Interfaces:**
+- Produces: `align_fdr_to_dprst_grid(fdr_path, dprst_path, out_path, logger) -> None` in `depstor.py` (moved verbatim from routing).
+
+- [ ] **Step 1: Move the function** — cut the body of `_align_fdr_to_dprst_grid` from `src/gfv2_params/depstor_builders/routing.py` into `src/gfv2_params/depstor.py` as public `align_fdr_to_dprst_grid` (identical body; it already uses `gdal`, `rasterio` which `depstor.py` imports — add imports if missing). In `routing.py`, delete the local def and import it: add `align_fdr_to_dprst_grid` to the `from ..depstor import (...)` block, and change the call site `_align_fdr_to_dprst_grid(...)` → `align_fdr_to_dprst_grid(...)`.
+
+- [ ] **Step 2: Run routing regression tests**
+
+Run: `pixi run -e dev --as-is pytest tests/test_routing_tiling.py -q`
+Expected: PASS (behavior unchanged).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/gfv2_params/depstor.py src/gfv2_params/depstor_builders/routing.py
+git commit -m "refactor(depstor): promote align_fdr_to_dprst_grid to shared depstor"
+```
+
+---
+
+### Task 4: `routing_hru` builder (barrier-aware labeled trace)
+
+**Files:**
+- Create: `src/gfv2_params/depstor_builders/routing_hru.py`
+- Modify: `src/gfv2_params/depstor_builders/__init__.py` (register), `configs/depstor/depstor_rasters.yml` (add step)
+- Test: `tests/test_routing_hru.py`
+
+**Interfaces:**
+- Consumes: `drains_to_dprst_labeled_kernel(fdr, label, barrier, fdr_nodata=255)` (Task 1); `align_fdr_to_dprst_grid` (Task 3); `hru_id` key (Task 2); existing `mask_fdr_to_vpu`, `vpu_pour_points`, `vpu_bbox`, `vpu_codes_present`, `read_aligned_uint8`, `RasterInfo`.
+- Produces: `drains_to_dprst_hru.tif` (int32; per draining cell = `nat_hru_id` of the reached depression, 0 else), key `"drains_to_dprst_hru"`.
+
+- [ ] **Step 1: Write the failing test** — `tests/test_routing_hru.py` (helper-level composition, no file I/O; mirrors `test_routing_tiling.py` style):
+
+```python
+import numpy as np
+from gfv2_params.depstor import mask_fdr_to_vpu, vpu_pour_points
+from gfv2_params.d8_routing import drains_to_dprst_labeled_kernel
+
+
+def test_labeled_trace_attributes_to_reached_hru_with_barrier():
+    # 1x5 single VPU (code 1). land -> land -> [dprst in HRU 42] , and a second
+    # chain where an on-stream barrier blocks the reach.
+    #   col: 0    1        2(dprst,HRU42)   3(onstream)    4(dprst,HRU9)
+    # flow all East; col4 pours to HRU9 but col3 is a barrier.
+    vpu = np.ones((1, 5), dtype=np.uint8)
+    fdr = np.array([[1, 1, 255, 1, 255]], dtype=np.uint8)
+    dprst = np.array([[0, 0, 1, 0, 1]], dtype=np.uint8)
+    onstream = np.array([[0, 0, 0, 1, 0]], dtype=np.uint8)
+    hru = np.array([[7, 7, 42, 8, 9]], dtype=np.int32)
+
+    fdr_m = mask_fdr_to_vpu(fdr, vpu, code=1)
+    label = np.where((dprst == 1) & (vpu == 1), hru, 0).astype(np.int32)
+    barrier = vpu_pour_points(onstream, vpu, code=1)
+    out, _ = drains_to_dprst_labeled_kernel(fdr_m, label, barrier)
+    # col0,col1 reach dprst HRU42; col2 is the dprst (label 42); col3 barrier=0;
+    # col4 is its own dprst (label 9).
+    assert out.tolist() == [[42, 42, 42, 0, 9]]
+```
+
+- [ ] **Step 2: Run to verify it fails / passes**
+
+Run: `pixi run -e dev --as-is pytest tests/test_routing_hru.py -q`
+Expected: PASS once Task 1 is in (this pins the composition `routing_hru.build` relies on). Acceptable per the additive design (documents intended wiring).
+
+- [ ] **Step 3: Implement the builder** — `src/gfv2_params/depstor_builders/routing_hru.py`. It mirrors `routing.build` but runs the labeled kernel and writes int32 **per-VPU windowed** (the labeled output is int32 ≈ 4× the binary — never held whole-CONUS; read-modify-write each VPU window so overlapping bboxes don't clobber neighbours):
+
+```python
+"""HRU-labeled, barrier-aware upslope routing → drains_to_dprst_hru.tif.
+
+Same per-VPU D8 tiling as `routing`, but each depression cell is labelled by its
+HRU id (hru_id.tif) and the labeled kernel attributes every draining cell to the
+HRU of the depression it reaches. On-stream waterbodies are barriers. Written
+per-VPU windowed: the int32 output is ~4x the binary drains, so it is never held
+whole-CONUS.
+"""
+from __future__ import annotations
+
+import numpy as np
+import rasterio
+from rasterio.windows import Window
+
+from ..d8_routing import drains_to_dprst_labeled_kernel
+from ..depstor import (
+    RasterInfo, align_fdr_to_dprst_grid, mask_fdr_to_vpu, read_aligned_uint8,
+    vpu_bbox, vpu_codes_present, vpu_pour_points,
+)
+from .context import BuildContext
+
+
+def build(step_cfg: dict, ctx: BuildContext, logger) -> dict:
+    if ctx.fdr_raster is None or not ctx.fdr_raster.exists():
+        raise FileNotFoundError(f"routing_hru needs fdr_raster: {ctx.fdr_raster}")
+    output_path = ctx.resolve_output(step_cfg["output"])
+    dprst_path = ctx.require("dprst")
+    onstream_path = ctx.require("onstream")
+    vpu_id_path = ctx.require("vpu_id")
+    hru_id_path = ctx.require("hru_id")
+    keep_intermediates = bool(step_cfg.get("keep_intermediates", False))
+
+    logger.info("--- routing_hru (per-VPU labeled) ---")
+    if output_path.exists() and not ctx.force:
+        logger.info("  Output exists — skipping (pass --force to rebuild)")
+        return {"drains_to_dprst_hru": output_path}
+
+    info = RasterInfo.from_path(ctx.template_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fdr_aligned = output_path.parent / "fdr_aligned_hru.tif"
+
+    try:
+        align_fdr_to_dprst_grid(ctx.fdr_raster, dprst_path, fdr_aligned, logger)
+        vpu_id = read_aligned_uint8(vpu_id_path, info)
+        codes = vpu_codes_present(vpu_id)
+
+        profile = dict(
+            driver="GTiff", height=info.height, width=info.width, count=1,
+            dtype="int32", crs=info.crs, transform=info.transform, nodata=0,
+            compress="LZW", tiled=True, blockxsize=256, blockysize=256, bigtiff="YES",
+        )
+        with rasterio.open(output_path, "w", **profile) as dst, \
+                rasterio.open(fdr_aligned) as fdr_src, \
+                rasterio.open(dprst_path) as dprst_src, \
+                rasterio.open(onstream_path) as onstream_src, \
+                rasterio.open(hru_id_path) as hru_src:
+            for code in codes:
+                bbox = vpu_bbox(vpu_id, code)
+                r0, r1, c0, c1 = bbox
+                window = Window(c0, r0, c1 - c0, r1 - r0)
+                vpu_win = vpu_id[r0:r1, c0:c1]
+                fdr_win = fdr_src.read(1, window=window)
+                dprst_win = dprst_src.read(1, window=window)
+                onstream_win = onstream_src.read(1, window=window)
+                hru_win = hru_src.read(1, window=window)
+
+                fdr_masked = mask_fdr_to_vpu(fdr_win, vpu_win, code, nodata=255)
+                label = np.where((dprst_win == 1) & (vpu_win == code), hru_win, 0).astype(np.int32)
+                barrier = vpu_pour_points(onstream_win, vpu_win, code)
+                out, n_cycles = drains_to_dprst_labeled_kernel(fdr_masked, label, barrier, fdr_nodata=255)
+                if n_cycles:
+                    logger.warning("  VPU %d: %d flow cycle(s) — cells non-draining", code, n_cycles)
+
+                # read-modify-write only this VPU's cells (bboxes overlap at corners)
+                existing = dst.read(1, window=window)
+                sel = (vpu_win == code) & (out > 0)
+                existing[sel] = out[sel]
+                dst.write(existing, 1, window=window)
+                logger.info("  VPU %d: %d labelled drain cells", code, int(sel.sum()))
+    finally:
+        if not keep_intermediates and fdr_aligned.exists():
+            fdr_aligned.unlink()
+    return {"drains_to_dprst_hru": output_path}
+```
+
+Register in `__init__.py`: import `routing_hru`, add `"routing_hru": routing_hru.build` to `BUILDERS`, insert `"routing_hru"` in `STEP_ORDER` right after `"routing"`. In `configs/depstor/depstor_rasters.yml`, add after the `routing` step:
+
+```yaml
+  - name: routing_hru
+    output: drains_to_dprst_hru.tif
+```
+
+- [ ] **Step 4: Run the test**
+
+Run: `pixi run -e dev --as-is pytest tests/test_routing_hru.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/gfv2_params/depstor_builders/routing_hru.py src/gfv2_params/depstor_builders/__init__.py \
+  configs/depstor/depstor_rasters.yml tests/test_routing_hru.py
+git commit -m "feat(depstor): routing_hru labeled barrier-aware trace (drains_to_dprst_hru)"
+```
+
+---
+
+### Task 5: `same_hru_drains` builder (replaces the two `intersect` steps)
+
+**Files:**
+- Create: `src/gfv2_params/depstor_builders/same_hru_drains.py`
+- Modify: `src/gfv2_params/depstor_builders/__init__.py` (`drains_perv`/`drains_imperv` → `same_hru_drains.build`), `configs/depstor/depstor_rasters.yml` (repoint the two steps' `inputs`)
+- Test: `tests/test_same_hru_drains.py`
+
+**Interfaces:**
+- Consumes: keys `drains_to_dprst_hru` (int32), `hru_id` (int32), `perv`/`imperv` (uint8); `RasterInfo`, `uint8_binary_profile`, `assert_raster_aligned`.
+- Produces: `drains_perv_binary.tif` / `drains_imperv_binary.tif` (uint8 1/255), keys `drains_perv`/`drains_imperv` (via `output_key`) — SAME as the replaced `intersect` step.
+
+- [ ] **Step 1: Write the failing test** — `tests/test_same_hru_drains.py`:
+
+```python
+import numpy as np
+from gfv2_params.depstor import same_hru_intersect
+
+
+def test_same_hru_intersect_keeps_only_matching_hru():
+    labeled = np.array([[42, 42, 9, 0]], dtype=np.int32)   # reached-HRU per cell
+    hru_id = np.array([[42, 8, 9, 5]], dtype=np.int32)     # cell's own HRU
+    land = np.array([[1, 1, 1, 1]], dtype=np.uint8)         # perv everywhere
+    out = same_hru_intersect(labeled, hru_id, land)
+    # col0: 42==42 & perv -> 1 ; col1: 42!=8 -> 255 ; col2: 9==9 -> 1 ; col3: 0!=5 -> 255
+    assert out.tolist() == [[1, 255, 1, 255]]
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pixi run -e dev --as-is pytest tests/test_same_hru_drains.py -q`
+Expected: FAIL — `cannot import name 'same_hru_intersect'`.
+
+- [ ] **Step 3: Implement helper + builder**
+
+In `src/gfv2_params/depstor.py` (near `intersect_binaries`):
+
+```python
+def same_hru_intersect(labeled: np.ndarray, hru_id: np.ndarray, land: np.ndarray) -> np.ndarray:
+    """1 where a land cell drains to a depression in its OWN HRU, else 255."""
+    hit = (labeled == hru_id) & (labeled > 0) & (land == 1)
+    out = np.full(land.shape, np.uint8(255), dtype=np.uint8)
+    out[hit] = 1
+    return out
+```
+
+Create `src/gfv2_params/depstor_builders/same_hru_drains.py`:
+
+```python
+"""Same-HRU drains: land cells draining to a depression in their OWN HRU.
+
+Replaces the plain `intersect` for drains_perv/drains_imperv. The same-HRU
+restriction is a RASTER-SPACE intersection (labeled drains == rasterised hru_id),
+applied before aggregation -- NOT a gdptools operation -- because it is a
+per-cell comparison gdptools' partial-pixel weights cannot express. It
+reproduces the legacy `Con(rSro == hru)` (docs/0b_TB_depr_stor.py:214). The
+per-HRU COUNT downstream still uses gdptools.
+"""
+from __future__ import annotations
+
+import rasterio
+from rasterio.windows import Window
+
+from ..depstor import RasterInfo, assert_raster_aligned, same_hru_intersect, uint8_binary_profile
+from .context import BuildContext
+
+STRIP_ROWS = 1024
+
+
+def build(step_cfg: dict, ctx: BuildContext, logger) -> dict:
+    name = step_cfg["name"]
+    inputs = step_cfg["inputs"]  # [drains_to_dprst_hru, hru_id, perv|imperv]
+    if not isinstance(inputs, list) or len(inputs) != 3:
+        raise ValueError(f"same_hru_drains step '{name}' needs inputs: [labeled, hru_id, land]")
+    labeled_path = ctx.require(inputs[0])
+    hru_path = ctx.require(inputs[1])
+    land_path = ctx.require(inputs[2])
+    output_path = ctx.resolve_output(step_cfg["output"])
+    output_key = step_cfg.get("output_key", name)
+
+    logger.info("--- %s (same-HRU) ---", name)
+    if output_path.exists() and not ctx.force:
+        logger.info("  Output exists — skipping (pass --force to rebuild)")
+        return {output_key: output_path}
+
+    info = RasterInfo.from_path(ctx.template_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    n_hit = 0
+    with rasterio.open(labeled_path) as lab_src, rasterio.open(hru_path) as hru_src, \
+            rasterio.open(land_path) as land_src, \
+            rasterio.open(output_path, "w", **uint8_binary_profile(info)) as dst:
+        assert_raster_aligned(lab_src, info, inputs[0])
+        assert_raster_aligned(hru_src, info, inputs[1])
+        assert_raster_aligned(land_src, info, inputs[2])
+        for row_off in range(0, info.height, STRIP_ROWS):
+            h = min(STRIP_ROWS, info.height - row_off)
+            window = Window(0, row_off, info.width, h)
+            out = same_hru_intersect(lab_src.read(1, window=window),
+                                     hru_src.read(1, window=window),
+                                     land_src.read(1, window=window))
+            dst.write(out, 1, window=window)
+            n_hit += int((out == 1).sum())
+    logger.info("  %d same-HRU %s cells", n_hit, output_key)
+    return {output_key: output_path}
+```
+
+In `__init__.py`: import `same_hru_drains`; change `"drains_perv": intersect.build` and `"drains_imperv": intersect.build` to `same_hru_drains.build`. (`intersect` stays imported only if still referenced elsewhere; if not, drop it from the import.) In `configs/depstor/depstor_rasters.yml`, repoint the two steps' inputs:
+
+```yaml
+  - name: drains_perv
+    inputs: [drains_to_dprst_hru, hru_id, perv]
+    output_key: drains_perv
+    output: drains_perv_binary.tif
+  - name: drains_imperv
+    inputs: [drains_to_dprst_hru, hru_id, imperv]
+    output_key: drains_imperv
+    output: drains_imperv_binary.tif
+```
+
+- [ ] **Step 4: Run the test**
+
+Run: `pixi run -e dev --as-is pytest tests/test_same_hru_drains.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/gfv2_params/depstor.py src/gfv2_params/depstor_builders/same_hru_drains.py \
+  src/gfv2_params/depstor_builders/__init__.py configs/depstor/depstor_rasters.yml \
+  tests/test_same_hru_drains.py
+git commit -m "feat(depstor): same_hru_drains restricts drains_perv/imperv to own HRU"
+```
+
+---
+
+### Task 6: Docs
+
+**Files:**
+- Modify: `docs/ARCHITECTURE.md`, `CLAUDE.md`
+
+- [ ] **Step 1: ARCHITECTURE.md** — in the depstor section, document the new chain (`hru_id` → `routing_hru` → `same_hru_drains`) and state, verbatim in intent: the same-HRU restriction on `sro_to_dprst_perv/imperv` is a **raster-space intersection** — labeled drains (`drains_to_dprst_hru.tif`) compared cell-by-cell against a hard-rasterised `hru_id.tif` — applied **before** aggregation, **not** a gdptools operation, **because** it is a per-cell test (reached-HRU vs. own HRU) that gdptools' partial-pixel weighting cannot express; the per-HRU **count still uses gdptools**; it reproduces legacy `Con(rSro == hru)` (`0b_TB_depr_stor.py:214`); tradeoff is a 1-pixel HRU-boundary approximation, immaterial vs. the basin-scale signal. Note `drains_to_dprst`/`drains_to_dprst_frac` stay HRU-agnostic.
+
+- [ ] **Step 2: CLAUDE.md** — add a depstor gotchas bullet: `sro_to_dprst_perv/imperv` are same-HRU-restricted via a raster intersection (`drains_to_dprst_hru == hru_id`) in `same_hru_drains`, NOT via gdptools — because it's a per-cell reached-HRU-vs-own-HRU test; per-HRU counts still use gdptools; matches legacy `Con(rSro == hru)`. `drains_to_dprst` itself stays HRU-agnostic.
+
+- [ ] **Step 3: pre-commit + commit**
+
+Run: `pixi run -e dev pre-commit run --files docs/ARCHITECTURE.md CLAUDE.md`
+Expected: PASS (or auto-fix, re-stage).
+
+```bash
+git add docs/ARCHITECTURE.md CLAUDE.md
+git commit -m "docs(depstor): document raster-space same-HRU restriction for sro_to_dprst_*"
+```
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** hru_id (T2), labeled-kernel barrier (T1), routing_hru (T4, needs the T3 shared align helper), same_hru_drains replacing intersect (T5), docs incl. the raster-vs-gdptools requirement (T6), CONUS per-VPU-windowed int32 write (T4). `depstor_params.yml` unchanged (verified — `same_hru_drains` reuses filenames/keys).
+- **Type consistency:** labeled kernel returns int32; `hru_id`/`drains_to_dprst_hru` are int32; `same_hru_intersect(labeled:int32, hru_id:int32, land:uint8) -> uint8`; `rasterize_ids -> int32`. Keys `drains_to_dprst_hru`, `hru_id`, `drains_perv`, `drains_imperv` consistent across T2/T4/T5 and the config.
+- **No same-HRU restriction leaks into `drains_to_dprst_frac`:** that param still sources `drains_to_dprst.tif` from `routing` (unchanged).
+- **Validation (post-merge, HPC):** rebuild from `hru_id` (or full depstor), then re-aggregate `sro_to_dprst_*`; expect the VPU-15 shift (0.0256 → 0.0207 area-weighted; ~945 cross-HRU HRUs drop toward 0). Not a unit-test step.

--- a/docs/superpowers/specs/2026-07-02-same-hru-drains-design.md
+++ b/docs/superpowers/specs/2026-07-02-same-hru-drains-design.md
@@ -1,0 +1,141 @@
+# Same-HRU restriction for `sro_to_dprst_*` — design
+
+Date: 2026-07-02
+Status: approved (brainstorming)
+Issue: #160
+Branch: feat/same-hru-drains
+
+## Problem
+
+The open-source `drains_to_dprst` method credits a pervious/impervious cell to
+its **own** HRU's `sro_to_dprst_perv/imperv` if it drains to **any** depression,
+including one in a *different* (downstream) HRU. The legacy ArcPy method
+restricted this to same-HRU depressions via `Con(rSro_to_dprst == hru,
+rSro_to_dprst)` (`docs/0b_TB_depr_stor.py:214`). We dropped that restriction.
+
+Evidence (VPU 15, rebuilt rasters, 2026-07-02; labeled trace matched production
+`drains_to_dprst.tif` at 100.00%): 19.4% of `drains_perv` cells drain to a
+different HRU's depression; VPU-wide area-weighted `sro_to_dprst_perv` is 1.24×
+legacy; the effect is concentrated (median per-HRU diff 0) in a tail of ~70–120
+HRUs, some saturating to 1.0 with `dprst_frac ≈ 0` (a pairing PRMS can't honor);
+945 HRUs flip 0 → >0. Endorheic/playa terrain drives it.
+
+## Goal
+
+Restore the legacy same-HRU restriction on `sro_to_dprst_perv/imperv` only,
+**additively** — leaving the merged `routing`/`intersect` binary
+`drains_to_dprst` path (#159) untouched — and preserve every current raster
+product and the entire parameter-aggregation config.
+
+## Approach (selected: additive)
+
+Rejected alternative — **integrated**: fold HRU labeling into `routing`, derive
+the binary `drains_to_dprst.tif` as `labeled > 0`, compare in `intersect`. No
+duplicate trace, but rewrites the just-merged/reviewed routing+intersect code.
+Chosen additive path costs one extra per-VPU D8 pass but touches no working
+step (matches the "finish the product, don't refactor working steps"
+guidance).
+
+### New / changed components
+
+1. **`hru_id` raster builder** (new step). Rasterizes the fabric's `nat_hru_id`
+   (the profile `id_feature`) onto the depstor **template grid** → `hru_id.tif`
+   (int32, `0` = no HRU). Reads `hru_gpkg` / `hru_layer` / `id_feature` from the
+   active fabric profile via `require_config_key` (never hardcoded). This is the
+   open-source equivalent of the legacy `nhrug`. Depends only on the template +
+   fabric; placed early (after `landmask`).
+
+2. **Barrier support in `drains_to_dprst_labeled_kernel`** (`d8_routing.py`).
+   Add the `barrier` argument (parity with `drains_to_dprst_kernel`; the
+   follow-up deferred from #159). Barrier cells (on-stream waterbodies) seed
+   non-draining and terminate any path that reaches them as label `0`.
+
+3. **`routing_hru` builder** (new step, additive). Mirrors `routing`'s
+   FDR-alignment + per-VPU tiling, reusing the existing alignment /
+   `mask_fdr_to_vpu` / `vpu_pour_points` helpers. The FDR-alignment helper is
+   promoted to a shared location (`depstor.py`) so neither routing builder
+   imports the other's privates — a behavior-preserving move; `routing`'s binary
+   path is unchanged and still covered by its tests. Per VPU: `label = hru_id
+   where dprst == 1` (VPU-scoped), `barrier = onstream` (VPU-scoped), run the
+   barrier-aware **labeled** kernel → `drains_to_dprst_hru.tif` (int32; each
+   draining cell carries the `nat_hru_id` of the depression it reaches, `0`
+   elsewhere).
+
+4. **`same_hru_drains` builder** (new step; **replaces the two `intersect`
+   steps** for these outputs). Streaming strips (STRIP_ROWS like `intersect`):
+   `drains_perv_binary = (drains_to_dprst_hru == hru_id) & (perv == 1)`;
+   `drains_imperv_binary = (drains_to_dprst_hru == hru_id) & (imperv == 1)`;
+   `255` background. **Writes the same filenames / output-keys as today**
+   (`drains_perv_binary.tif`, `drains_imperv_binary.tif`). Assert all inputs are
+   template-aligned (as `intersect`/`carea_map` do).
+
+### Data flow (aggregation UNCHANGED)
+
+```
+dprst, onstream, hru_id, FDR ─► routing_hru ─► drains_to_dprst_hru.tif
+hru_id, perv/imperv ─────────► same_hru_drains ─► drains_perv/imperv_binary.tif
+                                          │  gdptools zonal count (UNCHANGED)
+                                 drains_perv_frac, drains_imperv_frac
+                                          │  ratio (UNCHANGED)
+                                 sro_to_dprst_perv/imperv  ◄── corrected
+```
+
+`drains_to_dprst.tif` and `drains_to_dprst_frac` stay HRU-agnostic and unchanged.
+Because `same_hru_drains` writes the same filenames the `intersect` step did,
+**`depstor_params.yml` needs zero changes** — the fraction zonal count and the
+ratio division consume a corrected `drains_perv/imperv_binary.tif` transparently.
+
+### DAG / config (`depstor_rasters.yml`)
+
+Insert `hru_id` (after `landmask`), `routing_hru` (after `routing`), and
+`same_hru_drains` **in place of** the `drains_perv` / `drains_imperv`
+`intersect` steps. Existing `routing` → `drains_to_dprst.tif` untouched.
+Register the new builders in the `BUILDERS` dispatch table and `STEP_ORDER`.
+
+### Documentation (first-class requirement)
+
+`docs/ARCHITECTURE.md` and `CLAUDE.md` MUST state plainly:
+
+- The same-HRU restriction is a **raster-space intersection** — the labeled
+  drains raster compared cell-by-cell against a **hard-rasterized `hru_id`
+  grid** — applied **before** aggregation, **not** a gdptools operation.
+- **Why:** the test is a per-cell comparison (a cell's reached-HRU vs. its own
+  HRU) that gdptools' partial-pixel area-weighting cannot express; it
+  reproduces the legacy `nhrug` / `Con(rSro == hru)` behavior
+  (`0b_TB_depr_stor.py:214`).
+- The per-HRU **count still uses gdptools** (the fraction zonal step is
+  unchanged); only the same-HRU *selection* is raster-based.
+- **Tradeoff:** a 1-pixel-wide HRU-boundary approximation (a cell may be
+  area-credited to HRU A by gdptools weights but labeled HRU B by the hard
+  rasterization) — immaterial against the basin-scale cross-HRU signal, and
+  consistent with legacy.
+
+### Testing
+
+- `tests/test_hru_id.py` — rasterizes a tiny fabric, asserts per-cell ids +
+  template alignment.
+- `tests/test_drains_kernel.py` — labeled-kernel barrier cases (blocked upslope,
+  first-waterbody-wins, no-barrier equivalence).
+- `tests/test_routing_tiling.py` (or a new `test_routing_hru.py`) — per-VPU
+  labeled trace attributes cells to the reached depression's HRU; on-stream
+  barrier respected.
+- `tests/test_same_hru_drains.py` — same-HRU equality × perv/imperv; a cell
+  draining cross-HRU is excluded, same-HRU included.
+
+### CONUS-scale notes
+
+- `hru_id.tif` is a full int32 CONUS raster (~68 GB uncompressed; LZW-tiled on
+  disk, windowed in memory — never held whole). Rasterize streams to disk.
+- `routing_hru` is a second per-VPU trace with int32 label/output (heavier than
+  the binary kernel but per-VPU windowed); run at similar mem to `routing`.
+- All new builders follow the existing streaming/tiling discipline; no new
+  full-grid in-memory array.
+
+## Out of scope
+
+- Fabric-level depression-aware HRU delineation (root cause; a next-fabric
+  input, not this pipeline).
+- Runtime re-aggregation of `sro_to_dprst_*` on the fabric (HPC step after
+  merge; rasters are rebuilt but params not yet re-aggregated).
+- Exact (weighted) same-HRU test inside the zonal stat — deferred; the
+  raster-space approximation matches legacy and is sufficient.

--- a/scripts/build_depstor_rasters.py
+++ b/scripts/build_depstor_rasters.py
@@ -68,6 +68,7 @@ def _build_context(config: dict, force: bool) -> BuildContext:
     template_path = Path(require_config_key(config, "template_raster", "build_depstor_rasters"))
     hru_gpkg = Path(require_config_key(config, "hru_gpkg", "build_depstor_rasters"))
     hru_layer = require_config_key(config, "hru_layer", "build_depstor_rasters")
+    id_feature = require_config_key(config, "id_feature", "build_depstor_rasters")
 
     output_dir.mkdir(parents=True, exist_ok=True)
 
@@ -77,6 +78,7 @@ def _build_context(config: dict, force: bool) -> BuildContext:
         output_dir=output_dir,
         hru_gpkg=hru_gpkg,
         hru_layer=hru_layer,
+        id_feature=id_feature,
         segments_gpkg=Path(config["segments_gpkg"]) if config.get("segments_gpkg") else None,
         segments_layer=config.get("segments_layer", "nsegment"),
         waterbody_gpkg=Path(config["waterbody_gpkg"]) if config.get("waterbody_gpkg") else None,

--- a/scripts/build_depstor_rasters.py
+++ b/scripts/build_depstor_rasters.py
@@ -134,6 +134,8 @@ def _expected_outputs(step: dict) -> dict:
             "perv": "perv",
             "routing": "drains_to_dprst",
             "vpu_id": "vpu_id",
+            "hru_id": "hru_id",
+            "routing_hru": "drains_to_dprst_hru",
         }
         return {single_key[name]: step["output"]}
     outputs = step["outputs"]

--- a/scripts/diagnose/ab_drains_to_dprst.py
+++ b/scripts/diagnose/ab_drains_to_dprst.py
@@ -104,8 +104,14 @@ def _run_one_vpu(fdr_path, dprst_path, vpu_id_path, template_path, vpu_code,
             # too and attribute whole river-corridor catchments to them, so the
             # per-depression sum would not match the dprst-seeded binary drains.
             label_win[(vpu_win != code) | (dprst_win != 1)] = 0
-            labeled, _ = drains_to_dprst_labeled_kernel(fdr_masked, label_win,
-                                                        fdr_nodata=255)
+            # This A/B diagnostic has no on-stream barrier concept (see the
+            # no_barrier comment above for the binary kernel); pass an
+            # all-zero barrier so labeled coverage stays comparable to the
+            # barrier-free binary drains count in the n_labeled == n_drain
+            # self-check below.
+            labeled, _ = drains_to_dprst_labeled_kernel(
+                fdr_masked, label_win, np.zeros_like(label_win, dtype=np.uint8),
+                fdr_nodata=255)
             counts = per_depression_counts(labeled)
             # Consistency self-check: same pour-points => labeled coverage must
             # equal the binary dprst-drains count. A mismatch means the label

--- a/scripts/diagnose/ab_drains_to_dprst.py
+++ b/scripts/diagnose/ab_drains_to_dprst.py
@@ -34,12 +34,12 @@ from gfv2_params.d8_routing import (
 )
 from gfv2_params.depstor import (
     RasterInfo,
+    align_fdr_to_dprst_grid,
     mask_fdr_to_vpu,
     read_aligned_uint8,
     vpu_bbox,
     vpu_pour_points,
 )
-from gfv2_params.depstor_builders.routing import _align_fdr_to_dprst_grid
 
 _FDR_CHOICES = ("production", "fill", "breach")
 
@@ -66,7 +66,7 @@ def _run_one_vpu(fdr_path, dprst_path, vpu_id_path, template_path, vpu_code,
                  labels_path, out_tif, out_csv, logger):
     info = RasterInfo.from_path(template_path)
     fdr_aligned = out_tif.parent / f"_fdr_aligned_{vpu_code}.tif"
-    _align_fdr_to_dprst_grid(fdr_path, dprst_path, fdr_aligned, logger)
+    align_fdr_to_dprst_grid(fdr_path, dprst_path, fdr_aligned, logger)
     try:
         vpu_id = read_aligned_uint8(vpu_id_path, info)
         code = int(vpu_code)

--- a/src/gfv2_params/d8_routing.py
+++ b/src/gfv2_params/d8_routing.py
@@ -17,7 +17,9 @@ overlap with a barrier).
 
 `drains_to_dprst_labeled_kernel` extends this to per-depression attribution:
 each cell receives the label of the specific depression its D8 path reaches,
-enabling per-depression contributing-area counts.
+enabling per-depression contributing-area counts. It takes the same barrier
+treatment as `drains_to_dprst_kernel` (barrier seeds as a non-draining
+terminus; labels win any overlap with a barrier).
 
 This is the ONLY numba user in the package; it is deliberately isolated here so
 the widely-imported `depstor.py` stays numba-free.
@@ -153,7 +155,7 @@ def _resolve(fdr, pour, barrier, fdr_nodata):
 
 
 @njit(cache=True)
-def _resolve_labeled(fdr, label, fdr_nodata):
+def _resolve_labeled(fdr, label, barrier, fdr_nodata):
     ny, nx = fdr.shape
     st = np.zeros((ny, nx), dtype=np.uint8)
     lab = np.zeros((ny, nx), dtype=np.int32)
@@ -164,6 +166,13 @@ def _resolve_labeled(fdr, label, fdr_nodata):
             if label[r, c] > 0:
                 st[r, c] = _DRAINS
                 lab[r, c] = label[r, c]
+
+    # Seed barriers (on-stream waterbodies) as non-draining termini, but only
+    # where not already a label cell — labels win any overlap.
+    for r in range(ny):
+        for c in range(nx):
+            if barrier[r, c] == 1 and st[r, c] == _UNKNOWN:
+                st[r, c] = _NOT
 
     cap = 1 << 20
     stack_r = np.empty(cap, dtype=np.int64)
@@ -310,15 +319,24 @@ def drains_to_dprst_kernel(fdr_win, pour_win, barrier_win, fdr_nodata=255):
     return _resolve(fdr, pour, barrier, np.uint8(fdr_nodata))
 
 
-def drains_to_dprst_labeled_kernel(fdr_win, label_win, fdr_nodata=255):
+def drains_to_dprst_labeled_kernel(fdr_win, label_win, barrier_win, fdr_nodata=255):
     """Per-cell label of the depression its ESRI-D8 path reaches (0 = none).
 
     Like ``drains_to_dprst_kernel`` but attributes each draining cell to a
     specific depression. ``label_win`` carries each depression region's unique
     positive id at its cells (0 background); the return holds that id for every
     cell that drains there, enabling per-depression contributing-area counts via
-    ``np.bincount(out.ravel())``. Returns ``(out_int32, n_cycles)``.
+    ``np.bincount(out.ravel())``.
+
+    ``barrier_win`` (required, uint8, same shape): 1 = barrier cell (on-stream
+    waterbody). A flow path that reaches a barrier before it reaches a labeled
+    depression stops there and is `0` in the output — the first waterbody on
+    the flow path wins. Labels win any (impossible-by-construction) overlap
+    with a barrier.
+
+    Returns ``(out_int32, n_cycles)``.
     """
     fdr = np.ascontiguousarray(fdr_win, dtype=np.uint8)
     label = np.ascontiguousarray(label_win, dtype=np.int32)
-    return _resolve_labeled(fdr, label, np.uint8(fdr_nodata))
+    barrier = np.ascontiguousarray(barrier_win, dtype=np.uint8)
+    return _resolve_labeled(fdr, label, barrier, np.uint8(fdr_nodata))

--- a/src/gfv2_params/d8_routing.py
+++ b/src/gfv2_params/d8_routing.py
@@ -336,6 +336,14 @@ def drains_to_dprst_labeled_kernel(fdr_win, label_win, barrier_win, fdr_nodata=2
 
     Returns ``(out_int32, n_cycles)``.
     """
+    # numba runs with bounds-checking off; a smaller label/barrier than fdr
+    # would be silent out-of-bounds reads, not an error. Guard loudly in
+    # plain Python (parity with drains_to_dprst_kernel's guard above).
+    if not (fdr_win.shape == label_win.shape == barrier_win.shape):
+        raise ValueError(
+            f"fdr/label/barrier shapes must match: {fdr_win.shape}, "
+            f"{label_win.shape}, {barrier_win.shape}"
+        )
     fdr = np.ascontiguousarray(fdr_win, dtype=np.uint8)
     label = np.ascontiguousarray(label_win, dtype=np.int32)
     barrier = np.ascontiguousarray(barrier_win, dtype=np.uint8)

--- a/src/gfv2_params/depstor.py
+++ b/src/gfv2_params/depstor.py
@@ -186,6 +186,21 @@ def intersect_binaries(a: np.ndarray, b: np.ndarray) -> np.ndarray:
     return out
 
 
+def same_hru_intersect(labeled: np.ndarray, hru_id: np.ndarray, land: np.ndarray) -> np.ndarray:
+    """1 where a land cell drains to a depression in its OWN HRU, else 255.
+
+    `labeled` is the per-cell reached-depression HRU id (0 = doesn't drain to
+    any depression, from `drains_to_dprst_hru.tif`); `hru_id` is the cell's own
+    HRU id; `land` is a 1/255 binary mask (perv or imperv). Restores the same-HRU
+    restriction from the legacy `Con(rSro == hru)` (docs/0b_TB_depr_stor.py:214) —
+    a per-cell raster-space comparison, not a gdptools zonal operation.
+    """
+    hit = (labeled == hru_id) & (labeled > 0) & (land == 1)
+    out = np.full(land.shape, np.uint8(255), dtype=np.uint8)
+    out[hit] = 1
+    return out
+
+
 def compute_carea_map_binary(
     perv: np.ndarray,
     onstream: np.ndarray,

--- a/src/gfv2_params/depstor.py
+++ b/src/gfv2_params/depstor.py
@@ -79,6 +79,15 @@ def rasterize_binary(gdf, info: RasterInfo, all_touched: bool = False) -> np.nda
     return out
 
 
+def rasterize_ids(gdf, id_field: str, info: "RasterInfo") -> np.ndarray:
+    """Burn an integer id attribute onto the template grid (0 = no polygon)."""
+    shapes = ((geom, int(val)) for geom, val in zip(gdf.geometry, gdf[id_field]))
+    return rio_rasterize(
+        shapes, out_shape=(info.height, info.width), transform=info.transform,
+        fill=0, dtype="int32",
+    ).astype(np.int32, copy=False)
+
+
 def threshold_above(values: np.ndarray, threshold: float, src_nodata) -> np.ndarray:
     """Return uint8 binary mask: 1 where values >= threshold, else 255 (nodata).
 

--- a/src/gfv2_params/depstor.py
+++ b/src/gfv2_params/depstor.py
@@ -85,12 +85,22 @@ def rasterize_binary(gdf, info: RasterInfo, all_touched: bool = False) -> np.nda
     return out
 
 
-def rasterize_ids(gdf, id_field: str, info: "RasterInfo") -> np.ndarray:
+def rasterize_ids(
+    gdf, id_field: str, info: "RasterInfo", all_touched: bool = False,
+) -> np.ndarray:
     """Burn an integer id attribute onto the template grid (0 = no polygon).
 
     Geometries are reprojected to `info.crs` first if needed — a CRS-mismatched
     burn silently lands geometries in the wrong place (no error), so guard it as
     every other rasterize helper here does.
+
+    `all_touched` must match the footprint of any raster this output is later
+    compared against cell-by-cell. In particular, `hru_id.tif` needs
+    `all_touched=True` to match `land_mask.tif`/`perv_binary.tif` (rasterised
+    with `all_touched=True` in `landmask.py`) — otherwise HRU-boundary land
+    cells burn as `hru_id==0` under the default centroid rule, and
+    `same_hru_intersect` (which requires `labeled==hru_id & labeled>0`) silently
+    drops them, undercounting `drains_perv`/`drains_imperv` at every HRU edge.
     """
     if gdf.crs is None:
         raise ValueError("Input GeoDataFrame has no CRS")
@@ -101,7 +111,7 @@ def rasterize_ids(gdf, id_field: str, info: "RasterInfo") -> np.ndarray:
     shapes = ((geom, int(val)) for geom, val in zip(gdf.geometry, gdf[id_field]))
     return rio_rasterize(
         shapes, out_shape=(info.height, info.width), transform=info.transform,
-        fill=0, dtype="int32",
+        fill=0, dtype="int32", all_touched=all_touched,
     ).astype(np.int32, copy=False)
 
 

--- a/src/gfv2_params/depstor.py
+++ b/src/gfv2_params/depstor.py
@@ -19,6 +19,7 @@ from typing import Optional
 import numpy as np
 import pandas as pd
 import rasterio
+from osgeo import gdal
 from rasterio.coords import BoundingBox
 from rasterio.crs import CRS
 from rasterio.features import rasterize as rio_rasterize
@@ -387,6 +388,48 @@ def read_aligned_uint8(path: Path, info: RasterInfo) -> np.ndarray:
         if src.transform != info.transform:
             raise ValueError(f"Raster {path} transform mismatch with template")
         return src.read(1)
+
+
+def align_fdr_to_dprst_grid(fdr_path, dprst_path, out_path, logger) -> None:
+    """Materialise the FDR onto the dprst grid as a concrete GeoTIFF.
+
+    Streams via gdal.Warp (block-by-block, bounded RAM) rather than an in-memory
+    rioxarray.reproject_match: the latter materialised the full 16.9-billion-cell
+    CONUS array plus float intermediates and OOM-killed the step at ~400 GB on a
+    uint8 source that is only ~17 GB. The FDR clip already shares the dprst grid,
+    so this is a near-identity nearest-neighbour resample that just realises the
+    VRT into a concrete raster for fast per-VPU windowed reads.
+    """
+    logger.info("  Aligning FDR to dprst grid (gdal.Warp, streaming)...")
+    gdal.UseExceptions()
+    with rasterio.open(dprst_path) as d:
+        b = d.bounds
+        width, height, dst_srs = d.width, d.height, d.crs.to_wkt()
+    with rasterio.open(fdr_path) as f:
+        src_nodata = f.nodata
+    if out_path.exists():
+        out_path.unlink()
+    ds = gdal.Warp(
+        str(out_path),
+        str(fdr_path),
+        options=gdal.WarpOptions(
+            format="GTiff",
+            outputBounds=[b.left, b.bottom, b.right, b.top],
+            width=width,
+            height=height,
+            dstSRS=dst_srs,
+            resampleAlg="near",
+            outputType=gdal.GDT_Byte,
+            srcNodata=src_nodata,
+            dstNodata=255,
+            multithread=True,
+            warpMemoryLimit=2_000_000_000,
+            creationOptions=["COMPRESS=LZW", "TILED=YES", "BLOCKXSIZE=256", "BLOCKYSIZE=256", "BIGTIFF=YES"],
+        ),
+    )
+    if ds is None:
+        raise RuntimeError(f"gdal.Warp produced no dataset for {out_path} — FDR alignment failed.")
+    ds = None  # flush/close
 
 
 def vpu_codes_present(vpu_id: np.ndarray, nodata: int = 0) -> list[int]:

--- a/src/gfv2_params/depstor.py
+++ b/src/gfv2_params/depstor.py
@@ -2,8 +2,13 @@
 
 Ported from depstor's RasterPipeline (depstor/scripts/DepStor.py:42-410), but
 operating on numpy arrays + a shared raster template. The depstor "rasterize
-HRU polygons and tag cells with HRU IDs" pattern is intentionally NOT carried
-over — gdptools handles HRU overlay directly during zonal aggregation.
+HRU polygons and tag cells with HRU IDs" pattern is carried over narrowly: the
+`hru_id`/`routing_hru`/`same_hru_drains` builders rasterize `nat_hru_id`
+(`rasterize_ids` → `hru_id.tif`) to reinstate the legacy same-HRU restriction
+on `sro_to_dprst_perv/imperv` (`same_hru_intersect`, a per-cell raster-space
+test — see docs/ARCHITECTURE.md). Everywhere else, gdptools still handles HRU
+overlay directly during zonal aggregation, including the per-HRU COUNT for
+these same params.
 
 All raster outputs use the conventions:
 - uint8 binary masks: value 1 = present, value 255 = nodata

--- a/src/gfv2_params/depstor.py
+++ b/src/gfv2_params/depstor.py
@@ -80,7 +80,18 @@ def rasterize_binary(gdf, info: RasterInfo, all_touched: bool = False) -> np.nda
 
 
 def rasterize_ids(gdf, id_field: str, info: "RasterInfo") -> np.ndarray:
-    """Burn an integer id attribute onto the template grid (0 = no polygon)."""
+    """Burn an integer id attribute onto the template grid (0 = no polygon).
+
+    Geometries are reprojected to `info.crs` first if needed — a CRS-mismatched
+    burn silently lands geometries in the wrong place (no error), so guard it as
+    every other rasterize helper here does.
+    """
+    if gdf.crs is None:
+        raise ValueError("Input GeoDataFrame has no CRS")
+    if info.crs is None:
+        raise ValueError("RasterInfo has no CRS")
+    if gdf.crs != info.crs:
+        gdf = gdf.to_crs(info.crs)
     shapes = ((geom, int(val)) for geom, val in zip(gdf.geometry, gdf[id_field]))
     return rio_rasterize(
         shapes, out_shape=(info.height, info.width), transform=info.transform,

--- a/src/gfv2_params/depstor.py
+++ b/src/gfv2_params/depstor.py
@@ -338,9 +338,9 @@ def uint8_binary_profile(info: RasterInfo) -> dict:
     """Build the rasterio profile dict for a uint8 binary raster.
 
     Used by both the full-array writer (`write_uint8_binary`, below) and the
-    streaming depstor builders (`perv`, `carea_map`, `intersect`). Keeping a
-    single source means the two write paths can't drift on compression,
-    tiling, nodata, or BIGTIFF settings.
+    streaming depstor builders (`perv`, `carea_map`, `same_hru_drains`).
+    Keeping a single source means the two write paths can't drift on
+    compression, tiling, nodata, or BIGTIFF settings.
     """
     return {
         "driver": "GTiff",
@@ -388,7 +388,7 @@ def write_int32_regions(arr: np.ndarray, info: RasterInfo, out_path: Path) -> No
         "BIGTIFF": "YES",
     }
     with rasterio.open(out_path, "w", **profile) as dst:
-        dst.write(arr.astype(np.int32), 1)
+        dst.write(arr.astype(np.int32, copy=False), 1)
 
 
 def read_aligned_uint8(path: Path, info: RasterInfo) -> np.ndarray:

--- a/src/gfv2_params/depstor_builders/__init__.py
+++ b/src/gfv2_params/depstor_builders/__init__.py
@@ -14,7 +14,7 @@ These modules are thin orchestration wrappers around those helpers.
 
 from __future__ import annotations
 
-from . import carea_map, dprst, hru_id, imperv, intersect, landmask, perv, routing, vpu_id, waterbody, wbody_connectivity
+from . import carea_map, dprst, hru_id, imperv, intersect, landmask, perv, routing, routing_hru, vpu_id, waterbody, wbody_connectivity
 from .context import BuildContext
 
 BUILDERS = {
@@ -26,6 +26,7 @@ BUILDERS = {
     "perv":              perv.build,
     "hru_id":            hru_id.build,
     "routing":           routing.build,
+    "routing_hru":       routing_hru.build,
     "drains_perv":       intersect.build,
     "drains_imperv":     intersect.build,
     "vpu_id":            vpu_id.build,
@@ -49,6 +50,8 @@ BUILDERS = {
 #   perv               -> "perv"                   perv_binary.tif
 #   hru_id             -> "hru_id"                 hru_id.tif (int32, per-cell nat_hru_id)
 #   routing            -> "drains_to_dprst"        drains_to_dprst.tif (in-process D8 kernel)
+#   routing_hru        -> "drains_to_dprst_hru"     drains_to_dprst_hru.tif (int32, per-cell nat_hru_id
+#                                                    of the reached depression; labeled D8 kernel)
 #   drains_perv        -> "drains_perv"            drains_perv_binary.tif (output_key from config)
 #   drains_imperv      -> "drains_imperv"          drains_imperv_binary.tif (output_key from config)
 #   vpu_id             -> "vpu_id"                 vpu_id.tif (per-cell VPU code, multi-VPU only)
@@ -64,6 +67,7 @@ STEP_ORDER = [
     "hru_id",
     "vpu_id",
     "routing",
+    "routing_hru",
     "drains_perv",
     "drains_imperv",
     "carea_map",

--- a/src/gfv2_params/depstor_builders/__init__.py
+++ b/src/gfv2_params/depstor_builders/__init__.py
@@ -14,7 +14,7 @@ These modules are thin orchestration wrappers around those helpers.
 
 from __future__ import annotations
 
-from . import carea_map, dprst, imperv, intersect, landmask, perv, routing, vpu_id, waterbody, wbody_connectivity
+from . import carea_map, dprst, hru_id, imperv, intersect, landmask, perv, routing, vpu_id, waterbody, wbody_connectivity
 from .context import BuildContext
 
 BUILDERS = {
@@ -24,6 +24,7 @@ BUILDERS = {
     "wbody_connectivity": wbody_connectivity.build,
     "dprst":             dprst.build,
     "perv":              perv.build,
+    "hru_id":            hru_id.build,
     "routing":           routing.build,
     "drains_perv":       intersect.build,
     "drains_imperv":     intersect.build,
@@ -46,6 +47,7 @@ BUILDERS = {
 #   dprst              -> "dprst",                 dprst_binary.tif,
 #                         "onstream"               onstream_binary.tif
 #   perv               -> "perv"                   perv_binary.tif
+#   hru_id             -> "hru_id"                 hru_id.tif (int32, per-cell nat_hru_id)
 #   routing            -> "drains_to_dprst"        drains_to_dprst.tif (in-process D8 kernel)
 #   drains_perv        -> "drains_perv"            drains_perv_binary.tif (output_key from config)
 #   drains_imperv      -> "drains_imperv"          drains_imperv_binary.tif (output_key from config)
@@ -59,6 +61,7 @@ STEP_ORDER = [
     "wbody_connectivity",
     "dprst",
     "perv",
+    "hru_id",
     "vpu_id",
     "routing",
     "drains_perv",

--- a/src/gfv2_params/depstor_builders/__init__.py
+++ b/src/gfv2_params/depstor_builders/__init__.py
@@ -14,7 +14,7 @@ These modules are thin orchestration wrappers around those helpers.
 
 from __future__ import annotations
 
-from . import carea_map, dprst, hru_id, imperv, intersect, landmask, perv, routing, routing_hru, vpu_id, waterbody, wbody_connectivity
+from . import carea_map, dprst, hru_id, imperv, landmask, perv, routing, routing_hru, same_hru_drains, vpu_id, waterbody, wbody_connectivity
 from .context import BuildContext
 
 BUILDERS = {
@@ -27,8 +27,8 @@ BUILDERS = {
     "hru_id":            hru_id.build,
     "routing":           routing.build,
     "routing_hru":       routing_hru.build,
-    "drains_perv":       intersect.build,
-    "drains_imperv":     intersect.build,
+    "drains_perv":       same_hru_drains.build,
+    "drains_imperv":     same_hru_drains.build,
     "vpu_id":            vpu_id.build,
     "carea_map":         carea_map.build,
 }

--- a/src/gfv2_params/depstor_builders/context.py
+++ b/src/gfv2_params/depstor_builders/context.py
@@ -21,6 +21,7 @@ class BuildContext:
     output_dir: Path
     hru_gpkg: Path
     hru_layer: str
+    id_feature: str = "nat_hru_id"
     segments_gpkg: Path | None = None
     segments_layer: str = "nsegment"
     waterbody_gpkg: Path | None = None

--- a/src/gfv2_params/depstor_builders/hru_id.py
+++ b/src/gfv2_params/depstor_builders/hru_id.py
@@ -30,9 +30,15 @@ def build(step_cfg: dict, ctx: BuildContext, logger) -> dict:
     info = RasterInfo.from_path(ctx.template_path)
     gdf = gpd.read_file(ctx.hru_gpkg, layer=ctx.hru_layer)
     gdf = gdf[gdf.geometry.notna() & ~gdf.geometry.is_empty]
-    if (gdf[ctx.id_feature] <= 0).any():
-        raise ValueError(f"{ctx.id_feature} must be positive (0 is the no-HRU sentinel).")
-    ids = rasterize_ids(gdf, ctx.id_feature, info)
+    if gdf[ctx.id_feature].isna().any() or (gdf[ctx.id_feature] <= 0).any():
+        raise ValueError(
+            f"{ctx.id_feature} must be non-NaN and positive (0 is the no-HRU sentinel)."
+        )
+    # all_touched=True matches land_mask.tif/perv_binary.tif's footprint
+    # (landmask.py rasterises all_touched=True for the same reason); otherwise
+    # HRU-boundary land cells burn as hru_id==0 and same_hru_intersect silently
+    # drops them (undercounts drains_perv/imperv at every HRU edge).
+    ids = rasterize_ids(gdf, ctx.id_feature, info, all_touched=True)
     write_int32_regions(ids, info, output_path)
     n = int((ids > 0).sum())
     logger.info("  Rasterised %d HRUs | %d labelled cells (%.2f%%)", len(gdf), n, 100 * n / ids.size)

--- a/src/gfv2_params/depstor_builders/hru_id.py
+++ b/src/gfv2_params/depstor_builders/hru_id.py
@@ -1,0 +1,40 @@
+"""Build hru_id.tif: per-cell HRU id (nat_hru_id) rasterised onto the template.
+
+The open-source equivalent of the legacy `nhrug`. Consumed by `routing_hru`
+(to label depressions by HRU) and `same_hru_drains` (the same-HRU test). This
+is a raster-space HRU identity used only for the same-HRU restriction; per-HRU
+parameter COUNTS still use gdptools zonal weights downstream.
+"""
+from __future__ import annotations
+
+import geopandas as gpd
+
+from ..depstor import RasterInfo, rasterize_ids, write_int32_regions
+from .context import BuildContext
+
+
+def build(step_cfg: dict, ctx: BuildContext, logger) -> dict:
+    output_path = ctx.resolve_output(step_cfg["output"])
+    if not ctx.template_path.exists():
+        raise FileNotFoundError(f"Template raster not found: {ctx.template_path}")
+    if not ctx.hru_gpkg.exists():
+        raise FileNotFoundError(f"HRU fabric gpkg not found: {ctx.hru_gpkg}")
+
+    logger.info("--- hru_id ---")
+    logger.info("  HRU fabric: %s (layer=%s, id=%s)", ctx.hru_gpkg, ctx.hru_layer, ctx.id_feature)
+    logger.info("  Output    : %s", output_path)
+    if output_path.exists() and not ctx.force:
+        logger.info("  Output exists — skipping (pass --force to rebuild)")
+        return {"hru_id": output_path}
+
+    info = RasterInfo.from_path(ctx.template_path)
+    gdf = gpd.read_file(ctx.hru_gpkg, layer=ctx.hru_layer)
+    gdf = gdf[gdf.geometry.notna() & ~gdf.geometry.is_empty]
+    if (gdf[ctx.id_feature] <= 0).any():
+        raise ValueError(f"{ctx.id_feature} must be positive (0 is the no-HRU sentinel).")
+    ids = rasterize_ids(gdf, ctx.id_feature, info)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    write_int32_regions(ids, info, output_path)
+    n = int((ids > 0).sum())
+    logger.info("  Rasterised %d HRUs | %d labelled cells (%.2f%%)", len(gdf), n, 100 * n / ids.size)
+    return {"hru_id": output_path}

--- a/src/gfv2_params/depstor_builders/hru_id.py
+++ b/src/gfv2_params/depstor_builders/hru_id.py
@@ -33,7 +33,6 @@ def build(step_cfg: dict, ctx: BuildContext, logger) -> dict:
     if (gdf[ctx.id_feature] <= 0).any():
         raise ValueError(f"{ctx.id_feature} must be positive (0 is the no-HRU sentinel).")
     ids = rasterize_ids(gdf, ctx.id_feature, info)
-    output_path.parent.mkdir(parents=True, exist_ok=True)
     write_int32_regions(ids, info, output_path)
     n = int((ids > 0).sum())
     logger.info("  Rasterised %d HRUs | %d labelled cells (%.2f%%)", len(gdf), n, 100 * n / ids.size)

--- a/src/gfv2_params/depstor_builders/intersect.py
+++ b/src/gfv2_params/depstor_builders/intersect.py
@@ -1,8 +1,13 @@
 """Cell-wise intersection of two aligned uint8 binary rasters.
 
-Used for both drains_perv (drains_to_dprst x perv) and drains_imperv
-(drains_to_dprst x imperv). The step config names the inputs by their
-upstream-output key (`drains_to_dprst`, `perv`, `imperv`).
+`build()` here is no longer wired into `drains_perv`/`drains_imperv` — those
+steps were rewired to `same_hru_drains.build()` (a same-HRU-restricted
+intersection, not a plain one; see that module's docstring), and this module
+is not imported by `depstor_builders/__init__.py`'s `BUILDERS`/`STEP_ORDER`.
+It is retained as a generic two-input intersection builder in case a future
+step needs a plain cell-wise AND. `intersect_binaries` in `depstor.py` (the
+helper this module wraps) is still exercised directly by
+`tests/test_intersect_binaries.py`.
 """
 
 from __future__ import annotations

--- a/src/gfv2_params/depstor_builders/routing.py
+++ b/src/gfv2_params/depstor_builders/routing.py
@@ -26,12 +26,12 @@ from __future__ import annotations
 
 import numpy as np
 import rasterio
-from osgeo import gdal
 from rasterio.windows import Window
 
 from ..d8_routing import drains_to_dprst_kernel
 from ..depstor import (
     RasterInfo,
+    align_fdr_to_dprst_grid,
     assert_raster_aligned,
     assign_vpu_drains,
     mask_fdr_to_vpu,
@@ -47,48 +47,6 @@ from .context import BuildContext
 # ESRI-D8 flow codes plus the nodata/sink value (255). Any other value in the
 # FDR is unexpected and is silently treated as a sink by the kernel — surface it.
 _VALID_FDR_VALUES = frozenset({1, 2, 4, 8, 16, 32, 64, 128, 255})
-
-
-def _align_fdr_to_dprst_grid(fdr_path, dprst_path, out_path, logger) -> None:
-    """Materialise the FDR onto the dprst grid as a concrete GeoTIFF.
-
-    Streams via gdal.Warp (block-by-block, bounded RAM) rather than an in-memory
-    rioxarray.reproject_match: the latter materialised the full 16.9-billion-cell
-    CONUS array plus float intermediates and OOM-killed the step at ~400 GB on a
-    uint8 source that is only ~17 GB. The FDR clip already shares the dprst grid,
-    so this is a near-identity nearest-neighbour resample that just realises the
-    VRT into a concrete raster for fast per-VPU windowed reads.
-    """
-    logger.info("  Aligning FDR to dprst grid (gdal.Warp, streaming)...")
-    gdal.UseExceptions()
-    with rasterio.open(dprst_path) as d:
-        b = d.bounds
-        width, height, dst_srs = d.width, d.height, d.crs.to_wkt()
-    with rasterio.open(fdr_path) as f:
-        src_nodata = f.nodata
-    if out_path.exists():
-        out_path.unlink()
-    ds = gdal.Warp(
-        str(out_path),
-        str(fdr_path),
-        options=gdal.WarpOptions(
-            format="GTiff",
-            outputBounds=[b.left, b.bottom, b.right, b.top],
-            width=width,
-            height=height,
-            dstSRS=dst_srs,
-            resampleAlg="near",
-            outputType=gdal.GDT_Byte,
-            srcNodata=src_nodata,
-            dstNodata=255,
-            multithread=True,
-            warpMemoryLimit=2_000_000_000,
-            creationOptions=["COMPRESS=LZW", "TILED=YES", "BLOCKXSIZE=256", "BLOCKYSIZE=256", "BIGTIFF=YES"],
-        ),
-    )
-    if ds is None:
-        raise RuntimeError(f"gdal.Warp produced no dataset for {out_path} — FDR alignment failed.")
-    ds = None  # flush/close
 
 
 def build(step_cfg: dict, ctx: BuildContext, logger) -> dict:
@@ -118,7 +76,7 @@ def build(step_cfg: dict, ctx: BuildContext, logger) -> dict:
     fdr_aligned = output_path.parent / "fdr_aligned.tif"
 
     try:
-        _align_fdr_to_dprst_grid(ctx.fdr_raster, dprst_path, fdr_aligned, logger)
+        align_fdr_to_dprst_grid(ctx.fdr_raster, dprst_path, fdr_aligned, logger)
 
         # read_aligned_uint8 asserts vpu_id is on the exact template grid;
         # a mismatch would silently mosaic into the wrong CONUS region.

--- a/src/gfv2_params/depstor_builders/routing_hru.py
+++ b/src/gfv2_params/depstor_builders/routing_hru.py
@@ -14,8 +14,8 @@ from rasterio.windows import Window
 
 from ..d8_routing import drains_to_dprst_labeled_kernel
 from ..depstor import (
-    RasterInfo, align_fdr_to_dprst_grid, mask_fdr_to_vpu, read_aligned_uint8,
-    vpu_bbox, vpu_codes_present, vpu_pour_points,
+    RasterInfo, align_fdr_to_dprst_grid, assert_raster_aligned, mask_fdr_to_vpu,
+    read_aligned_uint8, vpu_bbox, vpu_codes_present, vpu_pour_points,
 )
 from .context import BuildContext
 
@@ -24,6 +24,7 @@ def build(step_cfg: dict, ctx: BuildContext, logger) -> dict:
     if ctx.fdr_raster is None or not ctx.fdr_raster.exists():
         raise FileNotFoundError(f"routing_hru needs fdr_raster: {ctx.fdr_raster}")
     output_path = ctx.resolve_output(step_cfg["output"])
+    landmask_path = ctx.require("landmask")
     dprst_path = ctx.require("dprst")
     onstream_path = ctx.require("onstream")
     vpu_id_path = ctx.require("vpu_id")
@@ -47,13 +48,23 @@ def build(step_cfg: dict, ctx: BuildContext, logger) -> dict:
         profile = dict(
             driver="GTiff", height=info.height, width=info.width, count=1,
             dtype="int32", crs=info.crs, transform=info.transform, nodata=0,
-            compress="LZW", tiled=True, blockxsize=256, blockysize=256, bigtiff="YES",
+            compress="LZW", tiled=True, blockxsize=256, blockysize=256,
         )
-        with rasterio.open(output_path, "w", **profile) as dst, \
+        profile["BIGTIFF"] = "YES"
+        with rasterio.open(output_path, "w+", **profile) as dst, \
                 rasterio.open(fdr_aligned) as fdr_src, \
                 rasterio.open(dprst_path) as dprst_src, \
                 rasterio.open(onstream_path) as onstream_src, \
-                rasterio.open(hru_id_path) as hru_src:
+                rasterio.open(hru_id_path) as hru_src, \
+                rasterio.open(landmask_path) as land_src:
+            # dprst/onstream/hru_id/landmask are windowed by vpu_id's grid; a
+            # same-shape but differently-georeferenced raster would be read at
+            # the wrong origin silently. Assert all are on the template grid
+            # (as routing.py does for dprst/onstream).
+            assert_raster_aligned(dprst_src, info, "dprst")
+            assert_raster_aligned(onstream_src, info, "onstream")
+            assert_raster_aligned(hru_src, info, "hru_id")
+            assert_raster_aligned(land_src, info, "landmask")
             for code in codes:
                 bbox = vpu_bbox(vpu_id, code)
                 r0, r1, c0, c1 = bbox
@@ -63,6 +74,7 @@ def build(step_cfg: dict, ctx: BuildContext, logger) -> dict:
                 dprst_win = dprst_src.read(1, window=window)
                 onstream_win = onstream_src.read(1, window=window)
                 hru_win = hru_src.read(1, window=window)
+                land_win = land_src.read(1, window=window)
 
                 fdr_masked = mask_fdr_to_vpu(fdr_win, vpu_win, code, nodata=255)
                 label = np.where((dprst_win == 1) & (vpu_win == code), hru_win, 0).astype(np.int32)
@@ -71,9 +83,11 @@ def build(step_cfg: dict, ctx: BuildContext, logger) -> dict:
                 if n_cycles:
                     logger.warning("  VPU %d: %d flow cycle(s) — cells non-draining", code, n_cycles)
 
-                # read-modify-write only this VPU's cells (bboxes overlap at corners)
+                # read-modify-write only this VPU's cells (bboxes overlap at corners),
+                # and only where land_mask.tif confirms the cell is land (never use
+                # FDR/hydro-DEM nodata as a land mask — see CLAUDE.md).
                 existing = dst.read(1, window=window)
-                sel = (vpu_win == code) & (out > 0)
+                sel = (vpu_win == code) & (out > 0) & (land_win == 1)
                 existing[sel] = out[sel]
                 dst.write(existing, 1, window=window)
                 logger.info("  VPU %d: %d labelled drain cells", code, int(sel.sum()))

--- a/src/gfv2_params/depstor_builders/routing_hru.py
+++ b/src/gfv2_params/depstor_builders/routing_hru.py
@@ -1,0 +1,83 @@
+"""HRU-labeled, barrier-aware upslope routing → drains_to_dprst_hru.tif.
+
+Same per-VPU D8 tiling as `routing`, but each depression cell is labelled by its
+HRU id (hru_id.tif) and the labeled kernel attributes every draining cell to the
+HRU of the depression it reaches. On-stream waterbodies are barriers. Written
+per-VPU windowed: the int32 output is ~4x the binary drains, so it is never held
+whole-CONUS.
+"""
+from __future__ import annotations
+
+import numpy as np
+import rasterio
+from rasterio.windows import Window
+
+from ..d8_routing import drains_to_dprst_labeled_kernel
+from ..depstor import (
+    RasterInfo, align_fdr_to_dprst_grid, mask_fdr_to_vpu, read_aligned_uint8,
+    vpu_bbox, vpu_codes_present, vpu_pour_points,
+)
+from .context import BuildContext
+
+
+def build(step_cfg: dict, ctx: BuildContext, logger) -> dict:
+    if ctx.fdr_raster is None or not ctx.fdr_raster.exists():
+        raise FileNotFoundError(f"routing_hru needs fdr_raster: {ctx.fdr_raster}")
+    output_path = ctx.resolve_output(step_cfg["output"])
+    dprst_path = ctx.require("dprst")
+    onstream_path = ctx.require("onstream")
+    vpu_id_path = ctx.require("vpu_id")
+    hru_id_path = ctx.require("hru_id")
+    keep_intermediates = bool(step_cfg.get("keep_intermediates", False))
+
+    logger.info("--- routing_hru (per-VPU labeled) ---")
+    if output_path.exists() and not ctx.force:
+        logger.info("  Output exists — skipping (pass --force to rebuild)")
+        return {"drains_to_dprst_hru": output_path}
+
+    info = RasterInfo.from_path(ctx.template_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fdr_aligned = output_path.parent / "fdr_aligned_hru.tif"
+
+    try:
+        align_fdr_to_dprst_grid(ctx.fdr_raster, dprst_path, fdr_aligned, logger)
+        vpu_id = read_aligned_uint8(vpu_id_path, info)
+        codes = vpu_codes_present(vpu_id)
+
+        profile = dict(
+            driver="GTiff", height=info.height, width=info.width, count=1,
+            dtype="int32", crs=info.crs, transform=info.transform, nodata=0,
+            compress="LZW", tiled=True, blockxsize=256, blockysize=256, bigtiff="YES",
+        )
+        with rasterio.open(output_path, "w", **profile) as dst, \
+                rasterio.open(fdr_aligned) as fdr_src, \
+                rasterio.open(dprst_path) as dprst_src, \
+                rasterio.open(onstream_path) as onstream_src, \
+                rasterio.open(hru_id_path) as hru_src:
+            for code in codes:
+                bbox = vpu_bbox(vpu_id, code)
+                r0, r1, c0, c1 = bbox
+                window = Window(c0, r0, c1 - c0, r1 - r0)
+                vpu_win = vpu_id[r0:r1, c0:c1]
+                fdr_win = fdr_src.read(1, window=window)
+                dprst_win = dprst_src.read(1, window=window)
+                onstream_win = onstream_src.read(1, window=window)
+                hru_win = hru_src.read(1, window=window)
+
+                fdr_masked = mask_fdr_to_vpu(fdr_win, vpu_win, code, nodata=255)
+                label = np.where((dprst_win == 1) & (vpu_win == code), hru_win, 0).astype(np.int32)
+                barrier = vpu_pour_points(onstream_win, vpu_win, code)
+                out, n_cycles = drains_to_dprst_labeled_kernel(fdr_masked, label, barrier, fdr_nodata=255)
+                if n_cycles:
+                    logger.warning("  VPU %d: %d flow cycle(s) — cells non-draining", code, n_cycles)
+
+                # read-modify-write only this VPU's cells (bboxes overlap at corners)
+                existing = dst.read(1, window=window)
+                sel = (vpu_win == code) & (out > 0)
+                existing[sel] = out[sel]
+                dst.write(existing, 1, window=window)
+                logger.info("  VPU %d: %d labelled drain cells", code, int(sel.sum()))
+    finally:
+        if not keep_intermediates and fdr_aligned.exists():
+            fdr_aligned.unlink()
+    return {"drains_to_dprst_hru": output_path}

--- a/src/gfv2_params/depstor_builders/routing_hru.py
+++ b/src/gfv2_params/depstor_builders/routing_hru.py
@@ -14,8 +14,14 @@ from rasterio.windows import Window
 
 from ..d8_routing import drains_to_dprst_labeled_kernel
 from ..depstor import (
-    RasterInfo, align_fdr_to_dprst_grid, assert_raster_aligned, mask_fdr_to_vpu,
-    read_aligned_uint8, vpu_bbox, vpu_codes_present, vpu_pour_points,
+    RasterInfo,
+    align_fdr_to_dprst_grid,
+    assert_raster_aligned,
+    mask_fdr_to_vpu,
+    read_aligned_uint8,
+    vpu_bbox,
+    vpu_codes_present,
+    vpu_pour_points,
 )
 from .context import BuildContext
 
@@ -65,6 +71,7 @@ def build(step_cfg: dict, ctx: BuildContext, logger) -> dict:
             assert_raster_aligned(onstream_src, info, "onstream")
             assert_raster_aligned(hru_src, info, "hru_id")
             assert_raster_aligned(land_src, info, "landmask")
+            n_total = 0
             for code in codes:
                 bbox = vpu_bbox(vpu_id, code)
                 r0, r1, c0, c1 = bbox
@@ -90,8 +97,17 @@ def build(step_cfg: dict, ctx: BuildContext, logger) -> dict:
                 sel = (vpu_win == code) & (out > 0) & (land_win == 1)
                 existing[sel] = out[sel]
                 dst.write(existing, 1, window=window)
-                logger.info("  VPU %d: %d labelled drain cells", code, int(sel.sum()))
+                n_sel = int(sel.sum())
+                n_total += n_sel
+                logger.info("  VPU %d: %d labelled drain cells", code, n_sel)
     finally:
         if not keep_intermediates and fdr_aligned.exists():
             fdr_aligned.unlink()
+
+    if n_total == 0:
+        raise RuntimeError(
+            f"drains_to_dprst_hru is all-nodata after routing {len(codes)} VPU(s) — "
+            "an all-empty mask is never a valid product. Check that dprst, vpu_id, "
+            "hru_id, and the FDR are aligned to the same template grid."
+        )
     return {"drains_to_dprst_hru": output_path}

--- a/src/gfv2_params/depstor_builders/same_hru_drains.py
+++ b/src/gfv2_params/depstor_builders/same_hru_drains.py
@@ -1,0 +1,55 @@
+"""Same-HRU drains: land cells draining to a depression in their OWN HRU.
+
+Replaces the plain `intersect` for drains_perv/drains_imperv. The same-HRU
+restriction is a RASTER-SPACE intersection (labeled drains == rasterised hru_id),
+applied before aggregation -- NOT a gdptools operation -- because it is a
+per-cell comparison gdptools' partial-pixel weights cannot express. It
+reproduces the legacy `Con(rSro == hru)` (docs/0b_TB_depr_stor.py:214). The
+per-HRU COUNT downstream still uses gdptools.
+"""
+from __future__ import annotations
+
+import rasterio
+from rasterio.windows import Window
+
+from ..depstor import RasterInfo, assert_raster_aligned, same_hru_intersect, uint8_binary_profile
+from .context import BuildContext
+
+STRIP_ROWS = 1024
+
+
+def build(step_cfg: dict, ctx: BuildContext, logger) -> dict:
+    name = step_cfg["name"]
+    inputs = step_cfg["inputs"]  # [drains_to_dprst_hru, hru_id, perv|imperv]
+    if not isinstance(inputs, list) or len(inputs) != 3:
+        raise ValueError(f"same_hru_drains step '{name}' needs inputs: [labeled, hru_id, land]")
+    labeled_path = ctx.require(inputs[0])
+    hru_path = ctx.require(inputs[1])
+    land_path = ctx.require(inputs[2])
+    output_path = ctx.resolve_output(step_cfg["output"])
+    output_key = step_cfg.get("output_key", name)
+
+    logger.info("--- %s (same-HRU) ---", name)
+    if output_path.exists() and not ctx.force:
+        logger.info("  Output exists — skipping (pass --force to rebuild)")
+        return {output_key: output_path}
+
+    info = RasterInfo.from_path(ctx.template_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    n_hit = 0
+    with rasterio.open(labeled_path) as lab_src, rasterio.open(hru_path) as hru_src, \
+            rasterio.open(land_path) as land_src, \
+            rasterio.open(output_path, "w", **uint8_binary_profile(info)) as dst:
+        assert_raster_aligned(lab_src, info, inputs[0])
+        assert_raster_aligned(hru_src, info, inputs[1])
+        assert_raster_aligned(land_src, info, inputs[2])
+        for row_off in range(0, info.height, STRIP_ROWS):
+            h = min(STRIP_ROWS, info.height - row_off)
+            window = Window(0, row_off, info.width, h)
+            out = same_hru_intersect(lab_src.read(1, window=window),
+                                     hru_src.read(1, window=window),
+                                     land_src.read(1, window=window))
+            dst.write(out, 1, window=window)
+            n_hit += int((out == 1).sum())
+    logger.info("  %d same-HRU %s cells", n_hit, output_key)
+    return {output_key: output_path}

--- a/src/gfv2_params/depstor_builders/same_hru_drains.py
+++ b/src/gfv2_params/depstor_builders/same_hru_drains.py
@@ -51,5 +51,14 @@ def build(step_cfg: dict, ctx: BuildContext, logger) -> dict:
                                      land_src.read(1, window=window))
             dst.write(out, 1, window=window)
             n_hit += int((out == 1).sum())
-    logger.info("  %d same-HRU %s cells", n_hit, output_key)
+    if n_hit == 0:
+        logger.warning(
+            "  0 same-HRU %s cells — suspicious for drains_perv (expect some "
+            "same-HRU pervious drainage on almost any fabric), but can be "
+            "legitimate for drains_imperv on a low-impervious fabric. Not "
+            "raising here: routing_hru's all-empty guard already hard-catches "
+            "upstream truncation of drains_to_dprst_hru.", output_key,
+        )
+    else:
+        logger.info("  %d same-HRU %s cells", n_hit, output_key)
     return {output_key: output_path}

--- a/tests/test_d8_routing_labeled.py
+++ b/tests/test_d8_routing_labeled.py
@@ -15,7 +15,8 @@ def test_two_depressions_get_distinct_labels_and_local_areas():
     # cols: [0]->E [1]->E [2]=dep7  [3]=dep9 [4]->W [5]->W
     fdr = np.array([[1, 1, 0, 0, 16, 16]], dtype=np.uint8)
     labels = np.array([[0, 0, 7, 9, 0, 0]], dtype=np.int32)
-    out, n_cycles = drains_to_dprst_labeled_kernel(fdr, labels, fdr_nodata=255)
+    barrier = np.zeros_like(labels, dtype=np.uint8)
+    out, n_cycles = drains_to_dprst_labeled_kernel(fdr, labels, barrier, fdr_nodata=255)
     assert n_cycles == 0
     # cols 0,1,2 attributed to depression 7; cols 3,4,5 to depression 9
     assert out.tolist() == [[7, 7, 7, 9, 9, 9]]
@@ -29,7 +30,8 @@ def test_cell_flowing_to_sink_gets_zero_label():
     # col0 -> E into col1; col1 has FDR nodata (sink, no depression)
     fdr = np.array([[1, 255]], dtype=np.uint8)
     labels = np.array([[0, 0]], dtype=np.int32)
-    out, n_cycles = drains_to_dprst_labeled_kernel(fdr, labels, fdr_nodata=255)
+    barrier = np.zeros_like(labels, dtype=np.uint8)
+    out, n_cycles = drains_to_dprst_labeled_kernel(fdr, labels, barrier, fdr_nodata=255)
     assert n_cycles == 0
     assert out.tolist() == [[0, 0]]
 
@@ -38,6 +40,7 @@ def test_cycle_marked_zero_and_counted():
     # col0 -> E (col1), col1 -> W (col0): a 2-cell cycle, no depression reached
     fdr = np.array([[1, 16]], dtype=np.uint8)
     labels = np.array([[0, 0]], dtype=np.int32)
-    out, n_cycles = drains_to_dprst_labeled_kernel(fdr, labels, fdr_nodata=255)
+    barrier = np.zeros_like(labels, dtype=np.uint8)
+    out, n_cycles = drains_to_dprst_labeled_kernel(fdr, labels, barrier, fdr_nodata=255)
     assert n_cycles == 1
     assert out.tolist() == [[0, 0]]

--- a/tests/test_drains_kernel.py
+++ b/tests/test_drains_kernel.py
@@ -262,6 +262,17 @@ def test_labeled_no_barrier_matches_unbarriered():
     assert n == 0
 
 
+def test_labeled_mismatched_shape_raises():
+    # Same guard as drains_to_dprst_kernel, but for the labeled wrapper: a
+    # label/barrier that isn't the same shape as fdr must raise, not silently
+    # OOB (numba runs bounds-check-off).
+    fdr = np.zeros((2, 2), dtype=np.uint8)
+    label = np.zeros((2, 2), dtype=np.int32)
+    barrier = np.zeros((2, 1), dtype=np.uint8)
+    with pytest.raises(ValueError):
+        drains_to_dprst_labeled_kernel(fdr, label, barrier)
+
+
 def test_labeled_first_waterbody_wins():
     # cell0 -> [dprst 5] -> [barrier]: label reached before barrier
     fdr = np.array([[1, 1, 255]], dtype=np.uint8)

--- a/tests/test_drains_kernel.py
+++ b/tests/test_drains_kernel.py
@@ -1,7 +1,10 @@
 import numpy as np
 import pytest
 
-from gfv2_params.d8_routing import drains_to_dprst_kernel
+from gfv2_params.d8_routing import (
+    drains_to_dprst_kernel,
+    drains_to_dprst_labeled_kernel,
+)
 
 # ESRI D8 codes used in the fixtures:
 #   1=E  2=SE  4=S  8=SW  16=W  32=NW  64=N  128=NE   255=nodata/sink
@@ -237,3 +240,33 @@ def test_mismatched_barrier_shape_raises():
     barrier = np.zeros((2, 1), dtype=np.uint8)
     with pytest.raises(ValueError):
         drains_to_dprst_kernel(fdr, pour, barrier)
+
+
+def test_labeled_barrier_blocks_upslope():
+    # cell0 -> cell1 -> [barrier] -> [dprst label 7]
+    fdr = np.array([[1, 1, 1, 255]], dtype=np.uint8)
+    label = np.array([[0, 0, 0, 7]], dtype=np.int32)
+    barrier = np.array([[0, 0, 1, 0]], dtype=np.uint8)
+    out, n = drains_to_dprst_labeled_kernel(fdr, label, barrier)
+    assert out.tolist() == [[0, 0, 0, 7]]
+    assert n == 0
+
+
+def test_labeled_no_barrier_matches_unbarriered():
+    # all-zero barrier reproduces the straight-chain label fill
+    fdr = np.array([[1, 1, 1, 255]], dtype=np.uint8)
+    label = np.array([[0, 0, 0, 7]], dtype=np.int32)
+    barrier = np.zeros_like(label, dtype=np.uint8)
+    out, n = drains_to_dprst_labeled_kernel(fdr, label, barrier)
+    assert out.tolist() == [[7, 7, 7, 7]]
+    assert n == 0
+
+
+def test_labeled_first_waterbody_wins():
+    # cell0 -> [dprst 5] -> [barrier]: label reached before barrier
+    fdr = np.array([[1, 1, 255]], dtype=np.uint8)
+    label = np.array([[0, 5, 0]], dtype=np.int32)
+    barrier = np.array([[0, 0, 1]], dtype=np.uint8)
+    out, n = drains_to_dprst_labeled_kernel(fdr, label, barrier)
+    assert out.tolist() == [[5, 5, 0]]
+    assert n == 0

--- a/tests/test_expected_outputs.py
+++ b/tests/test_expected_outputs.py
@@ -1,0 +1,34 @@
+"""Guards `build_depstor_rasters._expected_outputs` against a missing step.
+
+`_hydrate_existing_outputs` calls `_expected_outputs` for every step NOT in
+the current run (i.e. every --step / --from invocation), so an omitted single-
+output step name raises an unhandled KeyError before the orchestrator's own
+error handling can run (see `single_key` dict in `_expected_outputs`). This
+test reproduces that failure mode generically: every step declared in
+configs/depstor/depstor_rasters.yml must map to a non-empty output dict.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from scripts.build_depstor_rasters import _expected_outputs
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CONFIG_PATH = REPO_ROOT / "configs" / "depstor" / "depstor_rasters.yml"
+
+
+def test_every_configured_step_has_expected_outputs():
+    config = yaml.safe_load(CONFIG_PATH.read_text())
+    steps = config["steps"]
+    assert steps, "depstor_rasters.yml has no steps configured"
+
+    for step in steps:
+        produced = _expected_outputs(step)
+        assert isinstance(produced, dict) and produced, (
+            f"_expected_outputs() returned no output keys for step "
+            f"'{step['name']}' — every step in depstor_rasters.yml must be "
+            f"mapped so --step/--from resume works without a KeyError."
+        )

--- a/tests/test_hru_id.py
+++ b/tests/test_hru_id.py
@@ -1,5 +1,10 @@
+import logging
+
 import geopandas as gpd
 import numpy as np
+import pytest
+import rasterio
+from rasterio.transform import from_origin
 from shapely.geometry import box
 
 from gfv2_params.depstor import RasterInfo, rasterize_ids
@@ -7,8 +12,6 @@ from gfv2_params.depstor import RasterInfo, rasterize_ids
 
 def test_rasterize_ids_burns_attribute(tmp_path):
     # 4x4 grid, 1.0 cell size, origin (0, 4) north-up
-    import rasterio
-    from rasterio.transform import from_origin
     tpl = tmp_path / "tpl.tif"
     transform = from_origin(0, 4, 1, 1)
     with rasterio.open(tpl, "w", driver="GTiff", height=4, width=4, count=1,
@@ -22,3 +25,62 @@ def test_rasterize_ids_burns_attribute(tmp_path):
     out = rasterize_ids(gdf, "nat_hru_id", info)
     assert out.dtype == np.int32
     assert out[0, 0] == 11 and out[0, 3] == 22   # left half 11, right half 22
+
+
+def _write_template(path, n: int = 4) -> None:
+    transform = from_origin(0, n, 1, 1)
+    with rasterio.open(
+        path, "w", driver="GTiff", height=n, width=n, count=1, dtype="uint8",
+        crs="EPSG:5070", transform=transform,
+    ) as dst:
+        dst.write(np.zeros((n, n), dtype=np.uint8), 1)
+
+
+def _write_hru_gpkg(path, ids) -> None:
+    """Two squares (left half id=ids[0], right half id=ids[1]) on a 4x4 1m grid."""
+    gdf = gpd.GeoDataFrame(
+        {"nat_hru_id": list(ids)},
+        geometry=[box(0, 0, 2, 4), box(2, 0, 4, 4)], crs="EPSG:5070",
+    )
+    gdf.to_file(path, layer="nhru", driver="GPKG")
+
+
+def test_hru_id_build_writes_expected_int32_raster(tmp_path):
+    from gfv2_params.depstor_builders import hru_id
+    from gfv2_params.depstor_builders.context import BuildContext
+
+    template = tmp_path / "template.tif"
+    hru_gpkg = tmp_path / "fabric.gpkg"
+    _write_template(template)
+    _write_hru_gpkg(hru_gpkg, ids=(11, 22))
+
+    ctx = BuildContext(
+        fabric="t", template_path=template, output_dir=tmp_path,
+        hru_gpkg=hru_gpkg, hru_layer="nhru", id_feature="nat_hru_id",
+    )
+
+    produced = hru_id.build({"output": "hru_id.tif"}, ctx, logging.getLogger("test"))
+
+    out_path = produced["hru_id"]
+    with rasterio.open(out_path) as src:
+        assert src.dtypes[0] == "int32"
+        arr = src.read(1)
+    assert arr[0, 0] == 11 and arr[0, 3] == 22   # left half 11, right half 22
+
+
+def test_hru_id_build_raises_on_non_positive_id(tmp_path):
+    from gfv2_params.depstor_builders import hru_id
+    from gfv2_params.depstor_builders.context import BuildContext
+
+    template = tmp_path / "template.tif"
+    hru_gpkg = tmp_path / "fabric.gpkg"
+    _write_template(template)
+    _write_hru_gpkg(hru_gpkg, ids=(0, 22))  # 0 is the invalid/no-HRU sentinel
+
+    ctx = BuildContext(
+        fabric="t", template_path=template, output_dir=tmp_path,
+        hru_gpkg=hru_gpkg, hru_layer="nhru", id_feature="nat_hru_id",
+    )
+
+    with pytest.raises(ValueError):
+        hru_id.build({"output": "hru_id.tif"}, ctx, logging.getLogger("test"))

--- a/tests/test_hru_id.py
+++ b/tests/test_hru_id.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 import rasterio
 from rasterio.transform import from_origin
-from shapely.geometry import box
+from shapely.geometry import Polygon, box
 
 from gfv2_params.depstor import RasterInfo, rasterize_ids
 
@@ -25,6 +25,33 @@ def test_rasterize_ids_burns_attribute(tmp_path):
     out = rasterize_ids(gdf, "nat_hru_id", info)
     assert out.dtype == np.int32
     assert out[0, 0] == 11 and out[0, 3] == 22   # left half 11, right half 22
+
+
+def test_rasterize_ids_all_touched_burns_corner_clipped_pixel(tmp_path):
+    """hru_id.build() must pass all_touched=True (matching land_mask.tif's
+    footprint, see landmask.py) so an HRU-boundary land cell isn't left at
+    hru_id==0 and silently dropped by same_hru_intersect. Exercise the looser
+    footprint directly: a sliver that only clips a pixel's corner is burned
+    under all_touched=True but not under the default centroid-style fill.
+    """
+    tpl = tmp_path / "tpl.tif"
+    transform = from_origin(0, 4, 1, 1)
+    with rasterio.open(tpl, "w", driver="GTiff", height=4, width=4, count=1,
+                       dtype="uint8", crs="EPSG:5070", transform=transform) as d:
+        d.write(np.zeros((4, 4), np.uint8), 1)
+    info = RasterInfo.from_path(tpl)
+
+    # Pixel (row=0, col=2) spans x:[2,3], y:[3,4], center (2.5, 3.5). This
+    # sliver triangle only clips its top-left corner (2, 4) and stays well
+    # clear of the center.
+    corner_clip = Polygon([(2.0, 4.0), (2.2, 4.0), (2.0, 3.8)])
+    gdf = gpd.GeoDataFrame({"nat_hru_id": [77]}, geometry=[corner_clip], crs="EPSG:5070")
+
+    default_out = rasterize_ids(gdf, "nat_hru_id", info)
+    touched_out = rasterize_ids(gdf, "nat_hru_id", info, all_touched=True)
+
+    assert default_out[0, 2] == 0    # centroid-style fill: corner sliver not burned
+    assert touched_out[0, 2] == 77   # all_touched: any partial overlap is burned
 
 
 def _write_template(path, n: int = 4) -> None:

--- a/tests/test_hru_id.py
+++ b/tests/test_hru_id.py
@@ -1,0 +1,24 @@
+import geopandas as gpd
+import numpy as np
+from shapely.geometry import box
+
+from gfv2_params.depstor import RasterInfo, rasterize_ids
+
+
+def test_rasterize_ids_burns_attribute(tmp_path):
+    # 4x4 grid, 1.0 cell size, origin (0, 4) north-up
+    import rasterio
+    from rasterio.transform import from_origin
+    tpl = tmp_path / "tpl.tif"
+    transform = from_origin(0, 4, 1, 1)
+    with rasterio.open(tpl, "w", driver="GTiff", height=4, width=4, count=1,
+                       dtype="uint8", crs="EPSG:5070", transform=transform) as d:
+        d.write(np.zeros((4, 4), np.uint8), 1)
+    info = RasterInfo.from_path(tpl)
+    gdf = gpd.GeoDataFrame(
+        {"nat_hru_id": [11, 22]},
+        geometry=[box(0, 0, 2, 4), box(2, 0, 4, 4)], crs="EPSG:5070",
+    )
+    out = rasterize_ids(gdf, "nat_hru_id", info)
+    assert out.dtype == np.int32
+    assert out[0, 0] == 11 and out[0, 3] == 22   # left half 11, right half 22

--- a/tests/test_routing_hru.py
+++ b/tests/test_routing_hru.py
@@ -1,6 +1,14 @@
+import logging
+from pathlib import Path
+
 import numpy as np
+import rasterio
+from rasterio.transform import from_origin
+
 from gfv2_params.depstor import mask_fdr_to_vpu, vpu_pour_points
 from gfv2_params.d8_routing import drains_to_dprst_labeled_kernel
+from gfv2_params.depstor_builders import routing_hru
+from gfv2_params.depstor_builders.context import BuildContext
 
 
 def test_labeled_trace_attributes_to_reached_hru_with_barrier():
@@ -21,3 +29,73 @@ def test_labeled_trace_attributes_to_reached_hru_with_barrier():
     # col0,col1 reach dprst HRU42; col2 is the dprst (label 42); col3 barrier=0;
     # col4 is its own dprst (label 9).
     assert out.tolist() == [[42, 42, 42, 0, 9]]
+
+
+_N = (1, 5)
+_TRANSFORM = from_origin(0, 30, 30, 30)
+
+
+def _write(path: Path, arr: np.ndarray, dtype: str, nodata) -> None:
+    height, width = arr.shape
+    with rasterio.open(
+        path, "w", driver="GTiff", height=height, width=width, count=1, dtype=dtype,
+        crs="EPSG:5070", transform=_TRANSFORM, nodata=nodata,
+    ) as dst:
+        dst.write(arr.astype(dtype), 1)
+
+
+def test_build_writes_labeled_hru_raster_with_barrier_and_land_mask(tmp_path):
+    """End-to-end `build()` smoke test — exercises the w+ read-modify-write and
+    the land-mask carve, not just the kernel helpers.
+
+    Same 1x5 single-VPU layout as the helper-level test above, plus a
+    land_mask that marks col1 off-land even though the D8 trace reaches HRU 42
+    there — the write must drop it despite the kernel computing a label.
+    #   col: 0(land)  1(off-land)  2(dprst,HRU42)  3(onstream)  4(dprst,HRU9)
+    """
+    template = tmp_path / "template.tif"
+    _write(template, np.full((1, 5), 100.0), "float32", -9999.0)
+
+    fdr = np.array([[1, 1, 255, 1, 255]], dtype=np.uint8)
+    _write(tmp_path / "fdr.tif", fdr, "uint8", 255)
+
+    vpu = np.ones((1, 5), dtype=np.uint8)
+    _write(tmp_path / "vpu_id.tif", vpu, "uint8", 0)
+
+    dprst = np.array([[0, 0, 1, 0, 1]], dtype=np.uint8)
+    _write(tmp_path / "dprst_binary.tif", dprst, "uint8", 255)
+
+    onstream = np.array([[0, 0, 0, 1, 0]], dtype=np.uint8)
+    _write(tmp_path / "onstream_binary.tif", onstream, "uint8", 255)
+
+    hru = np.array([[7, 7, 42, 8, 9]], dtype=np.int32)
+    _write(tmp_path / "hru_id.tif", hru, "int32", 0)
+
+    # col1 is off-land despite draining to HRU 42.
+    land = np.array([[1, 0, 1, 1, 1]], dtype=np.uint8)
+    _write(tmp_path / "land_mask.tif", land, "uint8", 255)
+
+    ctx = BuildContext(
+        fabric="t", template_path=template, output_dir=tmp_path,
+        hru_gpkg=tmp_path / "x.gpkg", hru_layer="nhru",
+        fdr_raster=tmp_path / "fdr.tif",
+    )
+    ctx.paths.update({
+        "landmask": tmp_path / "land_mask.tif",
+        "dprst": tmp_path / "dprst_binary.tif",
+        "onstream": tmp_path / "onstream_binary.tif",
+        "vpu_id": tmp_path / "vpu_id.tif",
+        "hru_id": tmp_path / "hru_id.tif",
+    })
+
+    produced = routing_hru.build(
+        {"output": "drains_to_dprst_hru.tif"}, ctx, logging.getLogger("test"),
+    )
+
+    with rasterio.open(produced["drains_to_dprst_hru"]) as src:
+        out = src.read(1)
+
+    # col0 reaches HRU42 and is on land -> 42; col1 reaches HRU42 but is
+    # off-land -> forced to 0 (nodata); col2 is the dprst cell itself -> 42;
+    # col3 is the on-stream barrier -> 0; col4 is its own dprst (HRU9) -> 9.
+    assert out.tolist() == [[42, 0, 42, 0, 9]]

--- a/tests/test_routing_hru.py
+++ b/tests/test_routing_hru.py
@@ -5,8 +5,8 @@ import numpy as np
 import rasterio
 from rasterio.transform import from_origin
 
-from gfv2_params.depstor import mask_fdr_to_vpu, vpu_pour_points
 from gfv2_params.d8_routing import drains_to_dprst_labeled_kernel
+from gfv2_params.depstor import mask_fdr_to_vpu, vpu_pour_points
 from gfv2_params.depstor_builders import routing_hru
 from gfv2_params.depstor_builders.context import BuildContext
 
@@ -99,3 +99,67 @@ def test_build_writes_labeled_hru_raster_with_barrier_and_land_mask(tmp_path):
     # off-land -> forced to 0 (nodata); col2 is the dprst cell itself -> 42;
     # col3 is the on-stream barrier -> 0; col4 is its own dprst (HRU9) -> 9.
     assert out.tolist() == [[42, 0, 42, 0, 9]]
+
+
+def test_build_multi_vpu_overlapping_bboxes_do_not_clobber(tmp_path):
+    """2-VPU windowed read-modify-write, with OVERLAPPING VPU bounding boxes.
+
+    2x2 grid, vpu_id=[[1,2],[2,1]]: each code's cells sit on a diagonal, so
+    `vpu_bbox` for BOTH code 1 and code 2 spans the whole grid (their windows
+    fully overlap) — the layout the read-modify-write in routing_hru.build()
+    must handle without one VPU's write erasing the other's.
+
+    Layout (row, col):
+        (0,0)=VPU1 land  --SE--> (1,1)=VPU1 dprst, HRU 42
+        (0,1)=VPU2 land  --SW--> (1,0)=VPU2 dprst, HRU 99
+
+    Both VPU1 (processed first, ascending code order) and VPU2 write into the
+    identical full-grid window; the final raster must carry BOTH VPUs'
+    labelled cells.
+    """
+    template = tmp_path / "template.tif"
+    _write(template, np.full((2, 2), 100.0), "float32", -9999.0)
+
+    # SE (2) from (0,0)->(1,1); SW (8) from (0,1)->(1,0); dprst cells are sinks.
+    fdr = np.array([[2, 8], [255, 255]], dtype=np.uint8)
+    _write(tmp_path / "fdr.tif", fdr, "uint8", 255)
+
+    vpu = np.array([[1, 2], [2, 1]], dtype=np.uint8)
+    _write(tmp_path / "vpu_id.tif", vpu, "uint8", 0)
+
+    dprst = np.array([[0, 0], [1, 1]], dtype=np.uint8)
+    _write(tmp_path / "dprst_binary.tif", dprst, "uint8", 255)
+
+    onstream = np.zeros((2, 2), dtype=np.uint8)
+    _write(tmp_path / "onstream_binary.tif", onstream, "uint8", 255)
+
+    hru = np.array([[7, 8], [99, 42]], dtype=np.int32)
+    _write(tmp_path / "hru_id.tif", hru, "int32", 0)
+
+    land = np.ones((2, 2), dtype=np.uint8)
+    _write(tmp_path / "land_mask.tif", land, "uint8", 255)
+
+    ctx = BuildContext(
+        fabric="t", template_path=template, output_dir=tmp_path,
+        hru_gpkg=tmp_path / "x.gpkg", hru_layer="nhru",
+        fdr_raster=tmp_path / "fdr.tif",
+    )
+    ctx.paths.update({
+        "landmask": tmp_path / "land_mask.tif",
+        "dprst": tmp_path / "dprst_binary.tif",
+        "onstream": tmp_path / "onstream_binary.tif",
+        "vpu_id": tmp_path / "vpu_id.tif",
+        "hru_id": tmp_path / "hru_id.tif",
+    })
+
+    produced = routing_hru.build(
+        {"output": "drains_to_dprst_hru.tif"}, ctx, logging.getLogger("test"),
+    )
+
+    with rasterio.open(produced["drains_to_dprst_hru"]) as src:
+        out = src.read(1)
+
+    # VPU1's (0,0)->(1,1) trace (HRU 42) must survive VPU2's later write, and
+    # VPU2's (0,1)->(1,0) trace (HRU 99) must be present too — neither VPU's
+    # read-modify-write may zero the other's cells despite the full overlap.
+    assert out.tolist() == [[42, 99], [99, 42]]

--- a/tests/test_routing_hru.py
+++ b/tests/test_routing_hru.py
@@ -1,0 +1,23 @@
+import numpy as np
+from gfv2_params.depstor import mask_fdr_to_vpu, vpu_pour_points
+from gfv2_params.d8_routing import drains_to_dprst_labeled_kernel
+
+
+def test_labeled_trace_attributes_to_reached_hru_with_barrier():
+    # 1x5 single VPU (code 1). land -> land -> [dprst in HRU 42] , and a second
+    # chain where an on-stream barrier blocks the reach.
+    #   col: 0    1        2(dprst,HRU42)   3(onstream)    4(dprst,HRU9)
+    # flow all East; col4 pours to HRU9 but col3 is a barrier.
+    vpu = np.ones((1, 5), dtype=np.uint8)
+    fdr = np.array([[1, 1, 255, 1, 255]], dtype=np.uint8)
+    dprst = np.array([[0, 0, 1, 0, 1]], dtype=np.uint8)
+    onstream = np.array([[0, 0, 0, 1, 0]], dtype=np.uint8)
+    hru = np.array([[7, 7, 42, 8, 9]], dtype=np.int32)
+
+    fdr_m = mask_fdr_to_vpu(fdr, vpu, code=1)
+    label = np.where((dprst == 1) & (vpu == 1), hru, 0).astype(np.int32)
+    barrier = vpu_pour_points(onstream, vpu, code=1)
+    out, _ = drains_to_dprst_labeled_kernel(fdr_m, label, barrier)
+    # col0,col1 reach dprst HRU42; col2 is the dprst (label 42); col3 barrier=0;
+    # col4 is its own dprst (label 9).
+    assert out.tolist() == [[42, 42, 42, 0, 9]]

--- a/tests/test_same_hru_drains.py
+++ b/tests/test_same_hru_drains.py
@@ -1,5 +1,13 @@
+import logging
+from pathlib import Path
+
 import numpy as np
+import rasterio
+from rasterio.transform import from_origin
+
 from gfv2_params.depstor import same_hru_intersect
+from gfv2_params.depstor_builders import same_hru_drains
+from gfv2_params.depstor_builders.context import BuildContext
 
 
 def test_same_hru_intersect_keeps_only_matching_hru():
@@ -9,3 +17,64 @@ def test_same_hru_intersect_keeps_only_matching_hru():
     out = same_hru_intersect(labeled, hru_id, land)
     # col0: 42==42 & perv -> 1 ; col1: 42!=8 -> 255 ; col2: 9==9 -> 1 ; col3: 0!=5 -> 255
     assert out.tolist() == [[1, 255, 1, 255]]
+
+
+_N = (1, 5)
+_TRANSFORM = from_origin(0, 30, 30, 30)
+
+
+def _write(path: Path, arr: np.ndarray, dtype: str, nodata) -> None:
+    height, width = arr.shape
+    with rasterio.open(
+        path, "w", driver="GTiff", height=height, width=width, count=1, dtype=dtype,
+        crs="EPSG:5070", transform=_TRANSFORM, nodata=nodata,
+    ) as dst:
+        dst.write(arr.astype(dtype), 1)
+
+
+def test_build_excludes_cross_hru_cells_and_keeps_same_hru(tmp_path):
+    """`build()`-level test — the PR deliverable, not just the pure helper.
+
+    Same 1x5 layout style as test_routing_hru.py's build() test: col0/col1
+    drain to HRU 42's depression but sit in HRU 7 (cross-HRU -> excluded);
+    col2 is the depression cell itself, labeled 42 and own HRU 42 (same-HRU ->
+    kept); col3 has labeled==0 (doesn't drain to any depression -> excluded);
+    col4 drains to its own HRU 9's depression (same-HRU -> kept).
+    """
+    template = tmp_path / "template.tif"
+    _write(template, np.full(_N, 100.0), "float32", -9999.0)
+
+    labeled = np.array([[42, 42, 42, 0, 9]], dtype=np.int32)
+    _write(tmp_path / "drains_to_dprst_hru.tif", labeled, "int32", 0)
+
+    hru_id = np.array([[7, 7, 42, 8, 9]], dtype=np.int32)
+    _write(tmp_path / "hru_id.tif", hru_id, "int32", 0)
+
+    perv = np.array([[1, 1, 1, 1, 1]], dtype=np.uint8)
+    _write(tmp_path / "perv_binary.tif", perv, "uint8", 255)
+
+    ctx = BuildContext(
+        fabric="t", template_path=template, output_dir=tmp_path,
+        hru_gpkg=tmp_path / "x.gpkg", hru_layer="nhru",
+    )
+    ctx.paths.update({
+        "drains_to_dprst_hru": tmp_path / "drains_to_dprst_hru.tif",
+        "hru_id": tmp_path / "hru_id.tif",
+        "perv": tmp_path / "perv_binary.tif",
+    })
+
+    produced = same_hru_drains.build(
+        {
+            "name": "drains_perv",
+            "inputs": ["drains_to_dprst_hru", "hru_id", "perv"],
+            "output": "drains_perv_binary.tif",
+            "output_key": "drains_perv",
+        },
+        ctx,
+        logging.getLogger("test"),
+    )
+
+    with rasterio.open(produced["drains_perv"]) as src:
+        out = src.read(1)
+
+    assert out.tolist() == [[255, 255, 1, 255, 1]]

--- a/tests/test_same_hru_drains.py
+++ b/tests/test_same_hru_drains.py
@@ -1,0 +1,11 @@
+import numpy as np
+from gfv2_params.depstor import same_hru_intersect
+
+
+def test_same_hru_intersect_keeps_only_matching_hru():
+    labeled = np.array([[42, 42, 9, 0]], dtype=np.int32)   # reached-HRU per cell
+    hru_id = np.array([[42, 8, 9, 5]], dtype=np.int32)     # cell's own HRU
+    land = np.array([[1, 1, 1, 1]], dtype=np.uint8)         # perv everywhere
+    out = same_hru_intersect(labeled, hru_id, land)
+    # col0: 42==42 & perv -> 1 ; col1: 42!=8 -> 255 ; col2: 9==9 -> 1 ; col3: 0!=5 -> 255
+    assert out.tolist() == [[1, 255, 1, 255]]


### PR DESCRIPTION
## What & why

Closes #160. Restores the legacy same-HRU restriction to `sro_to_dprst_perv/imperv`: a pervious/impervious cell counts only if it drains to a depression in its **own** HRU (legacy ArcPy `Con(rSro == hru)`, `docs/0b_TB_depr_stor.py:214`). The open-source method had dropped it and over-credited cross-HRU drainage.

**Measured on VPU 15 (rebuilt rasters, labeled trace validated 100% vs production `drains_to_dprst.tif`):** 19.4% of `drains_perv` cells drain to a *different* HRU's depression; VPU-wide area-weighted `sro_to_dprst_perv` was 1.24× legacy; concentrated in ~70–120 HRUs (some saturating to 1.0 with `dprst_frac ≈ 0`), 945 HRUs flipping 0→>0.

## Approach (additive — leaves the merged binary `drains_to_dprst` path untouched)

New chain upstream of the **unchanged** parameter aggregation:
- **`hru_id`** builder → `hru_id.tif` (int32, rasterised `nat_hru_id`; the open-source `nhrug`).
- **barrier** added to `drains_to_dprst_labeled_kernel` (labeled D8) — the parity follow-up deferred from #159.
- **`align_fdr_to_dprst_grid`** promoted from `routing.py` to shared `depstor.py`.
- **`routing_hru`** builder → `drains_to_dprst_hru.tif` (int32; each draining cell = the reached depression's HRU; barrier-aware, land-masked, per-VPU windowed int32 write — no full-CONUS array).
- **`same_hru_drains`** builder **replaces the two `intersect` steps**: `drains_perv/imperv_binary = (drains_to_dprst_hru == hru_id) & perv/imperv`, writing the **same filenames** — so `depstor_params.yml` is untouched and `sro_to_dprst_*` correct transparently.

The same-HRU restriction is a **raster-space intersection** (labeled drains == rasterised `hru_id`), applied before aggregation — **not** a gdptools op — because it's a per-cell reached-HRU-vs-own-HRU test gdptools' partial-pixel weighting can't express. The per-HRU **count still uses gdptools**. `drains_to_dprst` / `drains_to_dprst_frac` stay HRU-agnostic. Tradeoff: a 1-pixel HRU-boundary approximation (matches legacy). Documented first-class in `ARCHITECTURE.md` + `CLAUDE.md`.

## Review hardening (beyond the original plan's example code)

Per-task + whole-branch reviews caught and fixed several issues the plan's example code missed:
- **`routing_hru`**: opened output `"w"` then `.read()` (would crash on the first VPU) → `"w+"`; **added land masking** (CLAUDE.md convention) and the `assert_raster_aligned` guards that `routing.py` has; added a `build()`-level smoke test.
- **Task 3 refactor** left a stale `_align_fdr_to_dprst_grid` import in the #147/#148 A/B diagnostic that would have broken CI test collection → repointed to the public helper.
- `rasterize_ids` CRS-reproject guard (silent-misalignment class); labeled-kernel shape guard (parity); `write_int32_regions` `astype(copy=False)` (drops a transient ~68 GB CONUS copy); `hru_id.build()`-level test.

## Testing

New/updated unit tests for the labeled-kernel barrier, `rasterize_ids`, `hru_id` (helper + `build()`), `routing_hru` (helper + `build()` I/O + land-mask), and `same_hru_drains`. Full affected-file sweep green locally in the pixi dev env. CI (`pytest tests/`) is the authoritative gate.

## Not done here (post-merge, HPC)

Code-only. Runtime re-aggregation of `sro_to_dprst_*` on the fabric is the next HPC step (rasters are rebuilt but params not yet re-aggregated): rebuild from `hru_id`, run `routing_hru` + `same_hru_drains`, then re-derive the ratios — expect the VPU-15 shift back toward legacy.

## Follow-ups (non-blocking)

- `intersect.py` is now unused by any step (kept in place; `intersect_binaries` is still a tested helper) — optional later cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)