### PR TITLE
Harden CONUS snarea run: PROJ firewall fix + Stage 2 memory/logging

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -337,6 +337,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/postgresql-18.3-h9d31465_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.6.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/proj-9.7.1-he0df7b0_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/proj-data-1.24-h707e725_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/prometheus-cpp-1.3.0-ha5d0236_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/propcache-0.3.1-py312h178313f_0.conda
@@ -712,6 +713,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/poppler-data-0.4.12-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/postgresql-18.3-h9d31465_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/proj-9.7.1-he0df7b0_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/proj-data-1.24-h707e725_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/prometheus-cpp-1.3.0-ha5d0236_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/propcache-0.3.1-py312h178313f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.2.2-py312h5253ce2_0.conda
@@ -1062,6 +1064,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/postgresql-18.3-h9d31465_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.6.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/proj-9.7.1-he0df7b0_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/proj-data-1.24-h707e725_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/prometheus-cpp-1.3.0-ha5d0236_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/propcache-0.3.1-py312h178313f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.2.2-py312h5253ce2_0.conda
@@ -1427,6 +1430,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/poppler-data-0.4.12-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/postgresql-18.3-h9d31465_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/proj-9.7.1-he0df7b0_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/proj-data-1.24-h707e725_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/prometheus-cpp-1.3.0-ha5d0236_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/propcache-0.3.1-py312h178313f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.2.2-py312h5253ce2_0.conda
@@ -1836,6 +1840,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/poppler-data-0.4.12-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/postgresql-18.3-h9d31465_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/proj-9.7.1-he0df7b0_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/proj-data-1.24-h707e725_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/prometheus-cpp-1.3.0-ha5d0236_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/propcache-0.3.1-py312h178313f_0.conda
@@ -3561,7 +3566,7 @@ packages:
 - pypi: ./
   name: gfv2-params
   version: 0.1.0
-  sha256: f401c14502e8180542aa62912819b280a80e7b0e21a2171cb30a731c7cf5fce7
+  sha256: ca296875856e94e5f8ab316d26f08d73a77050df30522431387728a121af6c84
   requires_dist:
   - gdptools>=0.3.13
   - pandas
@@ -6835,6 +6840,17 @@ packages:
   purls: []
   size: 3593669
   timestamp: 1770890751115
+- conda: https://conda.anaconda.org/conda-forge/noarch/proj-data-1.24-h707e725_0.conda
+  sha256: 104af9386bfbcdf516e707d1b3bf86e0771074dae7eaa51d009c03379b9bfe6e
+  md5: 6ed5c46273dc68be69305c41e60f70fa
+  depends:
+  - __unix
+  - proj >=7.0.0
+  license: Public domain | X/MIT | BSD-2/3/4-Clause | CC0 | CC-BY (v3.0 or later) | CC-BY-SA (v3.0 or later)
+  license_family: OTHER
+  purls: []
+  size: 791498866
+  timestamp: 1764624390801
 - conda: https://conda.anaconda.org/conda-forge/linux-64/prometheus-cpp-1.3.0-ha5d0236_0.conda
   sha256: 013669433eb447548f21c3c6b16b2ed64356f726b5f77c1b39d5ba17a8a4b8bc
   md5: a83f6a2fdc079e643237887a37460668

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,11 @@ gdal = "*"
 rasterio = "*"
 geopandas = "*"
 pyproj = "*"
+# Bundles PROJ's datum-shift grids locally so proj4-activate.sh sets
+# PROJ_NETWORK=OFF; without it PROJ defaults ON and tries to fetch grids from
+# cdn.proj.org, which the HPC firewall blocks -> to_crs(4326) returns inf and
+# crashes (see scripts/derive_aggregate.py). conda-forge only (no pip equivalent).
+proj-data = "*"
 numba = "*"
 llvmlite = "*"
 richdem = "*"

--- a/scripts/derive_aggregate.py
+++ b/scripts/derive_aggregate.py
@@ -194,11 +194,13 @@ def main() -> None:
     # cdn.proj.org — which the HPC firewall blocks, silently returning `inf` for
     # points in an unavailable grid tile. That crashes gdptools' centroid
     # reprojection (build_cf_dataset -> to_crs(4326)) for whole spatial batches
-    # (11/64 in the first CONUS gfv2 run). The grid-free "NAD83 to WGS 84 (1)"
-    # transform is accurate to ~1-2 m — irrelevant for the cosmetic CF lat/lon
-    # centroids; all SWE/SCA aggregation is in equal-area EPSG:5070. Durable
-    # project-wide alternative: add `proj-data` to the pixi env (then the
-    # activation script sets PROJ_NETWORK=OFF automatically).
+    # (11/64 in the first CONUS gfv2 run). Even the grid-free "NAD83 to WGS 84 (1)"
+    # fallback is accurate to <=~1-2 m — irrelevant for the cosmetic CF lat/lon
+    # centroids; all SWE/SCA aggregation is in equal-area EPSG:5070. This runtime
+    # guard is pyproj-scoped belt-and-suspenders; the durable env-wide fix is the
+    # pinned `proj-data` pixi dep, which makes proj4-activate.sh set
+    # PROJ_NETWORK=OFF for every tool (GDAL included) — and, with the grids then
+    # local, the transform is actually sub-meter.
     pyproj.network.set_network_enabled(False)
 
     cfg = load_config(Path(args.config), base_config_path=Path(args.base_config),

--- a/scripts/derive_aggregate.py
+++ b/scripts/derive_aggregate.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 import geopandas as gpd
 import pandas as pd
+import pyproj
 
 from gfv2_params.aggregate import aggregate_source
 from gfv2_params.aggregate.snodas import SNODAS_ADAPTER
@@ -186,6 +187,19 @@ def main() -> None:
                      help="Spatial batch index (aggregate mode only); omit to run whole-fabric.")
     args = ap.parse_args()
     logger = configure_logging("derive_aggregate")
+
+    # Force PROJ's grid-free datum transform. conda-forge proj defaults
+    # PROJ_NETWORK=ON when proj-data isn't installed (see the env's
+    # proj4-activate.sh), so NAD83->WGS84 tries to fetch a datum-shift grid from
+    # cdn.proj.org — which the HPC firewall blocks, silently returning `inf` for
+    # points in an unavailable grid tile. That crashes gdptools' centroid
+    # reprojection (build_cf_dataset -> to_crs(4326)) for whole spatial batches
+    # (11/64 in the first CONUS gfv2 run). The grid-free "NAD83 to WGS 84 (1)"
+    # transform is accurate to ~1-2 m — irrelevant for the cosmetic CF lat/lon
+    # centroids; all SWE/SCA aggregation is in equal-area EPSG:5070. Durable
+    # project-wide alternative: add `proj-data` to the pixi env (then the
+    # activation script sets PROJ_NETWORK=OFF automatically).
+    pyproj.network.set_network_enabled(False)
 
     cfg = load_config(Path(args.config), base_config_path=Path(args.base_config),
                        fabric=args.fabric)

--- a/scripts/derive_snarea_curve.py
+++ b/scripts/derive_snarea_curve.py
@@ -13,6 +13,8 @@ for the fabric, acceptable for Oregon per spec §8.3).
 from __future__ import annotations
 
 import argparse
+import logging
+import time
 from pathlib import Path
 
 import numpy as np
@@ -46,23 +48,43 @@ def validate_default_curve(arr: np.ndarray) -> None:
         raise ValueError(f"default_curve must be non-increasing, got {arr}")
 
 
-def read_daily_by_hru(nc_dir: Path, id_dim: str) -> dict[int, pd.DataFrame]:
+def read_daily_by_hru(
+    nc_dir: Path, id_dim: str, logger: logging.Logger | None = None
+) -> dict[int, pd.DataFrame]:
     """Concatenate per-year NCs into one daily DataFrame per HRU (index=date).
 
     The aggregated NC's HRU dimension is named ``id_dim`` (Stage 1 aggregates
     with `target_id = id_feature`, so the NC id-dim equals the fabric's
     `id_feature` directly).
+
+    Pass ``logger`` to trace the load phases: at CONUS scale the
+    ``to_dataframe()`` materializes ~2.8B rows (years x HRUs x days) and can take
+    tens of minutes, which is silent (and looks like a hang) without this.
     """
     files = sorted(Path(nc_dir).glob("*_agg_*.nc"))
     if not files:
         raise FileNotFoundError(f"No aggregated NCs in {nc_dir}")
+    t0 = time.perf_counter()
+    if logger:
+        logger.info("Opening %d per-year NCs (lazy) ...", len(files))
     ds = xr.open_mfdataset(files, combine="by_coords", data_vars="minimal")
+    if logger:
+        logger.info(
+            "Materializing daily frame for %d HRUs x %d days "
+            "(the slow/large step at CONUS scale) ...",
+            ds.sizes.get(id_dim, 0), ds.sizes.get("time", 0),
+        )
     df = ds[["swe", "scov"]].to_dataframe().reset_index()
     df = df.rename(columns={"scov": "sca"})
+    if logger:
+        logger.info("  materialized %d rows in %.0fs; grouping into per-HRU series ...",
+                    len(df), time.perf_counter() - t0)
     out: dict[int, pd.DataFrame] = {}
     for hru_id, grp in df.groupby(id_dim):
         s = grp.set_index("time")[["swe", "sca"]].sort_index()
         out[int(hru_id)] = s
+    if logger:
+        logger.info("  built %d per-HRU series in %.0fs total", len(out), time.perf_counter() - t0)
     return out
 
 
@@ -96,7 +118,7 @@ def main() -> None:
     validate_default_curve(default_curve)
 
     logger.info("Reading aggregated daily SWE/SCA from %s ...", nc_dir)
-    daily = read_daily_by_hru(nc_dir, id_feature)
+    daily = read_daily_by_hru(nc_dir, id_feature, logger=logger)
     logger.info("Loaded daily series for %d HRUs; reading SNODAS cell counts ...", len(daily))
     cells = cells_from_weights(weight_file, id_feature)
     water: dict[int, float] = {}
@@ -106,7 +128,7 @@ def main() -> None:
         logger.info("Loaded water fraction for %d HRUs from %s", len(water), args.water_csv)
 
     logger.info("Deriving representative snarea_curve for %d HRUs ...", len(daily))
-    table = build_snarea_curve(daily, cells, water, id_feature, sel, default_curve)
+    table = build_snarea_curve(daily, cells, water, id_feature, sel, default_curve, logger=logger)
     out = out_dir / cfg["merged_file"]
     table.to_csv(out, index=False)
     logger.info("Wrote %d HRU curves -> %s", len(table), out)

--- a/slurm_batch/HPC_REFERENCE.md
+++ b/slurm_batch/HPC_REFERENCE.md
@@ -753,18 +753,20 @@ cheap once weights exist. Stage 2 is a pure per-HRU pandas/numpy computation
 over the already-aggregated daily series — cheap per HRU, but its whole-fabric
 load is not: `read_daily_by_hru`'s `to_dataframe()` materializes ~21 years ×
 `n_hru` × daily rows at once (CONUS gfv2 ≈ 2.8 B rows, ~344 GB peak, ~31 min just
-to load). Run `derive_snarea_curve.batch` at **`--mem=384G`** for CONUS (64 GB
-OOMs; Oregon's 17k HRUs fit fine at the default). The load-phase and per-HRU
-derive-loop now emit progress logging so the long silent stretch is traceable.
+to load). `derive_snarea_curve.batch` therefore **defaults to `--mem=384G`**
+(64 GB OOMs on CONUS); Oregon and other small fabrics fit easily and can override
+down (`sbatch --mem=64G --time=02:00:00 …`). The load-phase and per-HRU
+derive-loop emit progress logging so the long silent stretch is traceable.
 
 **PROJ behind the HPC firewall.** conda-forge `proj` defaults `PROJ_NETWORK=ON`
 unless `proj-data` is installed; the firewall blocks `cdn.proj.org`, so gdptools'
 centroid `to_crs(4326)` returns `inf` and crashes whole Stage 1 batches (11/64 on
 the first CONUS gfv2 run — valid geometries, coordinates transform to `inf`).
 Two guards: `derive_aggregate.py` forces PROJ's grid-free transform
-(`pyproj.network.set_network_enabled(False)`; the ~1–2 m NAD83↔WGS84 shift is
-irrelevant for cosmetic CF centroids, all SWE/SCA math is in equal-area 5070),
-and `proj-data` is a pinned pixi dep so `proj4-activate.sh` sets
+(`pyproj.network.set_network_enabled(False)`; even the grid-free NAD83↔WGS84
+fallback is ≤~1–2 m — irrelevant for cosmetic CF centroids, and all SWE/SCA math
+is in equal-area 5070), and `proj-data` is a pinned pixi dep (grids local, so the
+transform is actually sub-meter) so `proj4-activate.sh` sets
 `PROJ_NETWORK=OFF` env-wide. Any other pipeline reprojecting to 4326 relies on
 the latter.
 

--- a/slurm_batch/HPC_REFERENCE.md
+++ b/slurm_batch/HPC_REFERENCE.md
@@ -750,7 +750,23 @@ polygon/cell intersection pass per batch) is the expensive step; each batch's
 weight CSV is cached to `weight_dir` and reused on subsequent runs (including
 across years) unless removed. The per-year `AggGen` aggregation itself is
 cheap once weights exist. Stage 2 is a pure per-HRU pandas/numpy computation
-over the already-aggregated daily series — cheap regardless of fabric size.
+over the already-aggregated daily series — cheap per HRU, but its whole-fabric
+load is not: `read_daily_by_hru`'s `to_dataframe()` materializes ~21 years ×
+`n_hru` × daily rows at once (CONUS gfv2 ≈ 2.8 B rows, ~344 GB peak, ~31 min just
+to load). Run `derive_snarea_curve.batch` at **`--mem=384G`** for CONUS (64 GB
+OOMs; Oregon's 17k HRUs fit fine at the default). The load-phase and per-HRU
+derive-loop now emit progress logging so the long silent stretch is traceable.
+
+**PROJ behind the HPC firewall.** conda-forge `proj` defaults `PROJ_NETWORK=ON`
+unless `proj-data` is installed; the firewall blocks `cdn.proj.org`, so gdptools'
+centroid `to_crs(4326)` returns `inf` and crashes whole Stage 1 batches (11/64 on
+the first CONUS gfv2 run — valid geometries, coordinates transform to `inf`).
+Two guards: `derive_aggregate.py` forces PROJ's grid-free transform
+(`pyproj.network.set_network_enabled(False)`; the ~1–2 m NAD83↔WGS84 shift is
+irrelevant for cosmetic CF centroids, all SWE/SCA math is in equal-area 5070),
+and `proj-data` is a pinned pixi dep so `proj4-activate.sh` sets
+`PROJ_NETWORK=OFF` env-wide. Any other pipeline reprojecting to 4326 relies on
+the latter.
 
 The Stage 1 SWE aggregation can optionally be cross-checked against the
 sibling `gfv2-spatial-targets` repo's `snodas_<year>_agg.nc` oracle.

--- a/slurm_batch/derive_snarea_curve.batch
+++ b/slurm_batch/derive_snarea_curve.batch
@@ -4,20 +4,23 @@
 #SBATCH --job-name=snarea_curve
 #SBATCH --output=logs/job_%j.out
 #SBATCH --error=logs/job_%j.err
-#SBATCH --time=02:00:00
+#SBATCH --time=06:00:00
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=4
-#SBATCH --mem=64G
+#SBATCH --mem=384G
 #
 # Stage 2 of the SNODAS -> snarea_curve pipeline: read the per-year aggregated
 # NetCDFs from Stage 1 (derive_snodas_aggregate.batch) and derive the per-HRU
 # PRMS snarea_curve parameter (11-point curve + hru_deplcrv + sdc_status) into
-# {data_root}/{fabric}/params/merged/nhm_snarea_curve_params.csv. Pure
-# pandas/numpy; depends only on Stage 1's output NCs + the cached weight CSV
-# (for per-HRU SNODAS cell counts).
+# {data_root}/{fabric}/params/merged/nhm_snarea_curve_params.csv. Per-HRU math is
+# pure pandas/numpy, but the WHOLE-FABRIC load is not: read_daily_by_hru's
+# to_dataframe() materializes ~n_years x n_hru x n_days rows at once (CONUS gfv2
+# ~2.8B rows, ~344 GB peak), so the default is sized for CONUS. Small fabrics
+# (e.g. oregon, ~17k HRUs) fit easily and can override down:
+#   FABRIC=oregon sbatch --mem=64G --time=02:00:00 slurm_batch/derive_snarea_curve.batch
 #
 # Run AFTER Stage 1 completes (chain it with --dependency=afterok:<stage1_id>):
-#   FABRIC=oregon sbatch slurm_batch/derive_snarea_curve.batch
+#   FABRIC=gfv2 sbatch slurm_batch/derive_snarea_curve.batch
 
 cd "$SLURM_SUBMIT_DIR"
 BASE_CONFIG=${BASE_CONFIG:-configs/base_config.yml}

--- a/src/gfv2_params/snarea/build.py
+++ b/src/gfv2_params/snarea/build.py
@@ -8,6 +8,8 @@ a single named constant so the swap is one edit + config override.
 
 from __future__ import annotations
 
+import logging
+
 import numpy as np
 import pandas as pd
 
@@ -108,13 +110,21 @@ def build_snarea_curve(
     id_feature: str,
     params: SelectionParams,
     default_curve: np.ndarray,
+    logger: logging.Logger | None = None,
+    log_every: int = 25_000,
 ) -> pd.DataFrame:
-    rows = [
-        build_hru_record(
+    """Per-HRU derivation loop. Pass ``logger`` to emit progress every
+    ``log_every`` HRUs — the loop is silent otherwise, which reads as a hang at
+    CONUS scale (361k HRUs take minutes)."""
+    items = sorted(daily_by_hru.items())
+    n = len(items)
+    rows = []
+    for i, (hru_id, daily) in enumerate(items, start=1):
+        rows.append(build_hru_record(
             hru_id, daily, cells_by_hru.get(hru_id, 0),
             water_by_hru.get(hru_id, 0.0), params, default_curve,
-        )
-        for hru_id, daily in sorted(daily_by_hru.items())
-    ]
+        ))
+        if logger is not None and (i % log_every == 0 or i == n):
+            logger.info("  derived %d/%d HRUs (%.0f%%)", i, n, 100 * i / n)
     df = pd.DataFrame(rows).rename(columns={"hru_id": id_feature})
     return df


### PR DESCRIPTION
## What

Two independent fixes discovered while running the **CONUS gfv2** SNODAS→`snarea_curve` pipeline end-to-end for the first time (the SDC-grouping validation run). Three atomic commits.

## 1. PROJ grid-free transform behind the HPC firewall (`fix(aggregate)`)

**Symptom:** 11 of 64 Stage-1 aggregate batches crashed with `GEOSException: Points of LinearRing do not form a closed linestring` inside gdptools' `build_cf_dataset` → `dissolved_gdf.to_crs(4326)`. Input geometries are **valid**; `make_valid`/`buffer(0)` don't help.

**Root cause:** conda-forge `proj` sets `PROJ_NETWORK=ON` when `proj-data` isn't installed (`proj4-activate.sh`). Behind the firewall PROJ can't fetch the NAD83→WGS84 datum-shift grid from `cdn.proj.org`, so the transform returns `inf` for points in an unavailable grid tile → the ring won't close. Spatially clustered (fine on Oregon).

**Fix (two guards):**
- `derive_aggregate.py` forces PROJ's grid-free transform (`pyproj.network.set_network_enabled(False)`). The ~1–2 m grid-free NAD83↔WGS84 shift is irrelevant for the cosmetic CF lat/lon centroids; all SWE/SCA aggregation is in equal-area EPSG:5070.
- `proj-data` pinned in `[tool.pixi.dependencies]` so `proj4-activate.sh` sets `PROJ_NETWORK=OFF` env-wide (fixes any other pipeline that reprojects to 4326).

**Verified:** with `proj-data` installed, `PROJ_NETWORK=OFF` and all 11 previously-failing batches reproject with finite centroids *without* the in-code disable. The full CONUS Stage 1 + merge then completed (64/64 batches, 21/21 per-year files).

## 2. Stage 2 progress logging (`feat(snarea)`)

At CONUS scale `derive_snarea_curve` was silent for ~31 min during `read_daily_by_hru`'s `to_dataframe()` (materializes ~2.8 B rows) and again through the 361k-HRU derive loop — indistinguishable from a hang. Adds optional `logger=` params (backward-compatible: existing callers/tests pass `None` → no output) and passes the configured **named** logger down (the log config uses `propagate=False`, so a module-level logger wouldn't emit). Logs load phases with row counts + elapsed, and derive-loop progress every 25k HRUs.

## 3. Docs (`docs(hpc)`)

`HPC_REFERENCE.md`: corrects the stale "Stage 2 is cheap regardless of fabric size" claim (whole-fabric load OOMs at 64 GB on CONUS — run `derive_snarea_curve.batch` at `--mem=384G`; ~344 GB peak measured) and documents the PROJ firewall crash + guards.

## Verification

- `pixi run -e dev pre-commit run --files …` → all hooks pass.
- `pixi install` materialized `proj-data`; verified `PROJ_NETWORK=OFF` + clean reprojection of the formerly-failing batch.
- End-to-end: CONUS Stage 1 → merge → Stage 2 (`--mem=384G`) completed; `nhm_snarea_curve_params.csv` written for all 361,471 HRUs.
- Logging changes are backward-compatible (optional params); CI is the test gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
