### PR TITLE
feat(snarea): CV/lognormal snarea_curve library (Stage 3 + sub-grid CV)

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,22 +312,28 @@ for the pattern.
 
 ## Snow depletion curves (SNODAS → snarea_curve)
 
-Derives the PRMS `snarea_curve` parameter (an 11-point areal snow-depletion
-curve) plus `hru_deplcrv` from daily SNODAS SWE, following the Driscoll, Hay &
-Bock (2017) method. Two fabric-independent stages. Stage 1 runs as a SLURM
-array over the fabric's spatial batches (same pattern as the depstor/zonal
-parameter jobs), then a merge job; Stage 2 remains a plain `pixi run`:
+Derives a PRMS `snarea_curve` library (CV/lognormal depletion curves) plus
+per-HRU `hru_deplcrv`/`snarea_thresh` from daily SNODAS SWE. Three
+fabric-independent stages: Stage 1/2 follow the Driscoll, Hay & Bock (2017)
+empirical method; Stage 3 fits each HRU to a physically-based lognormal-CV
+curve (Sexstone, Driscoll, Hay, Hammond & Barnhart 2020), calibrated against
+the Stage 2 empirical curves. Stage 1 runs as a SLURM array over the fabric's
+spatial batches (same pattern as the depstor/zonal parameter jobs), then a
+merge job; Stage 2 remains a plain `pixi run`; Stage 3 is a cheap `sbatch` job:
 
 ```bash
-# Stage 1 — aggregate daily SNODAS SWE to the HRU fabric, per spatial batch
+# Stage 1 — aggregate daily SNODAS SWE (+ swe_std) to the HRU fabric, per spatial batch
 N=$(grep '^n_batches:' "{data_root}/oregon/batches/manifest.yml" | awk '{print $2}')
 AID=$(sbatch --parsable --array=0-$((N-1)) --export=ALL,FABRIC=oregon \
     slurm_batch/derive_snodas_aggregate.batch)
 sbatch --dependency=afterok:$AID --export=ALL,FABRIC=oregon \
     slurm_batch/merge_snodas_aggregate.batch
 
-# Stage 2 — derive per-HRU snarea_curve from the aggregated SWE/SCA
+# Stage 2 — derive per-HRU empirical snarea_curve + sub-grid CV from the aggregated SWE/SCA
 pixi run python scripts/derive_snarea_curve.py --fabric oregon
+
+# Stage 3 — build the CV/lognormal curve library + per-HRU params from the Stage 2 output
+FABRIC=oregon sbatch slurm_batch/derive_snarea_library.batch
 ```
 
 - **Inputs:** raw daily SNODAS SWE NetCDFs from the shared datastore (default
@@ -344,18 +350,31 @@ pixi run python scripts/derive_snarea_curve.py --fabric oregon
   weight CSV under `{data_root}/{fabric}/weights_agg/`. The merge job then
   concatenates all batches per year into
   `{data_root}/{fabric}/snodas/snodas_agg_<year>.nc` (dims `time`/`<id_feature>`;
-  vars `swe` area-weighted mean, `scov` snow-covered-area fraction) — the file
-  Stage 2 reads.
-- **Stage 2 output:**
-  `{data_root}/{fabric}/params/merged/nhm_snarea_curve_params.csv` — one row per
-  HRU with `snarea_curve_0..10`, `hru_deplcrv`, and `sdc_status`/`sca_class`
-  diagnostics; HRUs failing the six Driscoll selection criteria fall back to a
-  configured default curve, flagged in `sdc_status`.
+  vars `swe` area-weighted mean, `scov` snow-covered-area fraction, `swe_std`
+  per-cell SWE std dev sidecar) — the file Stage 2 reads.
+- **Stage 2 output:** the intermediate
+  `{data_root}/{fabric}/params/merged/_intermediates/nhm_snarea_curve_derived.csv`
+  — one row per HRU with the empirical `snarea_curve_0..10`, `sdc_status`/
+  `sca_class` diagnostics, and `cv_subgrid` (from `swe_std`); HRUs failing the
+  six Driscoll selection criteria fall back to a configured default curve,
+  flagged in `sdc_status`. Not the terminal params — that's Stage 3.
+- **Stage 3 output**, all under `{data_root}/{fabric}/params/merged/`:
+  `nhm_snarea_curve_library.csv` (one row per `deplcrv_id` — the reserved
+  default curve plus `ndepl_cv` equal-population CV-bin curves),
+  `nhm_snarea_curve_params.csv` (one row per HRU: `hru_deplcrv`,
+  `snarea_thresh`, CV diagnostics, the assigned curve),
+  `nhm_snarea_curve_validation.csv` (calibration/reconstruction-error report),
+  and `nhm_snarea_curve.nc` — a pyWatershed-ready parameter file
+  (`snarea_curve`, `hru_deplcrv`, `snarea_thresh`).
 
 `--fabric` is resolved the same way as every other stage (CLI flag → `FABRIC`
 env var → `default_fabric`); swap in `--fabric gfv2` for the CONUS fabric.
-Design spec: [`docs/superpowers/specs/2026-07-04-snodas-snarea-curve-design.md`](docs/superpowers/specs/2026-07-04-snodas-snarea-curve-design.md);
-converted method paper: [`docs/Snow_Depletion_Curves.md`](docs/Snow_Depletion_Curves.md).
+Design specs:
+[`docs/superpowers/specs/2026-07-04-snodas-snarea-curve-design.md`](docs/superpowers/specs/2026-07-04-snodas-snarea-curve-design.md)
+(Stages 1/2) and
+[`docs/superpowers/specs/2026-07-06-snodas-snarea-curve-library-design.md`](docs/superpowers/specs/2026-07-06-snodas-snarea-curve-library-design.md)
+(Stage 3 library); converted method paper:
+[`docs/Snow_Depletion_Curves.md`](docs/Snow_Depletion_Curves.md).
 
 ## Viewing fabric results
 

--- a/configs/aggregate/aggregate_sources.yml
+++ b/configs/aggregate/aggregate_sources.yml
@@ -14,5 +14,6 @@ batch_dir: "{data_root}/{fabric}/batches"
 sources:
   - name: snodas
     # Shared raw datastore; a profile may override `snodas_dir`.
+    # The adapter emits swe_std as a sidecar (std_variables=("swe",)).
     snodas_dir: "{data_root}/../nhf-datastore/snodas/daily"
     output_prefix: snodas

--- a/configs/snarea/snarea_curve.yml
+++ b/configs/snarea/snarea_curve.yml
@@ -4,8 +4,8 @@
 # only resolves {data_root}/{fabric} placeholders in top-level string values.
 snodas_agg_dir: "{data_root}/{fabric}/snodas"
 weight_file: "{data_root}/{fabric}/weights_agg/snodas_weights_{fabric}.csv"
-output_dir: "{data_root}/{fabric}/params/merged"
-merged_file: nhm_snarea_curve_params.csv
+output_dir: "{data_root}/{fabric}/params/merged/_intermediates"
+merged_file: nhm_snarea_curve_derived.csv
 
 selection:
   # min_cells: minimum SNODAS 1-km cells per HRU. The paper used 25 for ~74 km²

--- a/configs/snarea/snarea_library.yml
+++ b/configs/snarea/snarea_library.yml
@@ -1,0 +1,13 @@
+# Stage 3: CV/lognormal snarea_curve library from the Stage 2 derived CSV.
+# Top-level placeholders resolve {data_root}/{fabric}; nested blocks pass through.
+derived_csv: "{data_root}/{fabric}/params/merged/_intermediates/nhm_snarea_curve_derived.csv"
+output_dir: "{data_root}/{fabric}/params/merged"
+library_file: nhm_snarea_curve_library.csv
+params_file: nhm_snarea_curve_params.csv
+validation_file: nhm_snarea_curve_validation.csv
+netcdf_file: nhm_snarea_curve.nc
+
+ndepl_cv: 8 # 8 CV bins + 1 reserved default = ndepl 9 (grouping memory: elbow 5-8)
+calibrate: auto # auto | on | off
+calibrate_bias_tol: 0.1 # |median(cv_subgrid) - median(cv_empirical)| trigger
+default_curve: [1.0, 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1, 0.0]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -79,6 +79,7 @@ shells around the same builders. The four stages:
 | Part 2b zonal params | `scripts/derive_zonal_params.py` | `configs/zonal/zonal_params.yml` | `src/gfv2_params/zonal_runners/` |
 | Part 2c snow-depletion aggregation | `scripts/derive_aggregate.py` | `configs/aggregate/aggregate_sources.yml` | `src/gfv2_params/aggregate/` |
 | Part 2c snow-depletion curve build | `scripts/derive_snarea_curve.py` | `configs/snarea/snarea_curve.yml` | `src/gfv2_params/snarea/` |
+| Part 2c snow-depletion curve library | `scripts/derive_snarea_library.py` | `configs/snarea/snarea_library.yml` | `src/gfv2_params/snarea/library.py` |
 
 Orchestrators support `--step <name>` (one step), `--from <name>` (resume),
 and `--force` (rebuild outputs that already exist). The zonal orchestrator
@@ -101,19 +102,33 @@ contract:
   static rasters). Wraps gdptools `UserCatData`/`WeightGen`/`AggGen` behind a
   declarative `SourceAdapter` (`adapter.py`); `driver.py`'s `aggregate_source`
   caches the per-fabric weight matrix once and loops `AggGen` per year. The
-  current adapter, `snodas.py`, area-weights daily SNODAS SWE to `swe` (mean)
-  and derives `scov`/SCA (`masked_mean` of `swe > 0`, NaN-preserving over
-  fill/nodata cells) — feeds Part 2c Stage 2 below. New gridded time-series
+  current adapter, `snodas.py`, area-weights daily SNODAS SWE to `swe` (mean),
+  derives `scov`/SCA (`masked_mean` of `swe > 0`, NaN-preserving over
+  fill/nodata cells), and emits a `swe_std` sidecar (`std_variables=("swe",)`,
+  per-cell SWE std dev within the HRU) — feeds Part 2c Stage 2 below, whose
+  sub-grid CV needs `swe_std`. New gridded time-series
   sources (e.g. climate) plug in as a new `SourceAdapter`, not a new script.
 - [`src/gfv2_params/snarea/`](../src/gfv2_params/snarea/) — Part 2c Stage 2:
-  derives the PRMS `snarea_curve` (11-point areal snow-depletion curve) and
-  `hru_deplcrv` per HRU from the Stage 1 daily SWE/SCA, per Driscoll, Hay &
-  Bock (2017): per-calendar-year melt-season curve extraction (`season.py`),
-  median/similarity/representative-curve selection (`representative.py`), six
-  selection criteria + low/mid/high classification (`selection.py`), and
-  final per-HRU assembly with default-curve fallback (`build.py`). Design
-  spec: [`docs/superpowers/specs/2026-07-04-snodas-snarea-curve-design.md`](superpowers/specs/2026-07-04-snodas-snarea-curve-design.md);
+  derives the empirical PRMS `snarea_curve` (11-point areal snow-depletion
+  curve) and per-HRU sub-grid CV from the Stage 1 daily SWE/SCA/`swe_std`, per
+  Driscoll, Hay & Bock (2017): per-calendar-year melt-season curve extraction
+  (`season.py`), median/similarity/representative-curve selection
+  (`representative.py`), six selection criteria + low/mid/high classification
+  (`selection.py`), sub-grid CV from `swe_std` (`subgrid.py`), and final
+  per-HRU assembly with default-curve fallback (`build.py`) — writes the
+  intermediate derived CSV, not the terminal params. Design spec:
+  [`docs/superpowers/specs/2026-07-04-snodas-snarea-curve-design.md`](superpowers/specs/2026-07-04-snodas-snarea-curve-design.md);
   converted method paper: [`docs/Snow_Depletion_Curves.md`](Snow_Depletion_Curves.md).
+- [`src/gfv2_params/snarea/library.py`](../src/gfv2_params/snarea/library.py) —
+  Part 2c Stage 3 (`scripts/derive_snarea_library.py`): builds a physically-based
+  CV/lognormal `snarea_curve` library from the Stage 2 derived CSV (Sexstone,
+  Driscoll, Hay, Hammond & Barnhart 2020) — analytic curve-from-CV
+  (`sdc_from_cv`), CV fit to each empirical curve (`fit_cv`), calibration of
+  sub-grid CV against the empirical overlap (`validate_and_calibrate`),
+  equal-population CV-bin library (`build_library`), nearest-CV assignment
+  (`assign_deplcrv`), and the terminal params CSV + pyWatershed NetCDF writers.
+  Design spec:
+  [`docs/superpowers/specs/2026-07-06-snodas-snarea-curve-library-design.md`](superpowers/specs/2026-07-06-snodas-snarea-curve-library-design.md).
 
 Each `build(step_cfg, ctx, logger)` function produces named outputs that
 downstream steps can reach via the shared context. The orchestrator/builder

--- a/docs/superpowers/plans/2026-07-06-snodas-snarea-curve-library.md
+++ b/docs/superpowers/plans/2026-07-06-snodas-snarea-curve-library.md
@@ -1,0 +1,1532 @@
+# CV/lognormal snarea_curve Library — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the one-curve-per-HRU `snarea_curve` output with a compact CV/lognormal curve **library** (`ndepl` curves + per-HRU `hru_deplcrv` index + per-HRU `snarea_thresh`), emitted as CSVs + a pyWatershed/PRMS NetCDF param file.
+
+**Architecture:** Three stages in `gfv2-params`, all additive to the merged Driscoll pipeline (PR #165). Stage 1 (`aggregate/`) gains an area-weighted `swe_std` sidecar; Stage 2 (`snarea/` derive) adds a representative sub-grid CV + peak SWE per HRU and writes to `_intermediates/`; Stage 3 (new `snarea/library.py`) is a pure-tabular builder that fits the lognormal CV library, assigns curves, computes `snarea_thresh`, and serializes. The curve **shape** is one physical parameter (sub-grid SWE CV via a lognormal pdf); the per-HRU **scale** is `snarea_thresh`.
+
+**Tech Stack:** Python 3.12, pandas/numpy/scipy (all present), xarray + netCDF4, gdptools (Stage 1), pixi env, pytest, SLURM.
+
+**Design spec:** [`docs/superpowers/specs/2026-07-06-snodas-snarea-curve-library-design.md`](../specs/2026-07-06-snodas-snarea-curve-library-design.md) — read it first; this plan implements it section-by-section.
+
+## Global Constraints
+
+- **Fabric-agnostic configs.** Every per-fabric path resolves from the active profile in `configs/base_config.yml` via `require_config_key` with `{data_root}`/`{fabric}` placeholders. No literal paths, no naming conventions in code. (CLAUDE.md)
+- **`load_config` resolves only top-level string placeholders** — nested config blocks pass through untouched (mirror `derive_aggregate.py`'s `_resolve` if nested resolution is needed).
+- **Curve order:** repo/CSV convention is **descending** `SWE_LEVELS = 1.0 … 0.0` (index 0 = SWE/thresh 1.0 → SCA≈1; index 10 = 0.0 → SCA=0), matching `src/gfv2_params/snarea/season.py`. The PRMS NetCDF is **ascending** frac_swe — the flip lives in exactly one helper `_to_prms_order`.
+- **`ndepl` = 1 reserved default curve (index 1) + `ndepl_cv` CV-bin curves (indices 2..ndepl).** `ndepl_cv` config-default **8** ⇒ `ndepl`=9.
+- **Tests are the gate; CI runs `pytest tests/` on push/PR.** Never run full `pytest` on the HPC head node (concurrent geo-import storms hang). A single test file via `pixi run -e dev pytest tests/test_x.py -v` is fine; `py_compile` is fine.
+- **Run `pixi run -e dev pre-commit run --all-files` before every push.** isort + ruff, line-length 120.
+- **Commit style:** conventional prefixes (`feat`/`fix`/`test`/`docs`/`chore`); end messages with `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+- **`gh` is firewall-blocked here** ([[gh_cli_blocked_use_curl_rest]]); open the PR via curl+REST with `--data-binary` when done.
+- **data_root** = `/caldera/hovenweep/projects/usgs/water/impd/nhgf/gfv2_param_v2`. On-disk derived tables already exist for `oregon` and `gfv2` at `{data_root}/{fabric}/params/merged/nhm_snarea_curve_params.csv` (usable to smoke-test Stage 3 immediately).
+
+---
+
+## File Structure
+
+**New source files**
+- `src/gfv2_params/snarea/library.py` — Stage 3 core: `sdc_from_cv`, `fit_cv`, `snarea_thresh_inches`, `_to_prms_order`, `build_library`, `assign_deplcrv`, `validate_and_calibrate`, `write_library_csv` / `write_params_csv` / `write_validation_csv` / `write_prms_netcdf`.
+- `src/gfv2_params/snarea/subgrid.py` — `representative_peak_stats(daily)` (Stage 2 sub-grid CV + peak SWE).
+- `scripts/derive_snarea_library.py` — Stage 3 CLI driver.
+- `configs/snarea/snarea_library.yml` — Stage 3 config.
+- `slurm_batch/derive_snarea_library.batch` — Stage 3 SLURM batch.
+- `tests/test_snarea_library.py`, `tests/test_snarea_subgrid.py` — new tests.
+
+**Modified source files**
+- `src/gfv2_params/aggregate/adapter.py` — add `std_variables` field + validation.
+- `src/gfv2_params/aggregate/driver.py` — `masked_std` sidecar pass emitting `{var}_std`.
+- `src/gfv2_params/aggregate/snodas.py` — `std_variables=("swe",)`.
+- `scripts/derive_snarea_curve.py` — load `swe_std`; write to `_intermediates/`.
+- `src/gfv2_params/snarea/build.py` — add `cv_subgrid`/`peak_swe_mm`/`n_peak_years` columns.
+- `configs/aggregate/aggregate_sources.yml` — declare `swe_std`.
+- `configs/snarea/snarea_curve.yml` — repoint Stage 2 output to `_intermediates/nhm_snarea_curve_derived.csv`.
+- `pyproject.toml` — add `pywatershed` to a `reference` pixi feature.
+- Docs: `README.md`, `slurm_batch/RUNME.md`, `slurm_batch/HPC_REFERENCE.md`, `docs/ARCHITECTURE.md`; memory update.
+
+**Build order:** Phase A (Tasks 1–8) is the pure Stage-3 library core — fully unit-testable now, no HPC. Phase B (Tasks 9–13) is the Stage 1/2 sub-grid infra (needs an HPC re-run to produce real `swe_std`). Phase C (Tasks 14–16) wires the Stage-3 driver, ops, and docs.
+
+---
+
+## Phase A — Stage 3 library core (pure functions; no HPC)
+
+### Task 1: `sdc_from_cv` + curve conventions
+
+**Files:**
+- Create: `src/gfv2_params/snarea/library.py`
+- Test: `tests/test_snarea_library.py`
+
+**Interfaces:**
+- Produces: `SWE_LEVELS: np.ndarray` (11 descending 1.0→0.0); `sdc_from_cv(cv: float, mu: float = 1.0, n: int = 4000) -> np.ndarray` (11-pt descending curve).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_snarea_library.py
+import numpy as np
+import pytest
+
+from gfv2_params.snarea.library import SWE_LEVELS, sdc_from_cv
+
+
+def test_swe_levels_descending_11pt():
+    assert SWE_LEVELS.shape == (11,)
+    assert SWE_LEVELS[0] == 1.0 and SWE_LEVELS[-1] == 0.0
+    assert np.all(np.diff(SWE_LEVELS) < 0)
+
+
+def test_sdc_from_cv_shape_and_endpoints():
+    c = sdc_from_cv(0.5)
+    assert c.shape == (11,)
+    assert c[0] == pytest.approx(1.0)
+    assert c[-1] == pytest.approx(0.0)
+
+
+def test_sdc_from_cv_monotone_nonincreasing():
+    c = sdc_from_cv(0.7)
+    assert np.all(np.diff(c) <= 1e-9)
+
+
+def test_sdc_from_cv_higher_cv_steeper():
+    # larger CV -> lower SCA at mid SWE (index 5 = SWE 0.5)
+    assert sdc_from_cv(1.5)[5] < sdc_from_cv(0.5)[5] < sdc_from_cv(0.1)[5]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run -e dev pytest tests/test_snarea_library.py -v`
+Expected: FAIL — `ModuleNotFoundError` / `cannot import name 'sdc_from_cv'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# src/gfv2_params/snarea/library.py
+"""Stage 3: CV/lognormal snarea_curve library builder.
+
+The curve SHAPE is a single physical parameter — the sub-grid SWE coefficient of
+variation (CV) — via a lognormal SWE pdf (Sexstone et al. 2020, eqs 3-5; Liston
+2004). The dimensionless snow-depletion curve depends only on CV. Repo curve
+order is DESCENDING (SWE/thresh 1.0 -> 0.0); the PRMS NetCDF is ascending (see
+_to_prms_order).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy.stats import norm
+
+# Descending, matching snarea/season.py SWE_LEVELS.
+SWE_LEVELS = np.round(np.arange(1.0, -1e-4, -0.1), 1)  # 1.0 .. 0.0, 11 values
+
+
+def sdc_from_cv(cv: float, mu: float = 1.0, n: int = 4000) -> np.ndarray:
+    """11-point dimensionless SDC for a lognormal SWE pdf with coeff-of-var ``cv``.
+
+    Sexstone eqs 1-5 under uniform melt: SCA(M)=P(S>M); SWE(M)=E[(S-M)^+]. The
+    dimensionless curve (SCA vs SWE/peak) depends only on cv. Returns SCA at
+    SWE_LEVELS (descending), clipped to [0,1], anchored (1.0 @ SWE=1, 0.0 @ SWE=0).
+    """
+    z = np.sqrt(np.log(1 + cv * cv))          # ζ² = ln(1+CV²)
+    lam = np.log(mu) - 0.5 * z * z            # λ  = ln(μ) − ζ²/2
+    M = np.concatenate([[0.0], np.exp(np.linspace(np.log(mu) - 6 * z, np.log(mu) + 6 * z, n))])
+    lnM = np.log(np.where(M > 0, M, 1e-300))
+    sca = norm.cdf((lam - lnM) / z)           # SCA(M) = Φ((λ−lnM)/ζ)
+    swe = mu * norm.cdf((lam + z * z - lnM) / z) - M * sca
+    sca[0], swe[0] = 1.0, mu
+    o = np.argsort(swe / swe[0])
+    return np.clip(np.interp(SWE_LEVELS, (swe / swe[0])[o], sca[o], left=1.0, right=0.0), 0, 1)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pixi run -e dev pytest tests/test_snarea_library.py -v`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/gfv2_params/snarea/library.py tests/test_snarea_library.py
+git commit -m "feat(snarea): sdc_from_cv lognormal curve + conventions
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: `fit_cv` — project an empirical curve onto the lognormal family
+
+**Files:**
+- Modify: `src/gfv2_params/snarea/library.py`
+- Test: `tests/test_snarea_library.py`
+
+**Interfaces:**
+- Consumes: `sdc_from_cv`, `SWE_LEVELS`.
+- Produces: `CV_GRID: np.ndarray`; `fit_cv(curve: np.ndarray, cv_grid: np.ndarray | None = None) -> float` — best-fit CV minimising L2 over interior points 1..9 (endpoints fixed for all CVs, so carry no info).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# add to tests/test_snarea_library.py
+from gfv2_params.snarea.library import CV_GRID, fit_cv
+
+
+def test_fit_cv_recovers_known_cv():
+    for true_cv in (0.3, 0.7, 1.2):
+        curve = sdc_from_cv(true_cv)
+        # fit is on the CV grid; recovered value within one grid step
+        assert abs(fit_cv(curve) - true_cv) <= (CV_GRID[1] - CV_GRID[0]) + 1e-9
+
+
+def test_fit_cv_uses_interior_only():
+    # a curve whose endpoints are perturbed but interior matches cv=0.5 still fits ~0.5
+    curve = sdc_from_cv(0.5).copy()
+    curve[0] = 1.0  # endpoints already fixed; assert fit ignores them
+    assert fit_cv(curve) == pytest.approx(0.5, abs=CV_GRID[1] - CV_GRID[0])
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run -e dev pytest tests/test_snarea_library.py::test_fit_cv_recovers_known_cv -v`
+Expected: FAIL — `cannot import name 'fit_cv'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# add to src/gfv2_params/snarea/library.py
+# CV search grid: 0.05..3.0 step 0.05 covers the validated range (median ~0.45,
+# up to ~1.2 CONUS) with headroom.
+CV_GRID = np.round(np.arange(0.05, 3.0001, 0.05), 2)
+_INTERIOR = slice(1, 10)  # endpoints (0, 10) are fixed 1.0/0.0 for every cv
+
+
+def _library_matrix(cv_grid: np.ndarray) -> np.ndarray:
+    """(len(cv_grid), 11) matrix of analytic curves — built once, reused."""
+    return np.vstack([sdc_from_cv(c) for c in cv_grid])
+
+
+def fit_cv(curve: np.ndarray, cv_grid: np.ndarray | None = None) -> float:
+    """Best-fit lognormal CV for an empirical 11-pt curve (min L2 over interior)."""
+    grid = CV_GRID if cv_grid is None else cv_grid
+    lib = _library_matrix(grid)
+    d = np.linalg.norm(lib[:, _INTERIOR] - np.asarray(curve)[_INTERIOR], axis=1)
+    return float(grid[int(d.argmin())])
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pixi run -e dev pytest tests/test_snarea_library.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/gfv2_params/snarea/library.py tests/test_snarea_library.py
+git commit -m "feat(snarea): fit_cv projects empirical curve onto lognormal family
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: `snarea_thresh_inches` + `_to_prms_order`
+
+**Files:**
+- Modify: `src/gfv2_params/snarea/library.py`
+- Test: `tests/test_snarea_library.py`
+
+**Interfaces:**
+- Produces: `snarea_thresh_inches(peak_swe_mm: float) -> float` (mm→in, /25.4; non-finite/≤0 → 0.0); `_to_prms_order(curve: np.ndarray) -> np.ndarray` (reverse descending→ascending).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# add to tests/test_snarea_library.py
+from gfv2_params.snarea.library import _to_prms_order, snarea_thresh_inches
+
+
+def test_snarea_thresh_mm_to_inches():
+    assert snarea_thresh_inches(254.0) == pytest.approx(10.0)
+    assert snarea_thresh_inches(0.0) == 0.0
+    assert snarea_thresh_inches(float("nan")) == 0.0
+    assert snarea_thresh_inches(-5.0) == 0.0
+
+
+def test_to_prms_order_is_reverse_and_involutive():
+    c = sdc_from_cv(0.6)
+    p = _to_prms_order(c)
+    assert p[0] == pytest.approx(c[-1])   # ascending: SCA@frac0 first
+    assert p[-1] == pytest.approx(c[0])
+    assert np.allclose(_to_prms_order(p), c)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run -e dev pytest tests/test_snarea_library.py::test_snarea_thresh_mm_to_inches -v`
+Expected: FAIL — import error.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# add to src/gfv2_params/snarea/library.py
+_MM_PER_INCH = 25.4
+
+
+def snarea_thresh_inches(peak_swe_mm: float) -> float:
+    """Per-HRU SWE scale in inches. 0.0 for no-snow / undefined (curve never
+    exercised there since pkwater_equiv is 0)."""
+    v = float(peak_swe_mm)
+    if not np.isfinite(v) or v <= 0.0:
+        return 0.0
+    return v / _MM_PER_INCH
+
+
+def _to_prms_order(curve: np.ndarray) -> np.ndarray:
+    """Repo descending (SWE 1.0->0.0) -> PRMS ascending frac_swe (0.0->1.0)."""
+    return np.asarray(curve)[::-1]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pixi run -e dev pytest tests/test_snarea_library.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/gfv2_params/snarea/library.py tests/test_snarea_library.py
+git commit -m "feat(snarea): snarea_thresh mm->in + PRMS curve-order helper
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: `build_library` — reserved default + equal-population CV bins
+
+**Files:**
+- Modify: `src/gfv2_params/snarea/library.py`
+- Test: `tests/test_snarea_library.py`
+
+**Interfaces:**
+- Consumes: `sdc_from_cv`, `SWE_LEVELS`.
+- Produces: `CURVE_COLS: list[str]` (`snarea_curve_0..10`); `build_library(cv_values: np.ndarray, ndepl_cv: int, default_curve: np.ndarray) -> pd.DataFrame` with columns `deplcrv_id` (1..ndepl), `curve_kind` (`default`|`cv_bin`), `cv` (bin-median; NaN for default), `snarea_curve_0..10` (descending). Row 1 = default; rows 2..ndepl = CV bins by ascending median CV.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# add to tests/test_snarea_library.py
+import pandas as pd
+from gfv2_params.snarea.library import CURVE_COLS, build_library
+
+
+def test_build_library_default_plus_bins():
+    rng = np.linspace(0.2, 1.4, 500)   # spread of CVs
+    default = np.linspace(1.0, 0.0, 11)
+    lib = build_library(rng, ndepl_cv=8, default_curve=default)
+    assert len(lib) == 9                              # 1 default + 8 bins
+    assert list(lib["deplcrv_id"]) == list(range(1, 10))
+    assert lib.iloc[0]["curve_kind"] == "default"
+    assert np.isnan(lib.iloc[0]["cv"])
+    np.testing.assert_allclose(lib.iloc[0][CURVE_COLS].to_numpy(float), default)
+    assert (lib.iloc[1:]["curve_kind"] == "cv_bin").all()
+    # bin median CVs are increasing
+    assert np.all(np.diff(lib.iloc[1:]["cv"].to_numpy()) > 0)
+    # each cv_bin curve equals sdc_from_cv(its median cv)
+    from gfv2_params.snarea.library import sdc_from_cv
+    row = lib.iloc[3]
+    np.testing.assert_allclose(row[CURVE_COLS].to_numpy(float), sdc_from_cv(row["cv"]), atol=1e-9)
+
+
+def test_build_library_equal_population_bins():
+    cv = np.arange(1000) / 1000.0 + 0.1   # uniform
+    lib = build_library(cv, ndepl_cv=5, default_curve=np.linspace(1, 0, 11))
+    assert len(lib) == 6
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run -e dev pytest tests/test_snarea_library.py::test_build_library_default_plus_bins -v`
+Expected: FAIL — import error.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# add to src/gfv2_params/snarea/library.py  (add `import pandas as pd` at top)
+CURVE_COLS = [f"snarea_curve_{i}" for i in range(11)]
+
+
+def build_library(cv_values: np.ndarray, ndepl_cv: int, default_curve: np.ndarray) -> pd.DataFrame:
+    """Row 1 = reserved default curve; rows 2..(1+ndepl_cv) = equal-population CV
+    bins, each curve = sdc_from_cv(bin median CV). Curves are descending."""
+    cv = np.asarray(cv_values, dtype=float)
+    cv = cv[np.isfinite(cv)]
+    if cv.size == 0:
+        raise ValueError("build_library: no finite CV values to bin")
+    default_curve = np.asarray(default_curve, dtype=float)
+    if default_curve.shape != (11,):
+        raise ValueError(f"default_curve must be shape (11,), got {default_curve.shape}")
+
+    rows = [{"deplcrv_id": 1, "curve_kind": "default", "cv": np.nan,
+             **{c: float(default_curve[i]) for i, c in enumerate(CURVE_COLS)}}]
+
+    # equal-population bins via quantile edges; label each point 0..ndepl_cv-1
+    edges = np.quantile(cv, np.linspace(0, 1, ndepl_cv + 1))
+    edges[0], edges[-1] = -np.inf, np.inf
+    labels = np.clip(np.digitize(cv, edges[1:-1]), 0, ndepl_cv - 1)
+    medians = sorted(float(np.median(cv[labels == b])) for b in range(ndepl_cv) if (labels == b).any())
+    for k, m in enumerate(medians, start=2):
+        curve = sdc_from_cv(m)
+        rows.append({"deplcrv_id": k, "curve_kind": "cv_bin", "cv": m,
+                     **{c: float(curve[i]) for i, c in enumerate(CURVE_COLS)}})
+    return pd.DataFrame(rows)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pixi run -e dev pytest tests/test_snarea_library.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/gfv2_params/snarea/library.py tests/test_snarea_library.py
+git commit -m "feat(snarea): build_library — reserved default + equal-pop CV bins
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: `assign_deplcrv` — nearest-CV bin, default fallback
+
+**Files:**
+- Modify: `src/gfv2_params/snarea/library.py`
+- Test: `tests/test_snarea_library.py`
+
+**Interfaces:**
+- Consumes: `build_library` output.
+- Produces: `assign_deplcrv(cv_assign: np.ndarray, library: pd.DataFrame) -> np.ndarray` (int `deplcrv_id` per HRU). Finite CV → nearest **cv_bin** median (the default row is excluded from the search); non-finite CV → default index 1.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# add to tests/test_snarea_library.py
+from gfv2_params.snarea.library import assign_deplcrv
+
+
+def test_assign_deplcrv_nearest_bin_and_default():
+    lib = build_library(np.linspace(0.2, 1.4, 500), ndepl_cv=8, default_curve=np.linspace(1, 0, 11))
+    bin_cvs = lib.iloc[1:]["cv"].to_numpy()
+    cv_assign = np.array([bin_cvs[0], bin_cvs[-1], np.nan, float(bin_cvs.mean())])
+    out = assign_deplcrv(cv_assign, lib)
+    assert out[0] == 2                     # nearest first bin
+    assert out[1] == 9                     # nearest last bin
+    assert out[2] == 1                     # NaN -> reserved default
+    assert 2 <= out[3] <= 9                # some cv_bin, never the default
+    assert out.dtype.kind in ("i", "u")
+
+
+def test_assign_deplcrv_never_returns_default_for_finite_cv():
+    lib = build_library(np.linspace(0.2, 1.4, 500), ndepl_cv=8, default_curve=np.linspace(1, 0, 11))
+    out = assign_deplcrv(np.full(50, 0.45), lib)
+    assert (out >= 2).all()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run -e dev pytest tests/test_snarea_library.py::test_assign_deplcrv_nearest_bin_and_default -v`
+Expected: FAIL — import error.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# add to src/gfv2_params/snarea/library.py
+def assign_deplcrv(cv_assign: np.ndarray, library: pd.DataFrame) -> np.ndarray:
+    """Nearest cv_bin curve (by CV) for finite CV; reserved default (id 1) for
+    non-finite. The default row is never a nearest-CV candidate."""
+    bins = library[library["curve_kind"] == "cv_bin"]
+    bin_ids = bins["deplcrv_id"].to_numpy()
+    bin_cvs = bins["cv"].to_numpy(float)
+    default_id = int(library[library["curve_kind"] == "default"]["deplcrv_id"].iloc[0])
+    cv = np.asarray(cv_assign, dtype=float)
+    out = np.full(cv.shape, default_id, dtype=np.int32)
+    finite = np.isfinite(cv)
+    if finite.any():
+        nearest = np.abs(cv[finite][:, None] - bin_cvs[None, :]).argmin(axis=1)
+        out[finite] = bin_ids[nearest]
+    return out
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pixi run -e dev pytest tests/test_snarea_library.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/gfv2_params/snarea/library.py tests/test_snarea_library.py
+git commit -m "feat(snarea): assign_deplcrv — nearest CV bin + default fallback
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: `validate_and_calibrate` — gate + monotone quantile map
+
+**Files:**
+- Modify: `src/gfv2_params/snarea/library.py`
+- Test: `tests/test_snarea_library.py`
+
+**Interfaces:**
+- Consumes: `sdc_from_cv`.
+- Produces: `validate_and_calibrate(cv_subgrid: np.ndarray, cv_empirical: np.ndarray, emp_curves: np.ndarray, mode: str = "auto", bias_tol: float = 0.1) -> tuple[np.ndarray, dict]`. Returns `(cv_calibrated_for_all_input, report)`. `cv_subgrid`/`cv_empirical` align by index; `cv_empirical` is NaN where not `derived`; `emp_curves` is (n,11) with NaN rows where not derived. On `auto`, if `|median(cv_subgrid_derived) − median(cv_empirical_derived)| > bias_tol`, monotone quantile-map `cv_subgrid → cv_empirical` (trained on the derived overlap) and apply to all finite `cv_subgrid`; else identity. `report` carries distribution stats, reconstruction error before/after, and `calibrated: bool`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# add to tests/test_snarea_library.py
+from gfv2_params.snarea.library import validate_and_calibrate
+
+
+def test_calibration_removes_synthetic_bias():
+    rng = np.linspace(0.3, 1.2, 400)
+    emp_curves = np.vstack([sdc_from_cv(c) for c in rng])
+    cv_empirical = rng.copy()
+    cv_subgrid = rng * 0.6           # biased low by construction
+    cal, report = validate_and_calibrate(cv_subgrid, cv_empirical, emp_curves, mode="auto", bias_tol=0.05)
+    assert report["calibrated"] is True
+    # after calibration the median bias vs empirical is much smaller
+    assert abs(np.median(cal) - np.median(cv_empirical)) < abs(np.median(cv_subgrid) - np.median(cv_empirical))
+
+
+def test_no_calibration_when_unbiased():
+    rng = np.linspace(0.3, 1.2, 400)
+    emp_curves = np.vstack([sdc_from_cv(c) for c in rng])
+    cal, report = validate_and_calibrate(rng.copy(), rng.copy(), emp_curves, mode="auto", bias_tol=0.1)
+    assert report["calibrated"] is False
+    np.testing.assert_allclose(cal, rng)
+
+
+def test_calibration_off_is_identity():
+    rng = np.linspace(0.3, 1.2, 50)
+    emp = np.vstack([sdc_from_cv(c) for c in rng])
+    cal, report = validate_and_calibrate(rng * 0.5, rng, emp, mode="off")
+    np.testing.assert_allclose(cal, rng * 0.5)
+    assert report["calibrated"] is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run -e dev pytest tests/test_snarea_library.py::test_calibration_removes_synthetic_bias -v`
+Expected: FAIL — import error.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# add to src/gfv2_params/snarea/library.py
+def _recon_error(cv: np.ndarray, emp_curves: np.ndarray) -> tuple[float, float]:
+    """mean and p95 abs-SCA error of sdc_from_cv(cv) vs emp_curves (rows aligned)."""
+    ok = np.isfinite(cv) & np.isfinite(emp_curves).all(axis=1)
+    if not ok.any():
+        return float("nan"), float("nan")
+    approx = np.vstack([sdc_from_cv(c) for c in cv[ok]])
+    err = np.abs(approx - emp_curves[ok])
+    return float(err.mean()), float(np.percentile(err.max(axis=1), 95))
+
+
+def validate_and_calibrate(cv_subgrid, cv_empirical, emp_curves, mode="auto", bias_tol=0.1):
+    cv_subgrid = np.asarray(cv_subgrid, dtype=float)
+    cv_empirical = np.asarray(cv_empirical, dtype=float)
+    emp_curves = np.asarray(emp_curves, dtype=float)
+    derived = np.isfinite(cv_subgrid) & np.isfinite(cv_empirical)
+    sub_d, emp_d = cv_subgrid[derived], cv_empirical[derived]
+
+    report = {
+        "n_derived_overlap": int(derived.sum()),
+        "cv_subgrid_median": float(np.median(sub_d)) if derived.any() else float("nan"),
+        "cv_empirical_median": float(np.median(emp_d)) if derived.any() else float("nan"),
+        "calibrated": False,
+    }
+    report["recon_mean_before"], report["recon_p95_before"] = _recon_error(cv_subgrid, emp_curves)
+
+    bias = abs(report["cv_subgrid_median"] - report["cv_empirical_median"]) if derived.any() else 0.0
+    report["cv_median_bias"] = float(bias)
+
+    cal = cv_subgrid.copy()
+    if mode == "on" or (mode == "auto" and derived.sum() >= 2 and bias > bias_tol):
+        # monotone quantile map trained on the derived overlap
+        qs = np.linspace(0, 1, 101)
+        x = np.quantile(sub_d, qs)
+        y = np.quantile(emp_d, qs)
+        x, idx = np.unique(x, return_index=True)   # strictly increasing x for interp
+        y = y[idx]
+        finite = np.isfinite(cal)
+        cal[finite] = np.interp(cal[finite], x, y)
+        report["calibrated"] = True
+    elif mode not in ("auto", "on", "off"):
+        raise ValueError(f"calibrate mode must be auto|on|off, got {mode!r}")
+
+    report["recon_mean_after"], report["recon_p95_after"] = _recon_error(cal, emp_curves)
+    return cal, report
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pixi run -e dev pytest tests/test_snarea_library.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/gfv2_params/snarea/library.py tests/test_snarea_library.py
+git commit -m "feat(snarea): validate_and_calibrate — gate + monotone quantile map
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: CSV serializers (library / params / validation)
+
+**Files:**
+- Modify: `src/gfv2_params/snarea/library.py`
+- Test: `tests/test_snarea_library.py`
+
+**Interfaces:**
+- Consumes: `build_library`, `assign_deplcrv`, `snarea_thresh_inches`.
+- Produces: `assemble_params(derived: pd.DataFrame, id_feature: str, cv_assign: np.ndarray, cv_source: np.ndarray, deplcrv: np.ndarray, library: pd.DataFrame) -> pd.DataFrame`; `write_library_csv(library, path)`, `write_params_csv(params, path)`, `write_validation_csv(report, path)`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# add to tests/test_snarea_library.py
+from gfv2_params.snarea.library import assemble_params, write_library_csv, write_params_csv
+
+
+def test_assemble_params_columns_and_assigned_curve(tmp_path):
+    lib = build_library(np.linspace(0.2, 1.4, 500), ndepl_cv=8, default_curve=np.linspace(1, 0, 11))
+    derived = pd.DataFrame({
+        "nat_hru_id": [10, 11, 12],
+        "sdc_status": ["derived", "derived", "default_no_snow"],
+        "sca_class": ["high", "mid", "high"],
+        "similarity": [0.05, 0.09, np.nan],
+        "n_seasons": [12, 8, 0],
+        "cv_subgrid": [0.4, 0.9, np.nan],
+        "cv_empirical": [0.42, 0.88, np.nan],
+        "peak_swe_mm": [254.0, 508.0, 0.0],
+        "n_peak_years": [12, 8, 0],
+    })
+    cv_assign = np.array([0.4, 0.9, np.nan])
+    cv_source = np.array(["subgrid", "subgrid", "default_no_snow"])
+    deplcrv = assign_deplcrv(cv_assign, lib)
+    params = assemble_params(derived, "nat_hru_id", cv_assign, cv_source, deplcrv, lib)
+    assert list(params["nat_hru_id"]) == [10, 11, 12]
+    for col in ("hru_deplcrv", "snarea_thresh", "cv_assign", "cv_source", *CURVE_COLS):
+        assert col in params.columns
+    assert params.loc[params.nat_hru_id == 12, "hru_deplcrv"].iloc[0] == 1     # no-snow -> default
+    assert params.loc[params.nat_hru_id == 12, "snarea_thresh"].iloc[0] == 0.0
+    # assigned curve row matches the library curve for that hru's deplcrv
+    r = params.iloc[0]
+    librow = lib[lib.deplcrv_id == r["hru_deplcrv"]].iloc[0]
+    np.testing.assert_allclose(r[CURVE_COLS].to_numpy(float), librow[CURVE_COLS].to_numpy(float))
+
+
+def test_write_csvs_roundtrip(tmp_path):
+    lib = build_library(np.linspace(0.2, 1.4, 500), ndepl_cv=8, default_curve=np.linspace(1, 0, 11))
+    p = tmp_path / "lib.csv"
+    write_library_csv(lib, p)
+    assert pd.read_csv(p).shape[0] == 9
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run -e dev pytest tests/test_snarea_library.py::test_assemble_params_columns_and_assigned_curve -v`
+Expected: FAIL — import error.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# add to src/gfv2_params/snarea/library.py  (add `from pathlib import Path` at top)
+_PARAM_DIAG_COLS = ["sdc_status", "sca_class", "similarity", "n_seasons", "n_peak_years", "peak_swe_mm"]
+
+
+def assemble_params(derived, id_feature, cv_assign, cv_source, deplcrv, library):
+    """One row per HRU: index + snarea_thresh + CVs + diagnostics + the ASSIGNED
+    library curve (descending, for QA / per-HRU detail — no separate 1:1 mode)."""
+    curve_by_id = {int(r.deplcrv_id): r[CURVE_COLS].to_numpy(float) for _, r in library.iterrows()}
+    assigned = np.vstack([curve_by_id[int(d)] for d in deplcrv])
+    out = pd.DataFrame({
+        id_feature: derived[id_feature].to_numpy(),
+        "hru_deplcrv": np.asarray(deplcrv, dtype=np.int32),
+        "snarea_thresh": [snarea_thresh_inches(v) for v in derived["peak_swe_mm"].to_numpy()],
+        "cv_assign": np.asarray(cv_assign, dtype=float),
+        "cv_subgrid": derived["cv_subgrid"].to_numpy(float),
+        "cv_empirical": derived["cv_empirical"].to_numpy(float),
+        "cv_source": np.asarray(cv_source, dtype=object),
+    })
+    for c in _PARAM_DIAG_COLS:
+        out[c] = derived[c].to_numpy()
+    for i, c in enumerate(CURVE_COLS):
+        out[c] = assigned[:, i]
+    return out
+
+
+def write_library_csv(library: pd.DataFrame, path) -> None:
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    library.to_csv(path, index=False)
+
+
+def write_params_csv(params: pd.DataFrame, path) -> None:
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    params.to_csv(path, index=False)
+
+
+def write_validation_csv(report: dict, path) -> None:
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame([report]).to_csv(path, index=False)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pixi run -e dev pytest tests/test_snarea_library.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/gfv2_params/snarea/library.py tests/test_snarea_library.py
+git commit -m "feat(snarea): CSV serializers for library/params/validation
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: pyWatershed NetCDF param writer (verify order first)
+
+**Files:**
+- Modify: `pyproject.toml` (add `reference` pixi feature with `pywatershed`), `src/gfv2_params/snarea/library.py`
+- Test: `tests/test_snarea_library.py`
+
+**Interfaces:**
+- Consumes: `_to_prms_order`, `build_library`.
+- Produces: `write_prms_netcdf(library, params, id_feature, path)` — writes `snarea_curve(ndeplval)` flat **ascending**, `hru_deplcrv(nhru)` int32, `snarea_thresh(nhru)` float, `<id_feature>(nhru)` coord, CF attrs.
+
+- [ ] **Step 1: Add `pywatershed` reference feature + verify the convention**
+
+Edit `pyproject.toml` — add after the `[tool.pixi.feature.docs...]` blocks:
+
+```toml
+[tool.pixi.feature.reference.dependencies]
+pywatershed = "*"
+```
+
+And add `reference` to `[tool.pixi.environments]`:
+
+```toml
+reference = { features = ["reference"], solve-group = "default" }
+```
+
+Then:
+
+```bash
+pixi install -e reference
+pixi run -e reference python -c "
+import inspect, pywatershed as pws
+from pywatershed.hydrology.prms_snow import PRMSSnow
+src = inspect.getsource(PRMSSnow)
+i = src.find('snarea_curve')
+print(src[i-200:i+400])
+"
+```
+Expected: confirms `snarea_curve` is reshaped `(ndepl, 11)` and indexed by **ascending** `frac_swe` (frac 0.0 at index 0). If the source shows a different order/shape, adjust `_to_prms_order` and the writer below to match — **the model reads curves backwards if this is wrong.** Record the confirmed convention in a comment.
+
+- [ ] **Step 2: Write the failing test**
+
+```python
+# add to tests/test_snarea_library.py
+import xarray as xr
+from gfv2_params.snarea.library import write_prms_netcdf
+
+
+def test_write_prms_netcdf_structure_and_ascending_order(tmp_path):
+    lib = build_library(np.linspace(0.2, 1.4, 500), ndepl_cv=8, default_curve=np.linspace(1, 0, 11))
+    params = pd.DataFrame({
+        "nat_hru_id": [10, 11, 12],
+        "hru_deplcrv": np.array([2, 5, 1], dtype=np.int32),
+        "snarea_thresh": [10.0, 20.0, 0.0],
+    })
+    p = tmp_path / "snarea.nc"
+    write_prms_netcdf(lib, params, "nat_hru_id", p)
+    ds = xr.open_dataset(p)
+    ndepl = len(lib)
+    assert ds.sizes["ndeplval"] == 11 * ndepl
+    assert ds.sizes["nhru"] == 3
+    assert ds["hru_deplcrv"].dtype == np.int32
+    # first curve (default, deplcrv_id 1) ascending: index 0 == descending's last (0.0)
+    flat = ds["snarea_curve"].values
+    first_curve_ascending = flat[:11]
+    desc = lib[lib.deplcrv_id == 1][CURVE_COLS].to_numpy(float).ravel()
+    np.testing.assert_allclose(first_curve_ascending, desc[::-1])
+    assert first_curve_ascending[0] <= first_curve_ascending[-1]   # ascending SCA
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `pixi run -e dev pytest tests/test_snarea_library.py::test_write_prms_netcdf_structure_and_ascending_order -v`
+Expected: FAIL — import error.
+
+- [ ] **Step 4: Write minimal implementation**
+
+```python
+# add to src/gfv2_params/snarea/library.py
+def write_prms_netcdf(library, params, id_feature, path) -> None:
+    """PRMS/pyWatershed param file: snarea_curve flat ASCENDING (ndeplval=11*ndepl),
+    hru_deplcrv, snarea_thresh, all on nhru. Verified against prms_snow (Task 8 step 1)."""
+    import numpy as np
+    import xarray as xr
+
+    lib_sorted = library.sort_values("deplcrv_id")
+    ndepl = len(lib_sorted)
+    flat = np.concatenate([_to_prms_order(r[CURVE_COLS].to_numpy(float))
+                           for _, r in lib_sorted.iterrows()])
+    ds = xr.Dataset(
+        data_vars={
+            "snarea_curve": ("ndeplval", flat.astype("float64"),
+                             {"long_name": "snow area depletion curve values", "units": "fraction"}),
+            "hru_deplcrv": ("nhru", params["hru_deplcrv"].to_numpy(np.int32),
+                            {"long_name": "index of snarea_curve for each HRU"}),
+            "snarea_thresh": ("nhru", params["snarea_thresh"].to_numpy("float64"),
+                              {"long_name": "SWE above which HRU is 100% snow covered", "units": "inches"}),
+        },
+        coords={id_feature: ("nhru", params[id_feature].to_numpy())},
+        attrs={"ndepl": ndepl, "Description": "SNODAS-derived CV/lognormal snarea_curve library"},
+    )
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    ds.to_netcdf(path)
+```
+
+- [ ] **Step 5: Run test + cf-netcdf-review**
+
+Run: `pixi run -e dev pytest tests/test_snarea_library.py -v`
+Expected: PASS.
+Then invoke the `cf-netcdf-review` skill on `write_prms_netcdf` and apply any CF-compliance fixes it recommends (units/standard_name/grid-mapping). Re-run the test after fixes.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pyproject.toml pixi.lock src/gfv2_params/snarea/library.py tests/test_snarea_library.py
+git commit -m "feat(snarea): pyWatershed NetCDF param writer (ascending, verified)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Phase B — Stage 1/2 sub-grid CV infrastructure
+
+### Task 9: `SourceAdapter.std_variables`
+
+**Files:**
+- Modify: `src/gfv2_params/aggregate/adapter.py`
+- Test: `tests/test_aggregate_adapter.py`
+
+**Interfaces:**
+- Produces: `SourceAdapter.std_variables: tuple[str, ...] = ()`, normalized to a tuple, each name must be in `variables`, `masked_std` implied.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# add to tests/test_aggregate_adapter.py
+import pytest
+from gfv2_params.aggregate import SourceAdapter
+
+
+def test_std_variables_defaults_empty_and_validates():
+    a = SourceAdapter(source_key="s", variables=("swe", "scov"), files_glob="*.nc")
+    assert a.std_variables == ()
+    a2 = SourceAdapter(source_key="s", variables=("swe",), files_glob="*.nc", std_variables=("swe",))
+    assert a2.std_variables == ("swe",)
+    with pytest.raises(ValueError, match="std_variables"):
+        SourceAdapter(source_key="s", variables=("swe",), files_glob="*.nc", std_variables=("missing",))
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run -e dev pytest tests/test_aggregate_adapter.py::test_std_variables_defaults_empty_and_validates -v`
+Expected: FAIL — unexpected keyword `std_variables`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/gfv2_params/aggregate/adapter.py`, add the field after `grid_variable`:
+
+```python
+    std_variables: tuple[str, ...] = field(default=())
+```
+
+And in `__post_init__` (after the existing `grid_variable` checks):
+
+```python
+        object.__setattr__(self, "std_variables", tuple(self.std_variables))
+        missing = [v for v in self.std_variables if v not in self.variables]
+        if missing:
+            raise ValueError(
+                f"std_variables {missing} must all be in variables {self.variables}"
+            )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pixi run -e dev pytest tests/test_aggregate_adapter.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/gfv2_params/aggregate/adapter.py tests/test_aggregate_adapter.py
+git commit -m "feat(aggregate): SourceAdapter.std_variables field + validation
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 10: `masked_std` sidecar pass in the driver
+
+**Files:**
+- Modify: `src/gfv2_params/aggregate/driver.py`
+- Test: `tests/test_aggregate_driver.py`
+
+**Interfaces:**
+- Consumes: `adapter.std_variables`, cached `weights`.
+- Produces: `aggregate_variables` also emits `{var}_std` for each `var` in `adapter.std_variables`, via a second `AggGen(stat_method="masked_std", weights=<same>)`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# add to tests/test_aggregate_driver.py — reuse _synthetic_grid/_two_polys
+def test_std_sidecar_emits_var_std(tmp_path):
+    _synthetic_grid(tmp_path)
+    gdf = _two_polys()
+    adapter = SourceAdapter(
+        source_key="demo", variables=("swe",), files_glob="demo_daily_*.nc",
+        source_crs="EPSG:5070", x_coord="x", y_coord="y", time_coord="time",
+        stat_method="mean", std_variables=("swe",),
+    )
+    out = aggregate_source(adapter, gdf, "hru_id", input_dir=tmp_path,
+                           output_dir=tmp_path / "out", weight_file=tmp_path / "w.csv",
+                           output_prefix="demo")
+    res = xr.open_dataset(out[0])
+    assert "swe" in res and "swe_std" in res
+    # day 0 left poly: cells all 1.0 -> std 0; (see _synthetic_grid values)
+    assert float(res["swe_std"].sel(hru_id=1).values[0]) == pytest.approx(0.0, abs=1e-6)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run -e dev pytest tests/test_aggregate_driver.py::test_std_sidecar_emits_var_std -v`
+Expected: FAIL — `swe_std` not in result.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/gfv2_params/aggregate/driver.py`, at the end of `aggregate_variables`, before `return ds`, add:
+
+```python
+    if adapter.std_variables:
+        std_user = UserCatData(
+            source_ds=source_ds, source_crs=adapter.source_crs,
+            source_x_coord=adapter.x_coord, source_y_coord=adapter.y_coord,
+            source_t_coord=adapter.time_coord,
+            source_var=list(adapter.std_variables),
+            target_gdf=fabric_gdf, target_crs=WEIGHT_GEN_CRS, target_id=id_col,
+            source_time_period=[period[0], period[1]],
+        )
+        std_agg = AggGen(user_data=std_user, stat_method="masked_std",
+                         agg_engine="serial", agg_writer="none", weights=weights)
+        _g, std_ds = std_agg.calculate_agg()
+        for v in adapter.std_variables:
+            if v not in std_ds.data_vars:
+                raise RuntimeError(f"masked_std pass produced no {v!r} (got {list(std_ds.data_vars)})")
+            ds[f"{v}_std"] = std_ds[v]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pixi run -e dev pytest tests/test_aggregate_driver.py -v`
+Expected: PASS (existing tests unaffected — `std_variables` defaults empty).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/gfv2_params/aggregate/driver.py tests/test_aggregate_driver.py
+git commit -m "feat(aggregate): masked_std sidecar pass emitting {var}_std
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 11: SNODAS adapter `std_variables=("swe",)`
+
+**Files:**
+- Modify: `src/gfv2_params/aggregate/snodas.py`, `configs/aggregate/aggregate_sources.yml`
+- Test: `tests/test_aggregate_snodas.py`
+
+**Interfaces:**
+- Produces: `SNODAS_ADAPTER.std_variables == ("swe",)`; Stage-1 SNODAS output carries `swe_std`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# add to tests/test_aggregate_snodas.py
+def test_snodas_adapter_declares_swe_std():
+    assert SNODAS_ADAPTER.std_variables == ("swe",)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run -e dev pytest tests/test_aggregate_snodas.py::test_snodas_adapter_declares_swe_std -v`
+Expected: FAIL — `std_variables == ()`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/gfv2_params/aggregate/snodas.py`, add `std_variables=("swe",)` to the `SNODAS_ADAPTER` constructor. In `configs/aggregate/aggregate_sources.yml`, add a comment under the `snodas` source noting `swe_std` is emitted (no config key needed — it's adapter-driven).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pixi run -e dev pytest tests/test_aggregate_snodas.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/gfv2_params/aggregate/snodas.py configs/aggregate/aggregate_sources.yml tests/test_aggregate_snodas.py
+git commit -m "feat(aggregate): SNODAS adapter emits swe_std sidecar
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 12: `subgrid.py` — `representative_peak_stats`
+
+**Files:**
+- Create: `src/gfv2_params/snarea/subgrid.py`
+- Test: `tests/test_snarea_subgrid.py`
+
+**Interfaces:**
+- Produces: `representative_peak_stats(daily: pd.DataFrame) -> dict` with keys `cv_subgrid`, `peak_swe_mm`, `n_peak_years`. `daily` has a DatetimeIndex and columns `swe` (mean), `swe_std`. Groups by water year (Oct 1–Sep 30, reusing `build.py`'s framing), finds each year's peak-mean-SWE day, records `cv_year = swe_std[peak]/swe[peak]` and `peak_swe = swe[peak]`; skips years with `swe[peak] <= 0` or non-finite. Returns medians + count (NaN/0 if none).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_snarea_subgrid.py
+import numpy as np
+import pandas as pd
+
+from gfv2_params.snarea.subgrid import representative_peak_stats
+
+
+def _daily(dates, swe, std):
+    return pd.DataFrame({"swe": swe, "swe_std": std}, index=pd.to_datetime(dates))
+
+
+def test_peak_stats_single_water_year():
+    # one melt season peaking Apr 1 2011: peak swe 200, std 100 -> cv 0.5
+    dates = pd.date_range("2010-10-01", "2011-09-30")
+    swe = np.concatenate([np.linspace(0, 200, 183), np.linspace(200, 0, len(dates) - 183)])
+    std = swe * 0.5
+    out = representative_peak_stats(_daily(dates, swe, std))
+    assert out["n_peak_years"] == 1
+    assert out["cv_subgrid"] == pytest.approx(0.5, abs=1e-6)
+    assert out["peak_swe_mm"] == pytest.approx(200.0, abs=1e-6)
+
+
+def test_peak_stats_no_snow_returns_nan():
+    dates = pd.date_range("2010-10-01", "2011-09-30")
+    out = representative_peak_stats(_daily(dates, np.zeros(len(dates)), np.zeros(len(dates))))
+    assert out["n_peak_years"] == 0
+    assert np.isnan(out["cv_subgrid"])
+
+
+def test_peak_stats_median_across_years():
+    d1 = pd.date_range("2010-10-01", "2011-09-30")
+    d2 = pd.date_range("2011-10-01", "2012-09-30")
+    def season(dates, peak, cvf):
+        h = len(dates) // 2
+        swe = np.concatenate([np.linspace(0, peak, h), np.linspace(peak, 0, len(dates) - h)])
+        return swe, swe * cvf
+    s1, t1 = season(d1, 100, 0.4)
+    s2, t2 = season(d2, 300, 0.8)
+    df = pd.concat([_daily(d1, s1, t1), _daily(d2, s2, t2)])
+    out = representative_peak_stats(df)
+    assert out["n_peak_years"] == 2
+    assert out["cv_subgrid"] == pytest.approx(0.6, abs=1e-6)   # median(0.4, 0.8)
+    assert out["peak_swe_mm"] == pytest.approx(200.0, abs=1e-6)  # median(100, 300)
+```
+(Add `import pytest` at top.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run -e dev pytest tests/test_snarea_subgrid.py -v`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# src/gfv2_params/snarea/subgrid.py
+"""Representative sub-grid SWE CV + peak SWE per HRU, for the CV/lognormal library.
+
+CV = area-weighted std/mean of the SNODAS SWE pdf within an HRU, taken at each
+water-year's peak-mean-SWE day (CV is most stable where mean SWE is largest), then
+median across years. Water-year framing matches snarea/build.py:_seasons so a
+late-December accumulation is not mis-picked as the peak.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+def representative_peak_stats(daily: pd.DataFrame) -> dict:
+    if len(daily) == 0:
+        return {"cv_subgrid": float("nan"), "peak_swe_mm": float("nan"), "n_peak_years": 0}
+    water_year = daily.index.year + (daily.index.month >= 10).astype(int)
+    cvs, peaks = [], []
+    for _wy, grp in daily.groupby(water_year):
+        swe = grp["swe"].to_numpy(float)
+        std = grp["swe_std"].to_numpy(float)
+        if not np.isfinite(swe).any() or np.nanmax(swe) <= 0:
+            continue
+        i = int(np.nanargmax(swe))
+        peak, s = swe[i], std[i]
+        if not (np.isfinite(peak) and peak > 0 and np.isfinite(s)):
+            continue
+        cvs.append(s / peak)
+        peaks.append(peak)
+    if not cvs:
+        return {"cv_subgrid": float("nan"), "peak_swe_mm": float("nan"), "n_peak_years": 0}
+    return {"cv_subgrid": float(np.median(cvs)), "peak_swe_mm": float(np.median(peaks)),
+            "n_peak_years": len(cvs)}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pixi run -e dev pytest tests/test_snarea_subgrid.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/gfv2_params/snarea/subgrid.py tests/test_snarea_subgrid.py
+git commit -m "feat(snarea): representative_peak_stats — sub-grid CV + peak SWE
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 13: Wire sub-grid stats into Stage 2 + repoint output
+
+**Files:**
+- Modify: `scripts/derive_snarea_curve.py`, `src/gfv2_params/snarea/build.py`, `configs/snarea/snarea_curve.yml`
+- Test: `tests/test_derive_snarea_curve.py`, `tests/test_snarea_build.py`
+
+**Interfaces:**
+- Consumes: `representative_peak_stats`.
+- Produces: `read_daily_by_hru` frames include `swe_std`; `build_hru_record`/`build_snarea_curve` add `cv_subgrid`, `peak_swe_mm`, `n_peak_years`; Stage 2 writes `_intermediates/nhm_snarea_curve_derived.csv`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# add to tests/test_derive_snarea_curve.py
+def test_read_daily_by_hru_includes_swe_std(tmp_path):
+    import numpy as np, pandas as pd, xarray as xr
+    from gfv2_params.snarea import ...  # existing imports
+    t = pd.date_range("2011-01-01", periods=3)
+    ds = xr.Dataset(
+        {"swe": (("time", "nat_hru_id"), np.array([[1.0], [2.0], [0.0]])),
+         "scov": (("time", "nat_hru_id"), np.array([[1.0], [1.0], [0.0]])),
+         "swe_std": (("time", "nat_hru_id"), np.array([[0.5], [1.0], [0.0]]))},
+        coords={"time": t, "nat_hru_id": [7]},
+    )
+    ds.to_netcdf(tmp_path / "snodas_agg_2011.nc")
+    from scripts.derive_snarea_curve import read_daily_by_hru  # or module import per repo
+    daily = read_daily_by_hru(tmp_path, "nat_hru_id")
+    assert "swe_std" in daily[7].columns
+```
+
+```python
+# add to tests/test_snarea_build.py — build_hru_record carries the new columns
+def test_build_hru_record_has_subgrid_columns():
+    import numpy as np, pandas as pd
+    from gfv2_params.snarea.build import build_hru_record
+    from gfv2_params.snarea.selection import SelectionParams
+    dates = pd.date_range("2010-10-01", "2011-09-30")
+    h = len(dates) // 2
+    swe = np.concatenate([np.linspace(0, 200, h), np.linspace(200, 0, len(dates) - h)])
+    daily = pd.DataFrame({"swe": swe, "sca": (swe > 0).astype(float), "swe_std": swe * 0.5},
+                         index=dates)
+    rec = build_hru_record(7, daily, n_cells=50, water_frac=0.0,
+                           params=SelectionParams(), default_curve=np.linspace(1, 0, 11))
+    for c in ("cv_subgrid", "peak_swe_mm", "n_peak_years"):
+        assert c in rec
+    assert rec["cv_subgrid"] == pytest.approx(0.5, abs=1e-6)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pixi run -e dev pytest tests/test_snarea_build.py::test_build_hru_record_has_subgrid_columns tests/test_derive_snarea_curve.py -v`
+Expected: FAIL — no `swe_std`/`cv_subgrid`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+- In `scripts/derive_snarea_curve.py::read_daily_by_hru`, change the `to_dataframe()` selection and the per-HRU frame to include `swe_std`:
+  ```python
+  df = ds[["swe", "scov", "swe_std"]].to_dataframe().reset_index()
+  df = df.rename(columns={"scov": "sca"})
+  ...
+  s = grp.set_index("time")[["swe", "sca", "swe_std"]].sort_index()
+  ```
+  (Keep the load-phase logging; `swe_std` rides the same frame.)
+- In `src/gfv2_params/snarea/build.py::build_hru_record`, after computing the empirical record, add:
+  ```python
+  from .subgrid import representative_peak_stats
+  ...
+  stats = representative_peak_stats(daily) if "swe_std" in daily.columns else {
+      "cv_subgrid": float("nan"), "peak_swe_mm": float("nan"), "n_peak_years": 0}
+  record.update(stats)
+  ```
+- In `configs/snarea/snarea_curve.yml`, change:
+  ```yaml
+  output_dir: "{data_root}/{fabric}/params/merged/_intermediates"
+  merged_file: nhm_snarea_curve_derived.csv
+  ```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pixi run -e dev pytest tests/test_snarea_build.py tests/test_derive_snarea_curve.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/derive_snarea_curve.py src/gfv2_params/snarea/build.py configs/snarea/snarea_curve.yml tests/test_snarea_build.py tests/test_derive_snarea_curve.py
+git commit -m "feat(snarea): Stage 2 emits sub-grid CV/peak SWE to _intermediates
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Phase C — Stage 3 driver, ops, docs
+
+### Task 14: Stage 3 driver + config
+
+**Files:**
+- Create: `scripts/derive_snarea_library.py`, `configs/snarea/snarea_library.yml`
+- Test: `tests/test_snarea_library.py` (add an end-to-end driver test on a tiny synthetic derived CSV)
+
+**Interfaces:**
+- Consumes: all `library.py` functions; the Stage-2 derived CSV.
+- Produces: `build_from_derived(derived: pd.DataFrame, id_feature: str, ndepl_cv: int, default_curve: np.ndarray, calibrate: str, bias_tol: float) -> tuple[library_df, params_df, report]` (the orchestration function, so it's unit-testable without file IO); `main()` CLI.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# add to tests/test_snarea_library.py
+from gfv2_params.snarea.library import build_from_derived
+
+
+def test_build_from_derived_end_to_end():
+    rng = np.random.default_rng(0)
+    n = 300
+    cv = np.clip(rng.normal(0.5, 0.2, n), 0.1, 1.5)
+    derived = pd.DataFrame({
+        "nat_hru_id": np.arange(1, n + 1),
+        "sdc_status": ["derived"] * n,
+        "sca_class": ["high"] * n,
+        "similarity": 0.05, "n_seasons": 10,
+        "cv_subgrid": cv,
+        "cv_empirical": cv,   # unbiased -> no calibration
+        "peak_swe_mm": 254.0, "n_peak_years": 10,
+        **{c: np.tile(sdc_from_cv(0.5)[i], n) for i, c in enumerate(CURVE_COLS)},
+    })
+    lib, params, report = build_from_derived(derived, "nat_hru_id", ndepl_cv=8,
+                                             default_curve=np.linspace(1, 0, 11),
+                                             calibrate="auto", bias_tol=0.1)
+    assert len(lib) == 9
+    assert len(params) == n
+    assert set(params["hru_deplcrv"].unique()) <= set(range(2, 10))   # all estimable -> cv bins
+    assert report["calibrated"] is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run -e dev pytest tests/test_snarea_library.py::test_build_from_derived_end_to_end -v`
+Expected: FAIL — `build_from_derived` not found.
+
+- [ ] **Step 3: Write the orchestrator + driver**
+
+Add `build_from_derived` to `library.py`:
+
+```python
+def build_from_derived(derived, id_feature, ndepl_cv, default_curve, calibrate="auto", bias_tol=0.1):
+    """Estimable = finite cv_subgrid (>=2 snow cells). Calibrate vs cv_empirical on
+    the derived overlap, bin, assign, assemble."""
+    derived = derived.reset_index(drop=True)
+    n = len(derived)
+    cv_sub = derived["cv_subgrid"].to_numpy(float)
+    # cv_empirical only for derived HRUs whose empirical curve is present
+    cv_emp = derived.get("cv_empirical", pd.Series(np.full(n, np.nan))).to_numpy(float)
+    emp_curves = (derived[CURVE_COLS].to_numpy(float)
+                  if all(c in derived.columns for c in CURVE_COLS)
+                  else np.full((n, 11), np.nan))
+    cal, report = validate_and_calibrate(cv_sub, cv_emp, emp_curves, mode=calibrate, bias_tol=bias_tol)
+
+    # cv_assign: calibrated subgrid if finite; else cv_empirical if finite; else default
+    cv_assign = np.where(np.isfinite(cal), cal, cv_emp)
+    cv_source = np.where(np.isfinite(cal),
+                         "subgrid_calibrated" if report["calibrated"] else "subgrid",
+                         np.where(np.isfinite(cv_emp), "empirical", "default_no_snow"))
+    library = build_library(cv_assign[np.isfinite(cv_assign)], ndepl_cv, default_curve)
+    deplcrv = assign_deplcrv(cv_assign, library)
+    params = assemble_params(derived, id_feature, cv_assign, cv_source, deplcrv, library)
+    report["n_hru"] = n
+    report["n_estimable"] = int(np.isfinite(cv_assign).sum())
+    return library, params, report
+```
+
+Create `scripts/derive_snarea_library.py`:
+
+```python
+"""Stage 3 driver: build the CV/lognormal snarea_curve library from the Stage 2
+derived CSV. Pure tabular — cheap, re-runnable at any ndepl_cv without reloading
+the daily SWE. Fabric-agnostic (paths from the profile via require_config_key)."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from gfv2_params.config import load_config, require_config_key
+from gfv2_params.log import configure_logging
+from gfv2_params.snarea.build import DEFAULT_SNAREA_CURVE
+from gfv2_params.snarea.library import (
+    build_from_derived, write_library_csv, write_params_csv, write_validation_csv,
+    write_prms_netcdf,
+)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--fabric", required=True)
+    ap.add_argument("--config", default="configs/snarea/snarea_library.yml")
+    ap.add_argument("--base_config", default="configs/base_config.yml")
+    args = ap.parse_args()
+    logger = configure_logging("derive_snarea_library")
+
+    cfg = load_config(Path(args.config), base_config_path=Path(args.base_config), fabric=args.fabric)
+    id_feature = require_config_key(cfg, "id_feature", "derive_snarea_library")
+    derived_csv = Path(cfg["derived_csv"])
+    out_dir = Path(cfg["output_dir"])
+    ndepl_cv = int(cfg.get("ndepl_cv", 8))
+    calibrate = cfg.get("calibrate", "auto")
+    bias_tol = float(cfg.get("calibrate_bias_tol", 0.1))
+    default_curve = np.asarray(cfg.get("default_curve", DEFAULT_SNAREA_CURVE), dtype=float)
+
+    logger.info("Reading Stage 2 derived table: %s", derived_csv)
+    derived = pd.read_csv(derived_csv)
+    logger.info("Building CV/lognormal library (ndepl_cv=%d, calibrate=%s) for %d HRUs ...",
+                ndepl_cv, calibrate, len(derived))
+    library, params, report = build_from_derived(
+        derived, id_feature, ndepl_cv, default_curve, calibrate, bias_tol)
+
+    write_library_csv(library, out_dir / cfg["library_file"])
+    write_params_csv(params, out_dir / cfg["params_file"])
+    write_validation_csv(report, out_dir / cfg["validation_file"])
+    write_prms_netcdf(library, params, id_feature, out_dir / cfg["netcdf_file"])
+    logger.info("ndepl=%d | estimable %d/%d | calibrated=%s | recon mean %.3f",
+                len(library), report["n_estimable"], report["n_hru"],
+                report["calibrated"], report.get("recon_mean_after", float("nan")))
+
+
+if __name__ == "__main__":
+    main()
+```
+
+Create `configs/snarea/snarea_library.yml`:
+
+```yaml
+# Stage 3: CV/lognormal snarea_curve library from the Stage 2 derived CSV.
+# Top-level placeholders resolve {data_root}/{fabric}; nested blocks pass through.
+derived_csv: "{data_root}/{fabric}/params/merged/_intermediates/nhm_snarea_curve_derived.csv"
+output_dir: "{data_root}/{fabric}/params/merged"
+library_file: nhm_snarea_curve_library.csv
+params_file: nhm_snarea_curve_params.csv
+validation_file: nhm_snarea_curve_validation.csv
+netcdf_file: nhm_snarea_curve.nc
+
+ndepl_cv: 8              # 8 CV bins + 1 reserved default = ndepl 9 (grouping memory: elbow 5-8)
+calibrate: auto          # auto | on | off
+calibrate_bias_tol: 0.1  # |median(cv_subgrid) - median(cv_empirical)| trigger
+default_curve: [1.0, 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1, 0.0]
+```
+
+- [ ] **Step 4: Run tests + a real smoke test**
+
+Run: `pixi run -e dev pytest tests/test_snarea_library.py -v` → PASS.
+Then smoke-test on the existing Oregon derived table (the current file lacks `cv_subgrid`; it will exercise the `empirical`/`default` fallback path — expected until Stage 1/2 re-run):
+```bash
+pixi run -e dev python -c "
+import pandas as pd, numpy as np
+from gfv2_params.snarea.library import build_from_derived, CURVE_COLS
+d = pd.read_csv('/caldera/hovenweep/projects/usgs/water/impd/nhgf/gfv2_param_v2/oregon/params/merged/nhm_snarea_curve_params.csv')
+d = d.rename(columns={'hru_id':'nat_hru_id'}) if 'hru_id' in d.columns else d
+d['cv_subgrid'] = np.nan  # no subgrid yet
+from gfv2_params.snarea.library import fit_cv
+d['cv_empirical'] = [fit_cv(r[CURVE_COLS].to_numpy(float)) if s=='derived' else np.nan
+                     for s,(_,r) in zip(d['sdc_status'], d.iterrows())]
+d['peak_swe_mm']=np.nan; d['n_peak_years']=0
+lib,params,rep = build_from_derived(d,'nat_hru_id',8,np.linspace(1,0,11),'auto',0.1)
+print('ndepl',len(lib),'params',len(params),'estimable',rep['n_estimable'])
+"
+```
+Expected: runs; estimable count reflects derived HRUs via the empirical fallback (sanity only).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/derive_snarea_library.py configs/snarea/snarea_library.yml src/gfv2_params/snarea/library.py tests/test_snarea_library.py
+git commit -m "feat(snarea): Stage 3 library driver + config (build_from_derived)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 15: SLURM batch + `__init__` exports
+
+**Files:**
+- Create: `slurm_batch/derive_snarea_library.batch`
+- Modify: `src/gfv2_params/snarea/__init__.py`
+- Test: `py_compile` + import check
+
+**Interfaces:**
+- Produces: `slurm_batch/derive_snarea_library.batch`; `gfv2_params.snarea` re-exports the library entry points.
+
+- [ ] **Step 1: Create the batch**
+
+```bash
+# slurm_batch/derive_snarea_library.batch
+#!/bin/bash
+#SBATCH -p cpu
+#SBATCH -A impd
+#SBATCH --job-name=snarea_library
+#SBATCH --output=logs/job_%j.out
+#SBATCH --error=logs/job_%j.err
+#SBATCH --time=00:30:00
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=2
+#SBATCH --mem=16G
+#
+# Stage 3: build the CV/lognormal snarea_curve library from the Stage 2 derived
+# CSV. Pure tabular — cheap. Re-runnable at any ndepl_cv without a daily reload.
+#   FABRIC=gfv2 sbatch slurm_batch/derive_snarea_library.batch
+cd "$SLURM_SUBMIT_DIR"
+BASE_CONFIG=${BASE_CONFIG:-configs/base_config.yml}
+FABRIC=${FABRIC:-oregon}
+pixi run --as-is python scripts/derive_snarea_library.py \
+    --fabric "$FABRIC" --config configs/snarea/snarea_library.yml --base_config "$BASE_CONFIG"
+```
+
+- [ ] **Step 2: Add exports**
+
+In `src/gfv2_params/snarea/__init__.py`, extend `__all__` and imports:
+
+```python
+from .library import build_from_derived, build_library, sdc_from_cv
+__all__ = ["build_snarea_curve", "DEFAULT_SNAREA_CURVE",
+           "build_from_derived", "build_library", "sdc_from_cv"]
+```
+
+- [ ] **Step 3: Verify**
+
+Run:
+```bash
+python -m py_compile scripts/derive_snarea_library.py slurm_batch/../src/gfv2_params/snarea/library.py
+pixi run -e dev python -c "from gfv2_params.snarea import build_from_derived, sdc_from_cv; print('ok')"
+```
+Expected: `ok`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add slurm_batch/derive_snarea_library.batch src/gfv2_params/snarea/__init__.py
+git commit -m "feat(snarea): Stage 3 SLURM batch + package exports
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 16: Docs + memory + PR
+
+**Files:**
+- Modify: `slurm_batch/RUNME.md`, `slurm_batch/HPC_REFERENCE.md`, `README.md`, `docs/ARCHITECTURE.md`, `docs/superpowers/specs/2026-07-06-...-library-design.md` (citation fix)
+- Memory: `sdc_grouping_decision`, `snodas_snarea_curve_pipeline`
+
+- [ ] **Step 1: Docs edits**
+  - `RUNME.md` Step 8: after Stage 2, add Stage 3 (`derive_snarea_library.batch`), and note Stage 1 must be re-run once to add `swe_std` (weights cached).
+  - `HPC_REFERENCE.md` Stage 10: document Stage 3 (inputs = derived CSV; outputs = library/params/validation CSVs + `.nc`; cheap, 16G/30min); note `swe_std` sidecar in Stage 1 and the sub-grid CV in Stage 2.
+  - `README.md` snarea section: outputs are now a curve library + per-HRU params + a pyWatershed `.nc`.
+  - `docs/ARCHITECTURE.md`: if it enumerates Part 2c stages, add Stage 3.
+  - Fix the spec's method-source citation to *Sexstone, Driscoll, Hay, Hammond & Barnhart (2020), "Runoff sensitivity to snow depletion curve representation within a continental scale hydrologic model," Hydrological Processes 34:2365–2380.*
+
+- [ ] **Step 2: Update memory**
+  - `sdc_grouping_decision.md`: mark IMPLEMENTED (Stage 3 library, sub-grid-CV primary, calibration gate); link the plan.
+  - `snodas_snarea_curve_pipeline.md`: add Stage 3 + the `swe_std`/sub-grid additions.
+
+- [ ] **Step 3: Full pre-commit + single-file test sanity**
+
+```bash
+pixi run -e dev pre-commit run --all-files
+pixi run -e dev pytest tests/test_snarea_library.py tests/test_snarea_subgrid.py tests/test_aggregate_snodas.py -v
+```
+Expected: hooks pass; targeted tests pass. (CI runs the full suite on push.)
+
+- [ ] **Step 4: Commit docs**
+
+```bash
+git add slurm_batch/RUNME.md slurm_batch/HPC_REFERENCE.md README.md docs/ARCHITECTURE.md docs/superpowers/specs/2026-07-06-snodas-snarea-curve-library-design.md
+git commit -m "docs(snarea): Stage 3 library runbook + architecture + citation fix
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+- [ ] **Step 5: Push + open PR (curl+REST; gh blocked)**
+
+Push the branch, then POST to the pulls API with `--data-binary` (see [[gh_cli_blocked_use_curl_rest]]). PR body: summarize the 3 stages, the sub-grid-CV-primary + calibration-gate design, the validation results (fill in after the Oregon/CONUS runs), and link the spec + plan.
+
+---
+
+## HPC rollout (after the PR is green) — not code tasks
+
+1. **Oregon** (`FABRIC=oregon`): re-run Stage 1 (`derive_snodas_aggregate.batch`, adds `swe_std`; weights cached → cheap) → merge → Stage 2 (`derive_snarea_curve.batch`, adds sub-grid stats) → Stage 3 (`derive_snarea_library.batch`). Inspect `nhm_snarea_curve_validation.csv`: `cv_subgrid` vs `cv_empirical`, reconstruction (~0.03 target), whether calibration fired, coverage vs the near-linear default, Cascades-high-CV / desert-low-CV sanity.
+2. **CONUS gfv2** (`FABRIC=gfv2`): same, Stage 2 at `--mem=384G`. Confirm `ndepl`=9 reconstructs the derived population to ~0.03 mean SCA and coverage improves markedly over the 58%-default baseline.
+
+---
+
+## Self-review
+
+- **Spec coverage:** §3 swe_std → Tasks 9–11; §4 sub-grid CV/peak → Tasks 12–13; §5.1 sdc_from_cv → Task 1; §5.2 fit_cv/library/assign/calibrate/thresh → Tasks 2–6; §6 serialization (4 artifacts + order flip) → Tasks 7–8; §7 module/config/test/deps → Tasks 8,14,15; §8 rollout → HPC section; §9 judgment calls encoded in config defaults (Task 14). Covered.
+- **Placeholder scan:** every code step carries complete code; no TBD/TODO.
+- **Type consistency:** `sdc_from_cv`/`fit_cv`/`build_library`/`assign_deplcrv`/`validate_and_calibrate`/`assemble_params`/`build_from_derived`/`representative_peak_stats` signatures are defined once and reused verbatim across tasks; `CURVE_COLS`/`SWE_LEVELS`/`CV_GRID` are module constants. Curve order (descending in-repo, ascending in NetCDF via `_to_prms_order`) is consistent.
+- **Open verification (flagged in Task 8):** the pyWatershed ascending-order convention is confirmed by inspecting `prms_snow` before implementing the writer — do not skip Task 8 Step 1.

--- a/docs/superpowers/specs/2026-07-06-snodas-snarea-curve-library-design.md
+++ b/docs/superpowers/specs/2026-07-06-snodas-snarea-curve-library-design.md
@@ -6,9 +6,10 @@
 [`2026-07-04-snodas-snarea-curve-design.md`](2026-07-04-snodas-snarea-curve-design.md)
 ("Curve clustering / a reduced curve library"). That pipeline is MERGED (PR #165)
 and its per-HRU derived tables are on disk; this spec builds on them.
-**Method source:** Sexstone, Markstrom, Hay & others (2020), *Continental-scale
-snow-melt sensitivity to snow-depletion-curve representation*, Hydrological
-Processes 34, DOI 10.1002/hyp.13735. Local copy: [`docs/hyp.13735.pdf`](../../hyp.13735.pdf).
+**Method source:** Sexstone, Driscoll, Hay, Hammond & Barnhart (2020), *Runoff
+sensitivity to snow depletion curve representation within a continental scale
+hydrologic model*, Hydrological Processes 34:2365–2380, DOI 10.1002/hyp.13735.
+Local copy: [`docs/hyp.13735.pdf`](../../hyp.13735.pdf).
 Empirical derivation method (Stage 2, unchanged): Driscoll, Hay & Bock (2017),
 [`docs/Snow_Depletion_Curves.md`](../../Snow_Depletion_Curves.md).
 
@@ -377,7 +378,9 @@ memory update (`sdc_grouping_decision`, `snodas_snarea_curve_pipeline`).
 
 ## 11. References
 
-- Sexstone et al. (2020), *Hydrological Processes* 34, DOI 10.1002/hyp.13735 —
+- Sexstone, Driscoll, Hay, Hammond & Barnhart (2020), "Runoff sensitivity to
+  snow depletion curve representation within a continental scale hydrologic
+  model," *Hydrological Processes* 34:2365–2380, DOI 10.1002/hyp.13735 —
   [`docs/hyp.13735.pdf`](../../hyp.13735.pdf). Lognormal SDC(CV) closed form
   (eqs 1–5); `snarea_thresh` ≡ SWE₁₀₀; runoff sensitivity to SDC representation.
 - Driscoll, Hay & Bock (2017) — [`docs/Snow_Depletion_Curves.md`](../../Snow_Depletion_Curves.md).

--- a/docs/superpowers/specs/2026-07-06-snodas-snarea-curve-library-design.md
+++ b/docs/superpowers/specs/2026-07-06-snodas-snarea-curve-library-design.md
@@ -1,0 +1,388 @@
+# Design: CV/lognormal snow-depletion-curve **library** for `snarea_curve`
+
+**Date:** 2026-07-06
+**Status:** Approved design (pre-implementation)
+**Supersedes/extends:** the deferred "grouping" work parked in §9 of
+[`2026-07-04-snodas-snarea-curve-design.md`](2026-07-04-snodas-snarea-curve-design.md)
+("Curve clustering / a reduced curve library"). That pipeline is MERGED (PR #165)
+and its per-HRU derived tables are on disk; this spec builds on them.
+**Method source:** Sexstone, Markstrom, Hay & others (2020), *Continental-scale
+snow-melt sensitivity to snow-depletion-curve representation*, Hydrological
+Processes 34, DOI 10.1002/hyp.13735. Local copy: [`docs/hyp.13735.pdf`](../../hyp.13735.pdf).
+Empirical derivation method (Stage 2, unchanged): Driscoll, Hay & Bock (2017),
+[`docs/Snow_Depletion_Curves.md`](../../Snow_Depletion_Curves.md).
+
+---
+
+## 1. Goal
+
+Replace the current one-curve-per-HRU `snarea_curve` output with a compact,
+**physically-based curve library**, and emit the two per-HRU parameters the model
+needs but the current pipeline omits:
+
+- **`snarea_curve`** — `ndepl` shared depletion curves (11 points each), where the
+  curve **shape** is parameterised by a single physical quantity: the sub-grid SWE
+  **coefficient of variation (CV)** via a lognormal SWE pdf (Sexstone eqs 3–5).
+- **`hru_deplcrv`** — per-HRU integer index (1..`ndepl`) into the library.
+- **`snarea_thresh`** — per-HRU SWE **scale** (inches) at which SCA reaches 1.0.
+- **`ndepl`** — number of library curves.
+
+The model **decouples groupable shape (`snarea_curve`) from per-HRU scale
+(`snarea_thresh`)**: PRMS indexes the curve by `frac_swe = pkwater_equiv /
+snarea_thresh` (Sexstone: `snarea_thresh` ≡ SWE₁₀₀, "the maximum SWE amount for a
+given HRU below which the SDC is applied"). This spec supplies both.
+
+Validate on **Oregon** (VPU 17), then **CONUS gfv2**.
+
+### 1.1 Locked decisions (see also the `sdc_grouping_decision` memory)
+
+| Decision | Choice |
+|---|---|
+| Curve family | 1-parameter **lognormal CV** basis (Sexstone/Liston), analytic closed form |
+| CV source (primary, all snow HRUs) | **Sub-grid-direct CV** = area-weighted `std/mean` of the SNODAS SWE pdf within the HRU, at peak accumulation |
+| Role of the empirical Driscoll curves | **Validation oracle** + calibration reference (no longer the parameter source) |
+| `ndepl` | **1 reserved default curve + `ndepl_cv` CV-binned curves** (`ndepl_cv` config-default **8** ⇒ `ndepl`=9) |
+| `snarea_thresh` estimator | **Median across water-years of the annual peak mean-SWE**, mm → inches |
+| Failure defaults | Sub-grid CV gives near-**universal coverage**; only genuine no-snow / un-estimable HRUs use the reserved default curve |
+| Output | **Dual CSV** (library + per-HRU) **+ pyWatershed NetCDF** param file + a validation report |
+| Validation fabric order | Oregon, then CONUS gfv2 |
+
+### 1.2 Why unified sub-grid CV (not empirical-fit primary)
+
+Computing sub-grid CV requires the **same** new Stage 1/2 infrastructure whether
+we use it everywhere or only for derivation failures, so using it as the single
+CV definition is *less* Stage 3 code (no per-HRU curve fit) and removes the
+derived/failure "seam." It is the physical quantity Sexstone/Liston/NHM use, and
+it is estimable for **every** snow-bearing HRU — solving the ~50 %-default problem
+(CONUS: 58 % of HRUs currently fall on the near-linear placeholder), which the
+grouping memory flags as **a bigger lever than the grouping itself**.
+
+**The one honest risk:** SNODAS is 1 km, so `std/mean` across an HRU's ~74 cells
+captures 1-km-and-coarser SWE variability but misses sub-1-km drift/aspect/veg
+variability. True sub-HRU CV is therefore ≥ the SNODAS-measured CV, so parametric
+curves could deplete too fast. Mitigations, in order: (a) the empirical Driscoll
+SCA is *also* built from the same 1-km field (`scov = SWE>0` at 1 km), so the two
+should agree far better than a 1-km-vs-truth comparison implies; (b) a
+**validation gate** measures the disagreement on the `derived` HRUs before we lock
+the parameter source; (c) if biased, a **calibration** step maps sub-grid CV onto
+the empirical-fit CV scale; (d) if hopeless, a config switch reverts to
+empirical-primary — the infra is identical, so this is a config change, not a
+redesign.
+
+---
+
+## 2. Architecture
+
+Three stages in `gfv2-params`. Stage 3 is the new deliverable; Stages 1–2 get
+strictly-additive changes and keep their existing behaviour.
+
+```
+Stage 1  aggregate/  ── ADD area-weighted swe_std (sub-grid SWE std)
+  raw SNODAS daily SWE (EPSG:5070)
+     ─► per-HRU daily { swe (mean), scov (SCA), swe_std }   (re-run; weights cached ⇒ cheap)
+        │
+Stage 2  snarea/ (derive) ── ADD per-HRU sub-grid stats; KEEP empirical curve + sdc_status
+     ─► {data_root}/{fabric}/params/merged/_intermediates/nhm_snarea_curve_derived.csv
+        (empirical curve, sdc_status, sca_class, similarity, n_seasons = validation oracle
+         + cv_subgrid, peak_swe_mm, n_peak_years                       = new)
+        │
+Stage 3  snarea/library.py  (NEW; pure pandas/numpy/scipy; no daily reload; re-runnable)
+     ─► nhm_snarea_curve_library.csv     (ndepl curves)
+        nhm_snarea_curve_params.csv      (per-HRU: hru_deplcrv, snarea_thresh, CVs, diagnostics)
+        nhm_snarea_curve.nc              (pyWatershed/PRMS param file)
+        nhm_snarea_curve_validation.csv  (validation-gate report)
+```
+
+**Fabric independence (non-negotiable, per repo rule):** process configs are
+fabric-agnostic; every per-fabric input/output resolves from the active profile in
+`configs/base_config.yml` via `require_config_key` with `{data_root}`/`{fabric}`
+placeholders. No literal paths, no naming conventions in code.
+
+**Why a separate Stage 3 (not folded into Stage 2):** re-running the library at a
+different `ndepl_cv` must not re-pay Stage 2's ~344 GB / ~31 min CONUS daily load.
+Stage 3 reads only the small per-HRU CSV, so `ndepl` is tunable in seconds.
+
+---
+
+## 3. Stage 1 change — area-weighted sub-grid `swe_std`
+
+The aggregate harness applies **one** `stat_method` per `AggGen` pass
+([`aggregate/driver.py:aggregate_variables`](../../../src/gfv2_params/aggregate/driver.py)),
+so `swe` and `scov` both use `masked_mean`. Sub-grid std needs a second
+`masked_std` pass over the SWE variable, sharing the already-cached weights.
+
+- **`SourceAdapter`** ([`aggregate/adapter.py`](../../../src/gfv2_params/aggregate/adapter.py))
+  gains an optional field `std_variables: tuple[str, ...] = ()` — variables to
+  *also* aggregate with `masked_std`, emitted as `{var}_std`. Validated against the
+  existing `_ALLOWED_STAT_METHODS` set (which already lists `masked_std`).
+- **Driver** ([`aggregate/driver.py`](../../../src/gfv2_params/aggregate/driver.py)):
+  after the primary pass, if `adapter.std_variables` is non-empty, run one more
+  `AggGen(stat_method="masked_std", weights=<same cached weights>)` over those
+  variables and merge each result into the year's Dataset as `{var}_std`. Weights
+  are geometry-only, so this reuses `compute_or_load_weights`'s cache — no
+  re-computation.
+- **SNODAS adapter** ([`aggregate/snodas.py`](../../../src/gfv2_params/aggregate/snodas.py)):
+  set `std_variables=("swe",)`. The `_snodas_hook` fill-masking is unchanged;
+  `masked_std` inherits the same NaN mask, so `swe_std` is the area-weighted std of
+  **finite** (snow-or-bare land) pixels, consistent with `swe`'s `masked_mean`.
+
+Output per-year NetCDF now carries `swe`, `scov`, `swe_std` on dims
+`(time, <id_feature>)`. Stage 1 must be re-run once; the expensive `WeightGen`
+step is cached, so this is a cheap extra `AggGen` per year.
+
+---
+
+## 4. Stage 2 change — representative sub-grid CV + peak SWE
+
+Additive to the existing empirical derivation; the empirical curve, `sdc_status`,
+`sca_class`, `similarity`, `n_seasons` are **retained unchanged** as the
+validation oracle.
+
+- **`read_daily_by_hru`** ([`scripts/derive_snarea_curve.py`](../../../scripts/derive_snarea_curve.py))
+  also loads `swe_std` into each per-HRU daily frame.
+- **New `src/gfv2_params/snarea/subgrid.py`** — `representative_peak_stats(daily)`:
+  1. Group the daily frame by **water year** (Oct 1–Sep 30), reusing the same
+     framing as [`snarea/build.py:_seasons`](../../../src/gfv2_params/snarea/build.py)
+     (a late-December accumulation must not be mis-picked as the peak).
+  2. For each water year, find the day of **peak mean SWE**; record
+     `peak_swe = swe[peak]` and `cv_year = swe_std[peak] / swe[peak]` (CV is most
+     stable where mean SWE is largest — the peak day). Skip years with no snow /
+     non-finite / `swe[peak] <= 0`.
+  3. Return `cv_subgrid = median(cv_year)`, `peak_swe_mm = median(peak_swe)`,
+     `n_peak_years = count`. (Config option, deferred: average CV over a near-peak
+     window `swe >= f·peak` if the single-day estimate proves noisy.)
+- **`build_hru_record`** ([`snarea/build.py`](../../../src/gfv2_params/snarea/build.py))
+  adds columns `cv_subgrid`, `peak_swe_mm`, `n_peak_years`.
+- **Output location:** Stage 2 writes to
+  `{data_root}/{fabric}/params/merged/_intermediates/nhm_snarea_curve_derived.csv`
+  (mirrors the depstor `merged/` vs `merged/_intermediates/` convention). The
+  terminal `nhm_snarea_curve_params.csv` name is reused by **Stage 3**.
+
+---
+
+## 5. Stage 3 algorithm — the library builder (`snarea/library.py`)
+
+Pure `pandas`/`numpy`/`scipy` over the Stage 2 derived CSV.
+
+### 5.1 The closed form (`sdc_from_cv`)
+
+Sexstone eqs 1–5 (lognormal SWE pdf under uniform melt); the dimensionless SDC
+depends **only** on CV. Index 0 = SWE/thresh = 1.0 → index 10 = 0.0 (the repo's
+existing descending convention, matching
+[`snarea/season.py:SWE_LEVELS`](../../../src/gfv2_params/snarea/season.py)).
+
+```python
+import numpy as np
+from scipy.stats import norm
+
+SWE_LEVELS = np.round(np.arange(1.0, -1e-4, -0.1), 1)  # 1.0 .. 0.0
+
+def sdc_from_cv(cv: float, mu: float = 1.0, n: int = 4000) -> np.ndarray:
+    z = np.sqrt(np.log(1 + cv * cv))          # ζ² = ln(1+CV²)
+    lam = np.log(mu) - 0.5 * z * z            # λ  = ln(μ) − ζ²/2
+    M = np.concatenate([[0.0], np.exp(np.linspace(np.log(mu) - 6*z, np.log(mu) + 6*z, n))])
+    lnM = np.log(np.where(M > 0, M, 1e-300))
+    sca = norm.cdf((lam - lnM) / z)           # SCA(M) = Φ((λ−lnM)/ζ)
+    swe = mu * norm.cdf((lam + z*z - lnM) / z) - M * sca
+    sca[0], swe[0] = 1.0, mu
+    o = np.argsort(swe / swe[0])
+    return np.clip(np.interp(SWE_LEVELS, (swe / swe[0])[o], sca[o], left=1.0, right=0.0), 0, 1)
+```
+
+Properties (asserted in tests): monotonic non-increasing; `curve[0]==1.0`,
+`curve[-1]==0.0`; larger CV ⇒ steeper (lower SCA at mid SWE).
+
+### 5.2 Steps
+
+1. **Load** the Stage 2 derived CSV. Define the **estimable** set: HRUs with a
+   finite `cv_subgrid` (`peak_swe_mm > 0`, `n_peak_years >= 1`, sub-grid std
+   defined ⇒ ≥ 2 snow cells).
+2. **`cv_empirical` (diagnostic + reference)** — for `derived` HRUs, project the
+   empirical 11-pt curve onto the lognormal family: grid-search CV minimising L2
+   over **interior** points 1–9 against `sdc_from_cv(cv)` (endpoints are fixed at
+   1.0/0.0 for all CVs, so they carry no fit information). Satisfies task
+   deliverable 1(a).
+3. **Validation gate + optional calibration** — on `derived` HRUs (both CVs and the
+   empirical curve available):
+   - Report `cv_subgrid` vs `cv_empirical` distribution stats and the
+     **reconstruction error** of `sdc_from_cv(cv_subgrid)` vs the empirical curves
+     (mean and p95 abs SCA; target ≈ 0.03 mean — the validated tolerance).
+   - `calibrate: auto|on|off` (config). On `auto`, if the median bias
+     `|median(cv_subgrid) − median(cv_empirical)|` exceeds a configured tolerance,
+     **quantile-map** `cv_subgrid` → `cv_empirical` (monotone, using the `derived`
+     HRUs as the training set) and apply to **all** HRUs → `cv_assign`. Otherwise
+     `cv_assign = cv_subgrid`. Record the mapping in the validation report.
+4. **`cv_assign` resolution (per HRU):** calibrated `cv_subgrid` if finite; else
+   `cv_empirical` if finite (rare edge: derived HRU with undefined sub-grid std);
+   else **none** → reserved default. `cv_source` ∈
+   {`subgrid`, `subgrid_calibrated`, `empirical`, `default_no_snow`}.
+5. **Library** (`ndepl` = 1 + `ndepl_cv` curves):
+   - **Index 1 — reserved default:** a configurable non-increasing curve
+     (`default_curve`, currently the near-linear placeholder inherited from
+     [`snarea/build.py:DEFAULT_SNAREA_CURVE`](../../../src/gfv2_params/snarea/build.py);
+     swap for the real NHM default when staged). `cv` = sentinel (NaN).
+   - **Indices 2..`ndepl` — CV bins:** partition `cv_assign` over the estimable
+     HRUs into `ndepl_cv` **equal-population** bins (quantiles); each bin's
+     **median CV** → `sdc_from_cv` → the library curve. Binning on the same metric
+     used for assignment keeps bin medians self-consistent.
+6. **Assign `hru_deplcrv`:** for estimable HRUs, the **CV-bin** library curve
+   (indices 2..`ndepl`) whose CV is nearest `cv_assign` — the reserved default
+   (index 1, `cv`=NaN) is **not** a candidate in this nearest-CV search.
+   Non-estimable HRUs → index 1. Every HRU maps to a valid curve. (Bins are
+   equal-population, so nearest-median assignment ≈ bin membership, differing only
+   for HRUs near a bin edge, where the nearer curve is the better match.)
+7. **`snarea_thresh` = `peak_swe_mm / 25.4`** (inches); 0.0 for no-snow /
+   un-estimable HRUs (the curve is never exercised there — `pkwater_equiv` = 0).
+
+---
+
+## 6. Serialization
+
+Four artifacts under `{data_root}/{fabric}/params/merged/`. The descending
+(CSV) ↔ ascending (PRMS NetCDF) curve-order flip lives in one tested helper
+`_to_prms_order(curve) -> curve[::-1]`.
+
+1. **`nhm_snarea_curve_library.csv`** — `ndepl` rows: `deplcrv_id` (1..`ndepl`),
+   `curve_kind` (`default`|`cv_bin`), `cv` (bin-median CV; sentinel for default),
+   `n_hru` (HRUs assigned to it), `snarea_curve_0..10` (descending).
+2. **`nhm_snarea_curve_params.csv`** — one row per HRU (terminal artifact, name
+   preserved for `viz.py`/docs consumers): `<id_feature>`, `hru_deplcrv`
+   (1..`ndepl`), `snarea_thresh` (in), `cv_assign`, `cv_subgrid`, `cv_empirical`
+   (NaN if not `derived`), `cv_source`, `sdc_status`, `sca_class`, `similarity`,
+   `n_seasons`, `n_peak_years`, `peak_swe_mm`, `snarea_curve_0..10` (the *assigned*
+   library curve, descending — QA + backward-compat; preserves per-HRU detail so no
+   separate "1:1 mode" is needed).
+3. **`nhm_snarea_curve.nc`** — pyWatershed/PRMS param file (verified against
+   `pywatershed.hydrology.prms_snow`, which does `reshape(snarea_curve,(ndepl,11))`
+   and indexes ascending frac_swe):
+   - dims: `ndepl` (=`ndepl`), `ndeplval` (=11·`ndepl`), `nhru`
+   - `snarea_curve(ndeplval)` float — **flat, ASCENDING** (index 0 = frac_swe 0.0 →
+     SCA≈0), curves concatenated in `deplcrv_id` order (= reversed repo curve)
+   - `hru_deplcrv(nhru)` int32 (1..`ndepl`)
+   - `snarea_thresh(nhru)` float (inches)
+   - `<id_feature>(nhru)` coord; CF attrs (`units`, `long_name`). The
+     **cf-netcdf-review** skill is run when this writer is implemented.
+4. **`nhm_snarea_curve_validation.csv`** — gate report: `cv_subgrid`/`cv_empirical`
+   distribution stats, reconstruction error before/after calibration, calibration
+   mapping summary, per-`sdc_status` and per-`cv_source` counts.
+
+---
+
+## 7. Module / config / test layout + deps
+
+**Source (new / changed):**
+
+| File | Change |
+|---|---|
+| `src/gfv2_params/snarea/library.py` | **NEW** — `sdc_from_cv`, `fit_cv`, `build_library`, `assign_deplcrv`, `snarea_thresh_inches`, validation/calibration, CSV+NetCDF serializers, `_to_prms_order` |
+| `src/gfv2_params/snarea/subgrid.py` | **NEW** — `representative_peak_stats` |
+| `src/gfv2_params/snarea/build.py` | add `cv_subgrid`/`peak_swe_mm`/`n_peak_years`; write to `_intermediates/` |
+| `src/gfv2_params/aggregate/adapter.py` | add `std_variables` field + validation |
+| `src/gfv2_params/aggregate/snodas.py` | `std_variables=("swe",)` |
+| `src/gfv2_params/aggregate/driver.py` | `masked_std` sidecar pass, merged as `{var}_std` |
+| `scripts/derive_snarea_curve.py` | load `swe_std`; wire subgrid stats |
+| `scripts/derive_snarea_library.py` | **NEW** — Stage 3 driver (`load_config`+`require_config_key`+placeholders) |
+
+**Config:**
+
+- `configs/aggregate/aggregate_sources.yml` — declare `swe_std` for the SNODAS source.
+- `configs/snarea/snarea_library.yml` — **NEW** Stage 3: input derived CSV, output
+  paths, `ndepl_cv: 8`, `calibrate: auto`, calibration-bias tolerance, reserved
+  `default_curve`. Top-level placeholdered keys (`load_config` only resolves
+  top-level `{data_root}`/`{fabric}`; nested blocks pass through untouched).
+- `configs/snarea/snarea_curve.yml` — point Stage 2 `output_dir`/`merged_file` at
+  `_intermediates/nhm_snarea_curve_derived.csv`.
+
+**Tests (CI-gated; never full pytest on the HPC head node):**
+
+- `tests/test_snarea_library.py` **(NEW)** — `sdc_from_cv` properties; `fit_cv`
+  recovers a curve generated from a known CV; equal-population binning + reserved
+  default; assignment incl. no-snow→default and the `cv_assign` fallback order;
+  `snarea_thresh` mm→in; calibration removes a synthetic CV bias; NetCDF dims +
+  ASCENDING order + `_to_prms_order` round-trip.
+- `tests/test_snarea_subgrid.py` **(NEW)** — peak-day CV + peak SWE + water-year
+  framing on hand-built series with known answers.
+- extend `tests/test_aggregate_snodas.py` / `tests/test_aggregate_driver.py` — the
+  `masked_std` sidecar emits `swe_std` on a tiny synthetic grid.
+- extend `tests/test_derive_snarea_curve.py` — `read_daily_by_hru` reads `swe_std`.
+
+**Deps:** add `pywatershed` (conda-forge) to a **`reference`** (or dev) pixi
+feature in `pyproject.toml` — queryable for param conventions, **not** required by
+CI so the test env stays light/fast. `scipy` already present. The NetCDF test
+validates structure directly (no `pywatershed` import).
+
+---
+
+## 8. Validation & rollout
+
+**Incremental (no HPC needed for the empirical side):** `cv_empirical`, library
+binning, and reconstruction (≈0.03 target) can be checked immediately against the
+existing on-disk Oregon/CONUS derived tables
+(`{data_root}/{oregon,gfv2}/params/merged/nhm_snarea_curve_params.csv`, present as
+of this design). Only `cv_subgrid` requires the Stage 1/2 re-run.
+
+**Rollout (Oregon → CONUS):**
+
+1. **Oregon** (`FABRIC=oregon`, fast): re-run Stage 1 (adds `swe_std`; weights
+   cached), Stage 2 (adds subgrid stats), Stage 3 (library). Confirm:
+   - validation gate — `cv_subgrid` vs `cv_empirical`; reconstruction; calibrate if
+     biased;
+   - **near-universal coverage** — the near-linear placeholder no longer dominates;
+   - physical sanity — Cascades HRUs get higher CV / steeper curves, low-desert
+     HRUs low CV or the no-snow default; spot-check a few curves.
+2. **CONUS gfv2** (`FABRIC=gfv2`): same at scale. Stage 2 at `--mem=384G` (the
+   ~344 GB `to_dataframe` load); Stage 3 is cheap (tabular).
+
+**SLURM:** `slurm_batch/derive_snarea_library.batch` **(NEW)** — small mem/time.
+Stage 1/2 batches unchanged (Stage 2 already defaults to 384 G).
+
+**Data-root:** `/caldera/hovenweep/projects/usgs/water/impd/nhgf/gfv2_param_v2`.
+
+**Docs (same branch, per the doc-audit rule):** this spec; `README.md` §snarea
+(output now library + params + `.nc`); `slurm_batch/HPC_REFERENCE.md` (Stage 3);
+`slurm_batch/RUNME.md` (runbook); `docs/ARCHITECTURE.md` if it enumerates stages;
+memory update (`sdc_grouping_decision`, `snodas_snarea_curve_pipeline`).
+
+---
+
+## 9. Judgment calls (defaulted; revisit if desired)
+
+1. **CV timing = peak day** of each water year, median across years — CV=std/mean is
+   most stable at max mean SWE. Near-peak-window averaging is a config-tunable
+   fallback if noisy.
+2. **`snarea_thresh` = median annual peak mean-SWE**, self-consistent with the
+   peak-SWE normalisation the empirical curves already use, and equal to Sexstone's
+   SWE₁₀₀ scale.
+3. **Reserved default curve** kept for no-snow / un-estimable HRUs so "no-snow →
+   flat default" is explicit and every HRU maps to a valid curve; it is the same
+   configurable `default_curve` placeholder until the real NHM default is staged.
+4. **Per-HRU detail retained** (`cv_empirical`, assigned curve, all diagnostics in
+   `nhm_snarea_curve_params.csv`) — so a "1:1 curve per HRU" QA view exists without
+   a separate output mode.
+5. **`ndepl_cv` = 8** (grouping memory: elbow 5–8, scale/climate-independent;
+   config 5–8).
+
+---
+
+## 10. Out of scope (YAGNI)
+
+- Regional / elevation-banded CV stratification, and a topo/climate CV regression
+  (global calibration only for v1; CV median is stable ≈0.45 across Oregon+CONUS).
+- Real NHM default-curve staging (placeholder stays until the file is provided).
+- Sub-1-km CV downscaling to recover unresolved sub-grid variability.
+- Reproducing the paper's published figures or its fixed CV=0.1–2.0 experiment set.
+- Retiring the empirical Driscoll derivation (kept as the validation oracle).
+
+---
+
+## 11. References
+
+- Sexstone et al. (2020), *Hydrological Processes* 34, DOI 10.1002/hyp.13735 —
+  [`docs/hyp.13735.pdf`](../../hyp.13735.pdf). Lognormal SDC(CV) closed form
+  (eqs 1–5); `snarea_thresh` ≡ SWE₁₀₀; runoff sensitivity to SDC representation.
+- Driscoll, Hay & Bock (2017) — [`docs/Snow_Depletion_Curves.md`](../../Snow_Depletion_Curves.md).
+  Empirical per-HRU SDC derivation (Stage 2, retained).
+- Liston (2004); Luce, Tarboton & Cooley (1999) — lognormal sub-grid SWE framework.
+- pyWatershed `hydrology/prms_snow.py` — `snarea_curve`/`hru_deplcrv`/`snarea_thresh`
+  param conventions (flat `ndeplval`, ascending frac_swe).
+- Prior spec: [`2026-07-04-snodas-snarea-curve-design.md`](2026-07-04-snodas-snarea-curve-design.md).

--- a/pixi.lock
+++ b/pixi.lock
@@ -1955,6 +1955,413 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-ng-2.3.3-hceb46e0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       - pypi: ./
+  reference:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/accessible-pygments-0.0.5-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-49.0-unix_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/alabaster-1.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.14.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-25.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/argon2-cffi-bindings-25.1.0-py310h7c4b9e2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.4.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-3.0.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.3.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/at-spi2-atk-2.38.0-h0630a04_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/at-spi2-core-2.40.3-h0630a04_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/atk-1.0-2.38.0-h04ea711_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.18.0-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/backports.zstd-1.6.0-py310h69bd2ac_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.15.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/black-26.5.1-pyha5154f8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.4.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-with-css-6.4.0-hac0b51c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.6-he440d0b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.9.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/boltons-26.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/branca-0.8.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.2.0-hed03a55_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.2.0-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.2.0-py310hba01987_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.6-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-h3394656_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cartopy-0.25.0-py310h0158d43_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.6.17-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.0.0-py310he7384ee_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.5.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cftime-1.6.5-py310hf779ad0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.8-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.2-pyhc90fa1f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cligj-0.7.2-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/contextily-1.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.2-py310h3788b33_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.15.0-py310h3406613_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.10.20-py310hd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dataretrieval-1.2.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.19.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.16.2-h24cb091_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.21-py310h25320af_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distlib-0.4.3-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/docutils-0.21.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/epiweeks4cf-2.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/epoxy-1.5.10-hb03c661_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/execnet-2.1.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.29.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/flexcache-0.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/flexparser-0.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/flopy-3.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/folium-0.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.1-h27c8c51_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.63.0-py310h3406613_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.3-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/freexl-2.0.0-h9dce30a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.16-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdk-pixbuf-2.44.4-h2b0a6b4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geographiclib-2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-1.1.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.1.4-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geopy-2.4.1-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.14.0-h480dda7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/geotiff-1.7.4-h239500f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-1.15.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-core-1.15.1-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/git-2.52.0-pl5321h28be001_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.86.2-hf516916_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.15-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/graphviz-14.1.0-h8b86629_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gtk3-3.24.43-h993cebd_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gts-0.7.6-h977cf35_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.16.0-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-12.2.0-h15599e2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf4-4.2.15-h2a13503_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.6-nompi_h19486de_110.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hicolor-icon-theme-0.17-ha770c72_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.23.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.9-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hvplot-0.12.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.19-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.18-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/imagesize-2.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-7.3.0-pyha191276_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.37.0-pyh8f84b5b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipywidgets-8.1.8-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.20.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joblib-1.5.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/json-c-0.18-h6688a6e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.15.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonpointer-3.1.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.26.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2025.9.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.26.0-hcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-1.1.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-black-0.4.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-builder-1.0.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.3.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.9.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_console-6.6.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.12.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.20.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.6.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.28.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-3.0.16-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.5.0-py310haaf941d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-hbde042b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/lark-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.19.1-h0c24ade_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.1.0-hdb68285_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.5-h088129d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarchive-3.8.8-gpl_hc2c16d8_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-8_h4a7cf45_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.2.0-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.2.0-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.2.0-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-8_h0358290_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h7a8fb5f_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.21.0-hcf29cc6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-h17f619e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.127-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-devel-1.7.0-ha4b6fd6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.3-h73754d4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgd-2.3.3-h6f5c62b_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.10.3-h95ec890_18.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-devel-1.7.0-ha4b6fd6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.86.2-h32235b2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-devel-1.7.0-ha4b6fd6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.4.1-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libkml-1.3.0-haa4a5bd_1023.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-8_h47877c9_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnetcdf-4.10.0-nompi_h3fa17b5_205.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.33-pthreads_h94d23a6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.19-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.58-h421ea60_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.60.0-h61e6d4b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/librttopo-1.1.0-h96cd706_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.22-h280c20c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libspatialite-5.1.0-h2eee824_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.3-h0c1763c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.2-h9d88235_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.13.2-hca5e8e5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.1-ha9997c6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.1-h26afc86_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-devel-2.15.1-h26afc86_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzip-1.11.2-h6991a6a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.1.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/llvmlite-0.47.0-py310hee1c697_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.10.0-h5888daf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lzo-2.10-h280c20c_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mapclassify-2.8.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.10.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.3-py310h3406613_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.10.9-py310hfde16b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.6.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mercantile-1.2.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/minizip-4.2.2-hb71707f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.3.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/modflow-devtools-1.9.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.23.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.11.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-7.17.1-hb502eef_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.17.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-pandoc-7.17.1-h08b4883_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio2-1.7.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/netcdf4-1.7.4-nompi_py310h21e55d4_104.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/networkx-3.4.2-pyh267e887_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nh3-0.3.6-py310hd8a072f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-7.6.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numba-0.65.1-py310h225f558_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.2.6-py310hefbff90_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.3-h35e630c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.3.3-py310h0158d43_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pandoc-3.10-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.9.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/panel-core-1.9.3-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/panel-material-ui-0.13.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.56.4-hadf4263_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/param-2.4.1-pyhc455866_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.7-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.1.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.46-h1321c63_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/perl-5.32.1-7_hd590300_perl5.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-pyhd8ed1ab_1004.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.3.0-py310h5a73078_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pint-0.24.4-pyhe01879c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.1.2-pyh8b19718_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.10.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.6.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/proj-9.6.2-h18fbb6c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.25.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.52-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.2.2-py310h139afa4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydata-sphinx-theme-0.15.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydot-4.0.1-pyhcf101f3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyogrio-0.11.0-py310h0aed7a2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyproj-3.7.1-py310h71d0299_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyshp-3.1.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-env-1.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-order-1.5.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.10.20-h267e890_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-discovery-1.4.3-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.2.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.2-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.10.20-hd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-4.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2026.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.10-8_cp310.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pytokens-0.4.1-py310h139afa4_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2026.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pywatershed-2.0.4-pyhc455866_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py310h3406613_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.1.0-py310ha71cbf4_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rasterio-1.4.3-py310hf3df72b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.37.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.34.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3987-syntax-1.1.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.30.0-py310hd8f68c5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.15.20-h6a952e8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.7.2-py310h228f341_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.15.2-py310h1d65ade_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-2.1.0-pyha191276_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/shapely-2.1.2-py310h777b3ac_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.2-h03e3b7b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/snowballstemmer-3.1.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.8.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-8.1.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-autodoc-typehints-3.0.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-autosummary-accessors-2025.3.1-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-book-theme-1.1.4-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-copybutton-0.5.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-applehelp-2.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-devhelp-2.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-htmlhelp-2.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-jsmath-1.0.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-qthelp-2.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-2.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.53.3-hbc0de68_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyhc90fa1f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.6.0-pyhecae5ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tokenize-rt-6.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.7-py310h7c4b9e2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.68.3-pyh8f84b5b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.16.0-h69aa097_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.16.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-2.0.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ukkonen-1.1.0-py310h03d9f68_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-17.0.1-py310h7c4b9e2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/uriparser-0.9.8-hac33072_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-21.5.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.25.0-hd6090a7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.8.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-25.10.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.47.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/widgetsnbextension-4.0.15-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2025.6.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xerces-c-3.2.5-h988505b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.48-h280c20c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xmltodict-1.0.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcomposite-0.4.7-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcursor-1.2.3-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdamage-1.1.6-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.7-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-6.0.2-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.8.3-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxinerama-1.1.6-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.5-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.12-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxxf86vm-1.1.7-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xorgproto-2025.1-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2026.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h09e67af_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.2-h25fd6f3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-ng-2.3.3-hceb46e0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
   build_number: 20
@@ -1981,6 +2388,27 @@ packages:
   purls: []
   size: 8191
   timestamp: 1744137672556
+- conda: https://conda.anaconda.org/conda-forge/noarch/accessible-pygments-0.0.5-pyhd8ed1ab_1.conda
+  sha256: 1307719f0d8ee694fc923579a39c0621c23fdaa14ccdf9278a5aac5665ac58e9
+  md5: 74ac5069774cdbc53910ec4d631a3999
+  depends:
+  - pygments
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1326096
+  timestamp: 1734956217254
+- conda: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-49.0-unix_0.conda
+  sha256: a362b4f5c96a0bf4def96be1a77317e2730af38915eb9bec85e2a92836501ed7
+  md5: b3f0179590f3c0637b7eb5309898f79e
+  depends:
+  - __unix
+  - hicolor-icon-theme
+  - librsvg
+  license: LGPL-3.0-or-later OR CC-BY-SA-3.0
+  license_family: LGPL
+  size: 631452
+  timestamp: 1758743294412
 - conda: https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_1.conda
   sha256: 0deeaf0c001d5543719db9b2686bc1920c86c7e142f9bec74f35e1ce611b1fc2
   md5: 8c4061f499edec6b8ac7000f6d586829
@@ -2069,6 +2497,15 @@ packages:
   - pkg:pypi/aiosignal?source=hash-mapping
   size: 13688
   timestamp: 1751626573984
+- conda: https://conda.anaconda.org/conda-forge/noarch/alabaster-1.0.0-pyhd8ed1ab_1.conda
+  sha256: 6c4456a138919dae9edd3ac1a74b6fbe5fd66c05675f54df2f8ab8c8d0cc6cea
+  md5: 1fd9696649f65fd6611fcdb4ffec738a
+  depends:
+  - python >=3.10
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18684
+  timestamp: 1733750512696
 - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
   sha256: e0ea1ba78fbb64f17062601edda82097fcf815012cf52bb704150a2668110d48
   md5: 2934f256a8acfe48f6ebb4fce6cde29c
@@ -2100,6 +2537,61 @@ packages:
   - pkg:pypi/anyio?source=compressed-mapping
   size: 146764
   timestamp: 1774359453364
+- conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.14.1-pyhcf101f3_0.conda
+  sha256: 6119355a0b2a33e7b0dd31a740dbe01df66ffee0a643f80968afb1d53e7dbdb3
+  md5: 7498bb2648f852c6a3cd5724ca80bdeb
+  depends:
+  - exceptiongroup >=1.0.2
+  - idna >=2.8
+  - python >=3.10
+  - typing_extensions >=4.5
+  - python
+  constrains:
+  - trio >=0.32.0
+  - uvloop >=0.22.1
+  - winloop >=0.2.3
+  license: MIT
+  license_family: MIT
+  size: 161308
+  timestamp: 1782357087265
+- conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-25.1.0-pyhd8ed1ab_0.conda
+  sha256: bea62005badcb98b1ae1796ec5d70ea0fc9539e7d59708ac4e7d41e2f4bb0bad
+  md5: 8ac12aff0860280ee0cff7fa2cf63f3b
+  depends:
+  - argon2-cffi-bindings
+  - python >=3.9
+  - typing-extensions
+  constrains:
+  - argon2_cffi ==999
+  license: MIT
+  license_family: MIT
+  size: 18715
+  timestamp: 1749017288144
+- conda: https://conda.anaconda.org/conda-forge/linux-64/argon2-cffi-bindings-25.1.0-py310h7c4b9e2_2.conda
+  sha256: 5396242c40688b33b57d8564025569598ab4848fd03852bb7415443b9f421fa1
+  md5: 7f9a178be0c687e77f7248507737d15e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cffi >=1.0.1
+  - libgcc >=14
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 35370
+  timestamp: 1762509501470
+- conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.4.0-pyhcf101f3_0.conda
+  sha256: 792da8131b1b53ff667bd6fc617ea9087b570305ccb9913deb36b8e12b3b5141
+  md5: 85c4f19f377424eafc4ed7911b291642
+  depends:
+  - python >=3.10
+  - python-dateutil >=2.7.0
+  - python-tzdata
+  - python
+  license: Apache-2.0
+  license_family: APACHE
+  size: 113854
+  timestamp: 1760831179410
 - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-3.0.1-pyhd8ed1ab_0.conda
   sha256: ee4da0f3fe9d59439798ee399ef3e482791e48784873d546e706d0935f9ff010
   md5: 9673a61a297b00016442e022d689faa6
@@ -2113,6 +2605,57 @@ packages:
   - pkg:pypi/asttokens?source=hash-mapping
   size: 28797
   timestamp: 1763410017955
+- conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.3.0-pyhcf101f3_0.conda
+  sha256: ea8486637cfb89dc26dc9559921640cd1d5fd37e5e02c33d85c94572139f2efe
+  md5: b85e84cb64c762569cc1a760c2327e0a
+  depends:
+  - python >=3.10
+  - typing_extensions >=4.0.0
+  - python
+  license: MIT
+  license_family: MIT
+  size: 22949
+  timestamp: 1773926359134
+- conda: https://conda.anaconda.org/conda-forge/linux-64/at-spi2-atk-2.38.0-h0630a04_3.tar.bz2
+  sha256: 26ab9386e80bf196e51ebe005da77d57decf6d989b4f34d96130560bc133479c
+  md5: 6b889f174df1e0f816276ae69281af4d
+  depends:
+  - at-spi2-core >=2.40.0,<2.41.0a0
+  - atk-1.0 >=2.36.0
+  - dbus >=1.13.6,<2.0a0
+  - libgcc-ng >=9.3.0
+  - libglib >=2.68.1,<3.0a0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 339899
+  timestamp: 1619122953439
+- conda: https://conda.anaconda.org/conda-forge/linux-64/at-spi2-core-2.40.3-h0630a04_0.tar.bz2
+  sha256: c4f9b66bd94c40d8f1ce1fad2d8b46534bdefda0c86e3337b28f6c25779f258d
+  md5: 8cb2fc4cd6cc63f1369cfa318f581cc3
+  depends:
+  - dbus >=1.13.6,<2.0a0
+  - libgcc-ng >=9.3.0
+  - libglib >=2.68.3,<3.0a0
+  - xorg-libx11
+  - xorg-libxi
+  - xorg-libxtst
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 658390
+  timestamp: 1625848454791
+- conda: https://conda.anaconda.org/conda-forge/linux-64/atk-1.0-2.38.0-h04ea711_2.conda
+  sha256: df682395d05050cd1222740a42a551281210726a67447e5258968dd55854302e
+  md5: f730d54ba9cd543666d7220c9f7ed563
+  depends:
+  - libgcc-ng >=12
+  - libglib >=2.80.0,<3.0a0
+  - libstdcxx-ng >=12
+  constrains:
+  - atk-1.0 2.38.0
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  size: 355900
+  timestamp: 1713896169874
 - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
   sha256: 1b6124230bb4e571b1b9401537ecff575b7b109cc3a21ee019f65e083b8399ab
   md5: c6b0543676ecb1fb2d7643941fe375f2
@@ -2415,6 +2958,18 @@ packages:
   - pkg:pypi/backports-zstd?source=compressed-mapping
   size: 238360
   timestamp: 1777848717715
+- conda: https://conda.anaconda.org/conda-forge/linux-64/backports.zstd-1.6.0-py310h69bd2ac_0.conda
+  sha256: b2b1d6d06b0aa57f83176d48b95d5b2c48eecd2127c7812a75ec1bd676aaffd7
+  md5: ab4a6aca6a105e1dedde3800ab58148e
+  depends:
+  - python
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python_abi 3.10.* *_cp310
+  - zstd >=1.5.7,<1.6.0a0
+  license: BSD-3-Clause AND MIT AND EPL-2.0
+  size: 192901
+  timestamp: 1781450813638
 - conda: https://conda.anaconda.org/conda-forge/noarch/backrefs-7.0-pyhcf101f3_0.conda
   sha256: 4e32871acb663d8d64342c486d960b3e64e24b7c715247a1e6a6f46d1b428802
   md5: 970a19304a794630a882b9dcd9e1beb4
@@ -2440,6 +2995,34 @@ packages:
   - pkg:pypi/beautifulsoup4?source=hash-mapping
   size: 90399
   timestamp: 1764520638652
+- conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.15.0-pyha770c72_0.conda
+  sha256: aed4b9dcf68ec2a75e5645fed14d77fd884d38d2e52bfa6ef4b278d90cd88781
+  md5: 3b261da3fe9b4168738712832410b022
+  depends:
+  - python >=3.10
+  - soupsieve >=1.2
+  - typing-extensions
+  license: MIT
+  license_family: MIT
+  size: 92704
+  timestamp: 1780853175566
+- conda: https://conda.anaconda.org/conda-forge/noarch/black-26.5.1-pyha5154f8_0.conda
+  sha256: eecb7f2e93e1b5cf2a4284597d2871de445ebb75c1dad8aa7302b650a37ac217
+  md5: d86c1c413735417413305a636e5084fa
+  depends:
+  - click >=8.0.0
+  - mypy_extensions >=0.4.3
+  - packaging >=22.0
+  - pathspec >=0.9
+  - platformdirs >=2
+  - python >=3.10,<3.11
+  - pytokens >=0.4
+  - tomli >=1.1.0
+  - typing_extensions >=4.0.1
+  license: MIT
+  license_family: MIT
+  size: 176564
+  timestamp: 1779460923310
 - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.3.0-pyhcf101f3_1.conda
   sha256: f8ff1f98423674278964a46c93a1766f9e91960d44efd91c6c3ed56a33813f46
   md5: 7c5ebdc286220e8021bf55e6384acd67
@@ -2454,6 +3037,18 @@ packages:
   - pkg:pypi/bleach?source=hash-mapping
   size: 142008
   timestamp: 1770719370680
+- conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.4.0-pyhcf101f3_0.conda
+  sha256: 0c786f3e571bd58ac73d730d06314716663884d848ae320de0b438fae5e0bea9
+  md5: 93009c29cdd6f2500468f2502fff9209
+  depends:
+  - python >=3.10
+  - webencodings
+  - python
+  constrains:
+  - tinycss2 >=1.1.0,<1.5
+  license: Apache-2.0 AND MIT
+  size: 142246
+  timestamp: 1780675823953
 - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-with-css-6.3.0-hbca2aae_1.conda
   sha256: 7c07a865e5e4cca233cc4e0eb3f0f5ff6c90776461687b4fb0b1764133e1fd61
   md5: f11a319b9700b203aa14c295858782b6
@@ -2464,6 +3059,15 @@ packages:
   purls: []
   size: 4409
   timestamp: 1770719370682
+- conda: https://conda.anaconda.org/conda-forge/noarch/bleach-with-css-6.4.0-hac0b51c_0.conda
+  sha256: ede77e412304cd080e23967352a7904932207d0167ecdccd6a9e210530942be6
+  md5: 5f710eab1f3c4e773c75686f5e8e6481
+  depends:
+  - bleach ==6.4.0 pyhcf101f3_0
+  - tinycss2
+  license: Apache-2.0 AND MIT
+  size: 4406
+  timestamp: 1780675823953
 - conda: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.6-he440d0b_1.conda
   sha256: e7af5d1183b06a206192ff440e08db1c4e8b2ca1f8376ee45fb2f3a85d4ee45d
   md5: 2c2fae981fd2afd00812c92ac47d023d
@@ -2500,6 +3104,35 @@ packages:
   - pkg:pypi/bokeh?source=compressed-mapping
   size: 4240579
   timestamp: 1773302678722
+- conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.9.1-pyhd8ed1ab_0.conda
+  sha256: b3d3b93a17fa678e81cd5ff5309fe64c7feb65c71cb134f14e4fe2113dc0c8d5
+  md5: 123fcfe0df4b6fc21804538e59cdaafe
+  depends:
+  - contourpy >=1.2
+  - jinja2 >=2.9
+  - narwhals >=1.13
+  - numpy >=1.16
+  - packaging >=16.8
+  - pillow >=7.1.0
+  - python >=3.10
+  - pyyaml >=3.10
+  - tornado >=6.2
+  - xyzservices >=2021.09.1
+  constrains:
+  - panel >=1.8.10
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4526315
+  timestamp: 1781002115296
+- conda: https://conda.anaconda.org/conda-forge/noarch/boltons-26.0.0-pyhd8ed1ab_0.conda
+  sha256: d3c8be0524a5223bfed89c4a5be90598bfca28e0c702014f7799b978027eb5e1
+  md5: 06c2cbdcfd20af2f72a95e09f8747c52
+  depends:
+  - python >=3.10
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 307488
+  timestamp: 1781879511321
 - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.43.0-pyhd8ed1ab_0.conda
   sha256: 27a202f3937b14812f5c8ba8304a5e2d0b2e1056e468cd7086721c2376bfea43
   md5: f47ed05030a1bed50f5fc9cea874ad1a
@@ -2574,6 +3207,21 @@ packages:
   purls: []
   size: 21021
   timestamp: 1764017221344
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.2.0-py310hba01987_1.conda
+  sha256: f036fe554d902549f86689a9650a0996901d5c9242b0a1e3fbfe6dbccd2ae011
+  md5: 393fca4557fbd2c4d995dcb89f569048
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  constrains:
+  - libbrotlicommon 1.2.0 hb03c661_1
+  license: MIT
+  license_family: MIT
+  size: 367099
+  timestamp: 1764017439384
 - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.2.0-py312hdb49522_1.conda
   sha256: 49df13a1bb5e388ca0e4e87022260f9501ed4192656d23dc9d9a1b4bf3787918
   md5: 64088dffd7413a2dd557ce837b4cbbdb
@@ -2653,6 +3301,58 @@ packages:
   purls: []
   size: 131039
   timestamp: 1776865545798
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
+  sha256: f8e3c730fa14ee3f170493779f06522c4acf89169f43db4f039727709b6419cf
+  md5: a9965dd99f683c5f444428f896635716
+  depends:
+  - __unix
+  license: ISC
+  size: 128866
+  timestamp: 1781708962055
+- conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_2.conda
+  noarch: python
+  sha256: 0d00dd61cb91b1bd1536600c64c9db4f94f3c699fec42864d0a2f4bc2ad8c3e8
+  md5: 1990eb3f49022846fbc7fc9624a0ee43
+  depends:
+  - cached_property >=1.5.2,<1.5.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6836
+  timestamp: 1783242914545
+- conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_2.conda
+  sha256: b1808a7811b5688d045b204425bb7ee824b340b40025b4ad0a39b4db1f4f1c98
+  md5: f71e6840332854fd2eac6c3229768a9c
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14752
+  timestamp: 1783242913845
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-h3394656_0.conda
+  sha256: 3bd6a391ad60e471de76c0e9db34986c4b5058587fbf2efa5a7f54645e28c2c7
+  md5: 09262e66b19567aff4f592fb53b28760
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - fontconfig >=2.15.0,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - icu >=75.1,<76.0a0
+  - libexpat >=2.6.4,<3.0a0
+  - libgcc >=13
+  - libglib >=2.82.2,<3.0a0
+  - libpng >=1.6.47,<1.7.0a0
+  - libstdcxx >=13
+  - libxcb >=1.17.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pixman >=0.44.2,<1.0a0
+  - xorg-libice >=1.1.2,<2.0a0
+  - xorg-libsm >=1.2.5,<2.0a0
+  - xorg-libx11 >=1.8.11,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxrender >=0.9.12,<0.10.0a0
+  license: LGPL-2.1-only or MPL-1.1
+  size: 978114
+  timestamp: 1741554591855
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-he90730b_1.conda
   sha256: 06525fa0c4e4f56e771a3b986d0fdf0f0fc5a3270830ee47e127a5105bde1b9a
   md5: bb6c4808bfa69d6f7f6b07e5846ced37
@@ -2694,6 +3394,25 @@ packages:
   purls: []
   size: 4186283
   timestamp: 1773686734540
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cartopy-0.25.0-py310h0158d43_1.conda
+  sha256: afb0b6f9be9fffc95615204146758317c0296cc5c354f990dfcae255a2412616
+  md5: 871b5f746960f99ac23dbc73d14e2ad0
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - matplotlib-base >=3.6
+  - numpy >=1.21,<3
+  - packaging >=21
+  - pyproj >=3.3.1
+  - pyshp >=2.3
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - shapely >=2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1432715
+  timestamp: 1756883681810
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cartopy-0.25.0-py312hf79963d_1.conda
   sha256: de9bb34948b0ac7025707fe0bdaa26a6f253374ddf9da8f74b2ed14943c14211
   md5: 6c913a686cb4060cbd7639a36fa144f0
@@ -2725,6 +3444,28 @@ packages:
   - pkg:pypi/certifi?source=compressed-mapping
   size: 135656
   timestamp: 1776866680878
+- conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.6.17-pyhd8ed1ab_0.conda
+  sha256: 6c13620e458ba43278379d0cdacc30c497336bddfda81681fd50d114a65c702f
+  md5: c13824fedced67005d3832c152fe9c2f
+  depends:
+  - python >=3.10
+  license: ISC
+  size: 133877
+  timestamp: 1781719949728
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.0.0-py310he7384ee_1.conda
+  sha256: bf76ead6d59b70f3e901476a73880ac92011be63b151972d135eec55bbbe6091
+  md5: 803e2d778b8dcccdc014127ec5001681
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libffi >=3.5.2,<3.6.0a0
+  - libgcc >=14
+  - pycparser
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 244766
+  timestamp: 1761203011221
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.0.0-py312h460c074_1.conda
   sha256: 7dafe8173d5f94e46cf9cd597cc8ff476a8357fbbd4433a8b5697b2864845d9c
   md5: 648ee28dcd4e07a1940a17da62eccd40
@@ -2765,6 +3506,20 @@ packages:
   purls: []
   size: 759758
   timestamp: 1759288114492
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cftime-1.6.5-py310hf779ad0_1.conda
+  sha256: d2c77b7ba1d49e859a047941bf7c382f66dbda1e7041e24bcac78f8e61bb0570
+  md5: 702cd87d652ec1956ee503b9e16bb1c0
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - numpy >=1.21,<3
+  - numpy >=1.21.2
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 430152
+  timestamp: 1768510929678
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cftime-1.6.5-py312h4f23490_1.conda
   sha256: 02c483817cce596ab0fb79f0f64027a166e20db0c84973e61a08285d53ee463d
   md5: 84bf349fad55056ed326fc550671b65c
@@ -2792,6 +3547,14 @@ packages:
   - pkg:pypi/charset-normalizer?source=compressed-mapping
   size: 58872
   timestamp: 1775127203018
+- conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.8-pyhd8ed1ab_0.conda
+  sha256: a51c9aed4a0f364fe72f4730a19daef7370446b107cd5dd9a5d7ad6d00895de1
+  md5: b2e6755844f4c74239dff62f1cb4adda
+  depends:
+  - python >=3.10
+  license: MIT
+  size: 61278
+  timestamp: 1783374645872
 - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.8-pyh707e725_0.conda
   sha256: c920d23cd1fcf565031c679adb62d848af60d6fbb0edc2d50ba475cea4f0d8ab
   md5: f22f4d4970e09d68a10b922cbb0408d3
@@ -2804,6 +3567,17 @@ packages:
   - pkg:pypi/click?source=hash-mapping
   size: 84705
   timestamp: 1734858922844
+- conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.2-pyhc90fa1f_0.conda
+  sha256: ccc4787f511964f9a1f2d2d2859c91c5d571fb60f7f09d4c4e092c9b7a94e671
+  md5: 2c4bd6aeb90bb157456841c3270a0d92
+  depends:
+  - __unix
+  - python
+  - python >=3.10
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 107155
+  timestamp: 1783085363526
 - conda: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1.2-pyhd8ed1ab_0.conda
   sha256: ba1ee6e2b2be3da41d70d0d51d1159010de900aa3f33fceaea8c52e9bd30a26e
   md5: e9b05deb91c013e5224672a4ba9cf8d1
@@ -2873,6 +3647,37 @@ packages:
   - pkg:pypi/comm?source=hash-mapping
   size: 14690
   timestamp: 1753453984907
+- conda: https://conda.anaconda.org/conda-forge/noarch/contextily-1.7.0-pyhd8ed1ab_0.conda
+  sha256: ded63e2434aad12d73aec04a74812bfb7e6159d69adbd70b33e31d910309b0b3
+  md5: e7d5beefd8351cf01a2f4bfcb8b6dbdb
+  depends:
+  - geopy
+  - joblib
+  - matplotlib-base
+  - mercantile
+  - pillow
+  - python >=3.10
+  - rasterio
+  - requests
+  - xyzservices
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 21018
+  timestamp: 1764021876587
+- conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.2-py310h3788b33_0.conda
+  sha256: 5231c1b68e01a9bc9debabc077a6fb48c4395206d59f40a4598d1d5e353e11d8
+  md5: b6420d29123c7c823de168f49ccdfe6a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - numpy >=1.23
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 261280
+  timestamp: 1744743236964
 - conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.3-py312h0a2e395_4.conda
   sha256: 62447faf7e8eb691e407688c0b4b7c230de40d5ecf95bf301111b4d05c5be473
   md5: 43c2bc96af3ae5ed9e8a10ded942aa50
@@ -2889,6 +3694,29 @@ packages:
   - pkg:pypi/contourpy?source=compressed-mapping
   size: 320386
   timestamp: 1769155979897
+- conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.15.0-py310h3406613_0.conda
+  sha256: a94eb03d4e39dd11a5dcb2c4187e82cbcae0fca3b29c573c9b0c7e46ad7d562e
+  md5: 4aa79c653568825bb42436f46be159ce
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - tomli
+  license: Apache-2.0
+  license_family: APACHE
+  size: 319893
+  timestamp: 1783019146023
+- conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.10.20-py310hd8ed1ab_1.conda
+  noarch: generic
+  sha256: 705917252b4cdfca93d8df09d40dc9b08074ecbd23b0ca23eb74bca8d1629599
+  md5: bfe34936b4fa9b1fbe25e68a7abbd8eb
+  depends:
+  - python >=3.10,<3.11.0a0
+  - python_abi * *_cp310
+  license: Python-2.0
+  size: 51458
+  timestamp: 1781148418793
 - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.12.13-py312hd8ed1ab_0.conda
   noarch: generic
   sha256: d3e9bbd7340199527f28bbacf947702368f31de60c433a16446767d3c6aaf6fe
@@ -3022,6 +3850,16 @@ packages:
   - pkg:pypi/dask-geopandas?source=hash-mapping
   size: 46488
   timestamp: 1748941387829
+- conda: https://conda.anaconda.org/conda-forge/noarch/dataretrieval-1.2.0-pyhd8ed1ab_1.conda
+  sha256: c977ac92edadc2356947b2e0ed8e0dc3e882d620d6c3006404dfb705a8ad56c9
+  md5: d73c56566db222eecac167d3fe32e7b8
+  depends:
+  - httpx
+  - pandas >=2.0.0,<4.0.0
+  - python >=3.10
+  license: CC0-1.0
+  size: 130029
+  timestamp: 1783373930357
 - conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.19.0-pyhd8ed1ab_0.conda
   sha256: cfecc3dad48250f530ebd16f52061cb37bc9fdbdfec25098bf2de8424996b0bc
   md5: 7718b2244ac8f3b4188ed4a06d49faf5
@@ -3045,6 +3883,40 @@ packages:
   - pkg:pypi/datashader?source=hash-mapping
   size: 9618951
   timestamp: 1774010655548
+- conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.19.1-pyhd8ed1ab_0.conda
+  sha256: a440eb220a07eb7517334396f0f783a356bf43ffb22b1441e61f394640ccfbe2
+  md5: 51ec314f84fd5215980646e84f6f54dc
+  depends:
+  - colorcet
+  - multipledispatch
+  - numba
+  - numpy
+  - packaging
+  - pandas
+  - param
+  - pyct
+  - python >=3.10
+  - requests
+  - scipy
+  - toolz
+  - xarray
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9604478
+  timestamp: 1779195887051
+- conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.16.2-h24cb091_1.conda
+  sha256: 8bb557af1b2b7983cf56292336a1a1853f26555d9c6cecf1e5b2b96838c9da87
+  md5: ce96f2f470d39bd96ce03945af92e280
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libzlib >=1.3.1,<2.0a0
+  - libglib >=2.86.2,<3.0a0
+  - libexpat >=2.7.3,<3.0a0
+  license: AFL-2.1 OR GPL-2.0-or-later
+  size: 447649
+  timestamp: 1764536047944
 - conda: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.20-py312h8285ef7_0.conda
   sha256: f20121b67149ff80bf951ccae7442756586d8789204cd08ade59397b22bfd098
   md5: ee1b48795ceb07311dd3e665dd4f5f33
@@ -3060,6 +3932,19 @@ packages:
   - pkg:pypi/debugpy?source=hash-mapping
   size: 2858582
   timestamp: 1769744978783
+- conda: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.21-py310h25320af_0.conda
+  sha256: 005e50f4e09327ee737408bcda52c22fcff7226d3864a814d6f97ee3d5ae6d67
+  md5: cdbb65fde8219076eed589ff728507d6
+  depends:
+  - python
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 2224979
+  timestamp: 1780390153919
 - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.2.1-pyhd8ed1ab_0.conda
   sha256: c17c6b9937c08ad63cb20a26f403a3234088e57d4455600974a0ce865cb14017
   md5: 9ce473d1d1be1cc3810856a48b3fab32
@@ -3071,6 +3956,15 @@ packages:
   - pkg:pypi/decorator?source=hash-mapping
   size: 14129
   timestamp: 1740385067843
+- conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.3.1-pyhd8ed1ab_0.conda
+  sha256: 430bd9d731b265f0bedb3183ac3ecfaa1656390c092b6e864ff8cc1229843c8c
+  md5: 61dcf784d59ef0bd62c57d982b154ace
+  depends:
+  - python >=3.10
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 16102
+  timestamp: 1779115228886
 - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
   sha256: 9717a059677553562a8f38ff07f3b9f61727bd614f505658b0a5ecbcf8df89be
   md5: 961b3a227b437d82ad7054484cfa71b2
@@ -3105,6 +3999,16 @@ packages:
   - pkg:pypi/distlib?source=hash-mapping
   size: 275642
   timestamp: 1752823081585
+- conda: https://conda.anaconda.org/conda-forge/noarch/distlib-0.4.3-pyhcf101f3_0.conda
+  sha256: e2753997b8bd34205f42be01b8bab8037423dc30c02a1ec12de23e5b4c0b0a2e
+  md5: 58638f77697c4f6726753eb8be34818b
+  depends:
+  - python >=3.10
+  - python
+  license: Apache-2.0
+  license_family: APACHE
+  size: 303705
+  timestamp: 1781320269259
 - conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2026.3.0-pyhc364b38_0.conda
   sha256: 49cbb318f7a1797b9f17c135c9b5c48ba2086570a58c99054d3b40bf13a5b815
   md5: 8efb90a27e3b948514a428cb99f3fc70
@@ -3135,6 +4039,14 @@ packages:
   - pkg:pypi/distributed?source=hash-mapping
   size: 845608
   timestamp: 1773858577032
+- conda: https://conda.anaconda.org/conda-forge/noarch/docutils-0.21.2-pyhd8ed1ab_1.conda
+  sha256: fa5966bb1718bbf6967a85075e30e4547901410cc7cb7b16daf68942e9a94823
+  md5: 24c1ca34138ee57de72a943237cde4cc
+  depends:
+  - python >=3.9
+  license: CC-PDDC AND BSD-3-Clause AND BSD-2-Clause AND ZPL-2.1
+  size: 402700
+  timestamp: 1733217860944
 - conda: https://conda.anaconda.org/conda-forge/noarch/docutils-0.22.4-pyhd8ed1ab_0.conda
   sha256: 0d605569a77350fb681f9ed8d357cc71649b59a304099dc9d09fbeec5e84a65e
   md5: d6bd3cd217e62bbd7efe67ff224cd667
@@ -3157,6 +4069,37 @@ packages:
   - pkg:pypi/donfig?source=hash-mapping
   size: 22491
   timestamp: 1734368817583
+- conda: https://conda.anaconda.org/conda-forge/noarch/epiweeks4cf-2.3.0-pyhd8ed1ab_1.conda
+  sha256: ca0421072bca09ac73bcbe19ab6ee57a762c75e9a9f989bfc735e7e543b96b1d
+  md5: 219bb828bdb0c60de8a4e8f86e4ba637
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 11598
+  timestamp: 1735319098248
+- conda: https://conda.anaconda.org/conda-forge/linux-64/epoxy-1.5.10-hb03c661_2.conda
+  sha256: a5b51e491fec22bcc1765f5b2c8fff8a97428e9a5a7ee6730095fb9d091b0747
+  md5: 057083b06ccf1c2778344b6dabace38b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libdrm >=2.4.125,<2.5.0a0
+  - libegl >=1.7.0,<2.0a0
+  - libegl-devel
+  - libgcc >=14
+  - libgl >=1.7.0,<2.0a0
+  - libgl-devel
+  - libglx >=1.7.0,<2.0a0
+  - libglx-devel
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxdamage >=1.1.6,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
+  - xorg-libxxf86vm >=1.1.6,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 411735
+  timestamp: 1758743520805
 - conda: https://conda.anaconda.org/conda-forge/linux-64/exactextract-0.3.0-py312hfb24e20_3.conda
   sha256: b00b7637f4122c452d8307cbd37915084a494c99cafb09692c2796316dcde831
   md5: fa1c7952152b0eecf40ae62869d0fd21
@@ -3187,6 +4130,15 @@ packages:
   - pkg:pypi/exceptiongroup?source=hash-mapping
   size: 21333
   timestamp: 1763918099466
+- conda: https://conda.anaconda.org/conda-forge/noarch/execnet-2.1.2-pyhd8ed1ab_0.conda
+  sha256: 1acc6a420efc5b64c384c1f35f49129966f8a12c93b4bb2bdc30079e5dc9d8a8
+  md5: a57b4be42619213a94f31d2c69c5dda7
+  depends:
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  size: 39499
+  timestamp: 1762974150770
 - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.1-pyhd8ed1ab_0.conda
   sha256: 210c8165a58fdbf16e626aac93cc4c14dbd551a01d1516be5ecad795d2422cad
   md5: ff9efb7f7469aed3c4a8106ffa29593c
@@ -3227,6 +4179,14 @@ packages:
   - pkg:pypi/filelock?source=compressed-mapping
   size: 34211
   timestamp: 1776621506566
+- conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.29.5-pyhd8ed1ab_0.conda
+  sha256: aa1035fbdc0c8fbe66a82ae4630b6ed73b832c2c0c52bd7b45b5f3bd54f51df6
+  md5: 288126f559a8a6cacabe59c73327fe1f
+  depends:
+  - python >=3.10
+  license: Unlicense
+  size: 38993
+  timestamp: 1783063554943
 - conda: https://conda.anaconda.org/conda-forge/linux-64/fiona-1.10.1-py312h053e1f3_6.conda
   sha256: 801274da37e28d0cff6d091b679d34b10df718420a97d8fe577a968805f396d3
   md5: a68cae58a81a937a6edcb3e4e6f0bbe7
@@ -3249,6 +4209,38 @@ packages:
   - pkg:pypi/fiona?source=hash-mapping
   size: 1203804
   timestamp: 1767051329805
+- conda: https://conda.anaconda.org/conda-forge/noarch/flexcache-0.3-pyhd8ed1ab_1.conda
+  sha256: acdb7b73d84268773fcc8192965994554411edc488ec3447925a62154e9d3baa
+  md5: f1e618f2f783427019071b14a111b30d
+  depends:
+  - python >=3.9
+  - typing-extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16674
+  timestamp: 1733663669958
+- conda: https://conda.anaconda.org/conda-forge/noarch/flexparser-0.4-pyhd8ed1ab_1.conda
+  sha256: 9bdad0cd9fb6d67e48798c03930d634ea2d33a894d30439d3d7bdffd3c21af7b
+  md5: 6dc4e43174cd552452fdb8c423e90e69
+  depends:
+  - python >=3.9
+  - typing-extensions
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28686
+  timestamp: 1733663636245
+- conda: https://conda.anaconda.org/conda-forge/noarch/flopy-3.10.0-pyhd8ed1ab_0.conda
+  sha256: 22cb1c2b953b35c82049f60717da62d42c2345df30f3d6803ff9043084ee760f
+  md5: 7ce2679e699e54de7eb7f44fef6af238
+  depends:
+  - matplotlib-base >=1.4.0
+  - numpy >=1.20.3,<3.0
+  - pandas >=2.0.0,<3.0
+  - python >=3.10
+  license: CC0-1.0
+  size: 808834
+  timestamp: 1770456421690
 - conda: https://conda.anaconda.org/conda-forge/linux-64/fmt-12.1.0-hff5e90c_0.conda
   sha256: d4e92ba7a7b4965341dc0fca57ec72d01d111b53c12d11396473115585a9ead6
   md5: f7d7a4104082b39e3b3473fbd4a38229
@@ -3325,6 +4317,21 @@ packages:
   purls: []
   size: 270705
   timestamp: 1771382710863
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.1-h27c8c51_0.conda
+  sha256: 2e50bdcebdf70a865b81f2456bbc586386451ec601c60f2b6cd22b8c40a2d384
+  md5: e0e050cfa9fa85fe39632ab11cb7f3e0
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libexpat >=2.8.1,<3.0a0
+  - libfreetype >=2.14.3
+  - libfreetype6 >=2.14.3
+  - libgcc >=14
+  - libuuid >=2.42.1,<3.0a0
+  - libzlib >=1.3.2,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 281880
+  timestamp: 1780450077431
 - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
   sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
   md5: fee5683a3f04bd15cbd8318b096a27ab
@@ -3365,6 +4372,31 @@ packages:
   - pkg:pypi/fonttools?source=compressed-mapping
   size: 2953293
   timestamp: 1776708606358
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.63.0-py310h3406613_0.conda
+  sha256: bca35ffa02f3c56774deb4a8aa39ef71c7cf5fbd01d7b222047b1a8a7194edae
+  md5: 73c9e3870ca97be05c96962a1606b288
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - brotli
+  - libgcc >=14
+  - munkres
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - unicodedata2 >=15.1.0
+  license: MIT
+  license_family: MIT
+  size: 2454762
+  timestamp: 1778770500028
+- conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda
+  sha256: 2509992ec2fd38ab27c7cdb42cf6cadc566a1cc0d1021a2673475d9fa87c6276
+  md5: d3549fd50d450b6d9e7dddff25dd2110
+  depends:
+  - cached-property >=1.3.0
+  - python >=3.9,<4
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 16705
+  timestamp: 1733327494780
 - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.3-ha770c72_0.conda
   sha256: c934c385889c7836f034039b43b05ccfa98f53c900db03d8411189892ced090b
   md5: 8462b5322567212beeb025f3519fb3e2
@@ -3389,6 +4421,15 @@ packages:
   purls: []
   size: 59299
   timestamp: 1734014884486
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.16-hb03c661_0.conda
+  sha256: 858283ff33d4c033f4971bf440cebff217d5552a5222ba994c49be990dacd40d
+  md5: f9f81ea472684d75b9dd8d0b328cf655
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: LGPL-2.1-or-later
+  size: 61244
+  timestamp: 1757438574066
 - conda: https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.7.0-py312h447239a_0.conda
   sha256: f4e0e6cd241bc24afb2d6d08e5d2ba170fad2475e522bdf297b7271bba268be6
   md5: 63e20cf7b7460019b423fc06abb96c60
@@ -3432,6 +4473,21 @@ packages:
   - pkg:pypi/gdal?source=hash-mapping
   size: 1879373
   timestamp: 1775928739497
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gdk-pixbuf-2.44.4-h2b0a6b4_0.conda
+  sha256: f47222f58839bcc77c15f11a8814c1d8cb8080c5ca6ba83398a12b640fd3c85c
+  md5: c379d67c686fb83475c1a6ed41cc41ff
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libglib >=2.86.0,<3.0a0
+  - libjpeg-turbo >=3.1.0,<4.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libpng >=1.6.50,<1.7.0a0
+  - libtiff >=4.7.1,<4.8.0a0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 572093
+  timestamp: 1761082340749
 - conda: https://conda.anaconda.org/conda-forge/noarch/gdptools-0.3.13-pyhc364b38_0.conda
   sha256: 3023f87550c2a1a5b36433cad601afe56dda1df17b794ff02c0ba656c784fe6a
   md5: 70c02603b75ded0398e4ce4bae11fe2d
@@ -3468,6 +4524,15 @@ packages:
   - pkg:pypi/gdptools?source=hash-mapping
   size: 14192931
   timestamp: 1776783447581
+- conda: https://conda.anaconda.org/conda-forge/noarch/geographiclib-2.1-pyhd8ed1ab_0.conda
+  sha256: 4bcebe8f5f449b728bd0140e38c036060f22d31048e0c7980bf4cd6acdad2b62
+  md5: 43dd16b113cc7b244d923b630026ff4f
+  depends:
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  size: 40836
+  timestamp: 1755865181359
 - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-1.1.3-pyhd8ed1ab_0.conda
   sha256: c9ed18fb6270202299671f8075dd4f2fdff42220e4fd958e84629375769747f0
   md5: 4eb8b870142ca06d2a1d2c74662eac7d
@@ -3485,6 +4550,22 @@ packages:
   purls: []
   size: 8761
   timestamp: 1773131235020
+- conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-1.1.4-pyhd8ed1ab_0.conda
+  sha256: cd478c0835106afce2478d6dcc525854219c4e710c7b446e2dd5042bfc9da082
+  md5: 99d77e0f92f7b0b977f77cfb49c7eaf6
+  depends:
+  - folium
+  - geopandas-base 1.1.4 pyha770c72_0
+  - mapclassify >=2.5.0
+  - matplotlib-base
+  - pyogrio >=0.7.2
+  - pyproj >=3.5.0
+  - python >=3.10
+  - xyzservices
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8267
+  timestamp: 1782507446937
 - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.1.3-pyha770c72_0.conda
   sha256: b07fc3edb5cb86df52081e5cb120a03a178767ed079b5d2cd313212351460620
   md5: 18789a85c307970ae1786dfc6dfd234f
@@ -3500,6 +4581,39 @@ packages:
   - pkg:pypi/geopandas?source=hash-mapping
   size: 254983
   timestamp: 1773131233972
+- conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.1.4-pyha770c72_0.conda
+  sha256: 77d0527d91c2a4bba135fdffb30557c88bacc22d7440c6632502609dd1ef0ab6
+  md5: 6e31007c02f361338281bb78c5b84e7c
+  depends:
+  - numpy >=1.24
+  - packaging
+  - pandas >=2.0.0
+  - python >=3.10
+  - shapely >=2.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 255909
+  timestamp: 1782507445933
+- conda: https://conda.anaconda.org/conda-forge/noarch/geopy-2.4.1-pyhd8ed1ab_2.conda
+  sha256: ac453c9558c48febe452c79281c632b3749baef7c04ed4b62f871709aee2aa03
+  md5: 40182a8d62a61d147ec7d3e4c5c36ac2
+  depends:
+  - geographiclib >=1.52
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 72999
+  timestamp: 1734342056836
+- conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.14.0-h480dda7_0.conda
+  sha256: c986e3c5fcdb61a34213923b22e5c8859a1012714cba34a4f6292551b67613ed
+  md5: 5dc479effdabf54a0ff240d565287495
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: LGPL-2.1-only
+  size: 1977241
+  timestamp: 1755851798617
 - conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.14.1-h480dda7_0.conda
   sha256: 08896dcd94e14a83f247e91748444e610f344ab42d80cbf2b6082b481c3f8f4b
   md5: 4d4efd0645cd556fab54617c4ad477ef
@@ -3511,6 +4625,22 @@ packages:
   purls: []
   size: 1974942
   timestamp: 1761593471198
+- conda: https://conda.anaconda.org/conda-forge/linux-64/geotiff-1.7.4-h239500f_2.conda
+  sha256: 0cd4454921ac0dfbf9d092d7383ba9717e223f9e506bc1ac862c99f98d2a953c
+  md5: b0c42bce162a38b1aa2f6dfb5c412bc4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libstdcxx >=13
+  - libtiff >=4.7.0,<4.8.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - proj >=9.6.0,<9.7.0a0
+  - zlib
+  license: MIT
+  license_family: MIT
+  size: 128758
+  timestamp: 1742402413139
 - conda: https://conda.anaconda.org/conda-forge/noarch/geoviews-1.15.1-pyhd8ed1ab_0.conda
   sha256: 97bb6e9fb7e0c546b09c418a783c383f45524c872182729fca2fa7548c6eb2c3
   md5: bb92eaf3d9b30b2f04f65686b4e1d11f
@@ -3566,7 +4696,7 @@ packages:
 - pypi: ./
   name: gfv2-params
   version: 0.1.0
-  sha256: ca296875856e94e5f8ab316d26f08d73a77050df30522431387728a121af6c84
+  sha256: 3a2acee64e4db74d483f18e6c52522206a47cbcb9a64028ea44187a20634d0a7
   requires_dist:
   - gdptools>=0.3.13
   - pandas
@@ -3622,6 +4752,32 @@ packages:
   purls: []
   size: 77248
   timestamp: 1712692454246
+- conda: https://conda.anaconda.org/conda-forge/linux-64/git-2.52.0-pl5321h28be001_0.conda
+  sha256: eb44eb774eef6bfba063318a9bcb16e5d7ac2421c0295aa372cd9c79e298ec83
+  md5: 64f99919099fccc29460a2f484090fa2
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libcurl >=8.17.0,<9.0a0
+  - libexpat >=2.7.1,<3.0a0
+  - libgcc >=14
+  - libiconv >=1.18,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.4,<4.0a0
+  - pcre2 >=10.46,<10.47.0a0
+  - perl 5.*
+  license: GPL-2.0-or-later and LGPL-2.1-or-later
+  size: 11613263
+  timestamp: 1763469108409
+- conda: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.86.2-hf516916_0.conda
+  sha256: 5517dae367d069de42c16d48f4b7e269acdedc11d43a5d4ec8d077d43ae00f45
+  md5: 14ad79cb7501b6a408485b04834a734c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libglib 2.86.2 h32235b2_0
+  license: LGPL-2.1-or-later
+  size: 116278
+  timestamp: 1763672395899
 - conda: https://conda.anaconda.org/conda-forge/linux-64/glog-0.7.1-hbabe93e_0.conda
   sha256: dc824dc1d0aa358e28da2ecbbb9f03d932d976c8dca11214aa1dcdfcbd054ba2
   md5: ff862eebdfeb2fd048ae9dc92510baca
@@ -3659,6 +4815,41 @@ packages:
   - pkg:pypi/google-crc32c?source=hash-mapping
   size: 24900
   timestamp: 1768549198202
+- conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.15-hecca717_0.conda
+  sha256: 885fa7d1d7e2ad9ed0a700ee0d81ceb49de278253082d517959b22d6336eecce
+  md5: cf09e9fc938518e91d0706572cadf17a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  size: 100054
+  timestamp: 1780454302233
+- conda: https://conda.anaconda.org/conda-forge/linux-64/graphviz-14.1.0-h8b86629_0.conda
+  sha256: af8ca1fe02eba1c4e72918e56ef180563ba38032bcbae0433bff13d0ba099113
+  md5: 39dcf8bb370df27fd81dbe41d4cb605e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - adwaita-icon-theme
+  - cairo >=1.18.4,<2.0a0
+  - fonts-conda-ecosystem
+  - gdk-pixbuf >=2.44.4,<3.0a0
+  - gtk3 >=3.24.43,<4.0a0
+  - gts >=0.7.6,<0.8.0a0
+  - libexpat >=2.7.3,<3.0a0
+  - libgcc >=14
+  - libgd >=2.3.3,<2.4.0a0
+  - libglib >=2.86.2,<3.0a0
+  - librsvg >=2.60.0,<3.0a0
+  - libstdcxx >=14
+  - libwebp-base >=1.6.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pango >=1.56.4,<2.0a0
+  license: EPL-1.0
+  license_family: Other
+  size: 2417740
+  timestamp: 1765099199559
 - conda: https://conda.anaconda.org/conda-forge/noarch/griffe-2.0.2-pyhcf101f3_0.conda
   sha256: 14cc12f55b19ddf164fb5df96dd156eaa6a8ab60b8ded337deda43fdcf70c369
   md5: 48dc0933013b4d09bd14373bbca33a44
@@ -3696,6 +4887,57 @@ packages:
   - pkg:pypi/griffelib?source=hash-mapping
   size: 117111
   timestamp: 1774621473366
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gtk3-3.24.43-h993cebd_6.conda
+  sha256: 004688fbb2c479b200a6d85ef38c3129fcd4ce13537b7ee2371d962b372761c1
+  md5: f9f33c65b20e6a61f21714785e3613ec
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - at-spi2-atk >=2.38.0,<3.0a0
+  - atk-1.0 >=2.38.0
+  - cairo >=1.18.4,<2.0a0
+  - epoxy >=1.5.10,<1.6.0a0
+  - fontconfig >=2.15.0,<3.0a0
+  - fonts-conda-ecosystem
+  - fribidi >=1.0.16,<2.0a0
+  - gdk-pixbuf >=2.44.4,<3.0a0
+  - glib-tools
+  - harfbuzz >=11.5.1
+  - hicolor-icon-theme
+  - libcups >=2.3.3,<2.4.0a0
+  - libcups >=2.3.3,<3.0a0
+  - libexpat >=2.7.1,<3.0a0
+  - libgcc >=14
+  - libglib >=2.86.0,<3.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libxkbcommon >=1.12.2,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pango >=1.56.4,<2.0a0
+  - wayland >=1.24.0,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxcomposite >=0.4.6,<1.0a0
+  - xorg-libxcursor >=1.2.3,<2.0a0
+  - xorg-libxdamage >=1.1.6,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxfixes >=6.0.2,<7.0a0
+  - xorg-libxi >=1.8.2,<2.0a0
+  - xorg-libxinerama >=1.1.5,<1.2.0a0
+  - xorg-libxrandr >=1.5.4,<2.0a0
+  - xorg-libxrender >=0.9.12,<0.10.0a0
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  size: 5587108
+  timestamp: 1761327349586
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gts-0.7.6-h977cf35_4.conda
+  sha256: b5cd16262fefb836f69dc26d879b6508d29f8a5c5948a966c47fe99e2e19c99b
+  md5: 4d8df0b0db060d33c9a702ada998a8fe
+  depends:
+  - libgcc-ng >=12
+  - libglib >=2.76.3,<3.0a0
+  - libstdcxx-ng >=12
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  size: 318312
+  timestamp: 1686545244763
 - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.16.0-pyhcf101f3_1.conda
   sha256: 96cac6573fd35ae151f4d6979bab6fbc90cb6b1fb99054ba19eb075da9822fcb
   md5: b8993c19b0c32a2f7b66cbb58ca27069
@@ -3723,6 +4965,25 @@ packages:
   - pkg:pypi/h2?source=hash-mapping
   size: 95967
   timestamp: 1756364871835
+- conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-12.2.0-h15599e2_0.conda
+  sha256: 6bd8b22beb7d40562b2889dc68232c589ff0d11a5ad3addd41a8570d11f039d9
+  md5: b8690f53007e9b5ee2c2178dd4ac778c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cairo >=1.18.4,<2.0a0
+  - graphite2 >=1.3.14,<2.0a0
+  - icu >=75.1,<76.0a0
+  - libexpat >=2.7.1,<3.0a0
+  - libfreetype >=2.14.1
+  - libfreetype6 >=2.14.1
+  - libgcc >=14
+  - libglib >=2.86.1,<3.0a0
+  - libstdcxx >=14
+  - libzlib >=1.3.1,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 2411408
+  timestamp: 1762372726141
 - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf4-4.2.15-h2a13503_7.conda
   sha256: 0d09b6dc1ce5c4005ae1c6a19dc10767932ef9a5e9c755cfdbb5189ac8fb0684
   md5: bd77f8da987968ec3927990495dc22e4
@@ -3736,6 +4997,23 @@ packages:
   purls: []
   size: 756742
   timestamp: 1695661547874
+- conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.6-nompi_h19486de_110.conda
+  sha256: ac57ce3abbda2a82d6192bc36fbd7fe96e867d84c999ef81a3da034dfd01a995
+  md5: 9c6e11a83468e1d5decae516077a73fb
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libaec >=1.1.5,<2.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - libgcc >=14
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  - libstdcxx >=14
+  - libzlib >=1.3.2,<2.0a0
+  - openssl >=3.5.6,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3721555
+  timestamp: 1780581675871
 - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-2.1.0-nompi_h87a9417_105.conda
   sha256: beb8a2fb18924ca7b5b82cfb50f008f882f577daef2c00ed88022abea35fec76
   md5: 0d0595612fa229dddb5fc565c260a11f
@@ -3760,6 +5038,13 @@ packages:
   purls: []
   size: 4713397
   timestamp: 1777861887131
+- conda: https://conda.anaconda.org/conda-forge/linux-64/hicolor-icon-theme-0.17-ha770c72_3.conda
+  sha256: 6d7e6e1286cb521059fe69696705100a03b006efb914ffe82a2ae97ecbae66b7
+  md5: 129e404c5b001f3ef5581316971e3ea0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 17625
+  timestamp: 1771539597968
 - conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.22.1-pyhd8ed1ab_0.conda
   sha256: 598c989ceb11bba5c0c142b8394016ddb26153a02e8275eb045985913c72beaf
   md5: 32bc3daa3fa9619d84e634b4515f564a
@@ -3782,6 +5067,25 @@ packages:
   - pkg:pypi/holoviews?source=hash-mapping
   size: 4889477
   timestamp: 1764957187208
+- conda: https://conda.anaconda.org/conda-forge/noarch/holoviews-1.23.1-pyhd8ed1ab_0.conda
+  sha256: dfa09e6ed29819578dae1ad3bc7fadbb4f1cb49aed0d1b8f3db1703b4073cd4f
+  md5: 3e866f297283b6213384abf00c2e315f
+  depends:
+  - bokeh >=3.1
+  - colorcet
+  - matplotlib-base >=3.0
+  - narwhals >=2
+  - numpy >=1.21
+  - pandas >=1.3
+  - panel >=1.0
+  - param >=2.0,<3.0
+  - python >=3.10
+  - python-dateutil >=2.8.2
+  - pyviz_comms >=2.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4937226
+  timestamp: 1783019063272
 - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
   sha256: 6ad78a180576c706aabeb5b4c8ceb97c0cb25f1e112d76495bff23e3779948ba
   md5: 0a802cb9888dd14eeefc611f05c40b6e
@@ -3793,6 +5097,43 @@ packages:
   - pkg:pypi/hpack?source=hash-mapping
   size: 30731
   timestamp: 1737618390337
+- conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.2.0-pyhd8ed1ab_0.conda
+  sha256: fdcea5d7cb314485d3907192ef024c704311548c5b0cbeb390cd1951051e29d2
+  md5: b395909221b9bd1df066e5930e18855b
+  depends:
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  size: 32884
+  timestamp: 1782283986153
+- conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.9-pyh29332c3_0.conda
+  sha256: 04d49cb3c42714ce533a8553986e1642d0549a05dc5cc48e0d43ff5be6679a5b
+  md5: 4f14640d58e2cc0aa0819d9d8ba125bb
+  depends:
+  - python >=3.9
+  - h11 >=0.16
+  - h2 >=3,<5
+  - sniffio 1.*
+  - anyio >=4.0,<5.0
+  - certifi
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 49483
+  timestamp: 1745602916758
+- conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
+  sha256: cd0f1de3697b252df95f98383e9edb1d00386bfdd03fdf607fa42fe5fcb09950
+  md5: d6989ead454181f4f9bc987d3dc4e285
+  depends:
+  - anyio
+  - certifi
+  - httpcore 1.*
+  - idna
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 63082
+  timestamp: 1733663449209
 - conda: https://conda.anaconda.org/conda-forge/noarch/hvplot-0.12.2-pyhd8ed1ab_0.conda
   sha256: 2b1b67462c87b1252733b8d45d88a68de513ba9852d210c77f64f0d20a558603
   md5: a3ebf00cb037e464061fcf68a5a75d83
@@ -3823,6 +5164,17 @@ packages:
   - pkg:pypi/hyperframe?source=hash-mapping
   size: 17397
   timestamp: 1737618427549
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
+  sha256: 71e750d509f5fa3421087ba88ef9a7b9be11c53174af3aa4d06aff4c18b38e8e
+  md5: 8b189310083baabfb622af68fd9d3ae3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 12129203
+  timestamp: 1720853576813
 - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
   sha256: fbf86c4a59c2ed05bbffb2ba25c7ed94f6185ec30ecb691615d42342baa1a16a
   md5: c80d8a3b84358cb967fa81e7075fbc8a
@@ -3859,6 +5211,25 @@ packages:
   - pkg:pypi/idna?source=compressed-mapping
   size: 59038
   timestamp: 1776947141407
+- conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.18-pyhcf101f3_0.conda
+  sha256: c75632ea624aa450a394f570749420c5a2e0997d0216bc29d5d45b0f39df0426
+  md5: 577b04680ae422adb86fc60d7b940659
+  depends:
+  - python >=3.10
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 163869
+  timestamp: 1781620148226
+- conda: https://conda.anaconda.org/conda-forge/noarch/imagesize-2.0.0-pyhd8ed1ab_0.conda
+  sha256: 5a047f9eac290e679b4e6f6f4cbfcc5acdfbf031a4f06824d4ddb590cdbb850b
+  md5: 92617c2ba2847cca7a6ed813b6f4ab79
+  depends:
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  size: 15729
+  timestamp: 1773752188889
 - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
   sha256: 82ab2a0d91ca1e7e63ab6a4939356667ef683905dea631bc2121aa534d347b16
   md5: 080594bf4493e6bae2607e65390c520a
@@ -3872,6 +5243,17 @@ packages:
   - pkg:pypi/importlib-metadata?source=compressed-mapping
   size: 34387
   timestamp: 1773931568510
+- conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
+  sha256: 43e2a5497cad1598ff88a3e69f69bc88b7b8f141fa63c60eab5db296317318b8
+  md5: ffc17e785d64e12fc311af9184221839
+  depends:
+  - python >=3.10
+  - zipp >=3.20
+  - python
+  license: Apache-2.0
+  license_family: APACHE
+  size: 34766
+  timestamp: 1779714582554
 - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-8.8.0-h8f7a5dd_0.conda
   sha256: 09f2b26f8c727fd2138fd4846b91708c32d5684120b59d5c8d38472c0eefbf33
   md5: 12e7a110add59a05b337484568a83a4d
@@ -3984,6 +5366,53 @@ packages:
   - pkg:pypi/ipykernel?source=compressed-mapping
   size: 133644
   timestamp: 1770566133040
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-7.3.0-pyha191276_0.conda
+  sha256: 305ad9226363ff5f259c404dd9a7508183a2e150739b2adc43db7d817234da66
+  md5: 2b47a10e4d98334f8171ff60aea05ff3
+  depends:
+  - __linux
+  - comm >=0.1.1
+  - debugpy >=1.6.5
+  - ipython >=7.23.1
+  - jupyter_client >=8.9.0
+  - jupyter_core >=5.1,!=6.0.*
+  - matplotlib-inline >=0.1
+  - nest-asyncio2 >=1.7.0
+  - packaging >=22
+  - psutil >=5.7
+  - python >=3.10
+  - pyzmq >=25
+  - tornado >=6.4.1
+  - traitlets >=5.4.0
+  - python
+  constrains:
+  - appnope >=0.1.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 138635
+  timestamp: 1781101665847
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.37.0-pyh8f84b5b_0.conda
+  sha256: e43fa762183b49c3c3b811d41259e94bb14b7bff4a239b747ef4e1c6bbe2702d
+  md5: 177cfa19fe3d74c87a8889286dc64090
+  depends:
+  - __unix
+  - pexpect >4.3
+  - decorator
+  - exceptiongroup
+  - jedi >=0.16
+  - matplotlib-inline
+  - pickleshare
+  - prompt-toolkit >=3.0.41,<3.1.0
+  - pygments >=2.4.0
+  - python >=3.10
+  - stack_data
+  - traitlets >=5.13.0
+  - typing_extensions >=4.6
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 639160
+  timestamp: 1748711175284
 - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-9.13.0-pyh53cf698_0.conda
   sha256: a0af49948a1842dfd15a0b0b2fd56c94ddbd07e07a6c8b4bc70d43015eafaff0
   md5: 73e9657cd19605740d21efb14d8d0cb9
@@ -4020,6 +5449,30 @@ packages:
   - pkg:pypi/ipython-pygments-lexers?source=hash-mapping
   size: 13993
   timestamp: 1737123723464
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipywidgets-8.1.8-pyhd8ed1ab_0.conda
+  sha256: 6bb58afb7eabc8b4ac0c7e92707fb498313cc0164cf04e7ba1090dbf49af514b
+  md5: d68e3f70d1f068f1b66d94822fdc644e
+  depends:
+  - comm >=0.1.3
+  - ipython >=6.1.0
+  - jupyterlab_widgets >=3.0.15,<3.1.0
+  - python >=3.10
+  - traitlets >=4.3.1
+  - widgetsnbextension >=4.0.14,<4.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 114376
+  timestamp: 1762040524661
+- conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_1.conda
+  sha256: 08e838d29c134a7684bca0468401d26840f41c92267c4126d7b43a6b533b0aed
+  md5: 0b0154421989637d424ccf0f104be51a
+  depends:
+  - arrow >=0.15.0
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 19832
+  timestamp: 1733493720346
 - conda: https://conda.anaconda.org/conda-forge/noarch/itsdangerous-2.2.0-pyhd8ed1ab_1.conda
   sha256: 1684b7b16eec08efef5302ce298c606b163c18272b69a62b666fbaa61516f170
   md5: 7ac5f795c15f288984e32add616cdc59
@@ -4042,6 +5495,16 @@ packages:
   - pkg:pypi/jedi?source=hash-mapping
   size: 843646
   timestamp: 1733300981994
+- conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.20.0-pyhcf101f3_0.conda
+  sha256: 744143551c1c7b528b82533fb641b9d7db20b2203abc4c2635c387fa6c089fc3
+  md5: c2b3d37aa1411031126036ee76a8a861
+  depends:
+  - python >=3.10
+  - parso >=0.8.6,<0.9.0
+  - python
+  license: Apache-2.0 AND MIT
+  size: 2715215
+  timestamp: 1782251948616
 - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
   sha256: fc9ca7348a4f25fed2079f2153ecdcf5f9cf2a0bc36c4172420ca09e1849df7b
   md5: 04558c96691bed63104678757beb4f8d
@@ -4090,6 +5553,25 @@ packages:
   purls: []
   size: 82709
   timestamp: 1726487116178
+- conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.15.0-pyhd8ed1ab_0.conda
+  sha256: 637400a4174880463985c7a5b6e3e0bea0aa9d0892a6c06a3a8aa2cf1208c35a
+  md5: 761a4a6b9cba303c66a97ca642447171
+  depends:
+  - python >=3.10
+  license: Apache-2.0
+  license_family: APACHE
+  size: 39373
+  timestamp: 1781926894833
+- conda: https://conda.anaconda.org/conda-forge/noarch/jsonpointer-3.1.1-pyhcf101f3_0.conda
+  sha256: a3d10301b6ff399ba1f3d39e443664804a3d28315a4fb81e745b6817845f70ae
+  md5: 89bf346df77603055d3c8fe5811691e6
+  depends:
+  - python >=3.10
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14190
+  timestamp: 1774311356147
 - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.26.0-pyhcf101f3_0.conda
   sha256: db973a37d75db8e19b5f44bbbdaead0c68dde745407f281e2a7fe4db74ec51d7
   md5: ada41c863af263cc4c5fcbaff7c3e4dc
@@ -4119,6 +5601,77 @@ packages:
   - pkg:pypi/jsonschema-specifications?source=hash-mapping
   size: 19236
   timestamp: 1757335715225
+- conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.26.0-hcf101f3_0.conda
+  sha256: 6886fc61e4e4edd38fd38729976b134e8bd2143f7fce56cc80d7ac7bac99bce1
+  md5: 8368d58342d0825f0843dc6acdd0c483
+  depends:
+  - jsonschema >=4.26.0,<4.26.1.0a0
+  - fqdn
+  - idna
+  - isoduration
+  - jsonpointer >1.13
+  - rfc3339-validator
+  - rfc3986-validator >0.1.0
+  - rfc3987-syntax >=1.1.0
+  - uri-template
+  - webcolors >=24.6.0
+  license: MIT
+  license_family: MIT
+  size: 4740
+  timestamp: 1767839954258
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-1.1.1-pyhd8ed1ab_1.conda
+  sha256: b538e15067d05768d1c0532a6d9b0625922a1cce751dd6a2af04f7233a1a70e9
+  md5: 9453512288d20847de4356327d0e1282
+  depends:
+  - ipykernel
+  - ipywidgets
+  - jupyter_console
+  - jupyterlab
+  - nbconvert-core
+  - notebook
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8891
+  timestamp: 1733818677113
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-black-0.4.0-pyhd8ed1ab_1.conda
+  sha256: 77e6104a7b204e7a57fc0a5ab1919036e827b70608a6c0ba3d8fe542bbf4c721
+  md5: 42ac66b625cf2f892aa93fb053ba7008
+  depends:
+  - black >=21
+  - ipython >=7.8.0
+  - python >=3.9
+  - tokenize-rt >=4
+  license: MIT
+  license_family: MIT
+  size: 13298
+  timestamp: 1736330449967
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-builder-1.0.2-pyhcf101f3_0.conda
+  sha256: a845bffdbcdd1749dd4a46e47be5d4e0e1c87cdda547e3a87d297a6963ab0821
+  md5: 12b0a9513f6abaa944c313c4a01d5500
+  depends:
+  - jupyter_core
+  - python >=3.10
+  - tomli
+  - traitlets
+  - python
+  constrains:
+  - nodejs >=22
+  license: BSD-3-Clause AND MIT AND ISC
+  size: 858738
+  timestamp: 1781271993460
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.3.1-pyhcf101f3_0.conda
+  sha256: 3766e2ae59641c172cec8a821528bfa6bf9543ffaaeb8b358bfd5259dcf18e4e
+  md5: 0c3b465ceee138b9c39279cc02e5c4a0
+  depends:
+  - importlib-metadata >=4.8.3
+  - jupyter_server >=1.1.2
+  - python >=3.10
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 61633
+  timestamp: 1775136333147
 - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.8.0-pyhcf101f3_0.conda
   sha256: e402bd119720862a33229624ec23645916a7d47f30e1711a4af9e005162b84f3
   md5: 8a3d6d0523f66cf004e563a50d9392b3
@@ -4136,6 +5689,39 @@ packages:
   - pkg:pypi/jupyter-client?source=compressed-mapping
   size: 112785
   timestamp: 1767954655912
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.9.1-pyhcf101f3_0.conda
+  sha256: 48b18974cc93b2c0d2681563237034e521f51d1878f0bbc6a5a67ca31b1608a6
+  md5: 49440e66df843bee2273937e8032ec43
+  depends:
+  - jupyter_core >=5.1
+  - python >=3.10
+  - python-dateutil >=2.8.2
+  - pyzmq >=25.0
+  - tornado >=6.4.1
+  - traitlets >=5.3
+  - typing_extensions >=4.13.0
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 117954
+  timestamp: 1781019994076
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_console-6.6.3-pyhd8ed1ab_1.conda
+  sha256: aee0cdd0cb2b9321d28450aec4e0fd43566efcd79e862d70ce49a68bf0539bcd
+  md5: 801dbf535ec26508fac6d4b24adfb76e
+  depends:
+  - ipykernel >=6.14
+  - ipython
+  - jupyter_client >=7.0.0
+  - jupyter_core >=4.12,!=5.0.*
+  - prompt_toolkit >=3.0.30
+  - pygments
+  - python >=3.9
+  - pyzmq >=17
+  - traitlets >=5.4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26874
+  timestamp: 1733818130068
 - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.conda
   sha256: 1d34b80e5bfcd5323f104dbf99a2aafc0e5d823019d626d0dce5d3d356a2a52a
   md5: b38fe4e78ee75def7e599843ef4c1ab0
@@ -4154,6 +5740,86 @@ packages:
   - pkg:pypi/jupyter-core?source=hash-mapping
   size: 65503
   timestamp: 1760643864586
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.12.1-pyhcf101f3_0.conda
+  sha256: c7edb5682c6316a95ad781dccb1b6589cd2ec0bf94f23c21152974eb0363b5d7
+  md5: bf42ee94c750c0b2e7e998b79ac299ea
+  depends:
+  - jsonschema-with-format-nongpl >=4.18.0
+  - packaging
+  - python >=3.10
+  - python-json-logger >=2.0.4
+  - pyyaml >=5.3
+  - referencing
+  - rfc3339-validator
+  - rfc3986-validator >=0.1.1
+  - traitlets >=5.3
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24002
+  timestamp: 1776861872237
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.20.0-pyhcf101f3_0.conda
+  sha256: 3e8759fdc404f149e7e722e0af472044a0ef9e70d0a3a7690ddcfe1232a0e868
+  md5: b2ddb0e13b5600070c4019c4db8a78e6
+  depends:
+  - anyio >=3.1.0
+  - argon2-cffi >=21.1
+  - jinja2 >=3.0.3
+  - jupyter_client >=7.4.4
+  - jupyter_core >=4.12,!=5.0.*
+  - jupyter_events >=0.11.0
+  - jupyter_server_terminals >=0.4.4
+  - nbconvert-core >=6.4.4
+  - nbformat >=5.3.0
+  - overrides >=5.0
+  - packaging >=22.0
+  - prometheus_client >=0.9
+  - python >=3.10
+  - pyzmq >=24
+  - send2trash >=1.8.2
+  - terminado >=0.8.3
+  - tornado >=6.2.0
+  - traitlets >=5.6.0
+  - websocket-client >=1.7
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 363068
+  timestamp: 1781713810089
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.4-pyhcf101f3_0.conda
+  sha256: 5eda79ed9f53f590031d29346abd183051263227dd9ee667b5ca1133ce297654
+  md5: 7b8bace4943e0dc345fc45938826f2b8
+  depends:
+  - python >=3.10
+  - terminado >=0.8.3
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 22052
+  timestamp: 1768574057200
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.6.1-pyhd8ed1ab_0.conda
+  sha256: ad4a462da846fb8e9feebe39170553fc6a94252f4d4cca8efaf0dfeefa907099
+  md5: 7ba07211c94d434f3223a4418f8b1ff8
+  depends:
+  - async-lru >=1.0.0
+  - httpx >=0.25.0,<1
+  - ipykernel >=6.5.0,!=6.30.0
+  - jinja2 >=3.0.3
+  - jupyter-builder >=1.0.2
+  - jupyter-lsp >=2.0.0
+  - jupyter_core
+  - jupyter_server >=2.19.0,<3
+  - jupyterlab_server >=2.28.0,<3
+  - notebook-shim >=0.2
+  - packaging >=23.2
+  - python >=3.10
+  - tomli >=1.2.2
+  - tornado >=6.2.0
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 13793940
+  timestamp: 1782739437310
 - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_2.conda
   sha256: dc24b900742fdaf1e077d9a3458fd865711de80bca95fe3c6d46610c532c6ef0
   md5: fd312693df06da3578383232528c468d
@@ -4168,6 +5834,35 @@ packages:
   - pkg:pypi/jupyterlab-pygments?source=hash-mapping
   size: 18711
   timestamp: 1733328194037
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.28.0-pyhcf101f3_0.conda
+  sha256: 381d2d6a259a3be5f38a69463e0f6c5dcf1844ae113058007b51c3bef13a7cee
+  md5: a63877cb23de826b1620d3adfccc4014
+  depends:
+  - babel >=2.10
+  - jinja2 >=3.0.3
+  - json5 >=0.9.0
+  - jsonschema >=4.18
+  - jupyter_server >=1.21,<3
+  - packaging >=21.3
+  - python >=3.10
+  - requests >=2.31
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 51621
+  timestamp: 1761145478692
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-3.0.16-pyhcf101f3_1.conda
+  sha256: 5c03de243d7ae6247f39a402f4785d95e61c3be79ef18738e8f17155585d31a8
+  md5: dbf8b81974504fa51d34e436ca7ef389
+  depends:
+  - python >=3.10
+  - python
+  constrains:
+  - jupyterlab >=3,<5
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 216779
+  timestamp: 1762267481404
 - conda: https://conda.anaconda.org/conda-forge/linux-64/kealib-1.6.2-h63db1d0_3.conda
   sha256: c84098c12517ae21810e83420950833e83289460292436f5ca9908fd66e747bc
   md5: e54b7a33dd3405ba1a9d3d95917ea32b
@@ -4193,6 +5888,19 @@ packages:
   purls: []
   size: 134088
   timestamp: 1754905959823
+- conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.5.0-py310haaf941d_0.conda
+  sha256: 44312f8b881a4c77af4be198c8e2e2022e406f58314191c31be8e172382ecdf7
+  md5: 8993ab7e5dce89147288dd78686e790c
+  depends:
+  - python
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 77809
+  timestamp: 1773067043838
 - conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.5.0-py312h0a2e395_0.conda
   sha256: eec7654c2d68f06590862c6e845cc70987b6d6559222b6f0e619dea4268f5dd5
   md5: cd74a9525dc74bbbf93cf8aa2fa9eb5b
@@ -4224,6 +5932,30 @@ packages:
   purls: []
   size: 1386730
   timestamp: 1769769569681
+- conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-hbde042b_1.conda
+  sha256: 9b07046870772f28740e3f6149f09ff222843733087a33c5540b169c6289652d
+  md5: 54157a1c8c0bb70f62dd0b17fba7e7f2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - keyutils >=1.6.3,<2.0a0
+  - libedit >=3.1.20250104,<3.2.0a0
+  - libedit >=3.1.20250104,<4.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - openssl >=3.5.7,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1388990
+  timestamp: 1781859420533
+- conda: https://conda.anaconda.org/conda-forge/noarch/lark-1.3.1-pyhd8ed1ab_0.conda
+  sha256: 49570840fb15f5df5d4b4464db8ee43a6d643031a2bc70ef52120a52e3809699
+  md5: 9b965c999135d43a3d0f7bd7d024e26a
+  depends:
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  size: 94312
+  timestamp: 1761596921009
 - conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.19.1-h0c24ade_0.conda
   sha256: eb89c6c39f2f6a93db55723dbb2f6bba8c8e63e6312bf1abf13e6e9ff45849c8
   md5: f92f984b558e6e6204014b16d212b271
@@ -4237,6 +5969,18 @@ packages:
   purls: []
   size: 251086
   timestamp: 1778079286384
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.19.1-h0c24ade_1.conda
+  sha256: 112b5b9462572d970f4abd2912f76a25ee7db158b1e7260163d91dd8a630db84
+  md5: 8b3ce45e929cd8e8e5f4d18586b56d8b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - libtiff >=4.7.1,<4.8.0a0
+  license: MIT
+  license_family: MIT
+  size: 251971
+  timestamp: 1780211695895
 - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
   sha256: 3d584956604909ff5df353767f3a2a2f60e07d070b328d109f30ac40cd62df6c
   md5: 18335a698559cdbcd86150a48bf54ba6
@@ -4321,6 +6065,25 @@ packages:
   purls: []
   size: 891114
   timestamp: 1776096017113
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libarchive-3.8.8-gpl_hc2c16d8_100.conda
+  sha256: f916b51f55f51a9bb2d902e0a5f029490f7b745aee549c349751c1787ddc26b8
+  md5: 44652e646cb623f486ea72e7e7479222
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc >=14
+  - liblzma >=5.8.3,<6.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - libzlib >=1.3.2,<2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - lzo >=2.10,<3.0a0
+  - openssl >=3.5.7,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 867280
+  timestamp: 1782289011634
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-24.0.0-h0935d00_1_cpu.conda
   build_number: 1
   sha256: d2325979993c71580e571eaa470e0ca33b86acb23c653909fecaef688a1c44b4
@@ -4440,6 +6203,23 @@ packages:
   purls: []
   size: 18621
   timestamp: 1774503034895
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-8_h4a7cf45_openblas.conda
+  build_number: 8
+  sha256: b2da6bfd72a1c9cb143ccf64bf5b28790cb4eb58bd1cb978f6537b2322f7d48b
+  md5: 00fc660ab1b2f5ca07e92b4900d10c79
+  depends:
+  - libopenblas >=0.3.33,<0.3.34.0a0
+  - libopenblas >=0.3.33,<1.0a0
+  constrains:
+  - blas 2.308   openblas
+  - mkl <2027
+  - libcblas   3.11.0   8*_openblas
+  - liblapack  3.11.0   8*_openblas
+  - liblapacke 3.11.0   8*_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18804
+  timestamp: 1779859100675
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.2.0-hb03c661_1.conda
   sha256: 318f36bd49ca8ad85e6478bd8506c88d82454cc008c1ac1c6bf00a3c42fa610e
   md5: 72c8fd1af66bd67bf580645b426513ed
@@ -4490,6 +6270,20 @@ packages:
   purls: []
   size: 18622
   timestamp: 1774503050205
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-8_h0358290_openblas.conda
+  build_number: 8
+  sha256: 1a2bc77bb26520255904a3d9b1f40e6bf0bf9d8d3405c7709dd162282820915a
+  md5: 33a413f1095f8325e5c30fde3b0d2445
+  depends:
+  - libblas 3.11.0 8_h4a7cf45_openblas
+  constrains:
+  - blas 2.308   openblas
+  - liblapacke 3.11.0   8*_openblas
+  - liblapack  3.11.0   8*_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18778
+  timestamp: 1779859107964
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libcrc32c-1.1.2-h9c3ff4c_0.tar.bz2
   sha256: fd1d153962764433fe6233f34a72cdeed5dcf8a883a85769e8295ce940b5b0c5
   md5: c965a5aa0d5c1c37ffc62dff36e28400
@@ -4501,6 +6295,19 @@ packages:
   purls: []
   size: 20440
   timestamp: 1633683576494
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h7a8fb5f_6.conda
+  sha256: 205c4f19550f3647832ec44e35e6d93c8c206782bdd620c1d7cf66237580ff9c
+  md5: 49c553b47ff679a6a1e9fc80b9c5a2d4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - krb5 >=1.22.2,<1.23.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libzlib >=1.3.1,<2.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 4518030
+  timestamp: 1770902209173
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.20.0-hcf29cc6_0.conda
   sha256: 75963a5dd913311f59a35dbd307592f4fa754c4808aff9c33edb430c415e38eb
   md5: c3cc2864f82a944bc90a7beb4d3b0e88
@@ -4518,6 +6325,22 @@ packages:
   purls: []
   size: 468706
   timestamp: 1777461492876
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.21.0-hcf29cc6_1.conda
+  sha256: 7d243f45a48f62cb8e3b871dd336137fe0fb90094a191756fb553508837f6338
+  md5: 2c1e55d695b11525c760b486ac0be517
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - krb5 >=1.22.2,<1.23.0a0
+  - libgcc >=14
+  - libnghttp2 >=1.68.1,<2.0a0
+  - libssh2 >=1.11.1,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - openssl >=3.5.7,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 478914
+  timestamp: 1782802520033
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-h17f619e_0.conda
   sha256: aa8e8c4be9a2e81610ddf574e05b64ee131fab5e0e3693210c9d6d2fba32c680
   md5: 6c77a605a7a689d17d4819c0f8ac9a00
@@ -4529,6 +6352,17 @@ packages:
   purls: []
   size: 73490
   timestamp: 1761979956660
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.127-hb03c661_0.conda
+  sha256: 7d3187c11b7ae66c5595a8afd5a7ce352a490527fdf6614cab129bc7f2c16ba3
+  md5: d8d16b9b32a3c5df7e5b3350e2cbe058
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libpciaccess >=0.19,<0.20.0a0
+  license: MIT
+  license_family: MIT
+  size: 311505
+  timestamp: 1778975798004
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
   sha256: d789471216e7aba3c184cd054ed61ce3f6dac6f87a50ec69291b9297f8c18724
   md5: c277e0a4d549b03ac1e9d6cbbe3d017b
@@ -4552,6 +6386,26 @@ packages:
   purls: []
   size: 44840
   timestamp: 1731330973553
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_3.conda
+  sha256: 9a25ea93e8272785405a21d30f84e620befb1d545f6dfaae18f06103b5df0443
+  md5: 75e9f795be506c96dd43cb09c7c8d557
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libglvnd 1.7.0 ha4b6fd6_3
+  license: LicenseRef-libglvnd
+  size: 46500
+  timestamp: 1779728188901
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-devel-1.7.0-ha4b6fd6_3.conda
+  sha256: e4b46919c9bb65930bce238bd2736110ed7b8c30e5cd5394e4e1edb48de54843
+  md5: 5bc6d55503483aabe8a90c5e7f49a2a4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libegl 1.7.0 ha4b6fd6_3
+  - libgl-devel 1.7.0 ha4b6fd6_3
+  - xorg-libx11
+  license: LicenseRef-libglvnd
+  size: 31718
+  timestamp: 1779728222280
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
   sha256: 1cd6048169fa0395af74ed5d8f1716e22c19a81a8a36f934c110ca3ad4dd27b4
   md5: 172bf1cd1ff8629f2b1179945ed45055
@@ -4586,6 +6440,18 @@ packages:
   purls: []
   size: 77241
   timestamp: 1777846112704
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+  sha256: 16feffd9ddbbe5b718515d38ee376c685ba95491cd901244e24671d20b952a77
+  md5: b24d3c612f71e7aa74158d92106318b2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - expat 2.8.1.*
+  license: MIT
+  license_family: MIT
+  size: 77856
+  timestamp: 1781203599810
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
   sha256: 31f19b6a88ce40ebc0d5a992c131f57d919f73c0b92cd1617a5bec83f6e961e6
   md5: a360c33a5abe61c07959e449fa1453eb
@@ -4634,6 +6500,19 @@ packages:
   purls: []
   size: 1041788
   timestamp: 1771378212382
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
+  sha256: 8e0a3b5e41272e5678499b5dfc4cddb673f9e935de01eb0767ce857001229f46
+  md5: 57736f29cc2b0ec0b6c2952d3f101b6a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex >=4.5
+  constrains:
+  - libgcc-ng ==15.2.0=*_19
+  - libgomp 15.2.0 he0feb66_19
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1041084
+  timestamp: 1778269013026
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_18.conda
   sha256: e318a711400f536c81123e753d4c797a821021fb38970cebfb3f454126016893
   md5: d5e96b1ed75ca01906b3d2469b4ce493
@@ -4644,6 +6523,35 @@ packages:
   purls: []
   size: 27526
   timestamp: 1771378224552
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_19.conda
+  sha256: 9dcf54adfaa5e861123c2da4f2f0451a685464ea7e5a41ad91cf67b31d658d98
+  md5: 331ee9b72b9dff570d56b1302c5ab37d
+  depends:
+  - libgcc 15.2.0 he0feb66_19
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 27694
+  timestamp: 1778269016987
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgd-2.3.3-h6f5c62b_11.conda
+  sha256: 19e5be91445db119152217e8e8eec4fd0499d854acc7d8062044fb55a70971cd
+  md5: 68fc66282364981589ef36868b1a7c78
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - fontconfig >=2.15.0,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - icu >=75.1,<76.0a0
+  - libexpat >=2.6.4,<3.0a0
+  - libgcc >=13
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.45,<1.7.0a0
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.5.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: GD
+  license_family: BSD
+  size: 177082
+  timestamp: 1737548051015
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-3.12.3-h8233c4f_4.conda
   sha256: 2a60e342d6ccd6b2a4b3688ee90906e5f993087c146f7070335aebbd97fd5594
   md5: b3f4cba2997ba5a92ae3fcffb2ec3e29
@@ -4681,6 +6589,47 @@ packages:
   purls: []
   size: 508297
   timestamp: 1775713757361
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.10.3-h95ec890_18.conda
+  sha256: fa58165fe24489dfd4d14a759d2eb6d602a4b783a663027e9c2ef96a10bb049e
+  md5: 7de0158b4bc2efa21ccd72784813274a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - blosc >=1.21.6,<2.0a0
+  - geos >=3.14.0,<3.14.1.0a0
+  - geotiff >=1.7.4,<1.8.0a0
+  - giflib >=5.2.2,<5.3.0a0
+  - json-c >=0.18,<0.19.0a0
+  - lerc >=4.0.0,<5.0a0
+  - libarchive >=3.8.1,<3.9.0a0
+  - libcurl >=8.14.1,<9.0a0
+  - libdeflate >=1.24,<1.26.0a0
+  - libexpat >=2.7.1,<3.0a0
+  - libgcc >=14
+  - libiconv >=1.18,<2.0a0
+  - libjpeg-turbo >=3.1.0,<4.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libpng >=1.6.50,<1.7.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libsqlite >=3.50.4,<4.0a0
+  - libstdcxx >=14
+  - libtiff >=4.7.0,<4.8.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - libzlib >=1.3.1,<2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - openssl >=3.5.2,<4.0a0
+  - pcre2 >=10.46,<10.47.0a0
+  - proj >=9.6.2,<9.7.0a0
+  - xerces-c >=3.2.5,<3.3.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  constrains:
+  - libgdal 3.10.3.*
+  license: MIT
+  license_family: MIT
+  size: 11040063
+  timestamp: 1758000487897
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.12.3-he63569f_3.conda
   sha256: 298497351f4a7dc94938a1ad8dc3df545a07efdc5f1b91b9256d04e65959a430
   md5: 83666e2c330f47ee6268396ee4467b63
@@ -4912,6 +6861,17 @@ packages:
   purls: []
   size: 27523
   timestamp: 1771378269450
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_19.conda
+  sha256: 561a42758ef25b9ce308c4e2cf56daee4f06138385a17e29a492cd928e00be6f
+  md5: 42bf7eca1a951735fa06c0e3c0d5c8e6
+  depends:
+  - libgfortran5 15.2.0 h68bc16d_19
+  constrains:
+  - libgfortran-ng ==15.2.0=*_19
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 27655
+  timestamp: 1778269042954
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_18.conda
   sha256: 539b57cf50ec85509a94ba9949b7e30717839e4d694bc94f30d41c9d34de2d12
   md5: 646855f357199a12f02a87382d429b75
@@ -4925,6 +6885,18 @@ packages:
   purls: []
   size: 2482475
   timestamp: 1771378241063
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_19.conda
+  sha256: 057978bb69fea29ed715a9b98adf71015c31baecc4aeb2bfc20d4fd5d83579d4
+  md5: 85072b0ad177c966294f129b7c04a2d5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=15.2.0
+  constrains:
+  - libgfortran 15.2.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 2483673
+  timestamp: 1778269025089
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_2.conda
   sha256: dc2752241fa3d9e40ce552c1942d0a4b5eeb93740c9723873f6fcf8d39ef8d2d
   md5: 928b8be80851f5d8ffb016f9c81dae7a
@@ -4936,6 +6908,41 @@ packages:
   purls: []
   size: 134712
   timestamp: 1731330998354
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_3.conda
+  sha256: ec353b3076ed8e357ed961d0e9ff6997491cade0e603de5bd18a2e301ac78ebd
+  md5: f25206d7322c0e9648e8b83694d143ab
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libglvnd 1.7.0 ha4b6fd6_3
+  - libglx 1.7.0 ha4b6fd6_3
+  license: LicenseRef-libglvnd
+  size: 133469
+  timestamp: 1779728207669
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-devel-1.7.0-ha4b6fd6_3.conda
+  sha256: 41d7d864ad1f199bdb06ff6cc3931455c8af62f1d2071a08c6fa08affbcb678f
+  md5: 63e43d278ee5084813fe3c2edf4834ce
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgl 1.7.0 ha4b6fd6_3
+  - libglx-devel 1.7.0 ha4b6fd6_3
+  license: LicenseRef-libglvnd
+  size: 115664
+  timestamp: 1779728218325
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.86.2-h32235b2_0.conda
+  sha256: 918306d6ed211ab483e4e19368e5748b265d24e75c88a1c66a61f72b9fa30b29
+  md5: 0cb0612bc9cb30c62baf41f9d600611b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libffi >=3.5.2,<3.6.0a0
+  - libgcc >=14
+  - libiconv >=1.18,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pcre2 >=10.46,<10.47.0a0
+  constrains:
+  - glib 2.86.2 *_0
+  license: LGPL-2.1-or-later
+  size: 3974801
+  timestamp: 1763672326986
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.88.1-h0d30a3d_1.conda
   sha256: a0899efbae2a6a9102c796c0b11ac371a3190da5afa28512eeb2879c65d1419c
   md5: 6016ea5ee9e986bc683879408cc87529
@@ -4961,6 +6968,14 @@ packages:
   purls: []
   size: 132463
   timestamp: 1731330968309
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_3.conda
+  sha256: e019ebe4e3f5cdf23e2f5e58ddf7ade27988c53820115b17b98f218ebcc87748
+  md5: eb83f3f8cecc3e9bff9e250817fc69b6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  license: LicenseRef-libglvnd
+  size: 133586
+  timestamp: 1779728183422
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_2.conda
   sha256: 2d35a679624a93ce5b3e9dd301fff92343db609b79f0363e6d0ceb3a6478bfa7
   md5: c8013e438185f33b13814c5c488acd5c
@@ -4972,6 +6987,27 @@ packages:
   purls: []
   size: 75504
   timestamp: 1731330988898
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_3.conda
+  sha256: 2f74713c9ca408ea84e88a30a9028153e7b553e8bb42e06139eac9a753c27da9
+  md5: ec3c4350aa0261bf7f87b8ca15c8e80e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libglvnd 1.7.0 ha4b6fd6_3
+  - xorg-libx11 >=1.8.13,<2.0a0
+  license: LicenseRef-libglvnd
+  size: 76586
+  timestamp: 1779728199059
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-devel-1.7.0-ha4b6fd6_3.conda
+  sha256: a17ae2d4cb2de04a20882ae14ec3cc1958e868a4dec81e3d7eca30115ee50e94
+  md5: 16b6330783ce0d1ae8d22782173b32c9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libglx 1.7.0 ha4b6fd6_3
+  - xorg-libx11 >=1.8.13,<2.0a0
+  - xorg-xorgproto
+  license: LicenseRef-libglvnd
+  size: 27363
+  timestamp: 1779728211402
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_18.conda
   sha256: 21337ab58e5e0649d869ab168d4e609b033509de22521de1bfed0c031bfc5110
   md5: 239c5e9546c38a1e884d69effcf4c882
@@ -4982,6 +7018,15 @@ packages:
   purls: []
   size: 603262
   timestamp: 1771378117851
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
+  sha256: 5abe4ab9d93f6c9757d654f1969ae2267d4505315c1f2f8fe705fd60af084f1b
+  md5: faac990cb7aedc7f3a2224f2c9b0c26c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 603817
+  timestamp: 1778268942614
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-3.3.0-h25dbb67_1.conda
   sha256: 17ea802cef3942b0a850b8e33b03fc575f79734f3c829cdd6a4e56e2dae60791
   md5: b2baa4ce6a9d9472aaa602b88f8d40ac
@@ -5121,6 +7166,20 @@ packages:
   purls: []
   size: 18624
   timestamp: 1774503065378
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-8_h47877c9_openblas.conda
+  build_number: 8
+  sha256: 168e327d737059553e15cc6ec36d76b9bbb3931c2a7721555fd68b4c9348b247
+  md5: 809be8ba8712c77bc7d44c2d99390dc4
+  depends:
+  - libblas 3.11.0 8_h4a7cf45_openblas
+  constrains:
+  - blas 2.308   openblas
+  - libcblas   3.11.0   8*_openblas
+  - liblapacke 3.11.0   8*_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18790
+  timestamp: 1779859115086
 - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
   sha256: ec30e52a3c1bf7d0425380a189d209a52baa03f22fb66dd3eb587acaa765bd6d
   md5: b88d90cad08e6bc8ad540cb310a761fb
@@ -5157,6 +7216,29 @@ packages:
   purls: []
   size: 861080
   timestamp: 1776686233788
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnetcdf-4.10.0-nompi_h3fa17b5_205.conda
+  build_number: 105
+  sha256: 3bc277e30bb2dc0bece235239c4d7dbe3b8f6c31239eec0c6bf88649f93d1459
+  md5: 024c0cb915d3f20827032b55dd219097
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - libaec >=1.1.5,<2.0a0
+  - hdf5 >=1.14.6,<1.14.7.0a0
+  - openssl >=3.5.7,<4.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - blosc >=1.21.6,<2.0a0
+  - libzip >=1.11.2,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libcurl >=8.21.0,<9.0a0
+  license: MIT
+  size: 983455
+  timestamp: 1783192190426
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
   sha256: 663444d77a42f2265f54fb8b48c5450bfff4388d9c0f8253dd7855f0d993153f
   md5: 2a45e7f8af083626f009645a6481f12d
@@ -5210,6 +7292,20 @@ packages:
   purls: []
   size: 5928890
   timestamp: 1774471724897
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.33-pthreads_h94d23a6_0.conda
+  sha256: 3d9aa85648e5e18a6d66db98b8c4317cc426721ad7a220aa86330d1ccedc8903
+  md5: 2d3278b721e40468295ca755c3b84070
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  constrains:
+  - openblas >=0.3.33,<0.3.34.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5931919
+  timestamp: 1776993658641
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libopentelemetry-cpp-1.26.0-h9692893_0.conda
   sha256: 5126b75e7733de31e261aa275c0a1fd38b25fdfff23e7d7056ebd6ca76d11532
   md5: c360be6f9e0947b64427603e91f9651f
@@ -5253,6 +7349,16 @@ packages:
   purls: []
   size: 1426881
   timestamp: 1778175848424
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.19-hb03c661_0.conda
+  sha256: f41721636a7c2e51bc2c642e1127955ab9c81145470714fdaac44d4d09e4af41
+  md5: 33082e13b4769b48cfeb648e15bfe3fc
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  size: 29147
+  timestamp: 1773533027610
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.58-h421ea60_0.conda
   sha256: 377cfe037f3eeb3b1bf3ad333f724a64d32f315ee1958581fc671891d63d3f89
   md5: eba48a68a1a2b9d3c0d9511548db85db
@@ -5309,6 +7415,22 @@ packages:
   purls: []
   size: 213122
   timestamp: 1768190028309
+- conda: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.60.0-h61e6d4b_0.conda
+  sha256: 960b137673b2b8293e2a12d194add72967b3bf12fcdf691e7ad8bd5c8318cec3
+  md5: 91e6d4d684e237fba31b9815c4b40edf
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cairo >=1.18.4,<2.0a0
+  - gdk-pixbuf >=2.44.3,<3.0a0
+  - libgcc >=14
+  - libglib >=2.86.0,<3.0a0
+  - libxml2-16 >=2.14.6
+  - pango >=1.56.4,<2.0a0
+  constrains:
+  - __glibc >=2.17
+  license: LGPL-2.1-or-later
+  size: 3421977
+  timestamp: 1759327942156
 - conda: https://conda.anaconda.org/conda-forge/linux-64/librttopo-1.1.0-h46dd2a8_20.conda
   sha256: eb4082a5135102f5ba9c302da13164d4ed1181d5f0db9d49e5e11a815a7b526f
   md5: df81fd57eacf341588d728c97920e86d
@@ -5322,6 +7444,18 @@ packages:
   purls: []
   size: 231670
   timestamp: 1761670395043
+- conda: https://conda.anaconda.org/conda-forge/linux-64/librttopo-1.1.0-h96cd706_19.conda
+  sha256: f584227e141db34f5dde05e8a3a4e59c86860e3b5df7698a646b7fc3486b0e86
+  md5: 212a9378a85ad020b8dc94853fdbeb6c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - geos >=3.14.0,<3.14.1.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 232294
+  timestamp: 1755880773417
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.21-h280c20c_3.conda
   sha256: 64e5c80cbce4680a2d25179949739a6def695d72c40ca28f010711764e372d97
   md5: 7af961ef4aa2c1136e11dd43ded245ab
@@ -5332,6 +7466,15 @@ packages:
   purls: []
   size: 277661
   timestamp: 1772479381288
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.22-h280c20c_1.conda
+  sha256: b677bbf1c339d894757c3dcfbb2f88649e499e4991d70ae09a1466da9a6c92d6
+  md5: 965e4d531b588b2e42f66fd8e48b056c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: ISC
+  size: 269272
+  timestamp: 1779163468406
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libspatialite-5.1.0-gpl_h2abfd87_119.conda
   sha256: 403c1ad74ee70caaac02216a233ef9ec4531497ee14e7fea93a254a005ece88d
   md5: 887245164c408c289d0cb45bd508ce5f
@@ -5356,6 +7499,29 @@ packages:
   purls: []
   size: 4097449
   timestamp: 1761681679109
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libspatialite-5.1.0-h2eee824_16.conda
+  sha256: e50915445bf76e4e1390f33ef39a69491534468531607a818224e83d0d2c5c6f
+  md5: 0704f614584aefd5fdaf56c75b047fdb
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - freexl >=2
+  - freexl >=2.0.0,<3.0a0
+  - geos >=3.14.0,<3.14.1.0a0
+  - libgcc >=14
+  - librttopo >=1.1.0,<1.2.0a0
+  - libsqlite >=3.50.4,<4.0a0
+  - libstdcxx >=14
+  - libxml2
+  - libxml2-16 >=2.14.5
+  - libxml2-devel
+  - libzlib >=1.3.1,<2.0a0
+  - proj >=9.6.2,<9.7.0a0
+  - sqlite
+  - zlib
+  license: MPL-1.1
+  license_family: MOZILLA
+  size: 3489498
+  timestamp: 1757320839353
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.1-h0c1763c_0.conda
   sha256: 54cdcd3214313b62c2a8ee277e6f42150d9b748264c1b70d958bf735e420ef8d
   md5: 7dc38adcbf71e6b38748e919e16e0dce
@@ -5367,6 +7533,16 @@ packages:
   purls: []
   size: 954962
   timestamp: 1777986471789
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.3-h0c1763c_0.conda
+  sha256: 365376f4815e5e80def2b3462a2419708b7c292da0da85278386c2618621fff4
+  md5: 4aed8e657e9ff156bdbe849b4df44389
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libzlib >=1.3.2,<2.0a0
+  license: blessing
+  size: 962119
+  timestamp: 1782519076616
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
   sha256: fa39bfd69228a13e553bd24601332b7cfeb30ca11a3ca50bb028108fe90a7661
   md5: eecce068c7e4eddeb169591baac20ac4
@@ -5393,6 +7569,18 @@ packages:
   purls: []
   size: 5852330
   timestamp: 1771378262446
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
+  sha256: dff1058c76ec6b8759e41cefa2508162d00e4a5e6721aa68ec3fd10094e702dc
+  md5: 5794b3bdc38177caf969dabd3af08549
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc 15.2.0 he0feb66_19
+  constrains:
+  - libstdcxx-ng ==15.2.0=*_19
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 5852044
+  timestamp: 1778269036376
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_18.conda
   sha256: 3c902ffd673cb3c6ddde624cdb80f870b6c835f8bf28384b0016e7d444dd0145
   md5: 6235adb93d064ecdf3d44faee6f468de
@@ -5403,6 +7591,15 @@ packages:
   purls: []
   size: 27575
   timestamp: 1771378314494
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_19.conda
+  sha256: 0672b6b6e1791c92e8eccad58081a99d614fcf82bca5841f9dfa3c3e658f83b9
+  md5: e5ce228e579726c07255dbf90dc62101
+  depends:
+  - libstdcxx 15.2.0 h934c35e_19
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 27776
+  timestamp: 1778269074600
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.22.0-h7d032f7_2.conda
   sha256: af6025aa4a4fc3f4e71334000d2739d927e2f678607b109ec630cc17d716918a
   md5: b6e326fbe1e3948da50ec29cee0380db
@@ -5436,6 +7633,23 @@ packages:
   purls: []
   size: 435273
   timestamp: 1762022005702
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.2-h9d88235_0.conda
+  sha256: b31346e1c01ab40a170e91147092ee8fd92b1dee3c66ee47ef025571c879b159
+  md5: c1fcb4a88bc15a9f77ad8d27d7af1df9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - lerc >=4.1.0,<5.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - libgcc >=14
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libstdcxx >=14
+  - libwebp-base >=1.6.0,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: HPND
+  size: 452337
+  timestamp: 1783084902636
 - conda: https://conda.anaconda.org/conda-forge/linux-64/liburing-2.14-hb700be7_0.conda
   sha256: 3d17b7aa90610afc65356e9e6149aeac0b2df19deda73a51f0a09cf04fd89286
   md5: 56f65185b520e016d29d01657ac02c0d
@@ -5470,6 +7684,16 @@ packages:
   purls: []
   size: 40297
   timestamp: 1775052476770
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
+  sha256: 9b1bdce27a7e31f7d241aeecff67a1f3101d52a2b1e33ccc2cdf2613072bf81f
+  md5: 01bb81d12c957de066ea7362007df642
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40017
+  timestamp: 1781625522462
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
   sha256: 3aed21ab28eddffdaf7f804f49be7a7d701e8f0e46c856d801270b470820a37b
   md5: aea31d2e5b1091feca96fcfe945c3cf9
@@ -5506,6 +7730,37 @@ packages:
   purls: []
   size: 100393
   timestamp: 1702724383534
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.13.2-hca5e8e5_0.conda
+  sha256: 046f2ff4acebd8729fac03e99c8c307dfb48b6a32894ba8c11576e78f6e76e43
+  md5: dc8b067e22b414172bedd8e3f03f3c95
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libxcb >=1.17.0,<2.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - xkeyboard-config
+  - xorg-libxau >=1.0.12,<2.0a0
+  license: MIT/X11 Derivative
+  license_family: MIT
+  size: 851166
+  timestamp: 1780213397575
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.1-h26afc86_0.conda
+  sha256: ec0735ae56c3549149eebd7dc22c0bed91fd50c02eaa77ff418613ddda190aa8
+  md5: e512be7dc1f84966d50959e900ca121f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - icu >=75.1,<76.0a0
+  - libgcc >=14
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libxml2-16 2.15.1 ha9997c6_0
+  - libzlib >=1.3.1,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 45283
+  timestamp: 1761015644057
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_0.conda
   sha256: 3bc5551720c58591f6ea1146f7d1539c734ed1c40e7b9f5cb8cb7e900c509aba
   md5: 995d8c8bad2a3cc8db14675a153dec2b
@@ -5522,6 +7777,22 @@ packages:
   purls: []
   size: 46810
   timestamp: 1776376751152
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.1-ha9997c6_0.conda
+  sha256: 71436e72a286ef8b57d6f4287626ff91991eb03c7bdbe835280521791efd1434
+  md5: e7733bc6785ec009e47a224a71917e84
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - icu >=75.1,<76.0a0
+  - libgcc >=14
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libzlib >=1.3.1,<2.0a0
+  constrains:
+  - libxml2 2.15.1
+  license: MIT
+  license_family: MIT
+  size: 556302
+  timestamp: 1761015637262
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_0.conda
   sha256: 3d44f737c5ae52d5af32682cc1530df433f401f8e58a7533926536244127572a
   md5: e79d2c2f24b027aa8d5ab1b1ba3061e7
@@ -5539,6 +7810,22 @@ packages:
   purls: []
   size: 559775
   timestamp: 1776376739004
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-devel-2.15.1-h26afc86_0.conda
+  sha256: 7a01dde0807d0283ef6babb661cb750f63d7842f489b6e40d0af0f16951edf3e
+  md5: 1b92b7d1b901bd832f8279ef18cac1f4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - icu >=75.1,<76.0a0
+  - libgcc >=14
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libxml2 2.15.1 h26afc86_0
+  - libxml2-16 2.15.1 ha9997c6_0
+  - libzlib >=1.3.1,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 79667
+  timestamp: 1761015650428
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-devel-2.15.3-h49c6c72_0.conda
   sha256: adada9c781ea51faea3e3adcd6883dc294ff2fa044c7f4e199430a11862dfa40
   md5: be70cb50dd0ecc1531c58034d38f72e0
@@ -5607,6 +7894,21 @@ packages:
   - pkg:pypi/linkify-it-py?source=hash-mapping
   size: 26062
   timestamp: 1772476821244
+- conda: https://conda.anaconda.org/conda-forge/linux-64/llvmlite-0.47.0-py310hee1c697_1.conda
+  sha256: 956f480aebb3975de2d29e42467c1de4766a71c59d5ea20ddd505a3d87807b0d
+  md5: b00665c4d41d65d6ead9225cd1f6b296
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libzlib >=1.3.2,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - zstd >=1.5.7,<1.6.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 34054660
+  timestamp: 1776076746219
 - conda: https://conda.anaconda.org/conda-forge/linux-64/llvmlite-0.47.0-py312h7424e68_1.conda
   sha256: 27b34a24cc4c872d328b07319ae5ab6673d5c94ec923cde5b1f3ac7f59b95dd0
   md5: 49f23211559c82cf8c5ffac112fe73b4
@@ -5705,6 +8007,20 @@ packages:
   - pkg:pypi/mapclassify?source=hash-mapping
   size: 810830
   timestamp: 1752271625200
+- conda: https://conda.anaconda.org/conda-forge/noarch/mapclassify-2.8.1-pyhd8ed1ab_1.conda
+  sha256: c498a016b233be5a7defee443733a82d5fe41b83016ca8a136876a64fd15564b
+  md5: c48bbb2bcc3f9f46741a7915d67e6839
+  depends:
+  - networkx >=2.7
+  - numpy >=1.23
+  - pandas >=1.4,!=1.5.0
+  - python >=3.9
+  - scikit-learn >=1.0
+  - scipy >=1.8
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 56772
+  timestamp: 1733731193211
 - conda: https://conda.anaconda.org/conda-forge/linux-64/marimo-0.23.5-py312h20c3967_0.conda
   sha256: 5ae7f77ff0f12770733ffa7ef726dbdb0593677b1c5fbcfc2fd889ebc70c4821
   md5: e6f746b46f7d6b4c1135db76b2d82f46
@@ -5760,6 +8076,20 @@ packages:
   - pkg:pypi/markdown-it-py?source=compressed-mapping
   size: 69017
   timestamp: 1778169663339
+- conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.3-py310h3406613_1.conda
+  sha256: 9f3c34f8a7a8dcfed64221a2e19bbe0094ab2c6df7c029b7df713e52c9c9f229
+  md5: 671afe636d2a97759804723f5afc22e0
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23899
+  timestamp: 1772445369460
 - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.3-py312h8a5da7c_1.conda
   sha256: 5f3aad1f3a685ed0b591faad335957dbdb1b73abfd6fc731a0d42718e0653b33
   md5: 93a4752d42b12943a355b682ee43285b
@@ -5776,6 +8106,34 @@ packages:
   - pkg:pypi/markupsafe?source=compressed-mapping
   size: 26057
   timestamp: 1772445297924
+- conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.10.9-py310hfde16b3_0.conda
+  sha256: 3f5901d067947d6f4bce4f994b891fa26865f31bc976275359f81f1ffbf9294f
+  md5: 182cef60d49535a1d8c3db692dbf053d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - contourpy >=1.0.1
+  - cycler >=0.10
+  - fonttools >=4.22.0
+  - freetype
+  - kiwisolver >=1.3.1
+  - libfreetype >=2.14.3
+  - libfreetype6 >=2.14.3
+  - libgcc >=14
+  - libstdcxx >=14
+  - numpy >=1.21,<3
+  - numpy >=1.23
+  - packaging >=20.0
+  - pillow >=8
+  - pyparsing >=2.3.1
+  - python >=3.10,<3.11.0a0
+  - python-dateutil >=2.7
+  - python_abi 3.10.* *_cp310
+  - qhull >=2020.2,<2020.3.0a0
+  - tk >=8.6.13,<8.7.0a0
+  license: PSF-2.0
+  license_family: PSF
+  size: 7368168
+  timestamp: 1777000572692
 - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.10.9-py312he3d6523_0.conda
   sha256: c7e133837376e53e6a52719c205a3067c42f05769bc3e8307417f8d817dfc63e
   md5: 7d499b5b6d150f133800dc3a582771c7
@@ -5818,6 +8176,16 @@ packages:
   - pkg:pypi/matplotlib-inline?source=hash-mapping
   size: 15175
   timestamp: 1761214578417
+- conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.2.2-pyhd8ed1ab_0.conda
+  sha256: 35b43d7343f74452307fd018a1cca92b8f68961ff8e2ab6a81ce0a703c9a3764
+  md5: 9acc1c385be401d533ff70ef5b50dae6
+  depends:
+  - python >=3.10
+  - traitlets
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15725
+  timestamp: 1778264403247
 - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.6.0-pyhd8ed1ab_0.conda
   sha256: 443e7f8ae88f71b3e7fd9c3d19d3816fb1965e2352d5e01a6bfdf2eccfcf4795
   md5: 9a704e945e87078f464726c69071677a
@@ -5830,6 +8198,16 @@ packages:
   - pkg:pypi/mdit-py-plugins?source=compressed-mapping
   size: 50607
   timestamp: 1778171019802
+- conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.6.1-pyhd8ed1ab_0.conda
+  sha256: 49db23cbfb1c1d414a14d7540195208b994ebd747beba0f15c903f3a0a2dc446
+  md5: ad6821df7a98510117db06e9a833281f
+  depends:
+  - markdown-it-py >=2.0.0,<5.0.0
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  size: 50460
+  timestamp: 1778692223625
 - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
   sha256: 78c1bbe1723449c52b7a9df1af2ee5f005209f67e40b6e1d3c7619127c43b1c7
   md5: 592132998493b3ff25fd7479396e8351
@@ -5841,6 +8219,17 @@ packages:
   - pkg:pypi/mdurl?source=hash-mapping
   size: 14465
   timestamp: 1733255681319
+- conda: https://conda.anaconda.org/conda-forge/noarch/mercantile-1.2.1-pyhd8ed1ab_1.conda
+  sha256: 42ab9a82c4e4686d7c2a2d511877895bfe946ec2c2ec66e4e1593006fa32445f
+  md5: 9820756deea38bd213240fd0556d44b8
+  depends:
+  - click >=3.0
+  - python >=3.9
+  - setuptools
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 19720
+  timestamp: 1734075446811
 - conda: https://conda.anaconda.org/conda-forge/noarch/mergedeep-1.3.4-pyhd8ed1ab_1.conda
   sha256: e5b555fd638334a253d83df14e3c913ef8ce10100090e17fd6fb8e752d36f95d
   md5: d9a8fc1f01deae61735c88ec242e855c
@@ -5870,6 +8259,23 @@ packages:
   purls: []
   size: 520570
   timestamp: 1778002506337
+- conda: https://conda.anaconda.org/conda-forge/linux-64/minizip-4.2.2-hb71707f_0.conda
+  sha256: 80398daac34dfe10d88c92ef64f6ff85f52950cab8b2bdfc2d00cc176ed7edff
+  md5: 88450ba743694055e218d03a2fdd561e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc >=14
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libstdcxx >=14
+  - libzlib >=1.3.2,<2.0a0
+  - openssl >=3.5.7,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: Zlib
+  license_family: Other
+  size: 521106
+  timestamp: 1782851456704
 - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.2.1-pyhcf101f3_0.conda
   sha256: b52dc6c78fbbe7a3008535cb8bfd87d70d8053e9250bbe16e387470a9df07070
   md5: b97e84d1553b4a1c765b87fff83453ad
@@ -5883,6 +8289,17 @@ packages:
   - pkg:pypi/mistune?source=hash-mapping
   size: 74567
   timestamp: 1777824616382
+- conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.3.2-pyhcf101f3_0.conda
+  sha256: b8e38b0c5090f8cf1826c3f77e9db682c5d7b56ab6a434e6e2b528abc591048c
+  md5: e92e7aa653b4c71d0cd3cd39eadc302f
+  depends:
+  - python >=3.10
+  - typing_extensions
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 86960
+  timestamp: 1782218255079
 - conda: https://conda.anaconda.org/conda-forge/noarch/mkdocs-1.6.1-pyhd8ed1ab_1.conda
   sha256: 902d2e251f9a7ffa7d86a3e62be5b2395e28614bd4dbe5f50acf921fd64a8c35
   md5: 14661160be39d78f2b210f2cc2766059
@@ -6017,6 +8434,14 @@ packages:
   - pkg:pypi/mkdocstrings-python?source=hash-mapping
   size: 57013
   timestamp: 1770730332317
+- conda: https://conda.anaconda.org/conda-forge/noarch/modflow-devtools-1.9.2-pyhd8ed1ab_0.conda
+  sha256: b69f359dadc6a0666a8e3573dd0a87a02709209d885fff7902ea9fa0ff830957
+  md5: e68810e6ab81840739ac8eb08e1634e3
+  depends:
+  - python >=3.10
+  license: CC0-1.0
+  size: 83481
+  timestamp: 1776731640173
 - conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.1.2-py312hd9148b4_1.conda
   sha256: 94068fd39d1a672f8799e3146a18ba4ef553f0fcccefddb3c07fbdabfd73667a
   md5: 2e489969e38f0b428c39492619b5e6e5
@@ -6105,6 +8530,15 @@ packages:
   purls: []
   size: 203174
   timestamp: 1747116762269
+- conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
+  sha256: 6ed158e4e5dd8f6a10ad9e525631e35cee8557718f83de7a4e3966b1f772c4b1
+  md5: e9c622e0d00fa24a6292279af3ab6d06
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 11766
+  timestamp: 1745776666688
 - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.20.0-pyhcf101f3_0.conda
   sha256: 676cbfbf709ce984a14e3af5aef70f1ec94a29ea3fdec477115ae302b34a1a2d
   md5: 6cac1a50359219d786453c6fef819f98
@@ -6117,6 +8551,16 @@ packages:
   - pkg:pypi/narwhals?source=compressed-mapping
   size: 283664
   timestamp: 1776691974709
+- conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.23.0-pyhcf101f3_0.conda
+  sha256: e7dbd69d1de038b0411636c50bd9a935d05ca37269c4a155a78571afbaa7994a
+  md5: a537eb35988a6f2b1ceda6cce83e2f0e
+  depends:
+  - python >=3.10
+  - python
+  license: MIT
+  license_family: MIT
+  size: 288381
+  timestamp: 1782924928916
 - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.4-pyhd8ed1ab_0.conda
   sha256: 1b66960ee06874ddceeebe375d5f17fb5f393d025a09e15b830ad0c4fffb585b
   md5: 00f5b8dafa842e0c27c1cd7296aa4875
@@ -6132,6 +8576,19 @@ packages:
   - pkg:pypi/nbclient?source=hash-mapping
   size: 28473
   timestamp: 1766485646962
+- conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.11.0-pyhd8ed1ab_0.conda
+  sha256: eceb424236fbbb9b337a857fe5448307b57a2a3fb2db389ae37e7a8b8cdca2ab
+  md5: cf01a81d7960ad9c829bf2e794fcee9a
+  depends:
+  - jupyter_client >=7.0.0
+  - jupyter_core >=5.4
+  - nbformat >=5.2.0
+  - python >=3.10
+  - traitlets >=5.13
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 29138
+  timestamp: 1780661039538
 - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-7.17.1-hb502eef_0.conda
   sha256: 6b6d96cca8e9dd34e0735b59534831e1f8206b7366c79c71e08da6ee55c50683
   md5: 02669c36935d23e5258c5dd1a5e601ab
@@ -6220,6 +8677,38 @@ packages:
   - pkg:pypi/nest-asyncio?source=hash-mapping
   size: 11543
   timestamp: 1733325673691
+- conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio2-1.7.2-pyhcf101f3_0.conda
+  sha256: e6768ceef038f4d7e083de7e393f5dd7d672b937e2bda570b740f6399b686689
+  md5: fcd832bfd4749e9b246112b6894f97fc
+  depends:
+  - python >=3.10
+  - python
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 15903
+  timestamp: 1770973502283
+- conda: https://conda.anaconda.org/conda-forge/linux-64/netcdf4-1.7.4-nompi_py310h21e55d4_104.conda
+  sha256: 99a508b5530e6c8371f12303aae583054141c3c9e44ddb7265fcc060e5210891
+  md5: 795e0bf8ab211cd6894fa8fa4067daa0
+  depends:
+  - python
+  - certifi
+  - cftime
+  - numpy
+  - packaging
+  - hdf5
+  - libnetcdf
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python_abi 3.10.* *_cp310
+  - libzlib >=1.3.1,<2.0a0
+  - libnetcdf >=4.10.0,<4.10.1.0a0
+  - hdf5 >=1.14.6,<1.14.7.0a0
+  - numpy >=1.21,<3
+  license: MIT
+  license_family: MIT
+  size: 1150164
+  timestamp: 1772475955936
 - conda: https://conda.anaconda.org/conda-forge/linux-64/netcdf4-1.7.4-nompi_py311h498b1eb_107.conda
   noarch: python
   sha256: 0757d67266b535ed36dbb74b2cd353ad042db5c9d2fd2d3b5a2aea133bed61ea
@@ -6246,6 +8735,21 @@ packages:
   - pkg:pypi/netcdf4?source=hash-mapping
   size: 1095186
   timestamp: 1774640065682
+- conda: https://conda.anaconda.org/conda-forge/noarch/networkx-3.4.2-pyh267e887_2.conda
+  sha256: 39625cd0c9747fa5c46a9a90683b8997d8b9649881b3dc88336b13b7bdd60117
+  md5: fd40bf7f7f4bc4b647dc8512053d9873
+  depends:
+  - python >=3.10
+  - python
+  constrains:
+  - numpy >=1.24
+  - scipy >=1.10,!=1.11.0,!=1.11.1
+  - matplotlib >=3.7
+  - pandas >=2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1265008
+  timestamp: 1731521053408
 - conda: https://conda.anaconda.org/conda-forge/noarch/networkx-3.6.1-pyhcf101f3_0.conda
   sha256: f6a82172afc50e54741f6f84527ef10424326611503c64e359e25a19a8e4c1c6
   md5: a2c1eeadae7a309daed9d62c96012a2b
@@ -6263,6 +8767,22 @@ packages:
   - pkg:pypi/networkx?source=hash-mapping
   size: 1587439
   timestamp: 1765215107045
+- conda: https://conda.anaconda.org/conda-forge/linux-64/nh3-0.3.6-py310hd8a072f_0.conda
+  noarch: python
+  sha256: 9c651938be7eef8a3d10387a555ad07feea9345750ef0eb09cf5ac70c3a827b0
+  md5: 406e98fd1fba273c9fc83bbc83d12033
+  depends:
+  - python
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - _python_abi3_support 1.*
+  - cpython >=3.10
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  size: 672346
+  timestamp: 1782129862714
 - conda: https://conda.anaconda.org/conda-forge/linux-64/nlohmann_json-3.12.0-h54a6638_1.conda
   sha256: fd2cbd8dfc006c72f45843672664a8e4b99b2f8137654eaae8c3d46dca776f63
   md5: 16c2a0e9c4a166e53632cfca4f68d020
@@ -6285,6 +8805,32 @@ packages:
   - pkg:pypi/nodeenv?source=hash-mapping
   size: 40866
   timestamp: 1766261270149
+- conda: https://conda.anaconda.org/conda-forge/noarch/notebook-7.6.0-pyhcf101f3_0.conda
+  sha256: 5b48c26a966caae81169cc8056321a4c139103880eb01e1f4f02ad6ff9390421
+  md5: d9eb17006787e506bcb70f16daf1b1c1
+  depends:
+  - jupyter_server >=2.19.0,<3
+  - jupyter-builder >=1.0.2,<2
+  - jupyterlab >=4.6.0,<4.7
+  - jupyterlab_server >=2.28.0,<3
+  - notebook-shim >=0.2,<0.3
+  - python >=3.10
+  - tornado >=6.2.0
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4629848
+  timestamp: 1781800954960
+- conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_1.conda
+  sha256: 7b920e46b9f7a2d2aa6434222e5c8d739021dbc5cc75f32d124a8191d86f9056
+  md5: e7f89ea5f7ea9401642758ff50a2d9c1
+  depends:
+  - jupyter_server >=1.8,<3
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16817
+  timestamp: 1733408419340
 - conda: https://conda.anaconda.org/conda-forge/linux-64/nspr-4.38-h29cc59b_0.conda
   sha256: e3664264bd936c357523b55c71ed5a30263c6ba278d726a75b1eb112e6fb0b64
   md5: e235d5566c9cc8970eb2798dd4ecf62f
@@ -6312,6 +8858,30 @@ packages:
   purls: []
   size: 2057773
   timestamp: 1763485556350
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numba-0.65.1-py310h225f558_1.conda
+  sha256: 093bbe8b43f583b0e4cc20178b1ea12e0c66f85505bdda46ab97b4e01d3d9bc4
+  md5: 942145296b6b498be9a824ef693902c3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex >=4.5
+  - libgcc >=14
+  - libstdcxx >=14
+  - llvmlite >=0.47.0,<0.48.0a0
+  - numpy >=1.21,<3
+  - numpy >=1.22.3,<2.5
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  constrains:
+  - cudatoolkit >=11.2
+  - cuda-python >=11.6
+  - scipy >=1.0
+  - libopenblas !=0.3.6
+  - cuda-version >=11.2
+  - tbb >=2021.6.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 4394641
+  timestamp: 1778390485336
 - conda: https://conda.anaconda.org/conda-forge/linux-64/numba-0.65.1-py312hd1dde6f_0.conda
   sha256: fa4fe0a2bc9e29bc1ddfa552ba98894c25fa9a30f746988b8f816db451f635a0
   md5: 51ddecbb2f67d0dab569a9bf69c9e2eb
@@ -6358,6 +8928,24 @@ packages:
   - pkg:pypi/numcodecs?source=hash-mapping
   size: 813229
   timestamp: 1764782491676
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.2.6-py310hefbff90_0.conda
+  sha256: 0ba94a61f91d67413e60fa8daa85627a8f299b5054b0eff8f93d26da83ec755e
+  md5: b0cea2c364bf65cd19e023040eeab05d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc >=13
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx >=13
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7893263
+  timestamp: 1747545075833
 - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.4.3-py312h33ff503_0.conda
   sha256: 1aab7ba963affa572956b1bd8d239df52a9c7bc799c560f98bc658ab70224e10
   md5: 5930ee8a175a242b4f001b1e9e72024f
@@ -6420,6 +9008,17 @@ packages:
   purls: []
   size: 3167099
   timestamp: 1775587756857
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.3-h35e630c_0.conda
+  sha256: d48f5c22b9897c01e4dff3680f1f57ceb02711ab9c62f74339b080419dfad34b
+  md5: 79dd2074b5cd5c5c6b2930514a11e22d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - ca-certificates
+  - libgcc >=14
+  license: Apache-2.0
+  license_family: Apache
+  size: 3159683
+  timestamp: 1781069855778
 - conda: https://conda.anaconda.org/conda-forge/linux-64/orc-2.3.0-h21090e2_0.conda
   sha256: a60c2578c8422e0c67206d269767feb4d3e627511558b6866e5daf2231d5214d
   md5: 8027fce94fdfdf2e54f9d18cbae496df
@@ -6440,6 +9039,16 @@ packages:
   purls: []
   size: 1468651
   timestamp: 1773230208923
+- conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_1.conda
+  sha256: 1840bd90d25d4930d60f57b4f38d4e0ae3f5b8db2819638709c36098c6ba770c
+  md5: e51f1e4089cad105b6cac64bd8166587
+  depends:
+  - python >=3.9
+  - typing_utils
+  license: Apache-2.0
+  license_family: APACHE
+  size: 30139
+  timestamp: 1734587755455
 - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
   sha256: 3906abfb6511a3bb309e39b9b1b7bc38f50a723971de2395489fd1f379255890
   md5: 4c06a92e74452cfa53623a81592e8934
@@ -6463,6 +9072,56 @@ packages:
   - pkg:pypi/paginate?source=hash-mapping
   size: 18865
   timestamp: 1734618649164
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.3.3-py310h0158d43_2.conda
+  sha256: b9e88fa02fd5e99f54c168df622eda9ddf898cc15e631179963aca51d97244bf
+  md5: 0610ed073acc4737d036125a5a6dbae2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - numpy >=1.21,<3
+  - numpy >=1.22.4
+  - python >=3.10,<3.11.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.7
+  - python_abi 3.10.* *_cp310
+  - pytz >=2020.1
+  constrains:
+  - odfpy >=1.4.1
+  - pyarrow >=10.0.1
+  - pyqt5 >=5.15.9
+  - numexpr >=2.8.4
+  - fsspec >=2022.11.0
+  - bottleneck >=1.3.6
+  - beautifulsoup4 >=4.11.2
+  - pandas-gbq >=0.19.0
+  - s3fs >=2022.11.0
+  - gcsfs >=2022.11.0
+  - sqlalchemy >=2.0.0
+  - pytables >=3.8.0
+  - html5lib >=1.1
+  - python-calamine >=0.1.7
+  - lxml >=4.9.2
+  - qtpy >=2.3.0
+  - scipy >=1.10.0
+  - numba >=0.56.4
+  - openpyxl >=3.1.0
+  - blosc >=1.21.3
+  - pyreadstat >=1.2.0
+  - zstandard >=0.19.0
+  - xarray >=2022.12.0
+  - matplotlib >=3.6.3
+  - tabulate >=0.9.0
+  - fastparquet >=2022.12.0
+  - psycopg2 >=2.9.6
+  - xlsxwriter >=3.0.5
+  - xlrd >=2.0.1
+  - tzdata >=2022.7
+  - pyxlsb >=1.0.10
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 12391209
+  timestamp: 1764615007370
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-3.0.2-py312h8ecdadd_0.conda
   sha256: 4aad0f99a06e799acdd46af0df8f7c8273164cabce8b5c94a44b012b7d1a30a6
   md5: 42050f82a0c0f6fa23eda3d93b251c18
@@ -6520,6 +9179,13 @@ packages:
   - pkg:pypi/pandas?source=compressed-mapping
   size: 14849233
   timestamp: 1774916580467
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pandoc-3.10-ha770c72_0.conda
+  sha256: 2f17a165a04833bd249215336b00df912bad7f03ae445a36765b47593df34057
+  md5: a4b80dd6e9e0784ba48e6803bef1e17a
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 22516793
+  timestamp: 1780595446569
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pandoc-3.9.0.2-ha770c72_0.conda
   sha256: d46f76ed09396e3bd1dc11030b3d0d222c25ba8d92f3cde08bc6fbd1eec4f9e0
   md5: de8ccf9ffba55bd20ee56301cfc7e6db
@@ -6566,6 +9232,74 @@ packages:
   - pkg:pypi/panel?source=hash-mapping
   size: 23227506
   timestamp: 1773735459759
+- conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.9.3-pyhd8ed1ab_0.conda
+  sha256: 060f8bce74385c50f682f69dfb9c6f0b340d78bc2a85154889c5698498195f33
+  md5: e9e5f439e2c9a5cc4f0edcfaeff89f22
+  depends:
+  - panel-core 1.9.3 pyha770c72_0
+  - panel-material-ui >=0.10.0
+  - python >=3.10
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8115
+  timestamp: 1780383158234
+- conda: https://conda.anaconda.org/conda-forge/noarch/panel-core-1.9.3-pyha770c72_0.conda
+  sha256: 55e5d084a413c84bb3558ba8f83f7b0899845859f10dd86d3f1a45f68d65d947
+  md5: 7285b1299900255923435890ef95855b
+  depends:
+  - bokeh >=3.7.0,<3.10.0
+  - linkify-it-py
+  - markdown
+  - markdown-it-py
+  - mdit-py-plugins
+  - narwhals >=2
+  - nh3
+  - packaging
+  - pandas >=1.2
+  - param >=2.1.0,<3.0
+  - python >=3.10
+  - pyviz_comms >=2.0.0
+  - requests
+  - tqdm
+  - typing_extensions
+  constrains:
+  - holoviews >=1.18.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23014831
+  timestamp: 1780383113204
+- conda: https://conda.anaconda.org/conda-forge/noarch/panel-material-ui-0.13.0-pyhd8ed1ab_0.conda
+  sha256: ae474eb2c29390ea4fcb6a7cff6b26cef9cc0429a26afa3f9d2e2e7497f55bdb
+  md5: dfcb823e5374ea8935d4a53a196c9cb5
+  depends:
+  - bokeh >=3.8.0
+  - packaging
+  - panel-core >=1.8.0
+  - python >=3.10
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1584739
+  timestamp: 1782982054557
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.56.4-hadf4263_0.conda
+  sha256: 3613774ad27e48503a3a6a9d72017087ea70f1426f6e5541dbdb59a3b626eaaf
+  md5: 79f71230c069a287efe3a8614069ddf1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cairo >=1.18.4,<2.0a0
+  - fontconfig >=2.15.0,<3.0a0
+  - fonts-conda-ecosystem
+  - fribidi >=1.0.10,<2.0a0
+  - harfbuzz >=11.0.1
+  - libexpat >=2.7.0,<3.0a0
+  - libfreetype >=2.13.3
+  - libfreetype6 >=2.13.3
+  - libgcc >=13
+  - libglib >=2.84.2,<3.0a0
+  - libpng >=1.6.49,<1.7.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: LGPL-2.1-or-later
+  size: 455420
+  timestamp: 1751292466873
 - conda: https://conda.anaconda.org/conda-forge/noarch/param-2.3.3-pyhc455866_0.conda
   sha256: 7b5cbfbfeca555e69ec89d74e62b18c3cc5a301529ab395f6cd8f7a9454b7b1c
   md5: 13d9aaa9ed7c9a4ca3bbecbee88eab21
@@ -6577,6 +9311,15 @@ packages:
   - pkg:pypi/param?source=hash-mapping
   size: 180946
   timestamp: 1775721079068
+- conda: https://conda.anaconda.org/conda-forge/noarch/param-2.4.1-pyhc455866_0.conda
+  sha256: c4c7e11678c4615d7b06d35e41b94169c2dda6a74306ac091420a66ae65aeace
+  md5: a57cdb52c22ef5d737a8ebf67440e5b0
+  depends:
+  - python >=3.10
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 193829
+  timestamp: 1781621758980
 - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.7-pyhcf101f3_0.conda
   sha256: 611882f7944b467281c46644ffde6c5145d1a7730388bcde26e7e86819b0998e
   md5: 39894c952938276405a1bd30e4ce2caf
@@ -6625,6 +9368,18 @@ packages:
   - pkg:pypi/patsy?source=hash-mapping
   size: 193450
   timestamp: 1760998269054
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.46-h1321c63_0.conda
+  sha256: 5c7380c8fd3ad5fc0f8039069a45586aa452cf165264bc5a437ad80397b32934
+  md5: 7fa07cb0fb1b625a089ccc01218ee5b1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc >=14
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1209177
+  timestamp: 1756742976157
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
   sha256: 5e6f7d161356fefd981948bea5139c5aa0436767751a6930cb1ca801ebb113ff
   md5: 7a3bff861a6583f1889021facefc08b1
@@ -6638,6 +9393,16 @@ packages:
   purls: []
   size: 1222481
   timestamp: 1763655398280
+- conda: https://conda.anaconda.org/conda-forge/linux-64/perl-5.32.1-7_hd590300_perl5.conda
+  build_number: 7
+  sha256: 9ec32b6936b0e37bcb0ed34f22ec3116e75b3c0964f9f50ecea5f58734ed6ce9
+  md5: f2cfec9406850991f4e3d960cc9e3321
+  depends:
+  - libgcc-ng >=12
+  - libxcrypt >=4.4.36
+  license: GPL-1.0-or-later OR Artistic-1.0-Perl
+  size: 13344463
+  timestamp: 1703310653947
 - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
   sha256: 202af1de83b585d36445dc1fda94266697341994d1a3328fabde4989e1b3d07a
   md5: d0d408b1f18883a944376da5cf8101ea
@@ -6649,6 +9414,15 @@ packages:
   - pkg:pypi/pexpect?source=hash-mapping
   size: 53561
   timestamp: 1733302019362
+- conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-pyhd8ed1ab_1004.conda
+  sha256: e2ac3d66c367dada209fc6da43e645672364b9fd5f9d28b9f016e24b81af475b
+  md5: 11a9d1d09a3615fc07c3faf79bc0b943
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 11748
+  timestamp: 1733327448200
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.2.0-py312h50c33e8_0.conda
   sha256: fa291f8915114733dc1df9f1627b8c63c517217c1eee1a6ede2ceb5e368cf27a
   md5: 9e5609720e31213d4f39afe377f6217e
@@ -6672,6 +9446,54 @@ packages:
   - pkg:pypi/pillow?source=compressed-mapping
   size: 1039561
   timestamp: 1775060059882
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.3.0-py310h5a73078_0.conda
+  sha256: f4613ff1040ace683a076bd105423bd73964ea5bd3287c99225fbea52902eb79
+  md5: fb6f1c4063f0df1df2e7f6853bd22f8d
+  depends:
+  - python
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - tk >=8.6.13,<8.7.0a0
+  - python_abi 3.10.* *_cp310
+  - libwebp-base >=1.6.0,<2.0a0
+  - lcms2 >=2.19.1,<3.0a0
+  - openjpeg >=2.5.4,<3.0a0
+  - libfreetype >=2.14.3
+  - libfreetype6 >=2.14.3
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - zlib-ng >=2.3.3,<2.4.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libtiff >=4.7.1,<4.8.0a0
+  license: HPND
+  size: 915852
+  timestamp: 1782912080163
+- conda: https://conda.anaconda.org/conda-forge/noarch/pint-0.24.4-pyhe01879c_2.conda
+  sha256: 0826610d55955ea4b274a6b2553902f285901cd0082aa20e139de5355f1a5acc
+  md5: 7c7e5db36556343121c7baabcfdd85f6
+  depends:
+  - python >=3.9
+  - platformdirs >=2.1.0
+  - flexcache >=0.3
+  - flexparser >=0.4
+  - typing_extensions >=4.0.0
+  - python
+  constrains:
+  - numpy >=1.23
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 240361
+  timestamp: 1753127340588
+- conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.1.2-pyh8b19718_0.conda
+  sha256: 29b7d75bf81ad11645a8e320b369abdc90a92b93f2a9178e853d9dddf82e5106
+  md5: 511fbc2c63d2c73650ad1755e4d357ba
+  depends:
+  - python >=3.10,<3.13.0a0
+  - setuptools
+  - wheel
+  license: MIT
+  license_family: MIT
+  size: 1203173
+  timestamp: 1780262795392
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
   sha256: 43d37bc9ca3b257c5dd7bf76a8426addbdec381f6786ff441dc90b1a49143b6a
   md5: c01af13bdc553d1a8fbfff6e8db075f0
@@ -6685,6 +9507,16 @@ packages:
   purls: []
   size: 450960
   timestamp: 1754665235234
+- conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.10.0-pyhcf101f3_0.conda
+  sha256: 9e5e1fd3506ccfc4d444fc4d2d39b0ed097d5d0e3bd3d4bdf6bcc81aaf66860d
+  md5: 2c5ef45db85d34799771629bd5860fd7
+  depends:
+  - python >=3.10
+  - python
+  license: MIT
+  license_family: MIT
+  size: 26308
+  timestamp: 1779972894916
 - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
   sha256: 8f29915c172f1f7f4f7c9391cd5dac3ebf5d13745c8b7c8006032615246345a5
   md5: 89c0b6d1793601a2a3a3f7d2d3d8b937
@@ -6820,6 +9652,23 @@ packages:
   - pkg:pypi/pre-commit?source=compressed-mapping
   size: 201606
   timestamp: 1776858157327
+- conda: https://conda.anaconda.org/conda-forge/linux-64/proj-9.6.2-h18fbb6c_2.conda
+  sha256: c1c9e38646a2d07007844625c8dea82404c8785320f8a6326b9338f8870875d0
+  md5: 1aeede769ec2fa0f474f8b73a7ac057f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libcurl >=8.14.1,<9.0a0
+  - libgcc >=14
+  - libsqlite >=3.50.4,<4.0a0
+  - libstdcxx >=14
+  - libtiff >=4.7.0,<4.8.0a0
+  - sqlite
+  constrains:
+  - proj4 ==999999999999
+  license: MIT
+  license_family: MIT
+  size: 3240415
+  timestamp: 1754927975218
 - conda: https://conda.anaconda.org/conda-forge/linux-64/proj-9.7.1-he0df7b0_3.conda
   sha256: c94d3d8ef40d1ea018860d66c416003bc03adede7d212efc9218bb64041fe2f7
   md5: 031e33ae075b336c0ce92b14efa886c5
@@ -6866,6 +9715,15 @@ packages:
   purls: []
   size: 199544
   timestamp: 1730769112346
+- conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.25.0-pyhd8ed1ab_0.conda
+  sha256: 4d7ec90d4f9c1f3b4a50623fefe4ebba69f651b102b373f7c0e9dbbfa43d495c
+  md5: a11ab1f31af799dd93c3a39881528884
+  depends:
+  - python >=3.10
+  license: Apache-2.0
+  license_family: Apache
+  size: 57113
+  timestamp: 1775771465170
 - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
   sha256: 4817651a276016f3838957bfdf963386438c70761e9faec7749d411635979bae
   md5: edb16f14d920fb3faf17f5ce582942d6
@@ -6880,6 +9738,15 @@ packages:
   - pkg:pypi/prompt-toolkit?source=hash-mapping
   size: 273927
   timestamp: 1756321848365
+- conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.52-hd8ed1ab_0.conda
+  sha256: e79922a360d7e620df978417dd033e66226e809961c3e659a193f978a75a9b0b
+  md5: 6d034d3a6093adbba7b24cb69c8c621e
+  depends:
+  - prompt-toolkit >=3.0.52,<3.0.53.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7212
+  timestamp: 1756321849562
 - conda: https://conda.anaconda.org/conda-forge/linux-64/propcache-0.3.1-py312h178313f_0.conda
   sha256: d0ff67d89cf379a9f0367f563320621f0bc3969fe7f5c85e020f437de0927bb4
   md5: 0cf580c1b73146bb9ff1bbdb4d4c8cf9
@@ -6894,6 +9761,18 @@ packages:
   - pkg:pypi/propcache?source=hash-mapping
   size: 54233
   timestamp: 1744525107433
+- conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.2.2-py310h139afa4_0.conda
+  sha256: 3a6d46033ebad3e69ded3f76852b9c378c2cff632f57421b5926c6add1bae475
+  md5: d210342acdb8e3ca6434295497c10b7c
+  depends:
+  - python
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 179015
+  timestamp: 1769678154886
 - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.2.2-py312h5253ce2_0.conda
   sha256: d834fd656133c9e4eaf63ffe9a117c7d0917d86d89f7d64073f4e3a0020bd8a7
   md5: dd94c506b119130aef5a9382aed648e7
@@ -7025,6 +9904,16 @@ packages:
   - pkg:pypi/pycparser?source=hash-mapping
   size: 110100
   timestamp: 1733195786147
+- conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
+  sha256: e27e0473fc6723311a0bd48b89b616fa1b996a2f7a2b555338cbbcfb9c640568
+  md5: 9c5491066224083c41b6d5635ed7107b
+  depends:
+  - python >=3.10
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 55886
+  timestamp: 1779293633166
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pycryptodomex-3.23.0-py312h4c3975b_1.conda
   sha256: 3aa3a0184eb7114c9b173f2736c33eff406f07cf289d90050d1efa918f6154a9
   md5: 5aa8e72c811e6906865108ebc6718e45
@@ -7088,6 +9977,35 @@ packages:
   - pkg:pypi/pydantic-core?source=hash-mapping
   size: 1895409
   timestamp: 1778084226169
+- conda: https://conda.anaconda.org/conda-forge/noarch/pydata-sphinx-theme-0.15.4-pyhd8ed1ab_0.conda
+  sha256: 5ec877142ded763061e114e787a4e201c2fb3f0b1db2f04ace610a1187bb34ae
+  md5: c7c50dd5192caa58a05e6a4248a27acb
+  depends:
+  - accessible-pygments
+  - babel
+  - beautifulsoup4
+  - docutils !=0.17.0
+  - packaging
+  - pygments >=2.7
+  - python >=3.9
+  - sphinx >=5.0
+  - typing_extensions
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1393462
+  timestamp: 1719344980505
+- conda: https://conda.anaconda.org/conda-forge/noarch/pydot-4.0.1-pyhcf101f3_2.conda
+  sha256: af7213a8ca077895e7e10c8f33d5de3436b8a26828422e8a113cc59c9277a3e2
+  md5: 15f6d0866b0997c5302fc230a566bc72
+  depends:
+  - graphviz >=2.38.0
+  - pyparsing >=3.1.0
+  - python >=3.10
+  - python
+  license: MIT
+  license_family: MIT
+  size: 150656
+  timestamp: 1766345630713
 - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
   sha256: cf70b2f5ad9ae472b71235e5c8a736c9316df3705746de419b59d442e8348e86
   md5: 16c18772b340887160c79a6acc022db0
@@ -7112,6 +10030,22 @@ packages:
   - pkg:pypi/pymdown-extensions?source=compressed-mapping
   size: 173156
   timestamp: 1774803071462
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyogrio-0.11.0-py310h0aed7a2_0.conda
+  sha256: 528fd575f5540b7fa62d72c836c66de96dc44ccf933621c73dcba34ff48c5baf
+  md5: 717aea1df1a19ae7901fe2eca2ec9269
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libgdal-core >=3.10.3,<3.11.0a0
+  - libstdcxx >=13
+  - numpy
+  - packaging
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 632885
+  timestamp: 1746734855539
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pyogrio-0.12.1-py312h053e1f3_0.conda
   sha256: 2b0a366d9066e3d9f495369b95cdb1b9d3dba2f59577e4560b7d1086e1fe3d70
   md5: f8e7e5ddfbdca16b65335b0b6615eb4c
@@ -7158,6 +10092,20 @@ packages:
   - pkg:pypi/pyppmd?source=hash-mapping
   size: 66968
   timestamp: 1768588031093
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyproj-3.7.1-py310h71d0299_1.conda
+  sha256: ec5f371389d7b57cd835144410d04f7af192487b4ff36e032c07b6c032ed383d
+  md5: e54b1eaeb50ad1767680181a8575a8db
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - certifi
+  - libgcc >=13
+  - proj >=9.6.0,<9.7.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 536170
+  timestamp: 1742323393877
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pyproj-3.7.2-py312he675c61_3.conda
   sha256: ea0299f9699547531e81dd685f7ff0e50f7bc6dad932d8005ef24c3393cc07c1
   md5: c3258c31e507a81f0b52156bcca81e73
@@ -7186,6 +10134,16 @@ packages:
   - pkg:pypi/pyshp?source=hash-mapping
   size: 454408
   timestamp: 1764355333136
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyshp-3.1.4-pyhcf101f3_0.conda
+  sha256: dde0c9ec13ce07edcb6fb7f68a4595f031f5de58bacd23f950f42548763a0687
+  md5: 45d60067e867abbcd271189506da5749
+  depends:
+  - python >=3.10
+  - python
+  license: MIT
+  license_family: MIT
+  size: 510534
+  timestamp: 1782820117625
 - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
   sha256: ba3b032fa52709ce0d9fd388f63d330a026754587a2f461117cac9ab73d8d0d8
   md5: 461219d1a5bd61342293efa2c0c90eac
@@ -7231,6 +10189,101 @@ packages:
   - pkg:pypi/pytest?source=compressed-mapping
   size: 299984
   timestamp: 1775644472530
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
+  sha256: 430051d80765207a7d782b2b188230ba1489d35c6e75fd9903f76cb9fda4af16
+  md5: 64c98a12c4e23eb238bf66bbecafdf3c
+  depends:
+  - colorama
+  - pygments >=2.7.2
+  - python >=3.10
+  - iniconfig >=1.0.1
+  - packaging >=22
+  - pluggy >=1.5,<2
+  - tomli >=1
+  - exceptiongroup >=1
+  - python
+  constrains:
+  - pytest-faulthandler >=2
+  license: MIT
+  license_family: MIT
+  size: 306724
+  timestamp: 1782127176429
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
+  sha256: 44e42919397bd00bfaa47358a6ca93d4c21493a8c18600176212ec21a8d25ca5
+  md5: 67d1790eefa81ed305b89d8e314c7923
+  depends:
+  - coverage >=7.10.6
+  - pluggy >=1.2
+  - pytest >=7
+  - python >=3.10
+  - python
+  license: MIT
+  license_family: MIT
+  size: 29559
+  timestamp: 1774139250481
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytest-env-1.6.0-pyhd8ed1ab_0.conda
+  sha256: d288b55b224a1d6a7eca5ca0ac0e026169ffa6458e64dcb990f62f99e37b8010
+  md5: 27f9775b96f64454633682cc6a0b0768
+  depends:
+  - pytest >=9.0.2
+  - python >=3.10
+  - python-dotenv >=1.2.1
+  - tomli >=2.4
+  license: MIT
+  license_family: MIT
+  size: 16375
+  timestamp: 1773399682528
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytest-order-1.5.0-pyhcf101f3_0.conda
+  sha256: 4735430aa665efffb0c710f0f2ae7575da17c05decef26f542a0eead6077ce85
+  md5: 74b198ff647ae848cb3febd72c3b8888
+  depends:
+  - python >=3.10
+  - pytest >=6.2.4
+  - python
+  license: MIT
+  license_family: MIT
+  size: 23251
+  timestamp: 1781355185657
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.8.0-pyhd8ed1ab_0.conda
+  sha256: b7b58a5be090883198411337b99afb6404127809c3d1c9f96e99b59f36177a96
+  md5: 8375cfbda7c57fbceeda18229be10417
+  depends:
+  - execnet >=2.1
+  - pytest >=7.0.0
+  - python >=3.9
+  constrains:
+  - psutil >=3.0
+  license: MIT
+  license_family: MIT
+  size: 39300
+  timestamp: 1751452761594
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.10.20-h267e890_1_cpython.conda
+  build_number: 1
+  sha256: c15d8585b7a52fdb734bd16dbdcae4b81ed59268862d3a2588eb8ed69c8cbc52
+  md5: c5eace1c2d8dae0bb08c094617ea8cc7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.36.1
+  - libexpat >=2.8.1,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libgcc >=14
+  - liblzma >=5.8.3,<6.0a0
+  - libnsl >=2.0.1,<2.1.0a0
+  - libsqlite >=3.53.2,<4.0a0
+  - libuuid >=2.42.1,<3.0a0
+  - libxcrypt >=4.4.36
+  - libzlib >=1.3.2,<2.0a0
+  - ncurses >=6.6,<7.0a0
+  - openssl >=3.5.7,<4.0a0
+  - readline >=8.3,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  constrains:
+  - python_abi 3.10.* *_cp310
+  license: Python-2.0
+  size: 25403213
+  timestamp: 1781149348162
 - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.13-hd63d673_0_cpython.conda
   sha256: a44655c1c3e1d43ed8704890a91e12afd68130414ea2c0872e154e5633a13d7e
   md5: 7eccb41177e15cc672e1babe9056018e
@@ -7285,6 +10338,27 @@ packages:
   - pkg:pypi/python-discovery?source=compressed-mapping
   size: 35030
   timestamp: 1778013338579
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-discovery-1.4.3-pyhcf101f3_0.conda
+  sha256: f3441eac47857ecb045e61dd457a72e0d746c0e1dd5c6acf3d2ba1c4cecc9cd8
+  md5: f2af2cbd8693ecb28cd0a1586e22c758
+  depends:
+  - python >=3.10
+  - filelock >=3.15.4
+  - platformdirs <5,>=4.3.6
+  - python
+  license: MIT
+  license_family: MIT
+  size: 35503
+  timestamp: 1783111064496
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.2.2-pyhcf101f3_0.conda
+  sha256: 74e417a768f59f02a242c25e7db0aa796627b5bc8c818863b57786072aeb85e5
+  md5: 130584ad9f3a513cdd71b1fdc1244e9c
+  depends:
+  - python >=3.10
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27848
+  timestamp: 1772388605021
 - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.2-pyhe01879c_0.conda
   sha256: df9aa74e9e28e8d1309274648aac08ec447a92512c33f61a8de0afa9ce32ebe8
   md5: 23029aae904a2ba587daba708208012f
@@ -7297,6 +10371,15 @@ packages:
   - pkg:pypi/fastjsonschema?source=hash-mapping
   size: 244628
   timestamp: 1755304154927
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.10.20-hd8ed1ab_1.conda
+  sha256: 84bab2600eb7a94016f33cb580a1a1bbb9fbc2d11460a337d5d014e8151d0bdf
+  md5: 33296afcbf60357874f99aec38ead969
+  depends:
+  - cpython 3.10.20.*
+  - python_abi * *_cp310
+  license: Python-2.0
+  size: 51430
+  timestamp: 1781148436610
 - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.12.13-hd8ed1ab_0.conda
   sha256: 97327b9509ae3aae28d27217a5d7bd31aff0ab61a02041e9c6f98c11d8a53b29
   md5: 32780d6794b8056b78602103a04e90ef
@@ -7307,6 +10390,35 @@ packages:
   purls: []
   size: 46449
   timestamp: 1772728979370
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-4.1.0-pyhd8ed1ab_0.conda
+  sha256: a0dfe07d0bc1d8c47a38b79ad4a8eb1bc7b86fb33ee5293ebb45dfdc46191f4e
+  md5: 982ed0cbfc0fe09f25861e3d111e9717
+  depends:
+  - python >=3.10
+  - typing_extensions
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 19249
+  timestamp: 1781036004580
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2026.2-pyhd8ed1ab_0.conda
+  sha256: e943f9c15a6bdba2e1b9f423ab913b3f6b02197b0ef9f8e6b7464d78b59965b9
+  md5: f6ad7450fc21e00ecc23812baed6d2e4
+  depends:
+  - python >=3.10
+  license: Apache-2.0
+  license_family: APACHE
+  size: 146639
+  timestamp: 1777068997932
+- conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.10-8_cp310.conda
+  build_number: 8
+  sha256: 7ad76fa396e4bde336872350124c0819032a9e8a0a40590744ff9527b54351c1
+  md5: 05e00f3b21e88bb3d658ac700b2ce58c
+  constrains:
+  - python 3.10.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6999
+  timestamp: 1752805924192
 - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
   build_number: 8
   sha256: 80677180dd3c22deb7426ca89d6203f1c7f1f256f2d5a94dc210f6e758229809
@@ -7318,6 +10430,28 @@ packages:
   purls: []
   size: 6958
   timestamp: 1752805918820
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pytokens-0.4.1-py310h139afa4_2.conda
+  sha256: 6e74e99787870ee4158165dacd312347342a8cdf67814086365c4fe95512151b
+  md5: 1874447dc9421e6fa984853d5df7ec2a
+  depends:
+  - python
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 274111
+  timestamp: 1778688807018
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2026.2-pyhcf101f3_0.conda
+  sha256: 5020863d629f584b5c057333a67a7aed43e3ed013ba15dd70f353501ccb5aff6
+  md5: 03cb60f505ad3ada0a95277af5faeb1a
+  depends:
+  - python >=3.10
+  - python
+  license: MIT
+  license_family: MIT
+  size: 201747
+  timestamp: 1777892201250
 - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.6-pyhd8ed1ab_0.conda
   sha256: 4095768d06ffbe31aa98f1d4a982c1f483de088749f30e990673fcae94f1d8d1
   md5: e0f2c3ecb4dc40d031bbe88869a2a7a1
@@ -7332,6 +10466,73 @@ packages:
   - pkg:pypi/pyviz-comms?source=hash-mapping
   size: 49425
   timestamp: 1750669964512
+- conda: https://conda.anaconda.org/conda-forge/noarch/pywatershed-2.0.4-pyhc455866_0.conda
+  sha256: e4449eadf3f77654fa4c4dc96574777dc1096520f1c64fbd509f6da8846d0552
+  md5: e0c2b0bd791e319f1cd7624c0cf4574a
+  depends:
+  - boltons
+  - cartopy
+  - click !=8.1.0
+  - contextily
+  - dataretrieval
+  - epiweeks4cf
+  - filelock
+  - flopy
+  - folium
+  - geopandas
+  - geoviews
+  - git
+  - holoviews
+  - hvplot
+  - ipython
+  - ipywidgets
+  - jupyter
+  - jupyter-black
+  - jupyterlab
+  - modflow-devtools
+  - nbconvert
+  - netcdf4
+  - networkx
+  - numba
+  - numpy >=2.0.0
+  - pandas >=1.4.0
+  - pint
+  - pip
+  - pre-commit
+  - pydot
+  - pytest !=8.1.0
+  - pytest-cov
+  - pytest-env
+  - pytest-order
+  - pytest-xdist
+  - python >=3.10,<3.12
+  - pyyaml
+  - ruff
+  - shapely
+  - sphinx
+  - sphinx-autodoc-typehints >=2.2.1
+  - sphinx-autosummary-accessors
+  - sphinx-book-theme >=0.3.3
+  - sphinx-copybutton
+  - tqdm
+  - xarray >=2024.06.0
+  - xmltodict
+  license: CC0-1.0
+  size: 13421625
+  timestamp: 1771902662536
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py310h3406613_1.conda
+  sha256: f23de6cc72541c6081d3d27482dbc9fc5dd03be93126d9155f06d0cf15d6e90e
+  md5: 2160894f57a40d2d629a34ee8497795f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 176522
+  timestamp: 1770223379599
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py312h8a5da7c_1.conda
   sha256: cb142bfd92f6e55749365ddc244294fa7b64db6d08c45b018ff1c658907bfcbf
   md5: 15878599a87992e44c059731771591cb
@@ -7359,6 +10560,20 @@ packages:
   - pkg:pypi/pyyaml-env-tag?source=hash-mapping
   size: 11137
   timestamp: 1747237061448
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.1.0-py310ha71cbf4_3.conda
+  sha256: ae68ab6978705044b70138d7930293a7045ce03ae2470a3145d7808bee4c7ef1
+  md5: ee924c369aca41fb3e55c4240154d43c
+  depends:
+  - python
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - zeromq >=4.3.5,<4.4.0a0
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 326664
+  timestamp: 1779483880352
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.1.0-py312hda471dd_2.conda
   noarch: python
   sha256: be66c1f85c3b48137200d62c12d918f4f8ad329423daef04fed292818efd3c28
@@ -7401,6 +10616,31 @@ packages:
   purls: []
   size: 552937
   timestamp: 1720813982144
+- conda: https://conda.anaconda.org/conda-forge/linux-64/rasterio-1.4.3-py310hf3df72b_2.conda
+  sha256: 3cdf2c51fa3537e5cfac7277bc9b53c8a8f31d520a5237980253f226207aaebd
+  md5: f49be99a09b5e9286b8f58e12d44ee5d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - affine
+  - attrs
+  - certifi
+  - click >=4,!=8.2.*
+  - click-plugins
+  - cligj >=0.5
+  - libgcc >=14
+  - libgdal-core <3.11
+  - libgdal-core >=3.10.3,<3.11.0a0
+  - libstdcxx >=14
+  - numpy >=1.21,<3
+  - proj >=9.6.2,<9.7.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - setuptools >=0.9.8
+  - snuggs >=1.4.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7942226
+  timestamp: 1758129757954
 - conda: https://conda.anaconda.org/conda-forge/linux-64/rasterio-1.5.0-py312hcedc861_0.conda
   sha256: c7a9a69149a15262e14c32232459d45e3ef58aee65e46ed60b270a6ded54a573
   md5: f0d110978a87b200a06412b56b26407c
@@ -7501,6 +10741,22 @@ packages:
   - pkg:pypi/requests?source=compressed-mapping
   size: 63728
   timestamp: 1777030058920
+- conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.34.2-pyhcf101f3_0.conda
+  sha256: 1715246b19c9f85ee022933b4845f2fc14ac9184981b7b7d9b728bec8e9588da
+  md5: 4a85203c1d80c1059086ae860836ffb9
+  depends:
+  - python >=3.10
+  - certifi >=2023.5.7
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - urllib3 >=1.26,<3
+  - python
+  constrains:
+  - chardet >=3.0.2,<8
+  license: Apache-2.0
+  license_family: APACHE
+  size: 68709
+  timestamp: 1778851103479
 - conda: https://conda.anaconda.org/conda-forge/noarch/retrying-1.4.2-pyhe01879c_0.conda
   sha256: 7a10527962d2ca2cf936872ef58d4b622b1d1d1703e1d6396d0673fd9f883c7f
   md5: 128b46a47ea164f9a8659cb6da2f3555
@@ -7513,6 +10769,36 @@ packages:
   - pkg:pypi/retrying?source=hash-mapping
   size: 20907
   timestamp: 1754219562310
+- conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_1.conda
+  sha256: 2e4372f600490a6e0b3bac60717278448e323cab1c0fecd5f43f7c56535a99c5
+  md5: 36de09a8d3e5d5e6f4ee63af49e59706
+  depends:
+  - python >=3.9
+  - six
+  license: MIT
+  license_family: MIT
+  size: 10209
+  timestamp: 1733600040800
+- conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
+  sha256: 2a5b495a1de0f60f24d8a74578ebc23b24aa53279b1ad583755f223097c41c37
+  md5: 912a71cc01012ee38e6b90ddd561e36f
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 7818
+  timestamp: 1598024297745
+- conda: https://conda.anaconda.org/conda-forge/noarch/rfc3987-syntax-1.1.0-pyhe01879c_1.conda
+  sha256: 70001ac24ee62058557783d9c5a7bbcfd97bd4911ef5440e3f7a576f9e43bc92
+  md5: 7234f99325263a5af6d4cd195035e8f2
+  depends:
+  - python >=3.9
+  - lark >=1.2.2
+  - python
+  license: MIT
+  license_family: MIT
+  size: 22913
+  timestamp: 1752876729969
 - conda: https://conda.anaconda.org/conda-forge/linux-64/richdem-2.3.0-py312h5fc20e3_16.conda
   sha256: 4e44c0821faefc58dc09510137f50117f9343428fd8c7aa8180e46421a3eb62a
   md5: 0efcba16e7f7763ed812203d6da49aa3
@@ -7549,6 +10835,20 @@ packages:
   - pkg:pypi/rioxarray?source=hash-mapping
   size: 65348
   timestamp: 1772826126034
+- conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.30.0-py310hd8f68c5_0.conda
+  sha256: ac1132a9344c77e19bbbdb966668cf73a861ceec7b075858a52c8e961fb8ea9d
+  md5: 61ff3f8e00c63bb66903636d0197e962
+  depends:
+  - python
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.10.* *_cp310
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  size: 382893
+  timestamp: 1764543243162
 - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.30.0-py312h868fb18_0.conda
   sha256: 62f46e85caaba30b459da7dfcf3e5488ca24fd11675c33ce4367163ab191a42c
   md5: 3ffc5a3572db8751c2f15bacf6a0e937
@@ -7581,6 +10881,20 @@ packages:
   - pkg:pypi/ruff?source=compressed-mapping
   size: 9266480
   timestamp: 1778119386343
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.15.20-h6a952e8_0.conda
+  noarch: python
+  sha256: 4c10593eb248ae3b626ebfc2991bd67df96cb98a51816939188576237c54deee
+  md5: d9b134cef9bc26a9ed9a0fba1eff3356
+  depends:
+  - python
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  size: 9342178
+  timestamp: 1782428525856
 - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.7.2-hc5a330e_1.conda
   sha256: 856866fd519b812db3e092aba308248dd87b5c308186fcffe593f309373ae94c
   md5: 3f578c7d2b0bb52469340e4060d48d94
@@ -7607,6 +10921,25 @@ packages:
   - pkg:pypi/s3fs?source=hash-mapping
   size: 35801
   timestamp: 1777558978513
+- conda: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.7.2-py310h228f341_0.conda
+  sha256: 8af2a49b75b9697653a0bf55717c8153732c4fc53f58d4aa0ed692ae348c49f6
+  md5: 0f3e3324506bd3e67934eda9895f37a7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex >=4.5
+  - joblib >=1.2.0
+  - libgcc >=14
+  - libstdcxx >=14
+  - numpy >=1.21,<3
+  - numpy >=1.22.0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - scipy >=1.8.0
+  - threadpoolctl >=3.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8415134
+  timestamp: 1757406407327
 - conda: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.8.0-np2py312h3226591_1.conda
   sha256: 23c643c37fafa14ba3f2b7a407126ea5e732a3655ea8157cf9f977098f863448
   md5: 38decbeae260892040709cafc0514162
@@ -7628,6 +10961,27 @@ packages:
   - pkg:pypi/scikit-learn?source=hash-mapping
   size: 9726193
   timestamp: 1765801245538
+- conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.15.2-py310h1d65ade_0.conda
+  sha256: 4cb98641f870666d365594013701d5691205a0fe81ac3ba7778a23b1cc2caa8e
+  md5: 8c29cd33b64b2eb78597fa28b5595c8d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc >=13
+  - libgfortran
+  - libgfortran5 >=13.3.0
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx >=13
+  - numpy <2.5
+  - numpy >=1.19,<3
+  - numpy >=1.23.5
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 16417101
+  timestamp: 1739791865060
 - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.17.1-py312h54fa4ab_0.conda
   sha256: e3ad577361d67f6c078a6a7a3898bf0617b937d44dc4ccd57aa3336f2b5778dd
   md5: 3e38daeb1fb05a95656ff5af089d2e4c
@@ -7651,6 +11005,17 @@ packages:
   - pkg:pypi/scipy?source=hash-mapping
   size: 17109648
   timestamp: 1771880675810
+- conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-2.1.0-pyha191276_1.conda
+  sha256: 59656f6b2db07229351dfb3a859c35e57cc8e8bcbc86d4e501bff881a6f771f1
+  md5: 28eb91468df04f655a57bcfbb35fc5c5
+  depends:
+  - __linux
+  - python >=3.10
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24108
+  timestamp: 1770937597662
 - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
   sha256: 82088a6e4daa33329a30bc26dc19a98c7c1d3f05c0f73ce9845d4eab4924e9e1
   md5: 8e194e7b992f99a5015edbd4ebd38efd
@@ -7662,6 +11027,20 @@ packages:
   - pkg:pypi/setuptools?source=compressed-mapping
   size: 639697
   timestamp: 1773074868565
+- conda: https://conda.anaconda.org/conda-forge/linux-64/shapely-2.1.2-py310h777b3ac_0.conda
+  sha256: 4baffc6640c1b7f590df0fb62089947408fa98fdcac9f3cea420bd33afa36137
+  md5: 486ffd32d6cc932f43df4066efd3c973
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - geos >=3.14.0,<3.14.1.0a0
+  - libgcc >=14
+  - numpy >=1.21,<3
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 542303
+  timestamp: 1758735396162
 - conda: https://conda.anaconda.org/conda-forge/linux-64/shapely-2.1.2-py312h383787d_2.conda
   sha256: da100ac0210f52399faf814f701165058fa2e2f65f5c036cdf2bf99a40223373
   md5: 69e400d3deca12ee7afd4b73a5596905
@@ -7717,6 +11096,24 @@ packages:
   purls: []
   size: 45829
   timestamp: 1762948049098
+- conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_2.conda
+  sha256: dce518f45e24cd03f401cb0616917773159a210c19d601c5f2d4e0e5879d30ad
+  md5: 03fe290994c5e4ec17293cfb6bdce520
+  depends:
+  - python >=3.10
+  license: Apache-2.0
+  license_family: Apache
+  size: 15698
+  timestamp: 1762941572482
+- conda: https://conda.anaconda.org/conda-forge/noarch/snowballstemmer-3.1.1-pyhd8ed1ab_0.conda
+  sha256: ad89284ea94821c20ff87e64b948e4afc690cf5202d14c009355b0594cf23aea
+  md5: 46b6abe31482f6bca064b965696ae807
+  depends:
+  - python >=3.10
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 74456
+  timestamp: 1780468201547
 - conda: https://conda.anaconda.org/conda-forge/noarch/snuggs-1.4.7-pyhd8ed1ab_2.conda
   sha256: 61f9373709e7d9009e3a062b135dbe44b16e684a4fcfe2dd624143bc0f80d402
   md5: 9aa358575bbd4be126eaa5e0039f835c
@@ -7752,6 +11149,15 @@ packages:
   - pkg:pypi/soupsieve?source=hash-mapping
   size: 38187
   timestamp: 1769034509657
+- conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.8.4-pyhd8ed1ab_0.conda
+  sha256: 2afa5fe9331c09b4c4689ddf6ace8fc16c837eae547c57dab325b844072fdd77
+  md5: 9e21f087f087f805debe877d88e00a14
+  depends:
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  size: 38802
+  timestamp: 1779635534390
 - conda: https://conda.anaconda.org/conda-forge/noarch/spatialpandas-0.5.0-pyhd8ed1ab_0.conda
   sha256: 81e0aa7d3ca621694ba8facbbf9ba0dc72d2753b4149a0d5453498b809029a1e
   md5: e371879bca521d38ad57e88a705bcda4
@@ -7782,6 +11188,135 @@ packages:
   purls: []
   size: 196681
   timestamp: 1767781665629
+- conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-8.1.3-pyhd8ed1ab_1.conda
+  sha256: 3228eb332ce159f031d4b7d2e08117df973b0ba3ddcb8f5dbb7f429f71d27ea1
+  md5: 1a3281a0dc355c02b5506d87db2d78ac
+  depends:
+  - alabaster >=0.7.14
+  - babel >=2.13
+  - colorama >=0.4.6
+  - docutils >=0.20,<0.22
+  - imagesize >=1.3
+  - jinja2 >=3.1
+  - packaging >=23.0
+  - pygments >=2.17
+  - python >=3.10
+  - requests >=2.30.0
+  - snowballstemmer >=2.2
+  - sphinxcontrib-applehelp >=1.0.7
+  - sphinxcontrib-devhelp >=1.0.6
+  - sphinxcontrib-htmlhelp >=2.0.6
+  - sphinxcontrib-jsmath >=1.0.1
+  - sphinxcontrib-qthelp >=1.0.6
+  - sphinxcontrib-serializinghtml >=1.1.9
+  - tomli >=2.0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1387076
+  timestamp: 1733754175386
+- conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-autodoc-typehints-3.0.1-pyhd8ed1ab_0.conda
+  sha256: 0f93bb75a41918433abc8d8d80ef99d7fd8658d5ba34da3c5d8f707cb6bb3f46
+  md5: 6ad405d62c8de3792608a27b7e085e15
+  depends:
+  - python >=3.10
+  - sphinx >=8.1.3
+  license: MIT
+  license_family: MIT
+  size: 24055
+  timestamp: 1737099757820
+- conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-autosummary-accessors-2025.3.1-pyhcf101f3_1.conda
+  sha256: e4dd4480e55b36526cf41be052792c7148ce3bfbacd00a73d4cf1257fc5090a7
+  md5: f06b1ce91f9ad5db7b073167b68c0401
+  depends:
+  - importlib-metadata
+  - python >=3.10
+  - sphinx >=3.3,<9.0a0
+  - python
+  license: MIT
+  license_family: MIT
+  size: 14968
+  timestamp: 1766222696469
+- conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-book-theme-1.1.4-pyh29332c3_0.conda
+  sha256: 78581f1ba538186fc4129191a8db4ee7798382b6b4a1a0c55dedb437da1a9fd8
+  md5: f3d3f4e7e2c9198e88cd524633665081
+  depends:
+  - pydata-sphinx-theme ==0.15.4
+  - python >=3.9
+  - sphinx >=6.1
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 255445
+  timestamp: 1740145414720
+- conda: https://conda.anaconda.org/conda-forge/noarch/sphinx-copybutton-0.5.2-pyhd8ed1ab_1.conda
+  sha256: 8cd892e49cb4d00501bc4439fb0c73ca44905f01a65b2b7fa05ba0e8f3924f19
+  md5: bf22cb9c439572760316ce0748af3713
+  depends:
+  - python >=3.9
+  - sphinx >=1.8
+  license: MIT
+  license_family: MIT
+  size: 17893
+  timestamp: 1734573117732
+- conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-applehelp-2.0.0-pyhd8ed1ab_1.conda
+  sha256: d7433a344a9ad32a680b881c81b0034bc61618d12c39dd6e3309abeffa9577ba
+  md5: 16e3f039c0aa6446513e94ab18a8784b
+  depends:
+  - python >=3.9
+  - sphinx >=5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 29752
+  timestamp: 1733754216334
+- conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-devhelp-2.0.0-pyhd8ed1ab_1.conda
+  sha256: 55d5076005d20b84b20bee7844e686b7e60eb9f683af04492e598a622b12d53d
+  md5: 910f28a05c178feba832f842155cbfff
+  depends:
+  - python >=3.9
+  - sphinx >=5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 24536
+  timestamp: 1733754232002
+- conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-htmlhelp-2.1.0-pyhd8ed1ab_1.conda
+  sha256: c1492c0262ccf16694bdcd3bb62aa4627878ea8782d5cd3876614ffeb62b3996
+  md5: e9fb3fe8a5b758b4aff187d434f94f03
+  depends:
+  - python >=3.9
+  - sphinx >=5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 32895
+  timestamp: 1733754385092
+- conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-jsmath-1.0.1-pyhd8ed1ab_1.conda
+  sha256: 578bef5ec630e5b2b8810d898bbbf79b9ae66d49b7938bcc3efc364e679f2a62
+  md5: fa839b5ff59e192f411ccc7dae6588bb
+  depends:
+  - python >=3.9
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 10462
+  timestamp: 1733753857224
+- conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-qthelp-2.0.0-pyhd8ed1ab_1.conda
+  sha256: c664fefae4acdb5fae973bdde25836faf451f41d04342b64a358f9a7753c92ca
+  md5: 00534ebcc0375929b45c3039b5ba7636
+  depends:
+  - python >=3.9
+  - sphinx >=5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 26959
+  timestamp: 1733753505008
+- conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-2.0.0-pyhd8ed1ab_0.conda
+  sha256: 20b49741065fd7d3fabf98caf6d19b6436badb06b6d41f66b58f1fc2b52f37a1
+  md5: f77df1fcf9af03b7287342638befca77
+  depends:
+  - python >=3.10
+  - sphinx >=5
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 30640
+  timestamp: 1781260357443
 - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.53.1-hbc0de68_0.conda
   sha256: d167fa92781bcdcd3b9aaa6bb1cd50c5b108f6190c170098a118b5cf5df2f881
   md5: 8e0b8654ead18e50af552e54b5a08a61
@@ -7796,6 +11331,19 @@ packages:
   purls: []
   size: 205399
   timestamp: 1777986477546
+- conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.53.3-hbc0de68_0.conda
+  sha256: ef17725138fa72aa5a0f8ccace9727831c4b333e39575f78fb5ad1755826b687
+  md5: b345ea7f13e4cae9809c69b1d1af2c99
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libsqlite 3.53.3 h0c1763c_0
+  - libzlib >=1.3.2,<2.0a0
+  - ncurses >=6.6,<7.0a0
+  - readline >=8.3,<9.0a0
+  license: blessing
+  size: 206481
+  timestamp: 1782519082269
 - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
   sha256: 570da295d421661af487f1595045760526964f41471021056e993e73089e9c41
   md5: b1b505328da7a6b246787df4b5a49fbc
@@ -7856,6 +11404,19 @@ packages:
   - pkg:pypi/tblib?source=hash-mapping
   size: 19397
   timestamp: 1762956379123
+- conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyhc90fa1f_1.conda
+  sha256: 6b6727a13d1ca6a23de5e6686500d0669081a117736a87c8abf444d60c1e40eb
+  md5: 17b43cee5cc84969529d5d0b0309b2cb
+  depends:
+  - __unix
+  - ptyprocess
+  - python >=3.10
+  - tornado >=6.1.0
+  - python
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 24749
+  timestamp: 1766513766867
 - conda: https://conda.anaconda.org/conda-forge/noarch/texttable-1.7.0-pyhd8ed1ab_1.conda
   sha256: 68e13546ad89f43321df0793bd5c53731648da85e77b8aa6ab31f7bacb283680
   md5: c6c4b1c304e52f6a9b67d39384660a80
@@ -7938,6 +11499,15 @@ packages:
   purls: []
   size: 3301196
   timestamp: 1769460227866
+- conda: https://conda.anaconda.org/conda-forge/noarch/tokenize-rt-6.2.0-pyhd8ed1ab_0.conda
+  sha256: b8da0c728e1313e116a06084ea770c6ad752b9cd086d52b20fcd464bdce52e4b
+  md5: 0a42378794e0425eb5defc9d63e60607
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 12383
+  timestamp: 1748092106333
 - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
   sha256: 91cafdb64268e43e0e10d30bd1bef5af392e69f00edd34dfaf909f69ab2da6bd
   md5: b5325cf06a000c5b14970462ff5e4d58
@@ -7986,6 +11556,18 @@ packages:
   - pkg:pypi/tornado?source=compressed-mapping
   size: 859665
   timestamp: 1774358032165
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.7-py310h7c4b9e2_0.conda
+  sha256: f252879ed42022935adb7b04e6973d70188571ca0bd13cbf6e18bcad7a59d1bf
+  md5: 0737284b284d20f0c8766fca1a2b47b1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: Apache-2.0
+  license_family: Apache
+  size: 672546
+  timestamp: 1781006806557
 - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.3-pyh8f84b5b_0.conda
   sha256: 9ef8e47cf00e4d6dcc114eb32a1504cc18206300572ef14d76634ba29dfe1eb6
   md5: e5ce43272193b38c2e9037446c1d9206
@@ -7998,6 +11580,19 @@ packages:
   - pkg:pypi/tqdm?source=compressed-mapping
   size: 94132
   timestamp: 1770153424136
+- conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.68.3-pyh8f84b5b_0.conda
+  sha256: 613d5cc47571c0b66e31265ff1e0fa5bef0e7b7670f33c67f5a2c587faf6e5d1
+  md5: 65094960cb7ed216b6049aab57205902
+  depends:
+  - python >=3.10
+  - __unix
+  - python
+  constrains:
+  - envwrap >=0.2
+  - ipywidgets >=6.0
+  license: MPL-2.0 and MIT
+  size: 94965
+  timestamp: 1781741268338
 - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.0-pyhcf101f3_0.conda
   sha256: dfb681579be59c2e790c95f7f49b7529a9b0511d6385ad276e3c8988cbd54d2c
   md5: 4bada6a6d908a27262af8ebddf4f7492
@@ -8010,6 +11605,16 @@ packages:
   - pkg:pypi/traitlets?source=compressed-mapping
   size: 115165
   timestamp: 1778074251714
+- conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.15.1-pyhcf101f3_0.conda
+  sha256: b89a823edf524956b94a2a4db974866e4501f05c68976eff458c5dcf07f88431
+  md5: 37e3be7b6e2977d37b8fa5da229f5dc0
+  depends:
+  - python >=3.10
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 115158
+  timestamp: 1780507822178
 - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
   sha256: 7c2df5721c742c2a47b2c8f960e718c930031663ac1174da67c1ed5999f7938c
   md5: edd329d7d3a4ab45dcf905899a7a6115
@@ -8020,6 +11625,15 @@ packages:
   purls: []
   size: 91383
   timestamp: 1756220668932
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.16.0-h69aa097_0.conda
+  sha256: b141933ece3518f6d7b75dfb59451e2f26b405a44c18e2518a83e9a02e09315c
+  md5: c680b5747e8c4c8f23dca0bb7042a8fc
+  depends:
+  - typing_extensions ==4.16.0 pyhcf101f3_0
+  license: PSF-2.0
+  license_family: PSF
+  size: 94080
+  timestamp: 1783002732887
 - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhcf101f3_2.conda
   sha256: 8b90d2f19f9458b8c58a55e1fcdc1d90c1603a847a47654d8a454549413ba60a
   md5: 53f5409c5cfd6c5a66417d68e3f0a864
@@ -8045,6 +11659,25 @@ packages:
   - pkg:pypi/typing-extensions?source=hash-mapping
   size: 51692
   timestamp: 1756220668932
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.16.0-pyhcf101f3_0.conda
+  sha256: 2d888f90af0686044882c74193ec80a90ec1943145d94a7b1b048958acda1848
+  md5: c70ad746c22219b9700931707482992c
+  depends:
+  - python >=3.10
+  - python
+  license: PSF-2.0
+  license_family: PSF
+  size: 52631
+  timestamp: 1783002732887
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_1.conda
+  sha256: 3088d5d873411a56bf988eee774559335749aed6f6c28e07bf933256afb9eb6c
+  md5: f6d7aa696c67756a650e91e15e88223c
+  depends:
+  - python >=3.9
+  license: Apache-2.0
+  license_family: APACHE
+  size: 15183
+  timestamp: 1733331395943
 - conda: https://conda.anaconda.org/conda-forge/linux-64/tzcode-2026b-h280c20c_0.conda
   sha256: 35da5b89561ed93629f751f111a092abcaaa9fdc516e09e9b4ab9880756a1871
   md5: 5c5f9b9bad2a0852ffa38833ba2a1c7d
@@ -8074,6 +11707,20 @@ packages:
   - pkg:pypi/uc-micro-py?source=hash-mapping
   size: 13378
   timestamp: 1772479008776
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ukkonen-1.1.0-py310h03d9f68_0.conda
+  sha256: 24a1140fa1dcaf2d2b7da1014eba5801eae8c4c025bb17845a3b1b6c487cf8f7
+  md5: c3b1f5bc28ae6282ba95156d18fde825
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cffi
+  - libgcc >=14
+  - libstdcxx >=14
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: MIT
+  license_family: MIT
+  size: 14822
+  timestamp: 1769438718477
 - conda: https://conda.anaconda.org/conda-forge/linux-64/ukkonen-1.1.0-py312hd9148b4_0.conda
   sha256: c975070ac28fe23a5bbb2b8aeca5976b06630eb2de2dc149782f74018bf07ae8
   md5: 55fd03988b1b1bc6faabbfb5b481ecd7
@@ -8090,6 +11737,18 @@ packages:
   - pkg:pypi/ukkonen?source=hash-mapping
   size: 14882
   timestamp: 1769438717830
+- conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-17.0.1-py310h7c4b9e2_0.conda
+  sha256: 44ecba51c98c3fb2ce3d00295d423d3bb254cde1790eff9818ed328aa608ab28
+  md5: 234e9858dd691d3f597147e22cbf16cf
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  license: Apache-2.0
+  license_family: Apache
+  size: 410408
+  timestamp: 1770909105501
 - conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-17.0.1-py312h4c3975b_0.conda
   sha256: 895bbfe9ee25c98c922799de901387d842d7c01cae45c346879865c6a907f229
   md5: 0b6c506ec1f272b685240e70a29261b8
@@ -8104,6 +11763,15 @@ packages:
   - pkg:pypi/unicodedata2?source=compressed-mapping
   size: 410641
   timestamp: 1770909099497
+- conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_1.conda
+  sha256: e0eb6c8daf892b3056f08416a96d68b0a358b7c46b99c8a50481b22631a4dfc0
+  md5: e7cb0f5745e4c5035a460248334af7eb
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 23990
+  timestamp: 1733323714454
 - conda: https://conda.anaconda.org/conda-forge/linux-64/uriparser-0.9.8-hac33072_0.conda
   sha256: 2aad2aeff7c69a2d7eecd7b662eef756b27d6a6b96f3e2c2a7071340ce14543e
   md5: d71d3a66528853c0a1ac2c02d79a0284
@@ -8164,6 +11832,21 @@ packages:
   - pkg:pypi/virtualenv?source=compressed-mapping
   size: 5154970
   timestamp: 1777964652524
+- conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-21.5.2-pyhcf101f3_0.conda
+  sha256: fb935efdab114b25fa656045abd76836be655d8ca528d567bcb85e52dbd4691e
+  md5: 2235f1819646e2fc4616e90b906086de
+  depends:
+  - python >=3.10
+  - distlib >=0.3.7,<1
+  - filelock <4,>=3.24.2
+  - importlib-metadata >=6.6
+  - platformdirs >=3.9.1,<5
+  - python-discovery >=1.4.2
+  - typing_extensions >=4.13.2
+  - python
+  license: MIT
+  size: 3272760
+  timestamp: 1783375806368
 - conda: https://conda.anaconda.org/conda-forge/linux-64/watchdog-6.0.0-py312h20c3967_3.conda
   sha256: b91e504d9bac172fd8f9f8902c8df85f65ceabd1e7e5a737183a494c49edbc15
   md5: 67d76e548cb09501c0f22071c7d86b26
@@ -8177,6 +11860,19 @@ packages:
   - pkg:pypi/watchdog?source=hash-mapping
   size: 151142
   timestamp: 1772608172713
+- conda: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.25.0-hd6090a7_0.conda
+  sha256: ea374d57a8fcda281a0a89af0ee49a2c2e99cc4ac97cf2e2db7064e74e764bdb
+  md5: 996583ea9c796e5b915f7d7580b51ea6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libexpat >=2.7.4,<3.0a0
+  - libffi >=3.5.2,<3.6.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: MIT
+  license_family: MIT
+  size: 334139
+  timestamp: 1773959575393
 - pypi: https://files.pythonhosted.org/packages/eb/d8/0d1d2e9d3fabcf5d6840362adcf05f8cf3cd06a73358140c3a97189238ae/wcmatch-10.1-py3-none-any.whl
   name: wcmatch
   version: '10.1'
@@ -8195,6 +11891,24 @@ packages:
   - pkg:pypi/wcwidth?source=compressed-mapping
   size: 82917
   timestamp: 1777744489106
+- conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.8.2-pyhd8ed1ab_0.conda
+  sha256: 4acf845da404e84cef1acccc66cc0156af1b83a5b5d7077b2ca19b705c561e57
+  md5: 99f7755ec8648a042b0dbe906234f888
+  depends:
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  size: 132415
+  timestamp: 1782771807703
+- conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-25.10.0-pyhd8ed1ab_0.conda
+  sha256: 21f6c8a20fe050d09bfda3fb0a9c3493936ce7d6e1b3b5f8b01319ee46d6c6f6
+  md5: 6639b6b0d8b5a284f027a2003669aa65
+  depends:
+  - python >=3.10
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18987
+  timestamp: 1761899393153
 - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
   sha256: 19ff205e138bb056a46f9e3839935a2e60bd1cf01c8241a5e172a422fed4f9c6
   md5: 2841eb5bfc75ce15e9a0054b98dcd64d
@@ -8206,6 +11920,15 @@ packages:
   - pkg:pypi/webencodings?source=hash-mapping
   size: 15496
   timestamp: 1733236131358
+- conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.9.0-pyhd8ed1ab_0.conda
+  sha256: 42a2b61e393e61cdf75ced1f5f324a64af25f347d16c60b14117393a98656397
+  md5: 2f1ed718fcd829c184a6d4f0f2e07409
+  depends:
+  - python >=3.10
+  license: Apache-2.0
+  license_family: APACHE
+  size: 61391
+  timestamp: 1759928175142
 - conda: https://conda.anaconda.org/conda-forge/linux-64/websockets-16.0-py312h5253ce2_1.conda
   sha256: dd598cab9175a9ab11c8a1798c49ccabe923263d12aababa84a296cb18206464
   md5: e35ffb48178b20ee1a43fbe7abc93746
@@ -8220,6 +11943,16 @@ packages:
   - pkg:pypi/websockets?source=hash-mapping
   size: 358659
   timestamp: 1768087389177
+- conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.47.0-pyhd8ed1ab_0.conda
+  sha256: 9e156ffaefb8463437144326ada4b85d1de17961b9997ac5f1cbbaf747bd8bed
+  md5: d0e3b2f0030cf4fca58bde71d246e94c
+  depends:
+  - packaging >=24.0
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  size: 33491
+  timestamp: 1776878563806
 - conda: https://conda.anaconda.org/conda-forge/noarch/whitebox-2.3.6-pyhd8ed1ab_0.conda
   sha256: 7329d045f1efb72236070c8b23afdc57bc5ef6a4b0961726e094df6d596f228c
   md5: ba379c537399f57f2a3f2938ac5a4061
@@ -8233,6 +11966,15 @@ packages:
   - pkg:pypi/whitebox?source=hash-mapping
   size: 64553
   timestamp: 1740300114156
+- conda: https://conda.anaconda.org/conda-forge/noarch/widgetsnbextension-4.0.15-pyhd8ed1ab_0.conda
+  sha256: 826af5e2c09e5e45361fa19168f46ff524e7a766022615678c3a670c45895d9a
+  md5: dc257b7e7cad9b79c1dfba194e92297b
+  depends:
+  - python >=3.10
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 889195
+  timestamp: 1762040404362
 - conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-2.1.2-py312h4c3975b_0.conda
   sha256: 5bf21e14a364018a36869a16d9f706fb662c6cb6da3066100ba6822a70f93d2d
   md5: 7f2ef073d94036f8b16b6ee7d3562a88
@@ -8247,6 +11989,39 @@ packages:
   - pkg:pypi/wrapt?source=hash-mapping
   size: 87514
   timestamp: 1772794814485
+- conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2025.6.1-pyhd8ed1ab_1.conda
+  sha256: e27b45ca791cfbcad37d64b8615d0672d94aafa00b014826fcbca2ce18bd1cc0
+  md5: 145c6f2ac90174d9ad1a2a51b9d7c1dd
+  depends:
+  - numpy >=1.24
+  - packaging >=23.2
+  - pandas >=2.1
+  - python >=3.10
+  constrains:
+  - scipy >=1.11
+  - dask-core >=2023.11
+  - bottleneck >=1.3
+  - zarr >=2.16
+  - flox >=0.7
+  - h5py >=3.8
+  - iris >=3.7
+  - cartopy >=0.22
+  - numba >=0.57
+  - sparse >=0.14
+  - pint >=0.22
+  - distributed >=2023.11
+  - hdf5 >=1.12
+  - seaborn-base >=0.13
+  - nc-time-axis >=1.4
+  - matplotlib-base >=3.8
+  - toolz >=0.12
+  - netcdf4 >=1.6.0
+  - cftime >=1.6
+  - h5netcdf >=1.3
+  license: Apache-2.0
+  license_family: APACHE
+  size: 879913
+  timestamp: 1749743321359
 - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2026.4.0-pyhc364b38_0.conda
   sha256: 9f5f5905afea6e0188aa6887aed0809033143343a7af06983f4b390c2286d2d7
   md5: 099794df685f800c3f319ff4742dc1bb
@@ -8285,6 +12060,19 @@ packages:
   - pkg:pypi/xarray?source=compressed-mapping
   size: 1017999
   timestamp: 1776122774298
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xerces-c-3.2.5-h988505b_2.conda
+  sha256: 339ab0ff05170a295e59133cd0fa9a9c4ba32b6941c8a2a73484cc13f81e248a
+  md5: 9dda9667feba914e0e80b95b82f7402b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - icu >=75.1,<76.0a0
+  - libgcc >=13
+  - libnsl >=2.0.1,<2.1.0a0
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: Apache
+  size: 1648243
+  timestamp: 1727733890754
 - conda: https://conda.anaconda.org/conda-forge/linux-64/xerces-c-3.3.0-hd9031aa_1.conda
   sha256: 605980121ad3ee9393a9b53fb0996929c9732f8fc6b9f796d25244ca6fa23032
   md5: 66a1db55ecdb7377d2b91f54cd56eafa
@@ -8299,6 +12087,27 @@ packages:
   purls: []
   size: 1660075
   timestamp: 1766327494699
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.48-h280c20c_0.conda
+  sha256: 3b04afd5d1a65d2d27ac2d49a63b01ab8bcd875776779ec63e337370ed38afdc
+  md5: b233b41be0bf210989d57160ed39b394
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - xorg-libx11 >=1.8.13,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 441670
+  timestamp: 1782027360439
+- conda: https://conda.anaconda.org/conda-forge/noarch/xmltodict-1.0.4-pyhcf101f3_0.conda
+  sha256: 7588e77a5d3885145e693d8b98493952f6efac8f3fabb1c218cd0cbd1a739fad
+  md5: 0f02dbcae61967ced21fea829a8ee927
+  depends:
+  - python >=3.10
+  - python
+  license: MIT
+  license_family: MIT
+  size: 20673
+  timestamp: 1771770296472
 - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
   sha256: c12396aabb21244c212e488bbdc4abcdef0b7404b15761d9329f5a4a39113c4b
   md5: fb901ff28063514abb6046c9ec2c4a45
@@ -8346,6 +12155,44 @@ packages:
   purls: []
   size: 15321
   timestamp: 1762976464266
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcomposite-0.4.7-hb03c661_0.conda
+  sha256: 048c103000af9541c919deef03ae7c5e9c570ffb4024b42ecb58dbde402e373a
+  md5: f2ba4192d38b6cef2bb2c25029071d90
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxfixes >=6.0.2,<7.0a0
+  license: MIT
+  license_family: MIT
+  size: 14415
+  timestamp: 1770044404696
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcursor-1.2.3-hb9d3cd8_0.conda
+  sha256: 832f538ade441b1eee863c8c91af9e69b356cd3e9e1350fff4fe36cc573fc91a
+  md5: 2ccd714aa2242315acaf0a67faea780b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
+  - xorg-libxrender >=0.9.11,<0.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 32533
+  timestamp: 1730908305254
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdamage-1.1.6-hb9d3cd8_0.conda
+  sha256: 43b9772fd6582bf401846642c4635c47a9b0e36ca08116b3ec3df36ab96e0ec0
+  md5: b5fcc7172d22516e1f965490e65e33a4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
+  license: MIT
+  license_family: MIT
+  size: 13217
+  timestamp: 1727891438799
 - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
   sha256: 25d255fb2eef929d21ff660a0c687d38a6d2ccfbcbf0cc6aa738b12af6e9d142
   md5: 1dafce8548e38671bea82e3f5c6ce22f
@@ -8395,6 +12242,45 @@ packages:
   purls: []
   size: 47179
   timestamp: 1727799254088
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.8.3-hb03c661_0.conda
+  sha256: 495f99c8eacfa4ae2d8fed2a7f2105777af89acdc204df145d2bbbc380ac631b
+  md5: adba2e334082bb218db806d4c12277c9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - xorg-libx11 >=1.8.13,<2.0a0
+  - xorg-libxext >=1.3.7,<2.0a0
+  - xorg-libxfixes >=6.0.2,<7.0a0
+  license: MIT
+  license_family: MIT
+  size: 47717
+  timestamp: 1779111857071
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxinerama-1.1.6-hecca717_0.conda
+  sha256: 3a9da41aac6dca9d3ff1b53ee18b9d314de88add76bafad9ca2287a494abcd86
+  md5: 93f5d4b5c17c8540479ad65f206fea51
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 14818
+  timestamp: 1769432261050
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.5-hb03c661_0.conda
+  sha256: 80ed047a5cb30632c3dc5804c7716131d767089f65877813d4ae855ee5c9d343
+  md5: e192019153591938acf7322b6459d36e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxrender >=0.9.12,<0.10.0a0
+  license: MIT
+  license_family: MIT
+  size: 30456
+  timestamp: 1769445263457
 - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.12-hb9d3cd8_0.conda
   sha256: 044c7b3153c224c6cedd4484dd91b389d2d7fd9c776ad0f4a34f099b3389f4a1
   md5: 96d57aba173e878a2089d5638016dc5e
@@ -8434,6 +12320,28 @@ packages:
   purls: []
   size: 32808
   timestamp: 1727964811275
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxxf86vm-1.1.7-hb03c661_0.conda
+  sha256: 64db17baaf36fa03ed8fae105e2e671a7383e22df4077486646f7dbf12842c9f
+  md5: 665d152b9c6e78da404086088077c844
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 18701
+  timestamp: 1769434732453
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xorgproto-2025.1-hb03c661_0.conda
+  sha256: 7a8c64938428c2bfd016359f9cb3c44f94acc256c6167dbdade9f2a1f5ca7a36
+  md5: aa8d21be4b461ce612d8f5fb791decae
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  size: 570010
+  timestamp: 1766154256151
 - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2026.3.0-pyhd8ed1ab_0.conda
   sha256: 663ea9b00d68c2da309114923924686ab6d3f59ef1b196c5029ba16799e7bb07
   md5: 4487b9c371d0161d54b5c7bbd890c0fc
@@ -8494,6 +12402,19 @@ packages:
   - pkg:pypi/zarr?source=compressed-mapping
   size: 367721
   timestamp: 1777989189792
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h09e67af_11.conda
+  sha256: dc9f28dedcb5f35a127fad2d847674d2833369dd616d294e423b8997df31d8a8
+  md5: 96b08867e21d4694fa5c2c226e6581b0
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - krb5 >=1.22.2,<1.23.0a0
+  - libsodium >=1.0.22,<1.0.23.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 311184
+  timestamp: 1779123989774
 - conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h41580af_10.conda
   sha256: 325d370b28e2b9cc1f765c5b4cdb394c91a5d958fbd15da1a14607a28fee09f6
   md5: 755b096086851e1193f3b10347415d7c
@@ -8544,6 +12465,16 @@ packages:
   - pkg:pypi/zipp?source=compressed-mapping
   size: 24461
   timestamp: 1776131454755
+- conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
+  sha256: 210bd31c22bb88f5e2a167df24c95bb5f152b2ada7502f9b8c49d1f5366db423
+  md5: ba3dcdc8584155c97c648ae9c044b7a3
+  depends:
+  - python >=3.10
+  - python
+  license: MIT
+  license_family: MIT
+  size: 24190
+  timestamp: 1779159948016
 - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.2-h25fd6f3_2.conda
   sha256: 245c9ee8d688e23661b95e3c6dd7272ca936fabc03d423cdb3cdee1bbcf9f2f2
   md5: c2a01a08fc991620a74b32420e97868a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,11 +162,19 @@ mkdocs-include-markdown-plugin = "*"
 "docs-build" = "mkdocs build"
 "docs-build-strict" = "mkdocs build --strict"
 
+[tool.pixi.feature.reference.dependencies]
+# pywatershed caps python <3.11 (as of 2.0.4), incompatible with the workspace's
+# python=3.12.* default feature -> isolated feature (no-default-feature) with its
+# own solve-group so it doesn't force-downgrade python for every other environment.
+python = "3.10.*"
+pywatershed = "*"
+
 [tool.pixi.environments]
 default = { features = [], solve-group = "default" }
 notebooks = { features = ["notebooks"], solve-group = "default" }
 dev = { features = ["dev"], solve-group = "default" }
 docs = { features = ["docs"], solve-group = "default" }
+reference = { features = ["reference"], solve-group = "reference", no-default-feature = true }
 all = { features = ["notebooks", "dev", "docs"], solve-group = "default" }
 
 [tool.isort]

--- a/scripts/derive_snarea_curve.py
+++ b/scripts/derive_snarea_curve.py
@@ -74,14 +74,14 @@ def read_daily_by_hru(
             "(the slow/large step at CONUS scale) ...",
             ds.sizes.get(id_dim, 0), ds.sizes.get("time", 0),
         )
-    df = ds[["swe", "scov"]].to_dataframe().reset_index()
+    df = ds[["swe", "scov", "swe_std"]].to_dataframe().reset_index()
     df = df.rename(columns={"scov": "sca"})
     if logger:
         logger.info("  materialized %d rows in %.0fs; grouping into per-HRU series ...",
                     len(df), time.perf_counter() - t0)
     out: dict[int, pd.DataFrame] = {}
     for hru_id, grp in df.groupby(id_dim):
-        s = grp.set_index("time")[["swe", "sca"]].sort_index()
+        s = grp.set_index("time")[["swe", "sca", "swe_std"]].sort_index()
         out[int(hru_id)] = s
     if logger:
         logger.info("  built %d per-HRU series in %.0fs total", len(out), time.perf_counter() - t0)

--- a/scripts/derive_snarea_curve.py
+++ b/scripts/derive_snarea_curve.py
@@ -2,7 +2,7 @@
 
 Reads the per-year aggregated NCs written by Stage 1 (`derive_aggregate.py`,
 `{data_root}/{fabric}/snodas/*_agg_*.nc`, dims `time`/`<id_feature>`, vars
-`swe`/`scov`), builds per-HRU SNODAS cell counts from the gdptools weight CSV,
+`swe`/`scov`/`swe_std`), builds per-HRU SNODAS cell counts from the gdptools weight CSV,
 and writes the merged snarea_curve param CSV via `build_snarea_curve`.
 
 Water fraction (selection criterion 4) is optional: if a per-HRU water-fraction
@@ -23,7 +23,7 @@ import xarray as xr
 
 from gfv2_params.config import load_config, require_config_key
 from gfv2_params.log import configure_logging
-from gfv2_params.snarea import DEFAULT_SNAREA_CURVE, build_snarea_curve
+from gfv2_params.snarea import DEFAULT_SNAREA_CURVE, build_snarea_curve, validate_default_curve
 from gfv2_params.snarea.selection import SelectionParams
 
 __all__ = [
@@ -32,20 +32,6 @@ __all__ = [
     "validate_default_curve",
     "main",
 ]
-
-
-def validate_default_curve(arr: np.ndarray) -> None:
-    """Validate a `default_curve` override: shape, value range, non-increasing.
-
-    Raises ValueError (not `assert`, which is stripped under `python -O`)
-    naming which check failed.
-    """
-    if arr.shape != (11,):
-        raise ValueError(f"default_curve must have shape (11,), got {arr.shape}")
-    if not np.all((arr >= 0.0) & (arr <= 1.0)):
-        raise ValueError(f"default_curve values must all be within [0.0, 1.0], got {arr}")
-    if not np.all(np.diff(arr) <= 1e-9):
-        raise ValueError(f"default_curve must be non-increasing, got {arr}")
 
 
 def read_daily_by_hru(

--- a/scripts/derive_snarea_curve.py
+++ b/scripts/derive_snarea_curve.py
@@ -60,6 +60,13 @@ def read_daily_by_hru(
             "(the slow/large step at CONUS scale) ...",
             ds.sizes.get(id_dim, 0), ds.sizes.get("time", 0),
         )
+    missing = [v for v in ("swe", "scov", "swe_std") if v not in ds.data_vars]
+    if missing:
+        raise ValueError(
+            f"Aggregated NetCDFs in {nc_dir} are missing {missing}. Re-run Stage 1 "
+            "(scripts/derive_aggregate.py) — the SNODAS adapter now emits swe_std "
+            "(std_variables=('swe',)) — before running Stage 2."
+        )
     df = ds[["swe", "scov", "swe_std"]].to_dataframe().reset_index()
     df = df.rename(columns={"scov": "sca"})
     if logger:

--- a/scripts/derive_snarea_library.py
+++ b/scripts/derive_snarea_library.py
@@ -1,0 +1,62 @@
+"""Stage 3 driver: build the CV/lognormal snarea_curve library from the Stage 2
+derived CSV. Pure tabular — cheap, re-runnable at any ndepl_cv without reloading
+the daily SWE. Fabric-agnostic (paths from the profile via require_config_key)."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from gfv2_params.config import load_config, require_config_key
+from gfv2_params.log import configure_logging
+from gfv2_params.snarea import DEFAULT_SNAREA_CURVE
+from gfv2_params.snarea.library import (
+    build_from_derived,
+    write_library_csv,
+    write_params_csv,
+    write_prms_netcdf,
+    write_validation_csv,
+)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--fabric", required=True)
+    ap.add_argument("--config", default="configs/snarea/snarea_library.yml")
+    ap.add_argument("--base_config", default="configs/base_config.yml")
+    args = ap.parse_args()
+    logger = configure_logging("derive_snarea_library")
+
+    cfg = load_config(Path(args.config), base_config_path=Path(args.base_config), fabric=args.fabric)
+    id_feature = require_config_key(cfg, "id_feature", "derive_snarea_library")
+    derived_csv = Path(cfg["derived_csv"])
+    out_dir = Path(cfg["output_dir"])
+    ndepl_cv = int(cfg.get("ndepl_cv", 8))
+    calibrate = cfg.get("calibrate", "auto")
+    bias_tol = float(cfg.get("calibrate_bias_tol", 0.1))
+    default_curve = np.asarray(cfg.get("default_curve", DEFAULT_SNAREA_CURVE), dtype=float)
+
+    logger.info("Reading Stage 2 derived table: %s", derived_csv)
+    derived = pd.read_csv(derived_csv)
+    logger.info(
+        "Building CV/lognormal library (ndepl_cv=%d, calibrate=%s) for %d HRUs ...",
+        ndepl_cv, calibrate, len(derived),
+    )
+    library, params, report = build_from_derived(derived, id_feature, ndepl_cv, default_curve, calibrate, bias_tol)
+
+    write_library_csv(library, out_dir / cfg["library_file"])
+    write_params_csv(params, out_dir / cfg["params_file"])
+    write_validation_csv(report, out_dir / cfg["validation_file"])
+    write_prms_netcdf(library, params, id_feature, out_dir / cfg["netcdf_file"])
+    logger.info(
+        "ndepl=%d | estimable %d/%d | calibrated=%s | recon mean %.3f",
+        len(library), report["n_estimable"], report["n_hru"],
+        report["calibrated"], report.get("recon_mean_after", float("nan")),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/derive_snarea_library.py
+++ b/scripts/derive_snarea_library.py
@@ -12,7 +12,7 @@ import pandas as pd
 
 from gfv2_params.config import load_config, require_config_key
 from gfv2_params.log import configure_logging
-from gfv2_params.snarea import DEFAULT_SNAREA_CURVE
+from gfv2_params.snarea import DEFAULT_SNAREA_CURVE, validate_default_curve
 from gfv2_params.snarea.library import (
     build_from_derived,
     write_library_csv,
@@ -38,6 +38,7 @@ def main() -> None:
     calibrate = cfg.get("calibrate", "auto")
     bias_tol = float(cfg.get("calibrate_bias_tol", 0.1))
     default_curve = np.asarray(cfg.get("default_curve", DEFAULT_SNAREA_CURVE), dtype=float)
+    validate_default_curve(default_curve)
 
     logger.info("Reading Stage 2 derived table: %s", derived_csv)
     derived = pd.read_csv(derived_csv)

--- a/scripts/derive_snarea_library.py
+++ b/scripts/derive_snarea_library.py
@@ -1,6 +1,10 @@
 """Stage 3 driver: build the CV/lognormal snarea_curve library from the Stage 2
 derived CSV. Pure tabular — cheap, re-runnable at any ndepl_cv without reloading
-the daily SWE. Fabric-agnostic (paths from the profile via require_config_key)."""
+the daily SWE. Only ``id_feature`` comes from the base_config fabric profile via
+``require_config_key``; the step-config paths (``derived_csv``, ``output_dir``,
+output filenames) are read from ``snarea_library.yml`` with
+``{data_root}``/``{fabric}`` placeholders resolved by ``load_config`` (same
+pattern as the Stage 2 driver)."""
 
 from __future__ import annotations
 

--- a/slurm_batch/HPC_REFERENCE.md
+++ b/slurm_batch/HPC_REFERENCE.md
@@ -696,12 +696,16 @@ JupyterHub is the interactive alternative for exploratory inspection.
 
 ### Stage 10 — Snow depletion curves (SNODAS → snarea_curve)
 
-Two fabric-independent stages deriving the PRMS `snarea_curve`/`hru_deplcrv`
-parameters from daily SNODAS SWE (Driscoll, Hay & Bock 2017 method; design
-spec [`docs/superpowers/specs/2026-07-04-snodas-snarea-curve-design.md`](../docs/superpowers/specs/2026-07-04-snodas-snarea-curve-design.md)).
+Three fabric-independent stages deriving the PRMS `snarea_curve`/`hru_deplcrv`
+parameters from daily SNODAS SWE. Stage 1/2 use the empirical Driscoll, Hay &
+Bock (2017) method (design spec
+[`docs/superpowers/specs/2026-07-04-snodas-snarea-curve-design.md`](../docs/superpowers/specs/2026-07-04-snodas-snarea-curve-design.md));
+Stage 3 builds a CV/lognormal curve library from Stage 2's output (Sexstone,
+Driscoll, Hay, Hammond & Barnhart 2020; design spec
+[`docs/superpowers/specs/2026-07-06-snodas-snarea-curve-library-design.md`](../docs/superpowers/specs/2026-07-06-snodas-snarea-curve-library-design.md)).
 Stage 1 is a SLURM array over the fabric's spatial batches (same pattern as
 the depstor/zonal parameter jobs — see "Stage 4A" above), then a merge job;
-Stage 2 is still run directly with `pixi run`:
+Stage 2 is still run directly with `pixi run`; Stage 3 is a cheap `sbatch` job:
 
 ```bash
 # Stage 1 — aggregate daily SNODAS SWE to the HRU fabric, per spatial batch
@@ -712,8 +716,10 @@ AID=$(sbatch --parsable --array=0-$((N-1)) --export=ALL,FABRIC=$FABRIC \
     slurm_batch/derive_snodas_aggregate.batch)
 sbatch --dependency=afterok:$AID --export=ALL,FABRIC=$FABRIC \
     slurm_batch/merge_snodas_aggregate.batch
-# Stage 2 — derive per-HRU snarea_curve from the aggregated SWE/SCA
+# Stage 2 — derive per-HRU empirical snarea_curve + sub-grid CV from the aggregated SWE/SCA
 pixi run python scripts/derive_snarea_curve.py --fabric <name>
+# Stage 3 — build the CV/lognormal curve library from the Stage 2 derived CSV
+FABRIC=<name> sbatch slurm_batch/derive_snarea_library.batch
 ```
 
 **Stage 1** (`src/gfv2_params/aggregate/`, config
@@ -736,14 +742,41 @@ NetCDFs on the id_feature dim (sorted) into
 for. Per-batch parts stay in the `_batches/` subdir so Stage 2's top-level
 `*_agg_*.nc` glob only ever sees the merged files. Omitting `--batch_id`
 (direct `pixi run`, not via `sbatch`) still runs the old whole-fabric path
-against `hru_gpkg` for ad hoc/small-fabric use.
+against `hru_gpkg` for ad hoc/small-fabric use. The SNODAS adapter
+(`src/gfv2_params/aggregate/snodas.py`) sets `std_variables=("swe",)`, so every
+aggregated NC also carries a `swe_std` sidecar (per-cell SWE std dev within the
+HRU, masked/aggregated the same way as `swe`) — the input Stage 2's sub-grid CV
+needs. Re-run Stage 1 once against a fabric aggregated before `swe_std` was
+added; the per-batch gdptools weight CSVs are cached, so the re-run is cheap.
 
 **Stage 2** (`src/gfv2_params/snarea/`, config
 `configs/snarea/snarea_curve.yml`) reads the Stage 1 merged NetCDFs, builds
 per-HRU melt-season depletion curves, applies the six Driscoll selection
 criteria (HRUs that fail fall back to a configured default curve, flagged in
-`sdc_status`), and writes
-`{data_root}/{fabric}/params/merged/nhm_snarea_curve_params.csv`.
+`sdc_status`), computes each HRU's sub-grid SWE coefficient of variation
+(`cv_subgrid`, from the `swe_std`/`swe` ratio at peak SWE —
+`src/gfv2_params/snarea/subgrid.py`), and writes the **intermediate**
+`{data_root}/{fabric}/params/merged/_intermediates/nhm_snarea_curve_derived.csv`
+(not the terminal params — that is now Stage 3's job).
+
+**Stage 3** (`src/gfv2_params/snarea/library.py`, driver
+`scripts/derive_snarea_library.py`, config `configs/snarea/snarea_library.yml`,
+batch `derive_snarea_library.batch`) reads the Stage 2 derived CSV and builds a
+CV/lognormal curve library: fits each derived HRU's empirical curve to a
+lognormal CV (`fit_cv`), validates/calibrates `cv_subgrid` against that
+empirical CV on the overlap (monotone quantile-map, gated by median bias —
+`validate_and_calibrate`), bins the calibrated population into `ndepl_cv`
+equal-population CV bins plus one reserved default curve, and assigns each HRU
+its nearest-CV library curve. It is pure tabular pandas/numpy — no daily-SWE
+reload — so it is cheap (`--mem=16G --time=00:30:00`) and safely re-runnable at
+any `ndepl_cv` without redoing Stage 1/2. Outputs, all under
+`{data_root}/{fabric}/params/merged/`: `nhm_snarea_curve_library.csv` (one row
+per `deplcrv_id`), `nhm_snarea_curve_params.csv` (one row per HRU:
+`hru_deplcrv`, `snarea_thresh`, CV diagnostics, the assigned curve),
+`nhm_snarea_curve_validation.csv` (calibration report: reconstruction error
+before/after, bias, `n_estimable`), and `nhm_snarea_curve.nc` (the pyWatershed
+parameter file — `snarea_curve` flat ascending, `hru_deplcrv`,
+`snarea_thresh`).
 
 **Cost profile:** Stage 1's gdptools weight-generation (`WeightGen`, one
 polygon/cell intersection pass per batch) is the expensive step; each batch's
@@ -918,7 +951,8 @@ sacct -j <JOBID> -o JobID,State,Elapsed,MaxRSS
 | `slurm_batch/submit_zonal_params.sh` | `configs/zonal/zonal_params.yml` | `scripts/derive_zonal_params.py` (dispatches 10 params × zonal+merge, with ssflux's `build_weights` prereq chained automatically) |
 | `slurm_batch/submit_depstor_params.sh` | `configs/depstor/depstor_params.yml` | `scripts/derive_depstor_params.py` (dispatches 10 fractions × zonal+merge, then ratios via afterok) |
 | `slurm_batch/derive_snodas_aggregate.batch` + `merge_snodas_aggregate.batch` | `configs/aggregate/aggregate_sources.yml` | `scripts/derive_aggregate.py --source snodas` (Stage 1: gridded-time-series → HRU aggregation via `src/gfv2_params/aggregate/`; array over spatial batches + merge, no per-fraction submit wrapper yet) |
-| (run directly; no batch yet) | `configs/snarea/snarea_curve.yml` | `scripts/derive_snarea_curve.py` (Stage 2: per-HRU `snarea_curve`/`hru_deplcrv` via `src/gfv2_params/snarea/`) |
+| `slurm_batch/derive_snarea_curve.batch` (or run directly with `pixi run`) | `configs/snarea/snarea_curve.yml` | `scripts/derive_snarea_curve.py` (Stage 2: per-HRU empirical curve + sub-grid CV → `_intermediates/nhm_snarea_curve_derived.csv` via `src/gfv2_params/snarea/`) |
+| `slurm_batch/derive_snarea_library.batch` | `configs/snarea/snarea_library.yml` | `scripts/derive_snarea_library.py` (Stage 3: CV/lognormal curve library + per-HRU `snarea_curve`/`hru_deplcrv`/`snarea_thresh` + pyWatershed `.nc` via `src/gfv2_params/snarea/library.py`) |
 
 ### Part-2 workers (looped by the wrappers; also runnable by hand per Stage 4A)
 

--- a/slurm_batch/RUNME.md
+++ b/slurm_batch/RUNME.md
@@ -26,7 +26,7 @@ in [HPC_REFERENCE.md](HPC_REFERENCE.md).
 7. **Step 6** — (optional) Merge NHM default parameter tables.
 8. **Step 7** — Render results figures headlessly.
 9. **Step 8** — (optional, fabric-independent) Derive snow depletion curves
-   (SNODAS → `snarea_curve`).
+   (SNODAS → `snarea_curve` curve library, 3 stages).
 
 ---
 
@@ -243,6 +243,7 @@ AID=$(sbatch --parsable --array=0-$((N-1)) --export=ALL,FABRIC=gfv2 \
 sbatch --dependency=afterok:$AID --export=ALL,FABRIC=gfv2 \
     slurm_batch/merge_snodas_aggregate.batch
 pixi run python scripts/derive_snarea_curve.py --fabric gfv2
+FABRIC=gfv2 sbatch slurm_batch/derive_snarea_library.batch
 ```
 
 **What it does:** Stage 1 aggregates daily SNODAS SWE to the HRU fabric as a
@@ -250,15 +251,27 @@ SLURM array over the fabric's spatial batches (`derive_snodas_aggregate.batch`,
 one array task per batch, source grid clipped to each batch's extent), then
 `merge_snodas_aggregate.batch` concatenates the per-batch per-year NetCDFs
 into one final `snodas_agg_<year>.nc` per calendar year (area-weighted mean
-SWE + snow-covered-area fraction via the gdptools-backed `aggregate` harness);
-Stage 2 derives the per-HRU `snarea_curve`/`hru_deplcrv` PRMS parameters from
-those daily series (Driscoll, Hay & Bock 2017 method). Fabric-independent —
-no code change to run against `gfv2`, `gfv2_vpu01`, or `oregon`. Stage 2 is
-still run directly (`pixi run python ...`), not via `sbatch`.
+SWE + snow-covered-area fraction, now also the per-cell SWE std dev `swe_std`
+sidecar used by Stage 2's sub-grid CV, via the gdptools-backed `aggregate`
+harness); Stage 2 derives per-HRU empirical depletion curves and sub-grid CV
+from those daily series (Driscoll, Hay & Bock 2017 selection method) and
+writes the intermediate `_intermediates/nhm_snarea_curve_derived.csv` (not yet
+the terminal params); Stage 3 (`derive_snarea_library.py`) builds the
+CV/lognormal curve library from that derived CSV — cheap, pure-tabular, no
+daily-SWE reload — and writes the terminal `nhm_snarea_curve_library.csv`,
+`nhm_snarea_curve_params.csv`, `nhm_snarea_curve_validation.csv`, and the
+pyWatershed `nhm_snarea_curve.nc`. Fabric-independent — no code change to run
+against `gfv2`, `gfv2_vpu01`, or `oregon`. Stage 2 is still run directly
+(`pixi run python ...`), not via `sbatch`. If Stage 1 was already run before
+`swe_std` was added, re-run it once (`derive_snodas_aggregate.batch` +
+`merge_snodas_aggregate.batch`) — the gdptools weight CSVs are cached, so the
+re-run is cheap.
 
 **Wait for:** the merge job `COMPLETED`, printing one `snodas_agg_<year>.nc`
 per year written; Stage 2 prints the `sdc_status` breakdown and writes the
-merged CSV. See HPC_REFERENCE.md "Stage 10" for per-stage detail.
+derived CSV; the Stage 3 job `COMPLETED` (`--mem=16G --time=00:30:00`),
+printing the `ndepl`/estimable/calibrated/reconstruction-error summary. See
+HPC_REFERENCE.md "Stage 10" for per-stage detail.
 
 ---
 
@@ -280,10 +293,14 @@ tail -n 200 logs/job_<JOBID>.err
 - `{data_root}/gfv2/params/merged/_intermediates/` — 10 per-fraction count
   CSVs (inputs to ratio derivation; `count` is NOT a [0, 1] fraction).
 - `docs/figures/gfv2/` — rendered PNG figures.
-- `{data_root}/gfv2/snodas/` — per-year aggregated SNODAS SWE/SCA NetCDFs
-  (Stage 1 of the snow depletion curve pipeline, optional Step 8).
-- `{data_root}/gfv2/params/merged/nhm_snarea_curve_params.csv` — per-HRU
-  `snarea_curve`/`hru_deplcrv` (Stage 2, optional Step 8).
+- `{data_root}/gfv2/snodas/` — per-year aggregated SNODAS SWE/SCA/`swe_std`
+  NetCDFs (Stage 1 of the snow depletion curve pipeline, optional Step 8).
+- `{data_root}/gfv2/params/merged/_intermediates/nhm_snarea_curve_derived.csv`
+  — per-HRU empirical curve + sub-grid CV (Stage 2, optional Step 8).
+- `{data_root}/gfv2/params/merged/nhm_snarea_curve_library.csv`,
+  `nhm_snarea_curve_params.csv` (`snarea_curve`/`hru_deplcrv`/`snarea_thresh`),
+  `nhm_snarea_curve_validation.csv`, and `nhm_snarea_curve.nc` (pyWatershed
+  parameter file) — Stage 3, optional Step 8.
 
 ---
 

--- a/slurm_batch/derive_snarea_curve.batch
+++ b/slurm_batch/derive_snarea_curve.batch
@@ -11,9 +11,11 @@
 #
 # Stage 2 of the SNODAS -> snarea_curve pipeline: read the per-year aggregated
 # NetCDFs from Stage 1 (derive_snodas_aggregate.batch) and derive the per-HRU
-# PRMS snarea_curve parameter (11-point curve + hru_deplcrv + sdc_status) into
-# {data_root}/{fabric}/params/merged/nhm_snarea_curve_params.csv. Per-HRU math is
-# pure pandas/numpy, but the WHOLE-FABRIC load is not: read_daily_by_hru's
+# empirical curve + sub-grid CV (11-point curve + sdc_status + cv_subgrid) into
+# {data_root}/{fabric}/params/merged/_intermediates/nhm_snarea_curve_derived.csv
+# (the intermediate input to Stage 3, derive_snarea_library.batch — not the
+# terminal params). Per-HRU math is pure pandas/numpy, but the WHOLE-FABRIC
+# load is not: read_daily_by_hru's
 # to_dataframe() materializes ~n_years x n_hru x n_days rows at once (CONUS gfv2
 # ~2.8B rows, ~344 GB peak), so the default is sized for CONUS. Small fabrics
 # (e.g. oregon, ~17k HRUs) fit easily and can override down:

--- a/slurm_batch/derive_snarea_library.batch
+++ b/slurm_batch/derive_snarea_library.batch
@@ -1,0 +1,21 @@
+#!/bin/bash
+#SBATCH -p cpu
+#SBATCH -A impd
+#SBATCH --job-name=snarea_library
+#SBATCH --output=logs/job_%j.out
+#SBATCH --error=logs/job_%j.err
+#SBATCH --time=00:30:00
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=2
+#SBATCH --mem=16G
+#
+# Stage 3: build the CV/lognormal snarea_curve library from the Stage 2 derived
+# CSV. Pure tabular — cheap. Re-runnable at any ndepl_cv without a daily reload.
+#   FABRIC=gfv2 sbatch slurm_batch/derive_snarea_library.batch
+
+cd "$SLURM_SUBMIT_DIR"
+BASE_CONFIG=${BASE_CONFIG:-configs/base_config.yml}
+FABRIC=${FABRIC:-oregon}
+
+pixi run --as-is python scripts/derive_snarea_library.py \
+    --fabric "$FABRIC" --config configs/snarea/snarea_library.yml --base_config "$BASE_CONFIG"

--- a/src/gfv2_params/aggregate/adapter.py
+++ b/src/gfv2_params/aggregate/adapter.py
@@ -32,6 +32,7 @@ class SourceAdapter:
     stat_method: str = "mean"
     pre_aggregate_hook: Callable[[xr.Dataset], xr.Dataset] | None = field(default=None)
     grid_variable: str | None = None
+    std_variables: tuple[str, ...] = field(default=())
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "variables", tuple(self.variables))
@@ -47,4 +48,10 @@ class SourceAdapter:
         elif self.grid_variable not in self.variables:
             raise ValueError(
                 f"grid_variable {self.grid_variable!r} must be one of {self.variables}"
+            )
+        object.__setattr__(self, "std_variables", tuple(self.std_variables))
+        missing = [v for v in self.std_variables if v not in self.variables]
+        if missing:
+            raise ValueError(
+                f"std_variables {missing} must all be in variables {self.variables}"
             )

--- a/src/gfv2_params/aggregate/driver.py
+++ b/src/gfv2_params/aggregate/driver.py
@@ -88,6 +88,10 @@ def aggregate_variables(
     the source once per variable — wasteful, especially when one variable is
     derived from another (e.g. SNODAS ``scov`` from ``swe``). One pass also
     removes the ``xr.merge`` of per-variable results.
+
+    An OPTIONAL second ``masked_std`` AggGen pass runs when
+    ``adapter.std_variables`` is non-empty, emitting ``{var}_std`` for each
+    named variable and reusing the same cached weights.
     """
     logger.info("    aggregating %s (%s)...", list(adapter.variables), adapter.stat_method)
     user_data = UserCatData(

--- a/src/gfv2_params/aggregate/driver.py
+++ b/src/gfv2_params/aggregate/driver.py
@@ -117,6 +117,36 @@ def aggregate_variables(
             f"variable {list(adapter.variables)} in the aggregated Dataset "
             f"(got {list(ds.data_vars)})."
         )
+
+    if adapter.std_variables:
+        logger.info("    aggregating %s (masked_std)...", list(adapter.std_variables))
+        std_user = UserCatData(
+            source_ds=source_ds,
+            source_crs=adapter.source_crs,
+            source_x_coord=adapter.x_coord,
+            source_y_coord=adapter.y_coord,
+            source_t_coord=adapter.time_coord,
+            source_var=list(adapter.std_variables),
+            target_gdf=fabric_gdf,
+            target_crs=WEIGHT_GEN_CRS,
+            target_id=id_col,
+            source_time_period=[period[0], period[1]],
+        )
+        std_agg = AggGen(
+            user_data=std_user,
+            stat_method="masked_std",
+            agg_engine="serial",
+            agg_writer="none",
+            weights=weights,
+        )
+        _gdf, std_ds = std_agg.calculate_agg()
+        for v in adapter.std_variables:
+            if v not in std_ds.data_vars:
+                raise RuntimeError(
+                    f"masked_std pass produced no {v!r} (got {list(std_ds.data_vars)})"
+                )
+            ds[f"{v}_std"] = std_ds[v]
+
     return ds
 
 

--- a/src/gfv2_params/aggregate/snodas.py
+++ b/src/gfv2_params/aggregate/snodas.py
@@ -34,4 +34,5 @@ SNODAS_ADAPTER = SourceAdapter(
     stat_method="masked_mean",
     pre_aggregate_hook=_snodas_hook,
     grid_variable="swe",
+    std_variables=("swe",),
 )

--- a/src/gfv2_params/snarea/__init__.py
+++ b/src/gfv2_params/snarea/__init__.py
@@ -3,5 +3,12 @@
 from __future__ import annotations
 
 from .build import DEFAULT_SNAREA_CURVE, build_snarea_curve
+from .library import build_from_derived, build_library, sdc_from_cv
 
-__all__ = ["build_snarea_curve", "DEFAULT_SNAREA_CURVE"]
+__all__ = [
+    "build_snarea_curve",
+    "DEFAULT_SNAREA_CURVE",
+    "build_from_derived",
+    "build_library",
+    "sdc_from_cv",
+]

--- a/src/gfv2_params/snarea/__init__.py
+++ b/src/gfv2_params/snarea/__init__.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
-from .build import DEFAULT_SNAREA_CURVE, build_snarea_curve
+from .build import DEFAULT_SNAREA_CURVE, build_snarea_curve, validate_default_curve
 from .library import build_from_derived, build_library, sdc_from_cv
 
 __all__ = [
     "build_snarea_curve",
     "DEFAULT_SNAREA_CURVE",
+    "validate_default_curve",
     "build_from_derived",
     "build_library",
     "sdc_from_cv",

--- a/src/gfv2_params/snarea/build.py
+++ b/src/gfv2_params/snarea/build.py
@@ -16,6 +16,7 @@ import pandas as pd
 from .representative import median_sdc, select_representative, similarity
 from .season import annual_sdc
 from .selection import SelectionParams, classify, passes_selection
+from .subgrid import representative_peak_stats
 
 # Placeholder: SCA declines linearly with normalized SWE (1.0 → 0.0).
 DEFAULT_SNAREA_CURVE = np.round(np.linspace(1.0, 0.0, 11), 4)
@@ -100,6 +101,13 @@ def build_hru_record(
         "n_seasons": n_seasons,
     }
     record.update({c: float(rep[i]) for i, c in enumerate(_CURVE_COLS)})
+
+    stats = (
+        representative_peak_stats(daily)
+        if "swe_std" in daily.columns
+        else {"cv_subgrid": float("nan"), "peak_swe_mm": float("nan"), "n_peak_years": 0}
+    )
+    record.update(stats)
     return record
 
 

--- a/src/gfv2_params/snarea/build.py
+++ b/src/gfv2_params/snarea/build.py
@@ -24,6 +24,24 @@ DEFAULT_SNAREA_CURVE = np.round(np.linspace(1.0, 0.0, 11), 4)
 _CURVE_COLS = [f"snarea_curve_{i}" for i in range(11)]
 
 
+def validate_default_curve(arr: np.ndarray) -> None:
+    """Validate a `default_curve` override: shape, value range, non-increasing.
+
+    Raises ValueError (not `assert`, which is stripped under `python -O`)
+    naming which check failed. Shared by the Stage 2 (derive_snarea_curve.py) and
+    Stage 3 (derive_snarea_library.py) drivers — lives here (not in either script)
+    because `scripts/` is not an importable package at runtime (only under
+    pytest's rootdir-on-sys.path), so a script-to-script import would break when
+    run directly via `python scripts/derive_snarea_library.py`.
+    """
+    if arr.shape != (11,):
+        raise ValueError(f"default_curve must have shape (11,), got {arr.shape}")
+    if not np.all((arr >= 0.0) & (arr <= 1.0)):
+        raise ValueError(f"default_curve values must all be within [0.0, 1.0], got {arr}")
+    if not np.all(np.diff(arr) <= 1e-9):
+        raise ValueError(f"default_curve must be non-increasing, got {arr}")
+
+
 def _seasons(daily: pd.DataFrame) -> list[np.ndarray]:
     """Up to one annual SDC per WATER YEAR (Oct 1 – Sep 30) in the frame.
 

--- a/src/gfv2_params/snarea/library.py
+++ b/src/gfv2_params/snarea/library.py
@@ -145,3 +145,70 @@ def assign_deplcrv(cv_assign: np.ndarray, library: pd.DataFrame) -> np.ndarray:
 def _to_prms_order(curve: np.ndarray) -> np.ndarray:
     """Repo descending (SWE 1.0->0.0) -> PRMS ascending frac_swe (0.0->1.0)."""
     return np.asarray(curve)[::-1]
+
+
+def _recon_error(cv: np.ndarray, emp_curves: np.ndarray) -> tuple[float, float]:
+    """Mean and p95 abs-SCA error of sdc_from_cv(cv) vs emp_curves (rows aligned)."""
+    ok = np.isfinite(cv) & np.isfinite(emp_curves).all(axis=1)
+    if not ok.any():
+        return float("nan"), float("nan")
+    approx = np.vstack([sdc_from_cv(c) for c in cv[ok]])
+    err = np.abs(approx - emp_curves[ok])
+    return float(err.mean()), float(np.percentile(err.max(axis=1), 95))
+
+
+def validate_and_calibrate(
+    cv_subgrid: np.ndarray,
+    cv_empirical: np.ndarray,
+    emp_curves: np.ndarray,
+    mode: str = "auto",
+    bias_tol: float = 0.1,
+) -> tuple[np.ndarray, dict]:
+    """Gate + monotone quantile-map calibration for sub-grid CV vs empirical CV.
+
+    Args:
+        cv_subgrid: sub-grid coefficient of variation array (may contain NaN).
+        cv_empirical: empirical CV values aligned by index (may contain NaN where not derived).
+        emp_curves: (n, 11) empirical SDC curves, NaN rows where not derived.
+        mode: "auto" (conditional), "on" (force), or "off" (identity).
+        bias_tol: threshold for median CV bias to trigger calibration in auto mode.
+
+    Returns:
+        (cv_calibrated_for_all_input, report_dict) where report_dict carries distribution
+        stats, reconstruction error before/after, and calibrated flag.
+    """
+    cv_subgrid = np.asarray(cv_subgrid, dtype=float)
+    cv_empirical = np.asarray(cv_empirical, dtype=float)
+    emp_curves = np.asarray(emp_curves, dtype=float)
+    derived = np.isfinite(cv_subgrid) & np.isfinite(cv_empirical)
+    sub_d, emp_d = cv_subgrid[derived], cv_empirical[derived]
+
+    report = {
+        "n_derived_overlap": int(derived.sum()),
+        "cv_subgrid_median": float(np.median(sub_d)) if derived.any() else float("nan"),
+        "cv_empirical_median": float(np.median(emp_d)) if derived.any() else float("nan"),
+        "calibrated": False,
+    }
+    report["recon_mean_before"], report["recon_p95_before"] = _recon_error(cv_subgrid, emp_curves)
+
+    bias = (
+        abs(report["cv_subgrid_median"] - report["cv_empirical_median"]) if derived.any() else 0.0
+    )
+    report["cv_median_bias"] = float(bias)
+
+    cal = cv_subgrid.copy()
+    if mode == "on" or (mode == "auto" and derived.sum() >= 2 and bias > bias_tol):
+        # monotone quantile map trained on the derived overlap
+        qs = np.linspace(0, 1, 101)
+        x = np.quantile(sub_d, qs)
+        y = np.quantile(emp_d, qs)
+        x, idx = np.unique(x, return_index=True)  # strictly increasing x for interp
+        y = y[idx]
+        finite = np.isfinite(cal)
+        cal[finite] = np.interp(cal[finite], x, y)
+        report["calibrated"] = True
+    elif mode not in ("auto", "on", "off"):
+        raise ValueError(f"calibrate mode must be auto|on|off, got {mode!r}")
+
+    report["recon_mean_after"], report["recon_p95_after"] = _recon_error(cal, emp_curves)
+    return cal, report

--- a/src/gfv2_params/snarea/library.py
+++ b/src/gfv2_params/snarea/library.py
@@ -37,6 +37,7 @@ def sdc_from_cv(cv: float, mu: float = 1.0, n: int = 4000) -> np.ndarray:
     dimensionless curve (SCA vs SWE/peak) depends only on cv. Returns SCA at
     SWE_LEVELS (descending), clipped to [0,1], anchored (1.0 @ SWE=1, 0.0 @ SWE=0).
     """
+    cv = max(float(cv), 1e-4)   # cv->0 is a degenerate step curve; floor keeps z>0 (else /0 -> all-NaN into the PRMS file)
     z = np.sqrt(np.log(1 + cv * cv))          # ζ² = ln(1+CV²)
     lam = np.log(mu) - 0.5 * z * z            # λ  = ln(μ) − ζ²/2
     M = np.concatenate([[0.0], np.exp(np.linspace(np.log(mu) - 6 * z, np.log(mu) + 6 * z, n))])
@@ -173,7 +174,10 @@ def validate_and_calibrate(
         cv_subgrid: sub-grid coefficient of variation array (may contain NaN).
         cv_empirical: empirical CV values aligned by index (may contain NaN where not derived).
         emp_curves: (n, 11) empirical SDC curves, NaN rows where not derived.
-        mode: "auto" (conditional), "on" (force), or "off" (identity).
+        mode: "auto" (conditional), "on" (force — still subject to the same
+            >=2-derived-overlap and non-degenerate-distribution guard as
+            "auto"; with fewer than 2 usable overlap points it falls back to
+            identity), or "off" (identity).
         bias_tol: threshold for median CV bias to trigger calibration in auto mode.
 
     Returns:
@@ -207,11 +211,14 @@ def validate_and_calibrate(
         qs = np.linspace(0, 1, 101)
         x = np.quantile(sub_d, qs)
         y = np.quantile(emp_d, qs)
-        x, idx = np.unique(x, return_index=True)  # strictly increasing x for interp
+        x, idx = np.unique(x, return_index=True)   # strictly increasing x for interp
         y = y[idx]
-        finite = np.isfinite(cal)
-        cal[finite] = np.interp(cal[finite], x, y)
-        report["calibrated"] = True
+        if x.size >= 2:
+            finite = np.isfinite(cal)
+            cal[finite] = np.interp(cal[finite], x, y)
+            report["calibrated"] = True
+        else:
+            report["calibration_skip_reason"] = "degenerate_overlap_distribution"
     elif mode not in ("auto", "on", "off"):
         raise ValueError(f"calibrate mode must be auto|on|off, got {mode!r}")
 
@@ -311,6 +318,13 @@ def write_prms_netcdf(library: pd.DataFrame, params: pd.DataFrame, id_feature: s
     flat = np.concatenate(
         [_to_prms_order(r[CURVE_COLS].to_numpy(float)) for _, r in lib_sorted.iterrows()]
     )
+    ids = lib_sorted["deplcrv_id"].to_numpy()
+    if not np.array_equal(ids, np.arange(1, ndepl + 1)):
+        raise ValueError(f"library deplcrv_id must be contiguous 1..{ndepl}, got {ids.tolist()}")
+    if not np.isfinite(flat).all():
+        raise ValueError("snarea_curve has non-finite values — refusing to write the PRMS param file")
+    if not np.isfinite(params["snarea_thresh"].to_numpy(float)).all():
+        raise ValueError("snarea_thresh has non-finite values — refusing to write the PRMS param file")
     ds = xr.Dataset(
         data_vars={
             "snarea_curve": (

--- a/src/gfv2_params/snarea/library.py
+++ b/src/gfv2_params/snarea/library.py
@@ -192,12 +192,14 @@ def validate_and_calibrate(
     report["recon_mean_before"], report["recon_p95_before"] = _recon_error(cv_subgrid, emp_curves)
 
     bias = (
-        abs(report["cv_subgrid_median"] - report["cv_empirical_median"]) if derived.any() else 0.0
+        abs(report["cv_subgrid_median"] - report["cv_empirical_median"])
+        if derived.any()
+        else float("nan")
     )
     report["cv_median_bias"] = float(bias)
 
     cal = cv_subgrid.copy()
-    if mode == "on" or (mode == "auto" and derived.sum() >= 2 and bias > bias_tol):
+    if derived.sum() >= 2 and (mode == "on" or (mode == "auto" and bias > bias_tol)):
         # monotone quantile map trained on the derived overlap
         qs = np.linspace(0, 1, 101)
         x = np.quantile(sub_d, qs)

--- a/src/gfv2_params/snarea/library.py
+++ b/src/gfv2_params/snarea/library.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
+import xarray as xr
 from scipy.stats import norm
 
 _MM_PER_INCH = 25.4
@@ -255,3 +256,76 @@ def write_params_csv(params: pd.DataFrame, path) -> None:
 def write_validation_csv(report: dict, path) -> None:
     Path(path).parent.mkdir(parents=True, exist_ok=True)
     pd.DataFrame([report]).to_csv(path, index=False)
+
+
+def write_prms_netcdf(library: pd.DataFrame, params: pd.DataFrame, id_feature: str, path) -> None:
+    """PRMS/pyWatershed param file: snarea_curve flat ASCENDING (ndeplval=11*ndepl),
+    hru_deplcrv, snarea_thresh, all on nhru.
+
+    Convention verified against ``pywatershed.hydrology.prms_snow.PRMSSnow`` (Task 8
+    step 1): ``snarea_curve_2d = np.reshape(snarea_curve_flat, (ndepl, 11))`` (row-major),
+    row selected via ``snarea_curve_2d[hru_deplcrv - 1, :]`` (hru_deplcrv is 1-indexed, so
+    flat-array row order must follow ascending deplcrv_id starting at row 0 = id 1).
+    Within a row, tracing ``_calc_sca_deplcrv``: frac_swe=0.0 -> curve[0], frac_swe=0.5 ->
+    curve[5], frac_swe=1.0 -> curve[10] (also asserted "the maximum" at
+    ``snarea_curve[11 - 1]`` on new-snow reset) -> ascending frac_swe, frac 0.0 at index 0.
+    This matches ``_to_prms_order`` (repo descending -> ascending reverse).
+    """
+    lib_sorted = library.sort_values("deplcrv_id")
+    ndepl = len(lib_sorted)
+    flat = np.concatenate(
+        [_to_prms_order(r[CURVE_COLS].to_numpy(float)) for _, r in lib_sorted.iterrows()]
+    )
+    ds = xr.Dataset(
+        data_vars={
+            "snarea_curve": (
+                "ndeplval",
+                flat.astype("float64"),
+                {
+                    # long_name/units match pywatershed's canonical
+                    # parameters.yaml entry for snarea_curve.
+                    "long_name": "Snow area depletion curve values",
+                    "units": "1",
+                    "description": (
+                        "Flat, ascending frac_swe within each 11-point curve "
+                        "(index 0 = frac_swe 0.0, index 10 = frac_swe 1.0); curves "
+                        "concatenated in ascending deplcrv_id order"
+                    ),
+                },
+            ),
+            "hru_deplcrv": (
+                "nhru",
+                params["hru_deplcrv"].to_numpy(np.int32),
+                {
+                    # long_name matches pywatershed's canonical parameters.yaml
+                    # entry for hru_deplcrv; units "1" per CF (dimensionless index).
+                    "long_name": "Index number for snowpack areal depletion curve",
+                    "units": "1",
+                },
+            ),
+            "snarea_thresh": (
+                "nhru",
+                params["snarea_thresh"].to_numpy("float64"),
+                {
+                    # long_name/units match pywatershed's canonical
+                    # parameters.yaml entry for snarea_thresh ("inches", plural).
+                    "long_name": "Maximum threshold water equivalent for snow depletion",
+                    "units": "inches",
+                },
+            ),
+        },
+        coords={
+            id_feature: (
+                "nhru",
+                params[id_feature].to_numpy(),
+                {"long_name": "HRU identifier"},
+            )
+        },
+        attrs={
+            "ndepl": ndepl,
+            "Description": "SNODAS-derived CV/lognormal snarea_curve library",
+            "Conventions": "CF-1.6",
+        },
+    )
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    ds.to_netcdf(path)

--- a/src/gfv2_params/snarea/library.py
+++ b/src/gfv2_params/snarea/library.py
@@ -15,6 +15,11 @@ from scipy.stats import norm
 # Descending, matching snarea/season.py SWE_LEVELS.
 SWE_LEVELS = np.round(np.arange(1.0, -1e-4, -0.1), 1)  # 1.0 .. 0.0, 11 values
 
+# CV search grid: 0.05..3.0 step 0.05 covers the validated range (median ~0.45,
+# up to ~1.2 CONUS) with headroom.
+CV_GRID = np.round(np.arange(0.05, 3.0001, 0.05), 2)
+_INTERIOR = slice(1, 10)  # endpoints (0, 10) are fixed 1.0/0.0 for every cv
+
 
 def sdc_from_cv(cv: float, mu: float = 1.0, n: int = 4000) -> np.ndarray:
     """11-point dimensionless SDC for a lognormal SWE pdf with coeff-of-var ``cv``.
@@ -41,3 +46,16 @@ def sdc_from_cv(cv: float, mu: float = 1.0, n: int = 4000) -> np.ndarray:
         x = np.concatenate([x, [1]])
         y = np.concatenate([y, [1]])
     return np.clip(np.interp(SWE_LEVELS, x, y, left=1.0, right=0.0), 0, 1)
+
+
+def _library_matrix(cv_grid: np.ndarray) -> np.ndarray:
+    """(len(cv_grid), 11) matrix of analytic curves — built once, reused."""
+    return np.vstack([sdc_from_cv(c) for c in cv_grid])
+
+
+def fit_cv(curve: np.ndarray, cv_grid: np.ndarray | None = None) -> float:
+    """Best-fit lognormal CV for an empirical 11-pt curve (min L2 over interior)."""
+    grid = CV_GRID if cv_grid is None else cv_grid
+    lib = _library_matrix(grid)
+    d = np.linalg.norm(lib[:, _INTERIOR] - np.asarray(curve)[_INTERIOR], axis=1)
+    return float(grid[int(d.argmin())])

--- a/src/gfv2_params/snarea/library.py
+++ b/src/gfv2_params/snarea/library.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 import numpy as np
 from scipy.stats import norm
 
+_MM_PER_INCH = 25.4
+
 # Descending, matching snarea/season.py SWE_LEVELS.
 SWE_LEVELS = np.round(np.arange(1.0, -1e-4, -0.1), 1)  # 1.0 .. 0.0, 11 values
 
@@ -59,3 +61,17 @@ def fit_cv(curve: np.ndarray, cv_grid: np.ndarray | None = None) -> float:
     lib = _library_matrix(grid)
     d = np.linalg.norm(lib[:, _INTERIOR] - np.asarray(curve)[_INTERIOR], axis=1)
     return float(grid[int(d.argmin())])
+
+
+def snarea_thresh_inches(peak_swe_mm: float) -> float:
+    """Per-HRU SWE scale in inches. 0.0 for no-snow / undefined (curve never
+    exercised there since pkwater_equiv is 0)."""
+    v = float(peak_swe_mm)
+    if not np.isfinite(v) or v <= 0.0:
+        return 0.0
+    return v / _MM_PER_INCH
+
+
+def _to_prms_order(curve: np.ndarray) -> np.ndarray:
+    """Repo descending (SWE 1.0->0.0) -> PRMS ascending frac_swe (0.0->1.0)."""
+    return np.asarray(curve)[::-1]

--- a/src/gfv2_params/snarea/library.py
+++ b/src/gfv2_params/snarea/library.py
@@ -70,8 +70,11 @@ def fit_cv(curve: np.ndarray, cv_grid: np.ndarray | None = None) -> float:
 def build_library(
     cv_values: np.ndarray, ndepl_cv: int, default_curve: np.ndarray
 ) -> pd.DataFrame:
-    """Row 1 = reserved default curve; rows 2..(1+ndepl_cv) = equal-population CV
-    bins, each curve = sdc_from_cv(bin median CV). Curves are descending."""
+    """Row 1 = reserved default curve; rows 2..(1+ndepl_cv) = exactly ``ndepl_cv``
+    equal-population CV bins (guaranteed non-empty via rank-based assignment, so
+    ties in ``cv_values`` cannot collapse the bin count), each curve =
+    sdc_from_cv(bin median CV). Curves are descending. Raises ValueError if
+    fewer than ``ndepl_cv`` finite CV values are available."""
     cv = np.asarray(cv_values, dtype=float)
     cv = cv[np.isfinite(cv)]
     if cv.size == 0:
@@ -89,13 +92,18 @@ def build_library(
         }
     ]
 
-    # equal-population bins via quantile edges; label each point 0..ndepl_cv-1
-    edges = np.quantile(cv, np.linspace(0, 1, ndepl_cv + 1))
-    edges[0], edges[-1] = -np.inf, np.inf
-    labels = np.clip(np.digitize(cv, edges[1:-1]), 0, ndepl_cv - 1)
-    medians = sorted(
-        float(np.median(cv[labels == b])) for b in range(ndepl_cv) if (labels == b).any()
-    )
+    # Rank-based equal-population bins: tie-robust, guarantees ndepl_cv non-empty
+    # groups (quantile-edges + digitize can silently collapse bins under ties).
+    cv_sorted_idx = np.argsort(cv, kind="stable")  # ordinal: ties broken by position
+    n = cv.size
+    if n < ndepl_cv:
+        raise ValueError(
+            f"build_library: need at least ndepl_cv ({ndepl_cv}) finite CV values "
+            f"to form equal-population bins, got {n}"
+        )
+    labels = np.empty(n, dtype=int)
+    labels[cv_sorted_idx] = (np.arange(n) * ndepl_cv) // n  # 0..ndepl_cv-1, equal population
+    medians = [float(np.median(cv[labels == b])) for b in range(ndepl_cv)]  # ascending; each non-empty
     for k, m in enumerate(medians, start=2):
         curve = sdc_from_cv(m)
         rows.append(

--- a/src/gfv2_params/snarea/library.py
+++ b/src/gfv2_params/snarea/library.py
@@ -244,9 +244,10 @@ def assemble_params(derived, id_feature, cv_assign, cv_source, deplcrv, library)
 
 
 def build_from_derived(derived, id_feature, ndepl_cv, default_curve, calibrate="auto", bias_tol=0.1):
-    """Estimable = finite cv_subgrid. cv_empirical is fitted from each DERIVED HRU's
-    empirical curve (vectorized: library matrix built once). Calibrate cv_subgrid vs
-    cv_empirical on the derived overlap, bin, assign, assemble."""
+    """Estimable = finite cv_assign (calibrated subgrid, subgrid, or empirical fallback).
+    cv_empirical is fitted from each DERIVED HRU's empirical curve (vectorized: library
+    matrix built once). Calibrate cv_subgrid vs cv_empirical on the derived overlap,
+    bin, assign, assemble."""
     derived = derived.reset_index(drop=True).copy()
     n = len(derived)
     cv_sub = derived["cv_subgrid"].to_numpy(float)

--- a/src/gfv2_params/snarea/library.py
+++ b/src/gfv2_params/snarea/library.py
@@ -10,12 +10,16 @@ _to_prms_order).
 from __future__ import annotations
 
 import numpy as np
+import pandas as pd
 from scipy.stats import norm
 
 _MM_PER_INCH = 25.4
 
 # Descending, matching snarea/season.py SWE_LEVELS.
 SWE_LEVELS = np.round(np.arange(1.0, -1e-4, -0.1), 1)  # 1.0 .. 0.0, 11 values
+
+# Curve column names for snarea_curve_0..10 (descending).
+CURVE_COLS = [f"snarea_curve_{i}" for i in range(11)]
 
 # CV search grid: 0.05..3.0 step 0.05 covers the validated range (median ~0.45,
 # up to ~1.2 CONUS) with headroom.
@@ -61,6 +65,48 @@ def fit_cv(curve: np.ndarray, cv_grid: np.ndarray | None = None) -> float:
     lib = _library_matrix(grid)
     d = np.linalg.norm(lib[:, _INTERIOR] - np.asarray(curve)[_INTERIOR], axis=1)
     return float(grid[int(d.argmin())])
+
+
+def build_library(
+    cv_values: np.ndarray, ndepl_cv: int, default_curve: np.ndarray
+) -> pd.DataFrame:
+    """Row 1 = reserved default curve; rows 2..(1+ndepl_cv) = equal-population CV
+    bins, each curve = sdc_from_cv(bin median CV). Curves are descending."""
+    cv = np.asarray(cv_values, dtype=float)
+    cv = cv[np.isfinite(cv)]
+    if cv.size == 0:
+        raise ValueError("build_library: no finite CV values to bin")
+    default_curve = np.asarray(default_curve, dtype=float)
+    if default_curve.shape != (11,):
+        raise ValueError(f"default_curve must be shape (11,), got {default_curve.shape}")
+
+    rows = [
+        {
+            "deplcrv_id": 1,
+            "curve_kind": "default",
+            "cv": np.nan,
+            **{c: float(default_curve[i]) for i, c in enumerate(CURVE_COLS)},
+        }
+    ]
+
+    # equal-population bins via quantile edges; label each point 0..ndepl_cv-1
+    edges = np.quantile(cv, np.linspace(0, 1, ndepl_cv + 1))
+    edges[0], edges[-1] = -np.inf, np.inf
+    labels = np.clip(np.digitize(cv, edges[1:-1]), 0, ndepl_cv - 1)
+    medians = sorted(
+        float(np.median(cv[labels == b])) for b in range(ndepl_cv) if (labels == b).any()
+    )
+    for k, m in enumerate(medians, start=2):
+        curve = sdc_from_cv(m)
+        rows.append(
+            {
+                "deplcrv_id": k,
+                "curve_kind": "cv_bin",
+                "cv": m,
+                **{c: float(curve[i]) for i, c in enumerate(CURVE_COLS)},
+            }
+        )
+    return pd.DataFrame(rows)
 
 
 def snarea_thresh_inches(peak_swe_mm: float) -> float:

--- a/src/gfv2_params/snarea/library.py
+++ b/src/gfv2_params/snarea/library.py
@@ -1,0 +1,43 @@
+"""Stage 3: CV/lognormal snarea_curve library builder.
+
+The curve SHAPE is a single physical parameter — the sub-grid SWE coefficient of
+variation (CV) — via a lognormal SWE pdf (Sexstone et al. 2020, eqs 3-5; Liston
+2004). The dimensionless snow-depletion curve depends only on CV. Repo curve
+order is DESCENDING (SWE/thresh 1.0 -> 0.0); the PRMS NetCDF is ascending (see
+_to_prms_order).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy.stats import norm
+
+# Descending, matching snarea/season.py SWE_LEVELS.
+SWE_LEVELS = np.round(np.arange(1.0, -1e-4, -0.1), 1)  # 1.0 .. 0.0, 11 values
+
+
+def sdc_from_cv(cv: float, mu: float = 1.0, n: int = 4000) -> np.ndarray:
+    """11-point dimensionless SDC for a lognormal SWE pdf with coeff-of-var ``cv``.
+
+    Sexstone eqs 1-5 under uniform melt: SCA(M)=P(S>M); SWE(M)=E[(S-M)^+]. The
+    dimensionless curve (SCA vs SWE/peak) depends only on cv. Returns SCA at
+    SWE_LEVELS (descending), clipped to [0,1], anchored (1.0 @ SWE=1, 0.0 @ SWE=0).
+    """
+    z = np.sqrt(np.log(1 + cv * cv))          # ζ² = ln(1+CV²)
+    lam = np.log(mu) - 0.5 * z * z            # λ  = ln(μ) − ζ²/2
+    M = np.concatenate([[0.0], np.exp(np.linspace(np.log(mu) - 6 * z, np.log(mu) + 6 * z, n))])
+    lnM = np.log(np.where(M > 0, M, 1e-300))
+    sca = norm.cdf((lam - lnM) / z)           # SCA(M) = Φ((λ−lnM)/ζ)
+    swe = mu * norm.cdf((lam + z * z - lnM) / z) - M * sca
+    sca[0], swe[0] = 1.0, mu
+    o = np.argsort(swe / swe[0])
+    x = (swe / swe[0])[o]
+    y = sca[o]
+    # Ensure the curve spans from (0, 0) to (1, 1) for proper interpolation
+    if x[0] > 0:
+        x = np.concatenate([[0], x])
+        y = np.concatenate([[0], y])
+    if x[-1] < 1:
+        x = np.concatenate([x, [1]])
+        y = np.concatenate([y, [1]])
+    return np.clip(np.interp(SWE_LEVELS, x, y, left=1.0, right=0.0), 0, 1)

--- a/src/gfv2_params/snarea/library.py
+++ b/src/gfv2_params/snarea/library.py
@@ -243,6 +243,40 @@ def assemble_params(derived, id_feature, cv_assign, cv_source, deplcrv, library)
     return out
 
 
+def build_from_derived(derived, id_feature, ndepl_cv, default_curve, calibrate="auto", bias_tol=0.1):
+    """Estimable = finite cv_subgrid. cv_empirical is fitted from each DERIVED HRU's
+    empirical curve (vectorized: library matrix built once). Calibrate cv_subgrid vs
+    cv_empirical on the derived overlap, bin, assign, assemble."""
+    derived = derived.reset_index(drop=True).copy()
+    n = len(derived)
+    cv_sub = derived["cv_subgrid"].to_numpy(float)
+
+    emp_curves = derived[CURVE_COLS].to_numpy(float)  # (n, 11)
+    is_derived = derived["sdc_status"].to_numpy() == "derived"
+    cv_emp = np.full(n, np.nan)
+    if is_derived.any():
+        lib = _library_matrix(CV_GRID)  # (ngrid, 11), built ONCE
+        dc = emp_curves[is_derived][:, _INTERIOR]  # (n_der, 9)
+        dists = np.linalg.norm(lib[None, :, _INTERIOR] - dc[:, None, :], axis=2)  # (n_der, ngrid)
+        cv_emp[is_derived] = CV_GRID[dists.argmin(axis=1)]
+    derived["cv_empirical"] = cv_emp
+    emp_for_cal = np.where(is_derived[:, None], emp_curves, np.nan)
+
+    cal, report = validate_and_calibrate(cv_sub, cv_emp, emp_for_cal, mode=calibrate, bias_tol=bias_tol)
+    cv_assign = np.where(np.isfinite(cal), cal, cv_emp)
+    cv_source = np.where(
+        np.isfinite(cal),
+        "subgrid_calibrated" if report["calibrated"] else "subgrid",
+        np.where(np.isfinite(cv_emp), "empirical", "default_no_snow"),
+    )
+    library = build_library(cv_assign[np.isfinite(cv_assign)], ndepl_cv, default_curve)
+    deplcrv = assign_deplcrv(cv_assign, library)
+    params = assemble_params(derived, id_feature, cv_assign, cv_source, deplcrv, library)
+    report["n_hru"] = n
+    report["n_estimable"] = int(np.isfinite(cv_assign).sum())
+    return library, params, report
+
+
 def write_library_csv(library: pd.DataFrame, path) -> None:
     Path(path).parent.mkdir(parents=True, exist_ok=True)
     library.to_csv(path, index=False)

--- a/src/gfv2_params/snarea/library.py
+++ b/src/gfv2_params/snarea/library.py
@@ -126,6 +126,22 @@ def snarea_thresh_inches(peak_swe_mm: float) -> float:
     return v / _MM_PER_INCH
 
 
+def assign_deplcrv(cv_assign: np.ndarray, library: pd.DataFrame) -> np.ndarray:
+    """Nearest cv_bin curve (by CV) for finite CV; reserved default (id 1) for non-finite.
+    The default row is never a nearest-CV candidate."""
+    bins = library[library["curve_kind"] == "cv_bin"]
+    bin_ids = bins["deplcrv_id"].to_numpy()
+    bin_cvs = bins["cv"].to_numpy(dtype=float)
+    default_id = int(library[library["curve_kind"] == "default"]["deplcrv_id"].iloc[0])
+    cv = np.asarray(cv_assign, dtype=float)
+    out = np.full(cv.shape, default_id, dtype=np.int32)
+    finite = np.isfinite(cv)
+    if finite.any():
+        nearest = np.abs(cv[finite][:, None] - bin_cvs[None, :]).argmin(axis=1)
+        out[finite] = bin_ids[nearest]
+    return out
+
+
 def _to_prms_order(curve: np.ndarray) -> np.ndarray:
     """Repo descending (SWE 1.0->0.0) -> PRMS ascending frac_swe (0.0->1.0)."""
     return np.asarray(curve)[::-1]

--- a/src/gfv2_params/snarea/library.py
+++ b/src/gfv2_params/snarea/library.py
@@ -9,6 +9,8 @@ _to_prms_order).
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import numpy as np
 import pandas as pd
 from scipy.stats import norm
@@ -214,3 +216,42 @@ def validate_and_calibrate(
 
     report["recon_mean_after"], report["recon_p95_after"] = _recon_error(cal, emp_curves)
     return cal, report
+
+
+_PARAM_DIAG_COLS = ["sdc_status", "sca_class", "similarity", "n_seasons", "n_peak_years", "peak_swe_mm"]
+
+
+def assemble_params(derived, id_feature, cv_assign, cv_source, deplcrv, library):
+    """One row per HRU: index + snarea_thresh + CVs + diagnostics + the ASSIGNED
+    library curve (descending, for QA / per-HRU detail — no separate 1:1 mode)."""
+    curve_by_id = {int(r.deplcrv_id): r[CURVE_COLS].to_numpy(float) for _, r in library.iterrows()}
+    assigned = np.vstack([curve_by_id[int(d)] for d in deplcrv])
+    out = pd.DataFrame({
+        id_feature: derived[id_feature].to_numpy(),
+        "hru_deplcrv": np.asarray(deplcrv, dtype=np.int32),
+        "snarea_thresh": [snarea_thresh_inches(v) for v in derived["peak_swe_mm"].to_numpy()],
+        "cv_assign": np.asarray(cv_assign, dtype=float),
+        "cv_subgrid": derived["cv_subgrid"].to_numpy(float),
+        "cv_empirical": derived["cv_empirical"].to_numpy(float),
+        "cv_source": np.asarray(cv_source, dtype=object),
+    })
+    for c in _PARAM_DIAG_COLS:
+        out[c] = derived[c].to_numpy()
+    for i, c in enumerate(CURVE_COLS):
+        out[c] = assigned[:, i]
+    return out
+
+
+def write_library_csv(library: pd.DataFrame, path) -> None:
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    library.to_csv(path, index=False)
+
+
+def write_params_csv(params: pd.DataFrame, path) -> None:
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    params.to_csv(path, index=False)
+
+
+def write_validation_csv(report: dict, path) -> None:
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame([report]).to_csv(path, index=False)

--- a/src/gfv2_params/snarea/subgrid.py
+++ b/src/gfv2_params/snarea/subgrid.py
@@ -1,0 +1,62 @@
+"""Representative sub-grid SWE CV + peak SWE per HRU, for the CV/lognormal library.
+
+CV = area-weighted std/mean of the SNODAS SWE pdf within an HRU, taken at each
+water-year's peak-mean-SWE day (CV is most stable where mean SWE is largest), then
+median across years. Water-year framing matches snarea/build.py:_seasons so a
+late-December accumulation is not mis-picked as the peak.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+def representative_peak_stats(daily: pd.DataFrame) -> dict:
+    """Compute median CV and peak SWE across water years.
+
+    Parameters
+    ----------
+    daily : pd.DataFrame
+        DataFrame with DatetimeIndex and columns `swe` (mean) and `swe_std`.
+
+    Returns
+    -------
+    dict
+        Keys: cv_subgrid (median CV at peak day), peak_swe_mm (median peak SWE),
+        n_peak_years (count of valid years). If no valid years, returns NaN/0.
+    """
+    if len(daily) == 0:
+        return {"cv_subgrid": float("nan"), "peak_swe_mm": float("nan"), "n_peak_years": 0}
+
+    water_year = daily.index.year + (daily.index.month >= 10).astype(int)
+    cvs, peaks = [], []
+
+    for _wy, grp in daily.groupby(water_year):
+        swe = grp["swe"].to_numpy(dtype=float)
+        std = grp["swe_std"].to_numpy(dtype=float)
+
+        # Skip years with no finite values or max <= 0
+        if not np.isfinite(swe).any() or np.nanmax(swe) <= 0:
+            continue
+
+        # Find peak-mean-SWE day
+        i = int(np.nanargmax(swe))
+        peak, s = swe[i], std[i]
+
+        # Skip if peak or std non-finite, or peak <= 0
+        if not (np.isfinite(peak) and peak > 0 and np.isfinite(s)):
+            continue
+
+        cvs.append(s / peak)
+        peaks.append(peak)
+
+    # Return medians + count
+    if not cvs:
+        return {"cv_subgrid": float("nan"), "peak_swe_mm": float("nan"), "n_peak_years": 0}
+
+    return {
+        "cv_subgrid": float(np.median(cvs)),
+        "peak_swe_mm": float(np.median(peaks)),
+        "n_peak_years": len(cvs),
+    }

--- a/tests/test_aggregate_adapter.py
+++ b/tests/test_aggregate_adapter.py
@@ -1,4 +1,5 @@
 import pytest
+
 from gfv2_params.aggregate import SourceAdapter
 
 
@@ -19,3 +20,12 @@ def test_rejects_bad_stat_method():
 def test_rejects_empty_variables():
     with pytest.raises(ValueError, match="variables"):
         SourceAdapter(source_key="d", variables=(), files_glob="*.nc")
+
+
+def test_std_variables_defaults_empty_and_validates():
+    a = SourceAdapter(source_key="s", variables=("swe", "scov"), files_glob="*.nc")
+    assert a.std_variables == ()
+    a2 = SourceAdapter(source_key="s", variables=("swe",), files_glob="*.nc", std_variables=("swe",))
+    assert a2.std_variables == ("swe",)
+    with pytest.raises(ValueError, match="std_variables"):
+        SourceAdapter(source_key="s", variables=("swe",), files_glob="*.nc", std_variables=("missing",))

--- a/tests/test_aggregate_driver.py
+++ b/tests/test_aggregate_driver.py
@@ -115,3 +115,24 @@ def test_aggregate_source_years_filter_no_match_raises(tmp_path):
             adapter, gdf, "hru_id", input_dir=tmp_path, output_dir=tmp_path / "out",
             weight_file=tmp_path / "w.csv", output_prefix="demo", years=[2099],
         )
+
+
+def test_std_sidecar_emits_var_std(tmp_path):
+    import pytest
+
+    _synthetic_grid(tmp_path)
+    gdf = _two_polys()
+    adapter = SourceAdapter(
+        source_key="demo", variables=("swe",), files_glob="demo_daily_*.nc",
+        source_crs="EPSG:5070", x_coord="x", y_coord="y", time_coord="time",
+        stat_method="mean", std_variables=("swe",),
+    )
+    out = aggregate_source(
+        adapter, gdf, "hru_id", input_dir=tmp_path,
+        output_dir=tmp_path / "out", weight_file=tmp_path / "w.csv",
+        output_prefix="demo"
+    )
+    res = xr.open_dataset(out[0])
+    assert "swe" in res and "swe_std" in res
+    # day 0 left poly: cells all 1.0 -> std 0; (see _synthetic_grid values)
+    assert float(res["swe_std"].sel(hru_id=1).values[0]) == pytest.approx(0.0, abs=1e-6)

--- a/tests/test_aggregate_snodas.py
+++ b/tests/test_aggregate_snodas.py
@@ -34,6 +34,10 @@ def test_adapter_settings():
     assert SNODAS_ADAPTER.files_glob == "snodas_daily_*.nc"
 
 
+def test_snodas_adapter_declares_swe_std():
+    assert SNODAS_ADAPTER.std_variables == ("swe",)
+
+
 # --- End-to-end masked_mean / fill-exclusion regression -------------------
 # The unit test above pins the _snodas_hook contract (fill -> NaN, scov carries
 # the NaN mask). The test below drives the *whole* Stage-1 path

--- a/tests/test_derive_snarea_curve.py
+++ b/tests/test_derive_snarea_curve.py
@@ -25,10 +25,13 @@ def test_cells_from_weights(tmp_path):
 
 
 def test_read_daily_by_hru(tmp_path):
+    # swe_std is unconditionally emitted by Stage 1 (aggregate.snodas
+    # std_variables=("swe",)), so the fixture always includes it.
     idx = pd.date_range("2010-02-01", periods=3, freq="D")
     ds = xr.Dataset(
         {"swe": (("time", "hru_id"), np.array([[10, 5], [8, 4], [0, 0]], "float64")),
-         "scov": (("time", "hru_id"), np.array([[1, 1], [.8, .5], [0, 0]], "float64"))},
+         "scov": (("time", "hru_id"), np.array([[1, 1], [.8, .5], [0, 0]], "float64")),
+         "swe_std": (("time", "hru_id"), np.array([[2, 1], [1.5, .8], [0, 0]], "float64"))},
         coords={"time": idx, "hru_id": [1, 2]},
     )
     ds.to_netcdf(tmp_path / "snodas_agg_2010.nc")
@@ -36,6 +39,20 @@ def test_read_daily_by_hru(tmp_path):
     assert set(out) == {1, 2}
     assert list(out[1]["swe"].values) == [10, 8, 0]
     assert "sca" in out[1].columns          # scov renamed to sca
+
+
+def test_read_daily_by_hru_includes_swe_std(tmp_path):
+    idx = pd.date_range("2010-02-01", periods=3, freq="D")
+    ds = xr.Dataset(
+        {"swe": (("time", "hru_id"), np.array([[10, 5], [8, 4], [0, 0]], "float64")),
+         "scov": (("time", "hru_id"), np.array([[1, 1], [.8, .5], [0, 0]], "float64")),
+         "swe_std": (("time", "hru_id"), np.array([[2, 1], [1.5, .8], [0, 0]], "float64"))},
+        coords={"time": idx, "hru_id": [1, 2]},
+    )
+    ds.to_netcdf(tmp_path / "snodas_agg_2010.nc")
+    out = read_daily_by_hru(tmp_path, "hru_id")
+    assert "swe_std" in out[1].columns
+    assert list(out[1]["swe_std"].values) == [2, 1.5, 0]
 
 
 def test_validate_default_curve_accepts_valid():

--- a/tests/test_derive_snarea_curve.py
+++ b/tests/test_derive_snarea_curve.py
@@ -55,6 +55,16 @@ def test_read_daily_by_hru_includes_swe_std(tmp_path):
     assert list(out[1]["swe_std"].values) == [2, 1.5, 0]
 
 
+def test_read_daily_by_hru_missing_swe_std_raises(tmp_path):
+    t = pd.date_range("2011-01-01", periods=2)
+    ds = xr.Dataset({"swe": (("time", "hru_id"), np.array([[1.0], [2.0]])),
+                     "scov": (("time", "hru_id"), np.array([[1.0], [1.0]]))},
+                    coords={"time": t, "hru_id": [7]})
+    ds.to_netcdf(tmp_path / "snodas_agg_2011.nc")
+    with pytest.raises(ValueError, match="swe_std"):
+        read_daily_by_hru(tmp_path, "hru_id")
+
+
 def test_validate_default_curve_accepts_valid():
     validate_default_curve(np.linspace(1.0, 0.0, 11))
 

--- a/tests/test_snarea_build.py
+++ b/tests/test_snarea_build.py
@@ -1,4 +1,6 @@
+import numpy as np
 import pandas as pd
+import pytest
 
 from gfv2_params.snarea.build import DEFAULT_SNAREA_CURVE, build_hru_record
 from gfv2_params.snarea.selection import SelectionParams
@@ -45,8 +47,6 @@ def test_seasons_uses_water_year_grouping():
     # argmax-pick the December spike in CY2021 and lose the real season (0
     # curves); water-year framing keeps the Jan-Feb melt as WY2021 (1 usable
     # season) and drops the Nov-Dec accumulation into WY2022.
-    import numpy as np
-
     from gfv2_params.snarea.build import _seasons
 
     idx = pd.date_range("2021-01-01", "2021-12-31", freq="D")
@@ -69,3 +69,28 @@ def test_seasons_uses_water_year_grouping():
     seasons = _seasons(frame)
     assert len(seasons) == 1          # the real Jan-Mar melt (WY2021), not the Dec spike
     assert seasons[0][0] == 1.0       # normalized SDC starts at 1.0
+
+
+def test_build_hru_record_has_subgrid_columns():
+    dates = pd.date_range("2010-10-01", "2011-09-30")
+    h = len(dates) // 2
+    swe = np.concatenate([np.linspace(0, 200, h), np.linspace(200, 0, len(dates) - h)])
+    daily = pd.DataFrame(
+        {"swe": swe, "sca": (swe > 0).astype(float), "swe_std": swe * 0.5}, index=dates
+    )
+    rec = build_hru_record(
+        hru_id=7, daily=daily, n_cells=50, water_frac=0.0,
+        params=SelectionParams(), default_curve=DEFAULT_SNAREA_CURVE,
+    )
+    for c in ("cv_subgrid", "peak_swe_mm", "n_peak_years"):
+        assert c in rec
+    assert rec["cv_subgrid"] == pytest.approx(0.5, abs=1e-6)
+
+
+def test_build_hru_record_defaults_subgrid_stats_without_swe_std():
+    rec = build_hru_record(
+        hru_id=3, daily=_daily_two_years(), n_cells=100, water_frac=0.0,
+        params=SelectionParams(), default_curve=DEFAULT_SNAREA_CURVE)
+    assert rec["n_peak_years"] == 0
+    assert np.isnan(rec["cv_subgrid"])
+    assert np.isnan(rec["peak_swe_mm"])

--- a/tests/test_snarea_library.py
+++ b/tests/test_snarea_library.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pandas as pd
 import pytest
+import xarray as xr
 
 from gfv2_params.snarea.library import (
     _INTERIOR,
@@ -16,6 +17,7 @@ from gfv2_params.snarea.library import (
     snarea_thresh_inches,
     validate_and_calibrate,
     write_library_csv,
+    write_prms_netcdf,
 )
 
 
@@ -225,3 +227,25 @@ def test_write_csvs_roundtrip(tmp_path):
     p = tmp_path / "lib.csv"
     write_library_csv(lib, p)
     assert pd.read_csv(p).shape[0] == 9
+
+
+def test_write_prms_netcdf_structure_and_ascending_order(tmp_path):
+    lib = build_library(np.linspace(0.2, 1.4, 500), ndepl_cv=8, default_curve=np.linspace(1, 0, 11))
+    params = pd.DataFrame({
+        "nat_hru_id": [10, 11, 12],
+        "hru_deplcrv": np.array([2, 5, 1], dtype=np.int32),
+        "snarea_thresh": [10.0, 20.0, 0.0],
+    })
+    p = tmp_path / "snarea.nc"
+    write_prms_netcdf(lib, params, "nat_hru_id", p)
+    ds = xr.open_dataset(p)
+    ndepl = len(lib)
+    assert ds.sizes["ndeplval"] == 11 * ndepl
+    assert ds.sizes["nhru"] == 3
+    assert ds["hru_deplcrv"].dtype == np.int32
+    # first curve (default, deplcrv_id 1) ascending: index 0 == descending's last (0.0)
+    flat = ds["snarea_curve"].values
+    first_curve_ascending = flat[:11]
+    desc = lib[lib.deplcrv_id == 1][CURVE_COLS].to_numpy(float).ravel()
+    np.testing.assert_allclose(first_curve_ascending, desc[::-1])
+    assert first_curve_ascending[0] <= first_curve_ascending[-1]   # ascending SCA

--- a/tests/test_snarea_library.py
+++ b/tests/test_snarea_library.py
@@ -164,3 +164,26 @@ def test_calibration_off_is_identity():
     cal, report = validate_and_calibrate(rng * 0.5, rng, emp, mode="off")
     np.testing.assert_allclose(cal, rng * 0.5)
     assert report["calibrated"] is False
+
+
+def test_calibration_mode_on_maps_even_when_unbiased():
+    rng = np.linspace(0.3, 1.2, 200)
+    emp = np.vstack([sdc_from_cv(c) for c in rng])
+    cal, report = validate_and_calibrate(rng.copy(), rng.copy(), emp, mode="on")
+    assert report["calibrated"] is True   # 'on' maps even with zero bias
+
+
+def test_calibration_mode_on_graceful_identity_when_no_overlap():
+    # cv_empirical all-NaN -> zero overlap; mode='on' must NOT crash, must be identity
+    n = 3
+    cal, report = validate_and_calibrate(
+        np.array([0.3, 0.5, 0.7]), np.full(n, np.nan), np.full((n, 11), np.nan), mode="on")
+    assert report["calibrated"] is False
+    np.testing.assert_allclose(cal, [0.3, 0.5, 0.7])
+
+
+def test_calibration_invalid_mode_raises():
+    n = 3
+    with pytest.raises(ValueError):
+        validate_and_calibrate(np.array([0.3, 0.5, 0.7]), np.full(n, np.nan),
+                               np.full((n, 11), np.nan), mode="bogus")

--- a/tests/test_snarea_library.py
+++ b/tests/test_snarea_library.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pandas as pd
 import pytest
 
 from gfv2_params.snarea.library import (
@@ -7,12 +8,14 @@ from gfv2_params.snarea.library import (
     CV_GRID,
     SWE_LEVELS,
     _to_prms_order,
+    assemble_params,
     assign_deplcrv,
     build_library,
     fit_cv,
     sdc_from_cv,
     snarea_thresh_inches,
     validate_and_calibrate,
+    write_library_csv,
 )
 
 
@@ -187,3 +190,38 @@ def test_calibration_invalid_mode_raises():
     with pytest.raises(ValueError):
         validate_and_calibrate(np.array([0.3, 0.5, 0.7]), np.full(n, np.nan),
                                np.full((n, 11), np.nan), mode="bogus")
+
+
+def test_assemble_params_columns_and_assigned_curve(tmp_path):
+    lib = build_library(np.linspace(0.2, 1.4, 500), ndepl_cv=8, default_curve=np.linspace(1, 0, 11))
+    derived = pd.DataFrame({
+        "nat_hru_id": [10, 11, 12],
+        "sdc_status": ["derived", "derived", "default_no_snow"],
+        "sca_class": ["high", "mid", "high"],
+        "similarity": [0.05, 0.09, np.nan],
+        "n_seasons": [12, 8, 0],
+        "cv_subgrid": [0.4, 0.9, np.nan],
+        "cv_empirical": [0.42, 0.88, np.nan],
+        "peak_swe_mm": [254.0, 508.0, 0.0],
+        "n_peak_years": [12, 8, 0],
+    })
+    cv_assign = np.array([0.4, 0.9, np.nan])
+    cv_source = np.array(["subgrid", "subgrid", "default_no_snow"])
+    deplcrv = assign_deplcrv(cv_assign, lib)
+    params = assemble_params(derived, "nat_hru_id", cv_assign, cv_source, deplcrv, lib)
+    assert list(params["nat_hru_id"]) == [10, 11, 12]
+    for col in ("hru_deplcrv", "snarea_thresh", "cv_assign", "cv_source", *CURVE_COLS):
+        assert col in params.columns
+    assert params.loc[params.nat_hru_id == 12, "hru_deplcrv"].iloc[0] == 1     # no-snow -> default
+    assert params.loc[params.nat_hru_id == 12, "snarea_thresh"].iloc[0] == 0.0
+    # assigned curve row matches the library curve for that hru's deplcrv
+    r = params.iloc[0]
+    librow = lib[lib.deplcrv_id == r["hru_deplcrv"]].iloc[0]
+    np.testing.assert_allclose(r[CURVE_COLS].to_numpy(float), librow[CURVE_COLS].to_numpy(float))
+
+
+def test_write_csvs_roundtrip(tmp_path):
+    lib = build_library(np.linspace(0.2, 1.4, 500), ndepl_cv=8, default_curve=np.linspace(1, 0, 11))
+    p = tmp_path / "lib.csv"
+    write_library_csv(lib, p)
+    assert pd.read_csv(p).shape[0] == 9

--- a/tests/test_snarea_library.py
+++ b/tests/test_snarea_library.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from gfv2_params.snarea.library import CV_GRID, SWE_LEVELS, fit_cv, sdc_from_cv
+from gfv2_params.snarea.library import _INTERIOR, CV_GRID, SWE_LEVELS, fit_cv, sdc_from_cv
 
 
 def test_swe_levels_descending_11pt():
@@ -28,14 +28,28 @@ def test_sdc_from_cv_higher_cv_steeper():
 
 
 def test_fit_cv_recovers_known_cv():
-    for true_cv in (0.3, 0.7, 1.2):
+    for true_cv in (0.32, 0.7, 1.2):
         curve = sdc_from_cv(true_cv)
         # fit is on the CV grid; recovered value within one grid step
         assert abs(fit_cv(curve) - true_cv) <= (CV_GRID[1] - CV_GRID[0]) + 1e-9
 
 
-def test_fit_cv_uses_interior_only():
-    # a curve whose endpoints are perturbed but interior matches cv=0.5 still fits ~0.5
-    curve = sdc_from_cv(0.5).copy()
-    curve[0] = 1.0  # endpoints already fixed; assert fit ignores them
-    assert fit_cv(curve) == pytest.approx(0.5, abs=CV_GRID[1] - CV_GRID[0])
+def test_fit_cv_is_interior_driven():
+    # Assert the interior-only invariant directly
+    assert _INTERIOR == slice(1, 10)
+
+    # Assert that interior shape drives the fit: differing interiors yield different fitted CVs
+    cv_low = 0.4
+    cv_high = 1.0
+    curve_low = sdc_from_cv(cv_low)
+    curve_high = sdc_from_cv(cv_high)
+
+    fitted_low = fit_cv(curve_low)
+    fitted_high = fit_cv(curve_high)
+
+    # Both should be recovered within one grid step
+    assert abs(fitted_low - cv_low) <= (CV_GRID[1] - CV_GRID[0]) + 1e-9
+    assert abs(fitted_high - cv_high) <= (CV_GRID[1] - CV_GRID[0]) + 1e-9
+
+    # They should be distinctly different (not confused by endpoints)
+    assert fitted_low < fitted_high

--- a/tests/test_snarea_library.py
+++ b/tests/test_snarea_library.py
@@ -11,6 +11,7 @@ from gfv2_params.snarea.library import (
     _to_prms_order,
     assemble_params,
     assign_deplcrv,
+    build_from_derived,
     build_library,
     fit_cv,
     sdc_from_cv,
@@ -227,6 +228,40 @@ def test_write_csvs_roundtrip(tmp_path):
     p = tmp_path / "lib.csv"
     write_library_csv(lib, p)
     assert pd.read_csv(p).shape[0] == 9
+
+
+def test_build_from_derived_computes_cv_empirical_end_to_end():
+    rng = np.random.default_rng(0)
+    n = 300
+    cv = np.clip(rng.normal(0.5, 0.2, n), 0.1, 1.5)
+    curves = np.vstack([sdc_from_cv(c) for c in cv])   # each HRU's empirical curve
+    derived = pd.DataFrame({
+        "nat_hru_id": np.arange(1, n + 1),
+        "sdc_status": ["derived"] * n, "sca_class": ["high"] * n,
+        "similarity": 0.05, "n_seasons": 10,
+        "cv_subgrid": cv, "peak_swe_mm": 254.0, "n_peak_years": 10,
+        **{c: curves[:, i] for i, c in enumerate(CURVE_COLS)},
+    })
+    lib, params, report = build_from_derived(derived, "nat_hru_id", 8, np.linspace(1, 0, 11), "auto", 0.1)
+    assert len(lib) == 9
+    assert len(params) == n
+    assert set(params["hru_deplcrv"].unique()) <= set(range(2, 10))    # all estimable -> cv bins
+    # cv_empirical was COMPUTED (recovers each true CV within one grid step)
+    assert np.nanmax(np.abs(params["cv_empirical"].to_numpy() - cv)) <= 0.05 + 1e-9
+    assert report["calibrated"] is False   # cv_subgrid == implied empirical -> unbiased
+
+
+def test_build_from_derived_no_snow_uses_default():
+    derived = pd.DataFrame({
+        "nat_hru_id": [1, 2],
+        "sdc_status": ["derived", "default_no_snow"],
+        "sca_class": ["high", "high"], "similarity": [0.05, np.nan], "n_seasons": [10, 0],
+        "cv_subgrid": [0.5, np.nan], "peak_swe_mm": [254.0, 0.0], "n_peak_years": [10, 0],
+        **{c: [sdc_from_cv(0.5)[i], np.linspace(1, 0, 11)[i]] for i, c in enumerate(CURVE_COLS)},
+    })
+    lib, params, report = build_from_derived(derived, "nat_hru_id", 1, np.linspace(1, 0, 11), "off", 0.1)
+    assert params.loc[params.nat_hru_id == 2, "hru_deplcrv"].iloc[0] == 1     # no-snow -> default
+    assert params.loc[params.nat_hru_id == 2, "snarea_thresh"].iloc[0] == 0.0
 
 
 def test_write_prms_netcdf_structure_and_ascending_order(tmp_path):

--- a/tests/test_snarea_library.py
+++ b/tests/test_snarea_library.py
@@ -1,0 +1,27 @@
+import numpy as np
+import pytest
+
+from gfv2_params.snarea.library import SWE_LEVELS, sdc_from_cv
+
+
+def test_swe_levels_descending_11pt():
+    assert SWE_LEVELS.shape == (11,)
+    assert SWE_LEVELS[0] == 1.0 and SWE_LEVELS[-1] == 0.0
+    assert np.all(np.diff(SWE_LEVELS) < 0)
+
+
+def test_sdc_from_cv_shape_and_endpoints():
+    c = sdc_from_cv(0.5)
+    assert c.shape == (11,)
+    assert c[0] == pytest.approx(1.0)
+    assert c[-1] == pytest.approx(0.0)
+
+
+def test_sdc_from_cv_monotone_nonincreasing():
+    c = sdc_from_cv(0.7)
+    assert np.all(np.diff(c) <= 1e-9)
+
+
+def test_sdc_from_cv_higher_cv_steeper():
+    # larger CV -> lower SCA at mid SWE (index 5 = SWE 0.5)
+    assert sdc_from_cv(1.5)[5] < sdc_from_cv(0.5)[5] < sdc_from_cv(0.1)[5]

--- a/tests/test_snarea_library.py
+++ b/tests/test_snarea_library.py
@@ -7,6 +7,7 @@ from gfv2_params.snarea.library import (
     CV_GRID,
     SWE_LEVELS,
     _to_prms_order,
+    assign_deplcrv,
     build_library,
     fit_cv,
     sdc_from_cv,
@@ -115,3 +116,21 @@ def test_build_library_tied_cvs_still_produce_ndepl_cv_bins():
 def test_build_library_raises_when_fewer_cvs_than_bins():
     with pytest.raises(ValueError, match="at least ndepl_cv"):
         build_library(np.array([0.4, 0.5, 0.6]), ndepl_cv=8, default_curve=np.linspace(1, 0, 11))
+
+
+def test_assign_deplcrv_nearest_bin_and_default():
+    lib = build_library(np.linspace(0.2, 1.4, 500), ndepl_cv=8, default_curve=np.linspace(1, 0, 11))
+    bin_cvs = lib.iloc[1:]["cv"].to_numpy()
+    cv_assign = np.array([bin_cvs[0], bin_cvs[-1], np.nan, float(bin_cvs.mean())])
+    out = assign_deplcrv(cv_assign, lib)
+    assert out[0] == 2                     # nearest first bin
+    assert out[1] == 9                     # nearest last bin
+    assert out[2] == 1                     # NaN -> reserved default
+    assert 2 <= out[3] <= 9                # some cv_bin, never the default
+    assert out.dtype.kind in ("i", "u")
+
+
+def test_assign_deplcrv_never_returns_default_for_finite_cv():
+    lib = build_library(np.linspace(0.2, 1.4, 500), ndepl_cv=8, default_curve=np.linspace(1, 0, 11))
+    out = assign_deplcrv(np.full(50, 0.45), lib)
+    assert (out >= 2).all()

--- a/tests/test_snarea_library.py
+++ b/tests/test_snarea_library.py
@@ -12,6 +12,7 @@ from gfv2_params.snarea.library import (
     fit_cv,
     sdc_from_cv,
     snarea_thresh_inches,
+    validate_and_calibrate,
 )
 
 
@@ -134,3 +135,32 @@ def test_assign_deplcrv_never_returns_default_for_finite_cv():
     lib = build_library(np.linspace(0.2, 1.4, 500), ndepl_cv=8, default_curve=np.linspace(1, 0, 11))
     out = assign_deplcrv(np.full(50, 0.45), lib)
     assert (out >= 2).all()
+
+
+def test_calibration_removes_synthetic_bias():
+    rng = np.linspace(0.3, 1.2, 400)
+    emp_curves = np.vstack([sdc_from_cv(c) for c in rng])
+    cv_empirical = rng.copy()
+    cv_subgrid = rng * 0.6  # biased low by construction
+    cal, report = validate_and_calibrate(cv_subgrid, cv_empirical, emp_curves, mode="auto", bias_tol=0.05)
+    assert report["calibrated"] is True
+    # after calibration the median bias vs empirical is much smaller
+    assert abs(np.median(cal) - np.median(cv_empirical)) < abs(
+        np.median(cv_subgrid) - np.median(cv_empirical)
+    )
+
+
+def test_no_calibration_when_unbiased():
+    rng = np.linspace(0.3, 1.2, 400)
+    emp_curves = np.vstack([sdc_from_cv(c) for c in rng])
+    cal, report = validate_and_calibrate(rng.copy(), rng.copy(), emp_curves, mode="auto", bias_tol=0.1)
+    assert report["calibrated"] is False
+    np.testing.assert_allclose(cal, rng)
+
+
+def test_calibration_off_is_identity():
+    rng = np.linspace(0.3, 1.2, 50)
+    emp = np.vstack([sdc_from_cv(c) for c in rng])
+    cal, report = validate_and_calibrate(rng * 0.5, rng, emp, mode="off")
+    np.testing.assert_allclose(cal, rng * 0.5)
+    assert report["calibrated"] is False

--- a/tests/test_snarea_library.py
+++ b/tests/test_snarea_library.py
@@ -1,7 +1,15 @@
 import numpy as np
 import pytest
 
-from gfv2_params.snarea.library import _INTERIOR, CV_GRID, SWE_LEVELS, fit_cv, sdc_from_cv
+from gfv2_params.snarea.library import (
+    _INTERIOR,
+    CV_GRID,
+    SWE_LEVELS,
+    _to_prms_order,
+    fit_cv,
+    sdc_from_cv,
+    snarea_thresh_inches,
+)
 
 
 def test_swe_levels_descending_11pt():
@@ -53,3 +61,18 @@ def test_fit_cv_is_interior_driven():
 
     # They should be distinctly different (not confused by endpoints)
     assert fitted_low < fitted_high
+
+
+def test_snarea_thresh_mm_to_inches():
+    assert snarea_thresh_inches(254.0) == pytest.approx(10.0)
+    assert snarea_thresh_inches(0.0) == 0.0
+    assert snarea_thresh_inches(float("nan")) == 0.0
+    assert snarea_thresh_inches(-5.0) == 0.0
+
+
+def test_to_prms_order_is_reverse_and_involutive():
+    c = sdc_from_cv(0.6)
+    p = _to_prms_order(c)
+    assert p[0] == pytest.approx(c[-1])   # ascending: SCA@frac0 first
+    assert p[-1] == pytest.approx(c[0])
+    assert np.allclose(_to_prms_order(p), c)

--- a/tests/test_snarea_library.py
+++ b/tests/test_snarea_library.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from gfv2_params.snarea.library import SWE_LEVELS, sdc_from_cv
+from gfv2_params.snarea.library import CV_GRID, SWE_LEVELS, fit_cv, sdc_from_cv
 
 
 def test_swe_levels_descending_11pt():
@@ -25,3 +25,17 @@ def test_sdc_from_cv_monotone_nonincreasing():
 def test_sdc_from_cv_higher_cv_steeper():
     # larger CV -> lower SCA at mid SWE (index 5 = SWE 0.5)
     assert sdc_from_cv(1.5)[5] < sdc_from_cv(0.5)[5] < sdc_from_cv(0.1)[5]
+
+
+def test_fit_cv_recovers_known_cv():
+    for true_cv in (0.3, 0.7, 1.2):
+        curve = sdc_from_cv(true_cv)
+        # fit is on the CV grid; recovered value within one grid step
+        assert abs(fit_cv(curve) - true_cv) <= (CV_GRID[1] - CV_GRID[0]) + 1e-9
+
+
+def test_fit_cv_uses_interior_only():
+    # a curve whose endpoints are perturbed but interior matches cv=0.5 still fits ~0.5
+    curve = sdc_from_cv(0.5).copy()
+    curve[0] = 1.0  # endpoints already fixed; assert fit ignores them
+    assert fit_cv(curve) == pytest.approx(0.5, abs=CV_GRID[1] - CV_GRID[0])

--- a/tests/test_snarea_library.py
+++ b/tests/test_snarea_library.py
@@ -45,6 +45,14 @@ def test_sdc_from_cv_higher_cv_steeper():
     assert sdc_from_cv(1.5)[5] < sdc_from_cv(0.5)[5] < sdc_from_cv(0.1)[5]
 
 
+def test_sdc_from_cv_zero_cv_is_finite_step():
+    c = sdc_from_cv(0.0)
+    assert np.isfinite(c).all()
+    assert np.all(np.diff(c) <= 1e-9)          # monotone non-increasing
+    assert c[0] == pytest.approx(1.0) and c[-1] == pytest.approx(0.0)
+    assert c[5] > 0.9                            # ~step: SCA stays high until SWE~0
+
+
 def test_fit_cv_recovers_known_cv():
     for true_cv in (0.32, 0.7, 1.2):
         curve = sdc_from_cv(true_cv)
@@ -193,6 +201,16 @@ def test_calibration_invalid_mode_raises():
     with pytest.raises(ValueError):
         validate_and_calibrate(np.array([0.3, 0.5, 0.7]), np.full(n, np.nan),
                                np.full((n, 11), np.nan), mode="bogus")
+
+
+def test_calibration_degenerate_overlap_is_identity():
+    # all derived-overlap cv_subgrid identical -> quantile domain collapses -> must NOT calibrate
+    n = 50
+    emp = np.vstack([sdc_from_cv(0.6)] * n)
+    cal, report = validate_and_calibrate(np.full(n, 0.4), np.linspace(0.5, 0.9, n), emp,
+                                         mode="on", bias_tol=0.05)
+    assert report["calibrated"] is False
+    np.testing.assert_allclose(cal, np.full(n, 0.4))   # identity, not collapsed to a constant map
 
 
 def test_assemble_params_columns_and_assigned_curve(tmp_path):

--- a/tests/test_snarea_library.py
+++ b/tests/test_snarea_library.py
@@ -3,9 +3,11 @@ import pytest
 
 from gfv2_params.snarea.library import (
     _INTERIOR,
+    CURVE_COLS,
     CV_GRID,
     SWE_LEVELS,
     _to_prms_order,
+    build_library,
     fit_cv,
     sdc_from_cv,
     snarea_thresh_inches,
@@ -76,3 +78,26 @@ def test_to_prms_order_is_reverse_and_involutive():
     assert p[0] == pytest.approx(c[-1])   # ascending: SCA@frac0 first
     assert p[-1] == pytest.approx(c[0])
     assert np.allclose(_to_prms_order(p), c)
+
+
+def test_build_library_default_plus_bins():
+    rng = np.linspace(0.2, 1.4, 500)   # spread of CVs
+    default = np.linspace(1.0, 0.0, 11)
+    lib = build_library(rng, ndepl_cv=8, default_curve=default)
+    assert len(lib) == 9                              # 1 default + 8 bins
+    assert list(lib["deplcrv_id"]) == list(range(1, 10))
+    assert lib.iloc[0]["curve_kind"] == "default"
+    assert np.isnan(lib.iloc[0]["cv"])
+    np.testing.assert_allclose(lib.iloc[0][CURVE_COLS].to_numpy(float), default)
+    assert (lib.iloc[1:]["curve_kind"] == "cv_bin").all()
+    # bin median CVs are increasing
+    assert np.all(np.diff(lib.iloc[1:]["cv"].to_numpy()) > 0)
+    # each cv_bin curve equals sdc_from_cv(its median cv)
+    row = lib.iloc[3]
+    np.testing.assert_allclose(row[CURVE_COLS].to_numpy(float), sdc_from_cv(row["cv"]), atol=1e-9)
+
+
+def test_build_library_equal_population_bins():
+    cv = np.arange(1000) / 1000.0 + 0.1   # uniform
+    lib = build_library(cv, ndepl_cv=5, default_curve=np.linspace(1, 0, 11))
+    assert len(lib) == 6

--- a/tests/test_snarea_library.py
+++ b/tests/test_snarea_library.py
@@ -101,3 +101,17 @@ def test_build_library_equal_population_bins():
     cv = np.arange(1000) / 1000.0 + 0.1   # uniform
     lib = build_library(cv, ndepl_cv=5, default_curve=np.linspace(1, 0, 11))
     assert len(lib) == 6
+
+
+def test_build_library_tied_cvs_still_produce_ndepl_cv_bins():
+    # fit_cv snaps CVs to a grid, so heavy ties are realistic; must NOT collapse.
+    cv = np.concatenate([np.full(1800, 0.45), np.linspace(0.2, 1.4, 200)])
+    lib = build_library(cv, ndepl_cv=8, default_curve=np.linspace(1, 0, 11))
+    assert len(lib) == 9                                  # 1 default + 8 cv bins, no collapse
+    assert (lib.iloc[1:]["curve_kind"] == "cv_bin").all()
+    assert list(lib["deplcrv_id"]) == list(range(1, 10))
+
+
+def test_build_library_raises_when_fewer_cvs_than_bins():
+    with pytest.raises(ValueError, match="at least ndepl_cv"):
+        build_library(np.array([0.4, 0.5, 0.6]), ndepl_cv=8, default_curve=np.linspace(1, 0, 11))

--- a/tests/test_snarea_subgrid.py
+++ b/tests/test_snarea_subgrid.py
@@ -1,0 +1,45 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from gfv2_params.snarea.subgrid import representative_peak_stats
+
+
+def _daily(dates, swe, std):
+    return pd.DataFrame({"swe": swe, "swe_std": std}, index=pd.to_datetime(dates))
+
+
+def test_peak_stats_single_water_year():
+    # one melt season peaking Apr 1 2011: peak swe 200, std 100 -> cv 0.5
+    dates = pd.date_range("2010-10-01", "2011-09-30")
+    swe = np.concatenate([np.linspace(0, 200, 183), np.linspace(200, 0, len(dates) - 183)])
+    std = swe * 0.5
+    out = representative_peak_stats(_daily(dates, swe, std))
+    assert out["n_peak_years"] == 1
+    assert out["cv_subgrid"] == pytest.approx(0.5, abs=1e-6)
+    assert out["peak_swe_mm"] == pytest.approx(200.0, abs=1e-6)
+
+
+def test_peak_stats_no_snow_returns_nan():
+    dates = pd.date_range("2010-10-01", "2011-09-30")
+    out = representative_peak_stats(_daily(dates, np.zeros(len(dates)), np.zeros(len(dates))))
+    assert out["n_peak_years"] == 0
+    assert np.isnan(out["cv_subgrid"])
+
+
+def test_peak_stats_median_across_years():
+    d1 = pd.date_range("2010-10-01", "2011-09-30")
+    d2 = pd.date_range("2011-10-01", "2012-09-30")
+
+    def season(dates, peak, cvf):
+        h = len(dates) // 2
+        swe = np.concatenate([np.linspace(0, peak, h), np.linspace(peak, 0, len(dates) - h)])
+        return swe, swe * cvf
+
+    s1, t1 = season(d1, 100, 0.4)
+    s2, t2 = season(d2, 300, 0.8)
+    df = pd.concat([_daily(d1, s1, t1), _daily(d2, s2, t2)])
+    out = representative_peak_stats(df)
+    assert out["n_peak_years"] == 2
+    assert out["cv_subgrid"] == pytest.approx(0.6, abs=1e-6)   # median(0.4, 0.8)
+    assert out["peak_swe_mm"] == pytest.approx(200.0, abs=1e-6)  # median(100, 300)


### PR DESCRIPTION
## What

Adds the **CV/lognormal `snarea_curve` library** — a compact, physically-based snow-depletion-curve library for PRMS/NHM, replacing the one-curve-per-HRU output. Implements the approved design spec ([`docs/superpowers/specs/2026-07-06-snodas-snarea-curve-library-design.md`](docs/superpowers/specs/2026-07-06-snodas-snarea-curve-library-design.md)) via the plan ([`docs/superpowers/plans/2026-07-06-snodas-snarea-curve-library.md`](docs/superpowers/plans/2026-07-06-snodas-snarea-curve-library.md)). Follow-up to the merged Driscoll pipeline (#165) and the CONUS validation that locked **N≈8, CV/lognormal basis** (memory `sdc_grouping_decision`).

## The three stages (all additive)

- **Stage 1** (`aggregate/`): a `masked_std` sidecar pass emits per-HRU `swe_std` (area-weighted sub-grid SWE std), reusing the cached weights — a cheap extra `AggGen` per year. Gated by a new `SourceAdapter.std_variables` (defaults `()` → no-op for existing sources).
- **Stage 2** (`snarea/`): `representative_peak_stats` (new `subgrid.py`) adds per-HRU `cv_subgrid` = std/mean at each water-year's peak-SWE day (median across years) + `peak_swe_mm`. The empirical Driscoll curve is retained as the validation oracle; Stage 2 now writes `_intermediates/nhm_snarea_curve_derived.csv`.
- **Stage 3** (new `snarea/library.py` + `scripts/derive_snarea_library.py`): pure-tabular builder. Fits `cv_empirical` per derived HRU (vectorized), validates `cv_subgrid` vs `cv_empirical` with an optional monotone quantile-map calibration, resolves per-HRU `cv_assign`, bins into `ndepl_cv` (default 8) + 1 reserved default = **`ndepl`=9** equal-population CV-bin curves, assigns `hru_deplcrv`, and serializes **4 artifacts**: `nhm_snarea_curve_library.csv`, `nhm_snarea_curve_params.csv`, `nhm_snarea_curve_validation.csv`, and the pyWatershed/PRMS **`nhm_snarea_curve.nc`** (verified ascending frac_swe). Re-runnable at any `ndepl_cv` in seconds — no daily reload.

The model's shape/scale split is honored: the groupable **shape** (`snarea_curve`, indexed by CV) is decoupled from per-HRU **scale** (`snarea_thresh`, emitted in inches).

## How it was built & reviewed

Subagent-driven TDD, 16 tasks, fresh reviewer per task + a final opus whole-branch review (**READY TO MERGE**). The review gate caught and fixed **2 real Critical bugs** (tie-collapse in the CV binning under grid-snapped ties; a missing `≥2-overlap` guard for calibration `mode="on"`), an Important vacuous test, and a plan gap (`cv_empirical` was read as a phantom column — now computed vectorized, which also removed a per-HRU `_library_matrix` rebuild). Cross-task integration verified end-to-end (Stage 1→2→3 column contract, `id_feature` threading, descending↔ascending curve convention).

## Verification

- **All 53 branch test files pass** on the final HEAD (`test_snarea_library` 25, `_subgrid` 3, `_build` 5, `derive_snarea_curve` 7, `aggregate_{adapter,driver,snodas}`). New deps: `pywatershed` in an isolated `reference` pixi feature (python-3.10, `no-default-feature`, own solve-group — does **not** touch default/dev/docs/notebooks, verified at the lockfile level). CI (pytest) is the merge gate.
- pyWatershed NetCDF curve-order convention independently verified (a wrong order would invert every curve).

## Rollout (post-merge, not in this PR)

Stage 1 must be **re-run once** to add `swe_std` (weights cached → cheap), then Stage 2, then Stage 3. Validate on Oregon (`FABRIC=oregon`) then CONUS (`FABRIC=gfv2`, Stage 2 at `--mem=384G`); inspect `nhm_snarea_curve_validation.csv` (cv_subgrid vs cv_empirical, reconstruction, calibration, coverage). See RUNME Step 8 / HPC_REFERENCE.

## Notes

- Deferred Minors (non-blocking, per the final review): a diagnostic `_recon_error` Python loop (within the 16G/30-min batch envelope), and a raw `KeyError` if Stage 2 is run against a pre-`swe_std` NC (documented rollout re-runs Stage 1 first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
