### PR TITLE
docs(depstor): stop naming retired conus_waterbodies.gpkg in builder docstrings

### DIFF
--- a/src/gfv2_params/depstor_builders/dprst_depth.py
+++ b/src/gfv2_params/depstor_builders/dprst_depth.py
@@ -112,7 +112,7 @@ def _load_dprst_polygons(ctx: BuildContext, logger) -> gpd.GeoDataFrame:
     fabric clip to `topo.load_fabric_dprst_polygons` — the SAME shared helper
     the SLURM plan hook (`tiling.py::_load_and_tag_for_plan`) calls, so the
     in-process builder path and the array/plan path can't diverge (both
-    reconstruct from `conus_waterbodies.gpkg` + the COMID union and clip to
+    reconstruct from the profile's `waterbody_gpkg` layer + the COMID union and clip to
     the fabric's HRU extent — without that clip a regional fabric would
     process the whole CONUS dprst set).
     """

--- a/src/gfv2_params/depstor_builders/waterbody.py
+++ b/src/gfv2_params/depstor_builders/waterbody.py
@@ -256,7 +256,7 @@ def merge_burn_add(
 def _concat_burn(wb_gdf: gpd.GeoDataFrame, burn: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
     """Append the (guard-cleared) BurnAdd rows to the waterbody frame."""
     burn = burn[wb_gdf.columns].copy()
-    # `member_comid` is a plain string in the real conus_waterbodies.gpkg, but
+    # `member_comid` is a plain string in the real waterbody layer, but
     # burn_add_to_waterbody_frame (Task 1) emits it as int64 (same value as COMID).
     # Left un-normalised, pd.concat below produces an `object` column with mixed
     # str/int rows. Nothing downstream reads it today -- select_connected_waterbodies

--- a/src/gfv2_params/dprst_depth/topo.py
+++ b/src/gfv2_params/dprst_depth/topo.py
@@ -63,9 +63,9 @@ def _read_vector_arrow(path, layer, columns, logger):
 def _clip_dprst_to_fabric(dprst, hru_gpkg, hru_layer, logger):
     """Keep only dprst polygons that intersect the fabric's HRU geometry.
 
-    The dprst polygon set is reconstructed from the SHARED CONUS
-    `conus_waterbodies.gpkg` (every fabric profile points `waterbody_gpkg`
-    there), so without this clip a regional fabric (e.g. oregon) would
+    The dprst polygon set is reconstructed from the profile's `waterbody_gpkg`
+    layer (the shared CONUS NHDPlus waterbodies), so without this clip a regional
+    fabric (e.g. oregon) would
     reconstruct and process the ENTIRE CONUS dprst set (~321k polygons),
     not its own — defeating the "prove it on a small fabric first" workflow
     and making a regional run cost the same as CONUS. Bbox-prefilter against
@@ -112,7 +112,7 @@ def load_fabric_dprst_polygons(
 
       1. Union the connected(WBAREACOMI) COMID set with the optional
          flow-through COMID set.
-      2. Load `conus_waterbodies.gpkg` and reconstruct the dprst polygon set
+      2. Load the profile's `waterbody_gpkg` layer and reconstruct the dprst polygon set
          (`dprst_polygons`: drop on-stream, force-Playa-dprst, exclude Ice Mass).
       3. Clip to the fabric's HRU geometry (`_clip_dprst_to_fabric`) — the
          fix for the CONUS-scope bug (a regional fabric would otherwise
@@ -487,7 +487,7 @@ def read_window(geom, best_topo: str, wesm_row=None, rim_buffer_m: float = 200.0
     caller has provenance for Phase 1 bucketing.
 
     `geom` is expected in EPSG:5070 — the CRS of the shipped dprst polygon set
-    (`conus_waterbodies.gpkg`), which is also this function's `dst_crs`, so
+    (the profile's `waterbody_gpkg` layer), which is also this function's `dst_crs`, so
     `rim_buffer_m` (metres) adds directly to `geom.bounds` with no reprojection.
     The 10 m tile grid is named by lon/lat, so only the centroid is reprojected
     to EPSG:4326 (via `transform_geom`) to resolve the tile name; the 1 m grid

--- a/src/gfv2_params/endorheic.py
+++ b/src/gfv2_params/endorheic.py
@@ -166,7 +166,7 @@ def closed_basin_comids(
     Dissolve first, then measure: a lake straddling two *adjacent* closed HUC12s is
     fully inside the closed system but majority-inside neither polygon on its own.
 
-    A waterbody is a COMID, not a row: `conus_waterbodies.gpkg` stores multi-part
+    A waterbody is a COMID, not a row: the waterbody layer stores multi-part
     waterbodies as multiple rows sharing one COMID (448,124 rows, strictly fewer
     unique COMIDs). Area and intersection-area are summed across all of a COMID's
     rows BEFORE dividing, so a COMID is never decided on the strength of one row


### PR DESCRIPTION
Comment/docstring-only cleanup, the follow-up flagged during the dprst_depth reference work.

The `gfv2` profile now reads the source-derived `nhd_waterbodies.gpkg` (PR #179), but several builder docstrings still named the retired hand-made `conus_waterbodies.gpkg` as the layer they load — misleading a reader who trusts the comment. Reworded to the profile key (`waterbody_gpkg`) or "the waterbody layer" so they stay correct across the repoint and across fabrics (which point at different layers).

- `dprst_depth/topo.py` (×3), `depstor_builders/dprst_depth.py`, `endorheic.py`, `depstor_builders/waterbody.py`.
- Left untouched: `download/nhd_waterbodies.py` and `download/nhd_burn_components.py`, which legitimately reference `conus_waterbodies.gpkg` as the layer they reverse-engineer / compare against.

No code change (`py_compile` clean).
