### PR TITLE
feat(dprst_depth): fail hard on a mass read-failure and a missing provenance parquet

### DIFF
--- a/configs/depstor/depstor_rasters.yml
+++ b/configs/depstor/depstor_rasters.yml
@@ -24,6 +24,7 @@ imperv_source: "{data_root}/input/lulc/nlcd_annual_imperv/Annual_NLCD_FctImp_201
 # base_config.yml alongside waterbody_gpkg/connected_comids_table).
 dprst_depth_floor_in: 49.0 # NHM calibrated dprst_depth_avg median fallback (in)
 dprst_hollister_n_min: 5 # min donors/group before a calibrated-Hollister fit is attempted
+dprst_depth_min_measured_frac: 0.5 # measured_fraction floor below which a mass read-failure RAISEs; 0 disables
 
 steps:
   - name: landmask

--- a/docs/dprst_depth_avg_reference.md
+++ b/docs/dprst_depth_avg_reference.md
@@ -31,7 +31,7 @@ storage*, this decides *how deep each one is* — it runs **after** `dprst`
 | File | Declares (for depth) | Read by |
 |---|---|---|
 | [`base_config.yml`](../configs/base_config.yml) | the `gfv2` profile keys the builder reads: `waterbody_gpkg`, `connected_comids_table`, `flowthrough_comids_table`, `hru_gpkg`, `wesm_index`, `ecoregions_gpkg`, `template_raster` | the builder |
-| [`depstor/depstor_rasters.yml`](../configs/depstor/depstor_rasters.yml) | the `dprst_depth` **step** (`batch_dir`, outputs) + two top-level knobs: `dprst_depth_floor_in: 49.0` ([:25](../configs/depstor/depstor_rasters.yml#L25)) and `dprst_hollister_n_min: 5` ([:26](../configs/depstor/depstor_rasters.yml#L26)) | `build_depstor_rasters.py` |
+| [`depstor/depstor_rasters.yml`](../configs/depstor/depstor_rasters.yml) | the `dprst_depth` **step** (`batch_dir`, outputs) + three top-level knobs: `dprst_depth_floor_in: 49.0` ([:25](../configs/depstor/depstor_rasters.yml#L25)), `dprst_hollister_n_min: 5` ([:26](../configs/depstor/depstor_rasters.yml#L26)), and `dprst_depth_min_measured_frac: 0.5` ([:27](../configs/depstor/depstor_rasters.yml#L27)) | `build_depstor_rasters.py` |
 | [`depstor/depstor_params.yml`](../configs/depstor/depstor_params.yml) | the `means:` `dprst_depth_avg` entry — `source_raster` (`dprst_depth.tif`), `provenance_source` (`dprst_depth_polygons.parquet`), `floor_in: 49.0` ([:109](../configs/depstor/depstor_params.yml#L109)) | `derive_depstor_params.py` |
 
 `dprst_depth_avg` is the pipeline's only **`means:`** parameter — a continuous
@@ -64,9 +64,11 @@ A depth physically comes from one of two 3DEP products, chosen per polygon:
 
 There is **no staged DEM and no elevation config key** — all elevation is live
 `/vsicurl` S3. Consequences the doc calls out under [§4](#4-staleness--maintenance):
-a network/firewall regression does not crash the builder — it degrades to a
-**mass-floored** product, because the builder only **warns** (never aborts) when
-under 50% of polygons get a measured depth.
+a network/firewall regression no longer produces a silently **mass-floored**
+product — `_fill_and_join` **raises `RuntimeError`** when under
+`dprst_depth_min_measured_frac` (default 0.5, `depstor_rasters.yml`) of
+polygons get a measured depth. Set the knob to `0` to disable (escape hatch
+for a legitimately high-flattening small fabric).
 
 ---
 
@@ -229,18 +231,6 @@ batches):
 
 ### Operational risks — *not* defects, but worth guarding
 
-- **Silent mass-floor on network failure.** Because elevation is live `/vsicurl`
-  S3 and the builder only **warns** (never aborts) when < 50% of polygons get a
-  measured depth, a firewall/S3 outage produces a product where everything is the
-  49-in floor — numerically valid, physically meaningless. This is the same class
-  of failure as the PROJ-network firewall issue already in the project's memory.
-  A CONUS run should be sanity-checked against the `method` distribution in
-  `dprst_depth_polygons.parquet` (expect `measured` to dominate).
-- **Provenance can silently degrade to `unknown`.** If
-  `dprst_depth_polygons.parquet` is missing at finalize time, `dprst_depth_avg`
-  is still computed correctly but every HRU's `dprst_depth_provenance` becomes
-  `unknown` (warn, not raise). The numeric param is robust; the provenance column
-  is the fragile part.
 - **`op_flow_thres` is a placeholder constant (1.0), not a derived product.** It
   is a per-HRU CSV in shape only, matching legacy ArcPy. No spatial computation
   stands behind it; nothing in the depstor DAG consumes it.
@@ -251,10 +241,24 @@ batches):
   `dprst_depth.py` and `topo.py` docstrings had named `conus_waterbodies.gpkg`;
   they now reference the profile's `waterbody_gpkg` layer, so they stay correct
   across the #179 repoint and across fabrics.
-- **The two operational risks above are not yet guarded in code.** A
-  measured-fraction hard-fail (so a 3DEP/S3 outage aborts rather than shipping a
-  mass-floored product) and a raise-on-missing-provenance are open follow-ups —
-  see the risk bullets, not yet implemented.
+- **Silent mass-floor on network failure — fixed (robustness guards).** Because
+  elevation is live `/vsicurl` S3, a firewall/S3 outage used to only **warn**
+  (never abort) when < 50% of polygons got a measured depth, silently shipping a
+  product where everything is the 49-in floor — numerically valid, physically
+  meaningless. This is the same class of failure as the PROJ-network firewall
+  issue already in the project's memory. `_fill_and_join` now **raises
+  `RuntimeError`** below `dprst_depth_min_measured_frac` (default 0.5; `0`
+  disables it as an escape hatch). A CONUS run should still be sanity-checked
+  against the `method` distribution in `dprst_depth_polygons.parquet` (expect
+  `measured` to dominate).
+- **Provenance silently degrading to `unknown` — fixed (robustness guards).**
+  If `dprst_depth_polygons.parquet` (a *configured* `provenance_source`) is
+  missing at finalize time, `run_mean_finalize` now **raises
+  `FileNotFoundError`** instead of warning and silently marking every HRU's
+  `dprst_depth_provenance` as `unknown` — a declared-but-missing
+  `provenance_source` means the builder run is incomplete/broken. Unconfigured
+  `provenance_source` (not this parameter's case) is unaffected: provenance
+  stays simply absent, no raise.
 
 ---
 

--- a/scripts/build_depstor_rasters.py
+++ b/scripts/build_depstor_rasters.py
@@ -113,6 +113,7 @@ def _build_context(config: dict, force: bool) -> BuildContext:
         ecoregions_gpkg=Path(config["ecoregions_gpkg"]) if config.get("ecoregions_gpkg") else None,
         dprst_depth_floor_in=float(config.get("dprst_depth_floor_in", 49.0)),
         dprst_hollister_n_min=int(config.get("dprst_hollister_n_min", 5)),
+        dprst_depth_min_measured_frac=float(config.get("dprst_depth_min_measured_frac", 0.5)),
         force=force,
     )
 

--- a/scripts/derive_depstor_params.py
+++ b/scripts/derive_depstor_params.py
@@ -119,6 +119,41 @@ def _find_mean(config: dict, name: str) -> dict:
     raise ValueError(f"Mean aggregation '{name}' not in config; available: {available}")
 
 
+def _resolve_provenance_df(provenance_source, hru_gdf, id_feature):
+    """Resolve `run_mean_finalize`'s per-HRU `provenance_df`, or raise.
+
+    `provenance_source` (a `means[].provenance_source` config value, e.g.
+    `dprst_depth`'s companion `dprst_depth_polygons.parquet`) is optional —
+    `None`/empty means no provenance is expected for this mean, and this
+    returns `None` (provenance stays absent downstream, unchanged behavior).
+
+    But if a `provenance_source` IS configured, it declares that a builder
+    run was supposed to produce that parquet. A missing file at that point
+    means the builder run is incomplete/broken — silently shipping
+    `dprst_depth_avg` with `dprst_depth_provenance` == "unknown" for every
+    HRU hides exactly that failure, so this raises `FileNotFoundError`
+    instead of warning.
+    """
+    import geopandas as gpd
+
+    from gfv2_params.dprst_depth.aggregate import area_weighted_provenance
+
+    if not provenance_source:
+        return None
+    prov_path = Path(provenance_source)
+    if not prov_path.exists():
+        raise FileNotFoundError(
+            f"provenance_source configured but not found: {prov_path} -- "
+            f"the builder run that should have produced this parquet appears "
+            f"incomplete or broken. Refusing to silently ship "
+            f"dprst_depth_avg with dprst_depth_provenance='unknown' for "
+            f"every HRU. Re-run the builder (dprst_depth) before finalizing, "
+            f"or fix the provenance_source path if it's stale."
+        )
+    polygons_gdf = gpd.read_parquet(prov_path)
+    return area_weighted_provenance(polygons_gdf, hru_gdf, id_feature)
+
+
 def _merge_paths(config: dict) -> tuple[Path, Path]:
     """Return (intermediates_dir, ratios_dir).
 
@@ -276,7 +311,7 @@ def run_mean_finalize(args, logger) -> None:
     """
     import geopandas as gpd
 
-    from gfv2_params.dprst_depth.aggregate import area_weighted_provenance, finalize_depth_params
+    from gfv2_params.dprst_depth.aggregate import finalize_depth_params
 
     config = _load_resolved_config(args)
     defaults = config["defaults"]
@@ -324,19 +359,8 @@ def run_mean_finalize(args, logger) -> None:
     hru_gdf = gpd.read_file(hru_gpkg, layer=hru_layer, columns=[id_feature])
     hru_ids = hru_gdf[id_feature]
 
-    provenance_df = None
     provenance_source = spec.get("provenance_source")
-    if provenance_source:
-        prov_path = Path(provenance_source)
-        if prov_path.exists():
-            polygons_gdf = gpd.read_parquet(prov_path)
-            provenance_df = area_weighted_provenance(polygons_gdf, hru_gdf, id_feature)
-        else:
-            logger.warning(
-                "  provenance_source configured but not found: %s -- "
-                "dprst_depth_provenance will be '%s' for every HRU with dprst cells",
-                prov_path, "unknown",
-            )
+    provenance_df = _resolve_provenance_df(provenance_source, hru_gdf, id_feature)
 
     out_df = finalize_depth_params(
         zonal_df, hru_ids, id_feature, floor_in=floor_in, provenance_df=provenance_df,

--- a/src/gfv2_params/depstor_builders/context.py
+++ b/src/gfv2_params/depstor_builders/context.py
@@ -72,6 +72,13 @@ class BuildContext:
     # fit_ecoregion_models attempts a CV-compared calibrated-Hollister fit
     # (fill.N_MIN_DEFAULT).
     dprst_hollister_n_min: int = 5
+    # Completeness gate on `_fill_and_join`'s measured_fraction (n_computed /
+    # n_total polygons with a real computed depth, before the fallback
+    # ladder). Below this, RAISE — a systemic read failure (S3 outage, HPC
+    # firewall regression), not genuine hydro-flattening. `0` (or negative)
+    # disables the guard (escape hatch for a legitimately high-flattening
+    # small fabric).
+    dprst_depth_min_measured_frac: float = 0.5
     paths: dict[str, Path] = field(default_factory=dict)
     force: bool = False
 

--- a/src/gfv2_params/depstor_builders/dprst_depth.py
+++ b/src/gfv2_params/depstor_builders/dprst_depth.py
@@ -291,17 +291,33 @@ def _fill_and_join(dprst: gpd.GeoDataFrame, depth_df: pd.DataFrame, ctx: BuildCo
         n_computed, n_total,
     )
 
-    # (#173 FIX 3) Completeness gate: a mass read-failure (S3 outage / HPC
-    # firewall regression — this project has hit this class before, see
-    # proj_network_firewall_inf) would otherwise ship a mostly-floored
-    # product with only INFO-level breadcrumbs. Flag loudly, don't abort.
+    # (#173 FIX 3, hardened by the robustness guards) Completeness gate: a
+    # mass read-failure (S3 outage / HPC firewall regression — this project
+    # has hit this class before, see proj_network_firewall_inf) would
+    # otherwise ship a mostly-floored product with only INFO-level
+    # breadcrumbs. Originally "flag loudly, don't abort" (a WARNING); now
+    # FAILS HARD by default — at CONUS scale genuine hydro-flattening only
+    # takes out ~11-22%, so a legitimate run sits near ~0.8 measured, and
+    # `< 0.5` means a systemic read failure, not flattening. Configurable via
+    # `ctx.dprst_depth_min_measured_frac` (`dprst_depth_min_measured_frac` in
+    # depstor_rasters.yml, default 0.5); set it to `0` (or negative) to
+    # disable the guard as an escape hatch for a legitimately
+    # high-flattening small fabric.
     measured_fraction = n_computed / n_total if n_total else 1.0
-    if measured_fraction < 0.5:
-        logger.warning(
-            "  only %.1f%% (%d/%d) of polygons have a computed depth — "
-            "investigate: possible systemic read failure (S3 outage, HPC "
-            "network/firewall regression) rather than genuine hydro-flattening",
-            100 * measured_fraction, n_computed, n_total,
+    threshold = ctx.dprst_depth_min_measured_frac
+    if threshold > 0 and measured_fraction < threshold:
+        raise RuntimeError(
+            f"only {100 * measured_fraction:.1f}% ({n_computed}/{n_total}) of "
+            f"dprst polygons have a computed depth — below the "
+            f"dprst_depth_min_measured_frac threshold ({threshold:.2f}). This "
+            f"almost certainly indicates a systemic read failure (S3 outage, "
+            f"HPC network/firewall regression — this project has hit this "
+            f"class before, see proj_network_firewall_inf) rather than "
+            f"genuine hydro-flattening, which fails only ~11-22% of polygons "
+            f"at CONUS scale. Investigate the 3DEP /vsicurl/ reads before "
+            f"re-running. Set dprst_depth_min_measured_frac to 0 (or "
+            f"negative) in depstor_rasters.yml to disable this guard, only "
+            f"if this fabric is legitimately high-flattening."
         )
 
     _log_achieved_resolution(dprst, merged, logger)

--- a/tests/test_dprst_depth.py
+++ b/tests/test_dprst_depth.py
@@ -429,6 +429,65 @@ def test_derive_depstor_params_mean_modes_wired():
         module._find_mean(config, "not_a_real_mean")
 
 
+# ---------------------------------------------------------------------------
+# Robustness guard 2: `run_mean_finalize`'s provenance_source resolution must
+# RAISE FileNotFoundError when a *configured* provenance_source is missing on
+# disk -- shipping dprst_depth_avg with every HRU silently mislabeled
+# "unknown" is exactly the failure to stop. Extracted as `_resolve_provenance_df`
+# (the tightest testable seam -- `run_mean_finalize` itself reads batch CSVs +
+# the master HRU gpkg via `_load_resolved_config`, which needs a real fabric
+# profile to exercise end-to-end).
+# ---------------------------------------------------------------------------
+
+
+def _load_derive_depstor_params_module():
+    """Load scripts/derive_depstor_params.py as a module -- mirrors
+    tests/test_dprst_depth_probe.py's importlib pattern (the script isn't a
+    package, so pytest can't `import` it directly)."""
+    spec = importlib.util.spec_from_file_location(
+        "derive_depstor_params",
+        Path(__file__).resolve().parent.parent / "scripts" / "derive_depstor_params.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_resolve_provenance_df_raises_on_missing_path(tmp_path):
+    module = _load_derive_depstor_params_module()
+    hru_gdf = gpd.GeoDataFrame({"hru_id": [1], "geometry": [box(0, 0, 1, 1)]}, crs=_CRS)
+    missing_path = tmp_path / "does_not_exist.parquet"
+
+    with pytest.raises(FileNotFoundError, match=str(missing_path)):
+        module._resolve_provenance_df(str(missing_path), hru_gdf, "hru_id")
+
+
+def test_resolve_provenance_df_returns_none_when_unconfigured():
+    module = _load_derive_depstor_params_module()
+    hru_gdf = gpd.GeoDataFrame({"hru_id": [1], "geometry": [box(0, 0, 1, 1)]}, crs=_CRS)
+
+    assert module._resolve_provenance_df(None, hru_gdf, "hru_id") is None
+    assert module._resolve_provenance_df("", hru_gdf, "hru_id") is None
+
+
+def test_resolve_provenance_df_reads_real_parquet(tmp_path):
+    """Positive path: an existing provenance_source is read and aggregated
+    via `area_weighted_provenance` (same shape as
+    `test_area_weighted_provenance_dominant_by_area`)."""
+    module = _load_derive_depstor_params_module()
+    polygons_gdf = gpd.GeoDataFrame(
+        {"method": ["measured"], "geometry": [box(0, 0, 40, 40)]}, crs=_CRS,
+    )
+    prov_path = tmp_path / "dprst_depth_polygons.parquet"
+    polygons_gdf.to_parquet(prov_path)
+    hru_gdf = gpd.GeoDataFrame({"hru_id": [1], "geometry": [box(-10, -10, 110, 110)]}, crs=_CRS)
+
+    out = module._resolve_provenance_df(str(prov_path), hru_gdf, "hru_id")
+
+    assert out is not None
+    assert out.set_index("hru_id").loc[1, "dprst_depth_provenance"] == "measured"
+
+
 def test_dprst_depth_skips_when_outputs_exist(tmp_path, monkeypatch):
     tmpl, lm, dm = _write_template_and_landmask(tmp_path)
     depth_out = tmp_path / "dprst_depth.tif"
@@ -460,6 +519,102 @@ def test_dprst_depth_skips_when_outputs_exist(tmp_path, monkeypatch):
 # (tiling.py --plan) populates batch_dir, previously exercised only by the
 # in-process branch (test_dprst_depth_build_end_to_end, no batch_dir).
 # ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Robustness guard 1: `_fill_and_join`'s measured_fraction completeness gate
+# must RAISE (not just warn) on a mass read-failure, with a configurable
+# threshold (`ctx.dprst_depth_min_measured_frac`, default 0.5) and a `0`/
+# negative escape hatch.
+# ---------------------------------------------------------------------------
+
+
+def _make_dprst_gdf(comids):
+    """Minimal fabric-clipped dprst polygon set, post-`_tag_polygons` shape:
+    carries `ecoregion`/`ftype` (which `_tag_polygons` normally sets from the
+    EPA ecoregions gpkg / `FTYPE` before `_fill_and_join` ever runs)."""
+    n = len(comids)
+    return gpd.GeoDataFrame(
+        {
+            "COMID": comids,
+            "ecoregion": ["17"] * n,
+            "ftype": ["LakePond"] * n,
+        },
+        geometry=[box(i * 10, 0, i * 10 + 1, 1) for i in range(n)],
+        crs=_CRS,
+    )
+
+
+def _make_depth_df(comids):
+    """A `depth_df` row per COMID -- non-flat, genuinely measured."""
+    return pd.DataFrame(
+        {
+            "COMID": comids,
+            "dprst_depth_m": [1.0] * len(comids),
+            "measured_max_m": [1.5] * len(comids),
+            "hollister_max_m": [1.2] * len(comids),
+            "flat": [False] * len(comids),
+            "resolution": ["10m"] * len(comids),
+            "method": ["measured"] * len(comids),
+        }
+    )
+
+
+def test_fill_and_join_raises_on_mass_read_failure():
+    """10 polygons, only 3 with a computed depth -> 30% measured, well below
+    the default 0.5 threshold -- must RAISE, not warn."""
+    dprst = _make_dprst_gdf(list(range(1, 11)))
+    depth_df = _make_depth_df([1, 2, 3])  # only COMIDs 1-3 got a computed depth
+
+    ctx = BuildContext(
+        fabric="t", template_path=Path("unused"), output_dir=Path("unused"),
+        hru_gpkg=Path("unused"), hru_layer="nhru",
+    )
+
+    with pytest.raises(RuntimeError, match=r"30\.0%|3/10|measured"):
+        dprst_depth._fill_and_join(dprst, depth_df, ctx, _L())
+
+
+def test_fill_and_join_does_not_raise_on_healthy_fraction():
+    """10 polygons, 8 with a computed depth -> 80% measured, comfortably
+    above the default 0.5 threshold -- must NOT raise."""
+    dprst = _make_dprst_gdf(list(range(1, 11)))
+    depth_df = _make_depth_df(list(range(1, 9)))  # COMIDs 1-8 computed
+
+    ctx = BuildContext(
+        fabric="t", template_path=Path("unused"), output_dir=Path("unused"),
+        hru_gpkg=Path("unused"), hru_layer="nhru",
+    )
+
+    out = dprst_depth._fill_and_join(dprst, depth_df, ctx, _L())
+    assert len(out) == 10
+    assert out["dprst_depth_m"].notna().all()
+
+
+def test_fill_and_join_escape_hatch_disables_guard():
+    """Same mass-read-failure inputs as the raising test above, but
+    `dprst_depth_min_measured_frac=0` (the documented escape hatch) must
+    disable the guard entirely -- no raise."""
+    dprst = _make_dprst_gdf(list(range(1, 11)))
+    depth_df = _make_depth_df([1, 2, 3])
+
+    ctx = BuildContext(
+        fabric="t", template_path=Path("unused"), output_dir=Path("unused"),
+        hru_gpkg=Path("unused"), hru_layer="nhru",
+        dprst_depth_min_measured_frac=0.0,
+    )
+
+    out = dprst_depth._fill_and_join(dprst, depth_df, ctx, _L())
+    assert len(out) == 10
+    assert out["dprst_depth_m"].notna().all()
+
+
+def test_build_context_dprst_depth_min_measured_frac_default():
+    ctx = BuildContext(
+        fabric="t", template_path=Path("unused"), output_dir=Path("unused"),
+        hru_gpkg=Path("unused"), hru_layer="nhru",
+    )
+    assert ctx.dprst_depth_min_measured_frac == pytest.approx(0.5)
 
 
 def test_compute_depths_ingests_and_dedupes_batch_parquets(tmp_path):


### PR DESCRIPTION
Implements the two robustness guards the `dprst_depth_avg` reference (#181/#184) flagged as open follow-ups. Both convert a silent `logger.warning` into a hard failure — the depth number is read live from 3DEP over `/vsicurl` S3, so a firewall/outage otherwise ships a silently mass-floored product (same class as the PROJ-firewall issue this project has hit before).

**Guard 1 — mass read-failure (builder).** The `measured_fraction` completeness gate now **raises** when below a configurable floor `dprst_depth_min_measured_frac` (default **0.5**) instead of only warning. At CONUS scale genuine hydro-flattening only takes out ~11–22% of polygons, so a legitimate run sits near ~0.8; `< 0.5` means a systemic read failure. **This reverses the prior "flag loudly, don't abort" decision** — with a config escape hatch (set the knob to `0`/negative to disable, for a legitimately high-flattening small fabric). Wired through `BuildContext`, `build_depstor_rasters.py`, and `depstor_rasters.yml` alongside the existing depth knobs.

**Guard 2 — missing provenance (finalize).** A *configured* `provenance_source` that's absent on disk now raises `FileNotFoundError` instead of silently marking every HRU `dprst_depth_provenance = "unknown"`. Unconfigured provenance is unaffected. Factored as `_resolve_provenance_df` for testability.

**Testing:** 7 new tests (4 + 3), red→green; full `tests/test_dprst_depth*.py` suite **71 passed**, no regressions. Docs updated to mark both risks resolved.

Scope note (per repo convention): guard 1 is a deliberate behavior reversal, mitigated by the escape-hatch knob.
