### PR TITLE
feat(params)!: canonical merged/ parameter set + declaration-driven gap-fill

### DIFF
--- a/configs/depstor/depstor_params.yml
+++ b/configs/depstor/depstor_params.yml
@@ -32,6 +32,12 @@ defaults:
   categorical: false
   count_column: count
 
+# NB for scripts/merge_and_fill_params.py: every `fractions` entry below carries
+# a `merged_file` key, but that key names the per-fraction COUNT csv written to
+# merged/_intermediates/ (see derive_depstor_params.py run_merge) -- never a
+# merged/ output. Fractions are intermediates, not consumer-facing params, and
+# are NOT declared `fill_columns` / NOT filled. Only `means` (merged_file) and
+# `ratios` (output_file) below land in merged/ and carry fill_columns.
 fractions:
   - name: perv_frac
     source_raster: "{data_root}/{fabric}/depstor_rasters/perv_binary.tif"
@@ -109,6 +115,12 @@ means:
     floor_in: 49.0
     units_in_raster: metres
     units_out: inches
+    # Observed on-disk header: hru_id,dprst_depth_avg,dprst_depth_provenance.
+    # dprst_depth_provenance (3dep_raw / hollister_flat / calibrated /
+    # no_dprst_cells) records HOW the value was derived per HRU -- provenance,
+    # not a PRMS parameter -- and is deliberately excluded, same reasoning as
+    # snarea_curve's cv_* columns.
+    fill_columns: [dprst_depth_avg]
 
 # Ratio derivations -- final PRMS parameters in {output_dir}/{merged_subdir}/.
 # numerator/denominator reference fraction `name`s above; derive_depstor_params
@@ -124,24 +136,28 @@ ratios:
     denominator: perv_frac
     clamp_to_one: false
     output_file: nhm_sro_to_dprst_perv_params.csv
+    fill_columns: [sro_to_dprst_perv]
 
   - name: sro_to_dprst_imperv
     numerator: drains_imperv_frac
     denominator: imperv_frac
     clamp_to_one: false
     output_file: nhm_sro_to_dprst_imperv_params.csv
+    fill_columns: [sro_to_dprst_imperv]
 
   - name: carea_max
     numerator: carea_t8_frac
     denominator: perv_frac
     clamp_to_one: true
     output_file: nhm_carea_max_params.csv
+    fill_columns: [carea_max]
 
   - name: smidx_coef
     numerator: carea_t156_frac
     denominator: perv_frac
     clamp_to_one: true
     output_file: nhm_smidx_coef_params.csv
+    fill_columns: [smidx_coef]
 
   # imperv_count / hru_pixel_count -- per-HRU fraction of land area classified
   # as impervious. Bounded in [0, 1] by construction.
@@ -150,6 +166,7 @@ ratios:
     denominator: hru_total
     clamp_to_one: false
     output_file: nhm_hru_percent_imperv_params.csv
+    fill_columns: [hru_percent_imperv]
 
   # dprst_count / hru_pixel_count -- per-HRU fraction of land area classified
   # as depression storage. Bounded in [0, 1] by construction.
@@ -162,3 +179,4 @@ ratios:
     denominator: hru_total
     clamp_to_one: false
     output_file: nhm_dprst_frac_params.csv
+    fill_columns: [dprst_frac]

--- a/configs/snarea/snarea_library.yml
+++ b/configs/snarea/snarea_library.yml
@@ -7,6 +7,30 @@ params_file: nhm_snarea_curve_params.csv
 validation_file: nhm_snarea_curve_validation.csv
 netcdf_file: nhm_snarea_curve.nc
 
+# scripts/merge_and_fill_params.py: fill_columns for `params_file` above.
+# Observed on-disk header: hru_id,hru_deplcrv,snarea_thresh,cv_assign,
+# cv_subgrid,cv_empirical,cv_source,sdc_status,sca_class,similarity,
+# n_seasons,n_peak_years,peak_swe_mm,snarea_curve_0..snarea_curve_10.
+# cv_* / cv_source / sdc_status / sca_class / similarity / n_seasons /
+# n_peak_years / peak_swe_mm are DELIBERATELY absent: NaN there means "not
+# derivable" (cv_empirical is derivable for only ~42% of HRUs by design;
+# cv_subgrid rescues the rest), which is a RESULT. Filling them would replace
+# the record of how each curve was derived with noise.
+fill_columns:
+  - hru_deplcrv
+  - snarea_thresh
+  - snarea_curve_0
+  - snarea_curve_1
+  - snarea_curve_2
+  - snarea_curve_3
+  - snarea_curve_4
+  - snarea_curve_5
+  - snarea_curve_6
+  - snarea_curve_7
+  - snarea_curve_8
+  - snarea_curve_9
+  - snarea_curve_10
+
 ndepl_cv: 8 # 8 CV bins + 1 reserved default = ndepl 9 (grouping memory: elbow 5-8)
 calibrate: auto # auto | on | off
 calibrate_bias_tol: 0.1 # |median(cv_subgrid) - median(cv_empirical)| trigger

--- a/configs/zonal/zonal_params.yml
+++ b/configs/zonal/zonal_params.yml
@@ -107,12 +107,16 @@ params:
     crosswalk_file: crosswalks/nhm_v11_nhm.csv # cov_type mapping only
     categorical: true
     merged_file: nhm_lulc_nhm_v11_params.csv
-    # Observed on-disk header (oregon + gfv2). NB: the current
-    # zonal_runners/lulc_prederived.py builder computes `rad_trncf` (Beer's-law
-    # transform), not `retention` -- the on-disk merged CSVs predate that
-    # rename and still carry `retention`. Declaring `retention` matches what a
-    # fill run actually finds in the file today; Task 1's guard raises loudly
-    # (not a silent skip) if a future regen renames the column to `rad_trncf`.
+    # Observed on-disk header: gfv2/oregon still carry `retention` (built before
+    # the zonal_runners/lulc_prederived.py rename); tjc (built after the rename)
+    # carries `rad_trncf` instead. This is a RENAME of the same computed
+    # quantity, not two different quantities -- lulc_prederived.py's own
+    # docstring says "There is no `retention` column: it was only ever a
+    # stand-in for rad_trncf, which this path computes directly." The alias
+    # group below (a list, not a plain string) resolves to whichever of the two
+    # is actually present in a given fabric's file; if NEITHER is present the
+    # guard still raises exactly as it would for a plain missing column, so a
+    # genuinely absent column cannot silently skip filling.
     fill_columns:
       [
         cov_type,
@@ -121,7 +125,7 @@ params:
         snow_intcp,
         covden_sum,
         covden_win,
-        retention,
+        [retention, rad_trncf],
       ]
 
   # NALCMS 2020: no keep raster -> crosswalk evergreen_retention column.

--- a/configs/zonal/zonal_params.yml
+++ b/configs/zonal/zonal_params.yml
@@ -29,13 +29,13 @@
 # for the Part 1 build_lulc_rasters step.
 
 defaults:
-  batch_dir:     "{data_root}/{fabric}/batches"
-  target_layer:  nhru
+  batch_dir: "{data_root}/{fabric}/batches"
+  target_layer: nhru
   # id_feature comes from the active fabric profile in base_config.yml
   # (e.g. gfv2 -> nat_hru_id, oregon -> hru_id), injected at load time.
-  output_dir:    "{data_root}/{fabric}/params"
+  output_dir: "{data_root}/{fabric}/params"
   merged_subdir: merged
-  weight_dir:    "{data_root}/shared/conus/weights"
+  weight_dir: "{data_root}/shared/conus/weights"
 
 params:
   # --- Continuous zonal stats on shared CONUS VRTs ---
@@ -43,34 +43,47 @@ params:
   - name: elevation
     script: zonal
     source_raster: "{data_root}/shared/conus/vrt/elevation.vrt"
-    categorical:   false
-    merged_file:   nhm_elevation_params.csv
+    categorical: false
+    merged_file: nhm_elevation_params.csv
+    # Value columns observed via `head -1 {data_root}/oregon/params/merged/
+    # nhm_elevation_params.csv` (also matches gfv2). None of these are
+    # provenance -- viz.py's ParamEntry only plots `mean`, but count/std/min/
+    # 25%/50%/75%/max/sum are plain exactextract zonal statistics with no
+    # "not derivable by design" meaning, unlike snarea_curve's cv_* columns
+    # below -- so all are safe, and desirable, to fill for a missing HRU.
+    fill_columns: [count, mean, std, min, "25%", "50%", "75%", max, sum]
 
   - name: slope
     script: zonal
     source_raster: "{data_root}/shared/conus/vrt/slope.vrt"
-    categorical:   false
-    merged_file:   nhm_slope_params.csv
+    categorical: false
+    merged_file: nhm_slope_params.csv
+    # Same value-column set as elevation (observed on-disk; same zonal script).
+    fill_columns: [count, mean, std, min, "25%", "50%", "75%", max, sum]
 
   - name: aspect
     script: zonal
     source_raster: "{data_root}/shared/conus/vrt/aspect.vrt"
-    categorical:   false
-    merged_file:   nhm_aspect_params.csv
+    categorical: false
+    merged_file: nhm_aspect_params.csv
+    # Same value-column set as elevation (observed on-disk; same zonal script).
+    fill_columns: [count, mean, std, min, "25%", "50%", "75%", max, sum]
 
   # --- Soils (categorical + continuous via the same script dispatcher) ---
 
   - name: soils
     script: soils
     source_raster: "{data_root}/input/soils_litho/TEXT_PRMS.tif"
-    categorical:   true
-    merged_file:   nhm_soils_params.csv
+    categorical: true
+    merged_file: nhm_soils_params.csv
+    fill_columns: [soils]
 
   - name: soil_moist_max
     script: soils
     source_raster: "{data_root}/shared/conus/derived/soil_moist_max.tif"
-    categorical:   false
-    merged_file:   nhm_soil_moist_max_params.csv
+    categorical: false
+    merged_file: nhm_soil_moist_max_params.csv
+    fill_columns: [soil_moist_max]
 
   # --- LULC sources (each derives cov_type / covden / interception + rad_trncf
   #     or retention) ---
@@ -82,49 +95,105 @@ params:
 
   - name: lulc_nhm_v11
     script: lulc_prederived
-    source_raster:  "{data_root}/input/lulc_veg/nhm_v11/LULC.tif"   # cov_type (5-class)
-    canopy_raster:  "{data_root}/input/lulc_veg/nhm_v11/CNPY.tif"   # covden_sum (MODIS VCF)
-    loss_raster:    "{data_root}/input/lulc_veg/nhm_v11/loss.tif"   # covden_win = covden_sum*(1-loss/100)
-    snow_raster:    "{data_root}/input/lulc_veg/nhm_v11/Snow.tif"   # snow_intcp  (/100 -> inch)
-    srain_raster:   "{data_root}/input/lulc_veg/nhm_v11/SRain.tif"  # srain_intcp (/100 -> inch)
-    wrain_raster:   "{data_root}/input/lulc_veg/nhm_v11/WRain.tif"  # wrain_intcp (/100 -> inch)
+    source_raster: "{data_root}/input/lulc_veg/nhm_v11/LULC.tif" # cov_type (5-class)
+    canopy_raster: "{data_root}/input/lulc_veg/nhm_v11/CNPY.tif" # covden_sum (MODIS VCF)
+    loss_raster: "{data_root}/input/lulc_veg/nhm_v11/loss.tif" # covden_win = covden_sum*(1-loss/100)
+    snow_raster: "{data_root}/input/lulc_veg/nhm_v11/Snow.tif" # snow_intcp  (/100 -> inch)
+    srain_raster: "{data_root}/input/lulc_veg/nhm_v11/SRain.tif" # srain_intcp (/100 -> inch)
+    wrain_raster: "{data_root}/input/lulc_veg/nhm_v11/WRain.tif" # wrain_intcp (/100 -> inch)
     # radtrn raster (cnpy*keep/100 over trees) built by the shared-rasters
     # build_lulc_rasters step -> zonal-meaned + Beer's-law -> rad_trncf.
-    radtrn_raster:  "{data_root}/shared/conus/derived/radtrn_nhm_v11.tif"
-    crosswalk_file: crosswalks/nhm_v11_nhm.csv  # cov_type mapping only
-    categorical:    true
-    merged_file:    nhm_lulc_nhm_v11_params.csv
+    radtrn_raster: "{data_root}/shared/conus/derived/radtrn_nhm_v11.tif"
+    crosswalk_file: crosswalks/nhm_v11_nhm.csv # cov_type mapping only
+    categorical: true
+    merged_file: nhm_lulc_nhm_v11_params.csv
+    # Observed on-disk header (oregon + gfv2). NB: the current
+    # zonal_runners/lulc_prederived.py builder computes `rad_trncf` (Beer's-law
+    # transform), not `retention` -- the on-disk merged CSVs predate that
+    # rename and still carry `retention`. Declaring `retention` matches what a
+    # fill run actually finds in the file today; Task 1's guard raises loudly
+    # (not a silent skip) if a future regen renames the column to `rad_trncf`.
+    fill_columns:
+      [
+        cov_type,
+        srain_intcp,
+        wrain_intcp,
+        snow_intcp,
+        covden_sum,
+        covden_win,
+        retention,
+      ]
 
   # NALCMS 2020: no keep raster -> crosswalk evergreen_retention column.
 
   - name: lulc_nalcms
     script: lulc
-    source_raster:  "{data_root}/input/lulc/nalcms_2020/NA_NALCMS_landcover_2020v2_30m.tif"
-    canopy_raster:  "{data_root}/input/lulc_veg/CNPY.tif"
+    source_raster: "{data_root}/input/lulc/nalcms_2020/NA_NALCMS_landcover_2020v2_30m.tif"
+    canopy_raster: "{data_root}/input/lulc_veg/CNPY.tif"
     crosswalk_file: crosswalks/nalcms_nhm.csv
-    categorical:    true
-    merged_file:    nhm_lulc_nalcms_params.csv
+    categorical: true
+    merged_file: nhm_lulc_nalcms_params.csv
+    # Observed on-disk header (oregon + gfv2); same 7 columns as lulc_nhm_v11.
+    fill_columns:
+      [
+        cov_type,
+        srain_intcp,
+        wrain_intcp,
+        snow_intcp,
+        covden_sum,
+        covden_win,
+        retention,
+      ]
 
   # NLCD 2021: no keep raster -> crosswalk evergreen_retention column.
 
   - name: lulc_nlcd
     script: lulc
-    source_raster:  "{data_root}/input/lulc_veg/nlcd/nlcd_2021_land_cover.tif"
-    canopy_raster:  "{data_root}/input/lulc_veg/nlcd/nlcd_2021_tree_canopy.tif"
+    source_raster: "{data_root}/input/lulc_veg/nlcd/nlcd_2021_land_cover.tif"
+    canopy_raster: "{data_root}/input/lulc_veg/nlcd/nlcd_2021_tree_canopy.tif"
     crosswalk_file: crosswalks/nlcd_nhm.csv
-    categorical:    true
-    merged_file:    nhm_lulc_nlcd_params.csv
+    categorical: true
+    merged_file: nhm_lulc_nlcd_params.csv
+    # DERIVED, not observed: no merged file exists for any fabric yet (inputs
+    # unstaged). Columns per zonal_runners/lulc.py's run_lulc_batch: cov_type +
+    # 3 interception + 2 covden + retention (no radtrn_raster is configured for
+    # this entry, so rad_trncf is never produced) -- same 7 as lulc_nalcms,
+    # which uses the identical `script: lulc` builder.
+    fill_columns:
+      [
+        cov_type,
+        srain_intcp,
+        wrain_intcp,
+        snow_intcp,
+        covden_sum,
+        covden_win,
+        retention,
+      ]
 
   # FORE-SCE bau_rcp45 2070: keep raster present -> raster-based retention.
 
   - name: lulc_foresce
     script: lulc
-    source_raster:  "{data_root}/input/lulc_veg/foresce/LULC_bau_rcp45_2070.tif"
-    canopy_raster:  "{data_root}/input/lulc_veg/foresce/CNPY.tif"
-    keep_raster:    "{data_root}/input/lulc_veg/foresce/keep.tif"
+    source_raster: "{data_root}/input/lulc_veg/foresce/LULC_bau_rcp45_2070.tif"
+    canopy_raster: "{data_root}/input/lulc_veg/foresce/CNPY.tif"
+    keep_raster: "{data_root}/input/lulc_veg/foresce/keep.tif"
     crosswalk_file: crosswalks/foresce_nhm.csv
-    categorical:    true
-    merged_file:    nhm_lulc_foresce_params.csv
+    categorical: true
+    merged_file: nhm_lulc_foresce_params.csv
+    # DERIVED, not observed: no merged file exists for any fabric yet (inputs
+    # unstaged). Same builder/reasoning as lulc_nlcd above -- keep_raster is
+    # present, so `retention` comes from the raster-based path rather than the
+    # crosswalk, but the column NAME is the same 7 as lulc_nalcms/lulc_nlcd.
+    fill_columns:
+      [
+        cov_type,
+        srain_intcp,
+        wrain_intcp,
+        snow_intcp,
+        covden_sum,
+        covden_win,
+        retention,
+      ]
 
   # --- ssflux (litho-weighted PRMS subsurface flux params) ---
   # Requires the CONUS-wide P2P weight matrix (build_weights mode) and a
@@ -134,18 +203,31 @@ params:
 
   - name: ssflux
     script: ssflux
-    depends_on:    build_weights
-    source_shapefile:  "{data_root}/input/soils_litho/Lithology_exp_Konly_Project.shp"
+    depends_on: build_weights
+    source_shapefile: "{data_root}/input/soils_litho/Lithology_exp_Konly_Project.shp"
     merged_slope_file: "{data_root}/{fabric}/params/merged/nhm_slope_params.csv"
-    merged_file:       nhm_ssflux_params.csv
+    merged_file: nhm_ssflux_params.csv
+    # Observed on-disk header (oregon + gfv2) is k_perm_wtd, mean_slope_fraction,
+    # hru_area, soil2gw_max, ssr2gw_rate, fastcoef_lin, slowcoef_lin, gwflow_coef,
+    # dprst_seep_rate_open, dprst_flow_coef. The first three are litho/slope
+    # INPUTS to the flux normalisation below, not PRMS parameters themselves --
+    # only the 7 derived flux params are declared fillable.
+    fill_columns:
+      - soil2gw_max
+      - ssr2gw_rate
+      - fastcoef_lin
+      - slowcoef_lin
+      - gwflow_coef
+      - dprst_seep_rate_open
+      - dprst_flow_coef
     # Lithology permeability + PRMS flux normalisation (lifted verbatim
     # from configs/zonal/ssflux_param.yml).
     k_perm_min: -16.48
     flux_params:
-      - {name: soil2gw_max,          min: 0.1,   max: 0.3}
-      - {name: ssr2gw_rate,          min: 0.3,   max: 0.7}
-      - {name: fastcoef_lin,         min: 0.01,  max: 0.6}
-      - {name: slowcoef_lin,         min: 0.005, max: 0.3}
-      - {name: gwflow_coef,          min: 0.005, max: 0.3}
-      - {name: dprst_seep_rate_open, min: 0.005, max: 0.2}
-      - {name: dprst_flow_coef,      min: 0.005, max: 0.5}
+      - { name: soil2gw_max, min: 0.1, max: 0.3 }
+      - { name: ssr2gw_rate, min: 0.3, max: 0.7 }
+      - { name: fastcoef_lin, min: 0.01, max: 0.6 }
+      - { name: slowcoef_lin, min: 0.005, max: 0.3 }
+      - { name: gwflow_coef, min: 0.005, max: 0.3 }
+      - { name: dprst_seep_rate_open, min: 0.005, max: 0.2 }
+      - { name: dprst_flow_coef, min: 0.005, max: 0.5 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -40,7 +40,9 @@ data_root/
     ├── fabric/                 # Merged fabric gpkg
     ├── batches/                # Per-batch gpkgs + manifest.yml
     ├── depstor_rasters/        # Depression-storage intermediate rasters
-    └── params/                 # Parameter outputs + merged/ + filled
+    └── params/                 # Parameter outputs; merged/ (canonical,
+                                 #   gap-filled) + merged/_unfilled/ (pre-fill
+                                 #   copies) + merged/_intermediates/
 ```
 
 **The invariant: every fabric reuses the same `shared/` rasters.** Per-VPU
@@ -204,6 +206,35 @@ SNODAS SWE NetCDFs. It defaults to the shared datastore path
 (`{data_root}/../nhf-datastore/snodas/daily`) in
 `configs/aggregate/aggregate_sources.yml` and only needs a profile entry if a
 fabric's SNODAS source differs from that default.
+
+### The `merged/` gap-fill convention (`fill_columns`)
+
+`fill_columns` is **not** a fabric-profile key — it is declared per param
+entry in `configs/zonal/zonal_params.yml` (`params:`),
+`configs/depstor/depstor_params.yml` (`means:`/`ratios:`), and the flat
+`configs/snarea/snarea_library.yml` (`snarea_curve`). `scripts/merge_and_fill_params.py`
+(Stage 7 / RUNME Step 5) reads that declaration to decide, per param, which
+columns it may KNN-fill. Two asymmetric guards, both in
+`resolve_fill_plan`: a declared column absent from the CSV raises (a typo
+would otherwise silently fill nothing); a param with no `fill_columns` that
+is nonetheless missing an HRU row also raises (a missing row admits no
+"not derivable" reading). A column that is present but **not** declared and
+carries NaN cells only warns, naming the column and the NaN count — a NaN
+cell can be a legitimate "not derivable" result (`cv_empirical` is derivable
+for only ~42% of HRUs by design; `cv_subgrid` exists to rescue the rest).
+
+`merged/<name>.csv` is the single canonical, always-gap-filled per-HRU file
+for every param that declares `fill_columns` — **consumers read
+`merged/*.csv`**. The retired `filled_` prefix required a consumer to know,
+per param *and* per fabric, which of two files was authoritative (the
+canonical set differed between `gfv2`, 2 files, and `oregon`, 4); only
+`viz.py` encoded that rule, and it is why four `oregon` params went unfilled
+until someone audited them by hand. The pre-fill (raw) copy is preserved
+once at `merged/_unfilled/<name>.csv` (`write_filled_in_place`, never
+overwritten on a re-run — the on-disk `merged/<name>.csv` is by then already
+filled), alongside the existing `merged/_intermediates/` per-fraction/derived
+CSVs. A one-time migration off an existing `filled_`-prefixed product is
+`scripts/migrate_filled_params.py` (dry-run by default, `--apply` required).
 
 ### Common fabrics
 

--- a/docs/nhm_source_crosscheck_2026-07.md
+++ b/docs/nhm_source_crosscheck_2026-07.md
@@ -127,7 +127,13 @@ scalar defaults. Both are wrong:
   `dprst_seep_rate_open := ssr2gw_rate` and `dprst_flow_coef := fastcoef_lin`.
 - They are on disk, per-HRU, for CONUS:
   `gfv2/params/merged/filled_nhm_ssflux_params.csv` (verified — columns present,
-  non-degenerate).
+  non-degenerate). [As of this audit's date, `merge_and_fill_params.py` wrote
+  a separate `filled_`-prefixed file per param, hardcoded to `ssflux` only —
+  the `filled_` prefix is **retired** as of 2026-07-25: `merge_and_fill_params.py`
+  now fills every param that declares `fill_columns` in place, and the current
+  file is `gfv2/params/merged/nhm_ssflux_params.csv`, always gap-filled. This
+  paragraph is left as a dated historical record of what was true on
+  2026-07-08 and is not itself stale.]
 - `src/gfv2_params/viz.py:530-531` already maps them for plotting.
 
 So Bucket 3 has exactly **one** true member: `smidx_exp` — and per (3), it is

--- a/docs/superpowers/plans/2026-07-25-param-fill-convention.md
+++ b/docs/superpowers/plans/2026-07-25-param-fill-convention.md
@@ -1,0 +1,706 @@
+# Parameter Gap-Fill Convention Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `{fabric}/params/merged/nhm_*_params.csv` the single canonical per-HRU parameter set — always gap-filled — retire the `filled_` prefix, and never overwrite provenance columns.
+
+**Architecture:** `scripts/merge_and_fill_params.py` gains a config-driven `fill_columns` declaration per param, writes in place, and moves the pre-fill copy to `merged/_unfilled/`. Undeclared columns are never filled, but never silently: a NaN cell warns, an absent HRU row raises. A separate one-time migration script converts existing `filled_*` products on both fabrics.
+
+**Tech Stack:** Python 3.12, pandas 3.0.2, geopandas 1.1.3, scikit-learn (KNN), pytest, pixi.
+
+**Spec:** [`docs/superpowers/specs/2026-07-25-param-fill-convention-design.md`](../specs/2026-07-25-param-fill-convention-design.md)
+
+## Global Constraints
+
+- **NEVER run `pytest` on the HPC head node** — concurrent geo-library imports trigger shared-FS metadata storms that hang it. Every test run goes through `srun`. Non-negotiable.
+- All tests must run in CI with **no data root** (no `/caldera` mount) — synthetic frames and `tmp_path` only.
+- Imports at the top of the file — ruff's default `E4` includes E402.
+- No new dependencies.
+- Run `pixi run -e dev pre-commit run --files <changed files>` before committing.
+- Branch `feat/param-fill-convention` is already checked out. Do NOT create or switch branches.
+- KNN fill stays `k=1` nearest-neighbour. This plan changes *what it runs against, where it writes, and what it refuses to touch* — never the interpolation itself.
+- **`_unfilled/<name>.csv` is written ONLY if it does not already exist.** Violating this destroys the true pre-fill copy on a second run, irreversibly, on a filesystem with no version control.
+
+---
+
+## File Structure
+
+**Modify:**
+- `scripts/merge_and_fill_params.py` — fill-column selection, the guard, in-place write, `_unfilled/`, dtype restore, all-params default mode
+- `configs/zonal/zonal_params.yml` — `fill_columns` per param
+- `configs/depstor/depstor_params.yml` — `fill_columns` per param
+- `src/gfv2_params/viz.py` — 7 hardcoded `filled_nhm_ssflux_params.csv` references
+- `slurm_batch/RUNME.md` §5, `docs/ARCHITECTURE.md`, `slurm_batch/HPC_REFERENCE.md`
+- `tests/test_merge_and_fill_params.py`
+
+**Create:**
+- `scripts/migrate_filled_params.py` — one-time migration, `--dry-run` default
+- `tests/test_migrate_filled_params.py`
+
+---
+
+## Task 1: Fill-column selection and the guard
+
+**Files:**
+- Modify: `scripts/merge_and_fill_params.py`
+- Test: `tests/test_merge_and_fill_params.py`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces:
+  - `resolve_fill_plan(param_df, declared, missing_ids, id_feature, param_name) -> FillPlan`
+  - `FillPlan` — a dataclass with `fill_columns: list[str]`, `undeclared_with_nan: dict[str, int]`
+
+**Why this is separate:** it is pure decision logic over a DataFrame, testable with no filesystem at all, and it is where the provenance-destroying bug would live.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_merge_and_fill_params.py` (put any new imports at the TOP of the file with the existing ones):
+
+```python
+def _frame():
+    """A snarea_curve-shaped frame: real params complete, provenance partly NaN."""
+    return pd.DataFrame({
+        "hru_id": [1, 2, 3],
+        "hru_deplcrv": [1.0, 2.0, np.nan],      # declared param, has a gap
+        "snarea_thresh": [0.1, 0.2, 0.3],        # declared param, complete
+        "cv_empirical": [np.nan, np.nan, 0.4],   # UNDECLARED provenance, NaN by design
+    })
+
+
+def test_only_declared_columns_are_filled():
+    plan = maf.resolve_fill_plan(
+        _frame(), declared=["hru_deplcrv", "snarea_thresh"],
+        missing_ids=set(), id_feature="hru_id", param_name="snarea_curve",
+    )
+    assert plan.fill_columns == ["hru_deplcrv", "snarea_thresh"]
+    assert "cv_empirical" not in plan.fill_columns
+
+
+def test_undeclared_column_with_nan_is_reported_not_filled():
+    plan = maf.resolve_fill_plan(
+        _frame(), declared=["hru_deplcrv", "snarea_thresh"],
+        missing_ids=set(), id_feature="hru_id", param_name="snarea_curve",
+    )
+    # cv_empirical has 2 NaN — surfaced for the caller to warn about, never filled.
+    assert plan.undeclared_with_nan == {"cv_empirical": 2}
+
+
+def test_absent_hru_row_with_no_declaration_raises():
+    """A missing ROW admits no provenance reading — it is a config error, not a result."""
+    with pytest.raises(ValueError, match="fill_columns"):
+        maf.resolve_fill_plan(
+            _frame(), declared=[], missing_ids={4, 5},
+            id_feature="hru_id", param_name="mystery_param",
+        )
+
+
+def test_absent_hru_row_with_declaration_is_fine():
+    plan = maf.resolve_fill_plan(
+        _frame(), declared=["hru_deplcrv"], missing_ids={4},
+        id_feature="hru_id", param_name="snarea_curve",
+    )
+    assert plan.fill_columns == ["hru_deplcrv"]
+
+
+def test_declared_column_absent_from_frame_raises():
+    """A typo'd fill_columns entry must fail loud, not silently fill nothing."""
+    with pytest.raises(ValueError, match="not present"):
+        maf.resolve_fill_plan(
+            _frame(), declared=["hru_deplcrv", "typo_column"], missing_ids=set(),
+            id_feature="hru_id", param_name="snarea_curve",
+        )
+```
+
+The existing test file loads the script via `importlib`; reuse that loader and bind it to `maf`. If the file does not already expose such a handle, add near the top:
+
+```python
+_SPEC = importlib.util.spec_from_file_location(
+    "merge_and_fill_params",
+    Path(__file__).resolve().parent.parent / "scripts" / "merge_and_fill_params.py",
+)
+maf = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(maf)
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+```bash
+srun -p cpu -A impd --mem=8G --time=00:15:00 \
+  pixi run -e dev pytest tests/test_merge_and_fill_params.py -q -k "declared or absent_hru"
+```
+
+Expected: `AttributeError: module 'merge_and_fill_params' has no attribute 'resolve_fill_plan'`.
+
+- [ ] **Step 3: Implement `resolve_fill_plan`**
+
+Add to `scripts/merge_and_fill_params.py`, above `fill_missing_values_knn`. Add `from dataclasses import dataclass, field` to the imports at the top.
+
+```python
+@dataclass
+class FillPlan:
+    """What a param's fill run may touch, and what it found but must not touch.
+
+    `fill_columns` is exactly the caller's declared list, intersected with nothing —
+    a declared column missing from the frame is an error, not a silent skip.
+    `undeclared_with_nan` is the caller's warning material: columns carrying NaN that
+    nobody declared fillable.
+    """
+
+    fill_columns: list[str] = field(default_factory=list)
+    undeclared_with_nan: dict[str, int] = field(default_factory=dict)
+
+
+# Columns that identify an HRU rather than parameterise it. Never fillable, and never
+# reported as an undeclared gap.
+ID_COLUMNS = {"hru_id", "nat_hru_id", "model_hru_idx", "vpu"}
+
+
+def resolve_fill_plan(param_df, declared, missing_ids, id_feature, param_name) -> FillPlan:
+    """Decide what to fill for one param, and what to surface without filling.
+
+    The selection is DECLARATION-driven, not gap-driven, because "has a NaN" does not
+    mean "is missing". `nhm_snarea_curve_params.csv` carries 7,891 rows with NaN, every
+    one in a provenance column -- `cv_empirical` is derivable for only ~42% of HRUs BY
+    DESIGN, and `cv_subgrid` exists to rescue the rest. Filling it would overwrite the
+    record of how each curve was derived with interpolated noise. Before this function
+    existed the column list was "everything except the id columns", which would have
+    done exactly that.
+
+    Two asymmetric guards, because the two kinds of gap differ in what they can mean:
+
+      * an undeclared column with NaN CELLS is ambiguous -- it may be a legitimate
+        "not derivable" -- so it is reported for the caller to WARN about;
+      * an absent HRU ROW is not ambiguous. The HRU is in the file or it is not, and no
+        provenance reading makes a missing HRU correct. With nothing declared fillable,
+        that is a configuration error and RAISES.
+    """
+    declared = list(declared or [])
+
+    absent = [c for c in declared if c not in param_df.columns]
+    if absent:
+        raise ValueError(
+            f"`fill_columns` for '{param_name}' names {absent}, which are not present in "
+            f"the parameter file (columns: {sorted(param_df.columns)}). Fix the config -- "
+            f"a typo here would silently fill nothing."
+        )
+
+    if missing_ids and not declared:
+        raise ValueError(
+            f"'{param_name}' is missing {len(missing_ids)} HRU row(s) but declares no "
+            f"`fill_columns`, so nothing would be filled and the gap would persist "
+            f"unnoticed. An absent HRU row is unambiguous -- unlike a NaN cell, it cannot "
+            f"be a legitimate 'not derivable' result. Add `fill_columns` for this param in "
+            f"its config entry."
+        )
+
+    undeclared_with_nan = {}
+    for col in param_df.columns:
+        if col in declared or col in ID_COLUMNS or col == id_feature:
+            continue
+        n_nan = int(param_df[col].isna().sum())
+        if n_nan:
+            undeclared_with_nan[col] = n_nan
+
+    return FillPlan(fill_columns=declared, undeclared_with_nan=undeclared_with_nan)
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+```bash
+srun -p cpu -A impd --mem=8G --time=00:15:00 \
+  pixi run -e dev pytest tests/test_merge_and_fill_params.py -q
+```
+
+Expected: all pass, including the file's pre-existing tests.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+pixi run -e dev pre-commit run --files scripts/merge_and_fill_params.py tests/test_merge_and_fill_params.py
+git add scripts/merge_and_fill_params.py tests/test_merge_and_fill_params.py
+git commit -m "feat(params): declaration-driven fill selection with asymmetric guards
+
+Column selection was 'everything except the id columns', which would overwrite
+snarea_curve's provenance -- cv_empirical is NaN for ~58% of HRUs BY DESIGN
+(cv_subgrid rescues them), and filling it replaces the record of how each curve
+was derived with interpolated noise.
+
+Selection is now declaration-driven. Undeclared columns are never filled but
+never silently: a NaN cell is reported for a warning, an absent HRU row RAISES.
+A row is either present or not -- no provenance reading makes a missing HRU
+correct -- so that one is a config error, not a result."
+```
+
+---
+
+## Task 2: In-place write, `_unfilled/`, idempotency, dtype restore
+
+**Files:**
+- Modify: `scripts/merge_and_fill_params.py`
+- Test: `tests/test_merge_and_fill_params.py`
+
+**Interfaces:**
+- Consumes: `resolve_fill_plan`, `FillPlan` from Task 1.
+- Produces: `write_filled_in_place(complete_df, param_file, original_df, dtypes) -> Path` — writes the filled frame to `param_file`, preserving the pre-fill copy at `param_file.parent / "_unfilled" / param_file.name`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_merge_and_fill_params.py`:
+
+```python
+def test_writes_in_place_and_preserves_raw(tmp_path):
+    p = tmp_path / "nhm_x_params.csv"
+    pd.DataFrame({"hru_id": [1, 2], "v": [1.0, np.nan]}).to_csv(p, index=False)
+    original = pd.read_csv(p)
+    filled = pd.DataFrame({"hru_id": [1, 2], "v": [1.0, 9.0]})
+
+    out = maf.write_filled_in_place(filled, p, original, {"v": np.dtype("float64")})
+
+    assert out == p
+    assert pd.read_csv(p)["v"].tolist() == [1.0, 9.0]          # canonical is filled
+    raw = pd.read_csv(tmp_path / "_unfilled" / "nhm_x_params.csv")
+    assert raw["v"].isna().sum() == 1                            # raw preserved
+
+
+def test_second_run_does_not_clobber_the_raw_copy(tmp_path):
+    """The irreversible one: a re-run must not move the FILLED file into _unfilled/."""
+    p = tmp_path / "nhm_x_params.csv"
+    pd.DataFrame({"hru_id": [1, 2], "v": [1.0, np.nan]}).to_csv(p, index=False)
+    original = pd.read_csv(p)
+    filled = pd.DataFrame({"hru_id": [1, 2], "v": [1.0, 9.0]})
+
+    maf.write_filled_in_place(filled, p, original, {"v": np.dtype("float64")})
+    # Run 2: the on-disk file is now already filled. Passing it as "original" is exactly
+    # what the orchestrator does on a re-run.
+    again = pd.read_csv(p)
+    maf.write_filled_in_place(filled, p, again, {"v": np.dtype("float64")})
+
+    raw = pd.read_csv(tmp_path / "_unfilled" / "nhm_x_params.csv")
+    assert raw["v"].isna().sum() == 1, "_unfilled/ must still hold the ORIGINAL raw frame"
+
+
+def test_categorical_dtype_is_restored(tmp_path):
+    """cov_type is an integer class (0-3). k=1 copies a real class, so it must stay int."""
+    p = tmp_path / "nhm_lulc_params.csv"
+    pd.DataFrame({"hru_id": [1, 2], "cov_type": [1, 3]}).to_csv(p, index=False)
+    original = pd.read_csv(p)
+    filled = pd.DataFrame({"hru_id": [1, 2], "cov_type": [1.0, 3.0]})  # KNN returns float
+
+    maf.write_filled_in_place(filled, p, original, {"cov_type": np.dtype("int64")})
+
+    got = pd.read_csv(p)
+    assert got["cov_type"].dtype.kind == "i"
+    assert got["cov_type"].tolist() == [1, 3]
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+```bash
+srun -p cpu -A impd --mem=8G --time=00:15:00 \
+  pixi run -e dev pytest tests/test_merge_and_fill_params.py -q -k "in_place or clobber or categorical"
+```
+
+Expected: `AttributeError: ... has no attribute 'write_filled_in_place'`.
+
+- [ ] **Step 3: Implement `write_filled_in_place`**
+
+Add to `scripts/merge_and_fill_params.py`:
+
+```python
+UNFILLED_DIRNAME = "_unfilled"
+
+
+def write_filled_in_place(complete_df, param_file, original_df, dtypes, logger=None):
+    """Write the filled frame OVER `param_file`, preserving the pre-fill copy.
+
+    `merged/<name>.csv` is the single canonical per-HRU parameter file -- always
+    gap-filled -- so a consumer's rule is one line: read `merged/*.csv`. The retired
+    `filled_` prefix required a consumer to know, per param AND per fabric, which of two
+    files was authoritative; the set differed between gfv2 (2 filled) and oregon (4), and
+    only `viz.py` encoded the rule.
+
+    The pre-fill copy goes to `merged/_unfilled/`, mirroring `merged/_intermediates/`.
+
+    IDEMPOTENCY, load-bearing: `_unfilled/<name>.csv` is written ONLY if it does not
+    already exist. On a re-run the on-disk file is ALREADY filled, so overwriting the
+    preserved copy with it would destroy the true raw version -- irreversibly, on a
+    shared filesystem with no version control.
+
+    `dtypes` restores each column's pre-fill dtype. KNN returns float64 even at k=1, which
+    silently turned `cov_type` (an integer class 0-3) into 0.0/1.0/2.0/3.0. No averaging
+    occurs at k=1, so the classes are correct -- but the dtype change is visible to any
+    consumer that does not cast.
+    """
+    unfilled_dir = param_file.parent / UNFILLED_DIRNAME
+    unfilled_dir.mkdir(parents=True, exist_ok=True)
+    raw_copy = unfilled_dir / param_file.name
+
+    if raw_copy.exists():
+        if logger:
+            logger.info(
+                "  %s already preserved at %s — not overwriting (a re-run's input is "
+                "already filled)", param_file.name, raw_copy,
+            )
+    else:
+        original_df.to_csv(raw_copy, index=False)
+        if logger:
+            logger.info("  pre-fill copy preserved -> %s", raw_copy)
+
+    out = complete_df.copy()
+    for col, dt in (dtypes or {}).items():
+        if col in out.columns and dt.kind in "iu" and out[col].notna().all():
+            out[col] = out[col].round().astype(dt)
+    out.to_csv(param_file, index=False)
+    if logger:
+        logger.info("  canonical parameter file written -> %s", param_file)
+    return param_file
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+```bash
+srun -p cpu -A impd --mem=8G --time=00:15:00 \
+  pixi run -e dev pytest tests/test_merge_and_fill_params.py -q
+```
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+pixi run -e dev pre-commit run --files scripts/merge_and_fill_params.py tests/test_merge_and_fill_params.py
+git add scripts/merge_and_fill_params.py tests/test_merge_and_fill_params.py
+git commit -m "feat(params): write the filled frame in place, preserving raw in _unfilled/
+
+merged/<name>.csv becomes the single canonical per-HRU file so a consumer's
+rule is 'read merged/*.csv'. Pre-fill copies go to merged/_unfilled/, mirroring
+merged/_intermediates/.
+
+_unfilled/<name>.csv is written ONLY if absent: on a re-run the on-disk file is
+already filled, and overwriting the preserved copy with it would destroy the
+true raw version irreversibly. Dedicated test.
+
+Restores pre-fill dtypes -- KNN returns float64 even at k=1, which turned
+cov_type from an integer class into 0.0/1.0/2.0/3.0."
+```
+
+---
+
+## Task 3: All-params default mode and `fill_columns` config
+
+**Files:**
+- Modify: `scripts/merge_and_fill_params.py`, `configs/zonal/zonal_params.yml`, `configs/depstor/depstor_params.yml`
+- Test: `tests/test_merge_and_fill_params.py`
+
+**Interfaces:**
+- Consumes: `resolve_fill_plan`, `write_filled_in_place`.
+- Produces: `iter_declared_params(zonal_cfg, depstor_cfg) -> list[tuple[str, str, list[str]]]` returning `(param_name, merged_file, fill_columns)`.
+
+- [ ] **Step 1: Add `fill_columns` to the configs**
+
+In `configs/zonal/zonal_params.yml`, add a `fill_columns:` list to each param entry:
+
+| param | `fill_columns` |
+| --- | --- |
+| `elevation` | the param's own value column(s) as they appear in its `merged_file` |
+| `slope` | same |
+| `aspect` | same |
+| `soils` | same |
+| `soil_moist_max` | `[soil_moist_max]` |
+| `lulc_nhm_v11` | `[cov_type, srain_intcp, wrain_intcp, snow_intcp, covden_sum, covden_win, retention]` |
+| `lulc_nalcms` | same 7 as `lulc_nhm_v11` |
+| `lulc_nlcd`, `lulc_foresce` | same 7 (configured but inputs unstaged) |
+| `ssflux` | `[soil2gw_max, ssr2gw_rate, fastcoef_lin, slowcoef_lin, gwflow_coef, dprst_seep_rate_open, dprst_flow_coef]` |
+| `snarea_curve` | `[hru_deplcrv, snarea_thresh, snarea_curve_0 … snarea_curve_10]` — **13 entries**, and NOT `cv_assign`, `cv_subgrid`, `cv_empirical`, `cv_source`, `sdc_status`, `sca_class`, `similarity`, `n_seasons`, `n_peak_years`, `peak_swe_mm` |
+
+Read each param's `merged_file` header on disk to get its exact value-column names rather than guessing — e.g.
+`head -1 {data_root}/oregon/params/merged/nhm_elevation_params.csv`. If a param's file is
+absent for every fabric, declare the columns its builder writes and say so in your report.
+
+Add a comment above `snarea_curve`'s list:
+
+```yaml
+    # cv_* / sdc_status / sca_class / similarity / n_seasons / n_peak_years / peak_swe_mm
+    # are DELIBERATELY absent: NaN there means "not derivable" (cv_empirical is derivable
+    # for only ~42% of HRUs by design; cv_subgrid rescues the rest), which is a RESULT.
+    # Filling them would replace the record of how each curve was derived with noise.
+```
+
+In `configs/depstor/depstor_params.yml`, add `fill_columns` to each of the 6 ratios plus `dprst_depth_avg`, each naming its single value column (e.g. `fill_columns: [dprst_frac]`).
+
+- [ ] **Step 2: Write the failing tests**
+
+```python
+def test_every_configured_param_declares_fill_columns():
+    """A param with no fill_columns cannot be gap-filled — catch it at config time."""
+    import yaml
+    root = Path(__file__).resolve().parent.parent
+    for cfg in [root / "configs/zonal/zonal_params.yml",
+                root / "configs/depstor/depstor_params.yml"]:
+        doc = yaml.safe_load(cfg.read_text())
+        for entry in doc.get("params", []):
+            if not entry.get("merged_file"):
+                continue
+            assert entry.get("fill_columns"), (
+                f"{entry['name']} in {cfg.name} has a merged_file but no fill_columns, so "
+                f"the gap-fill step would skip it and any missing HRU row would raise."
+            )
+
+
+def test_snarea_curve_does_not_declare_provenance_columns():
+    """Regression guard for the whole point of this change."""
+    import yaml
+    root = Path(__file__).resolve().parent.parent
+    doc = yaml.safe_load((root / "configs/zonal/zonal_params.yml").read_text())
+    entry = next(e for e in doc["params"] if e["name"] == "snarea_curve")
+    forbidden = {"cv_assign", "cv_subgrid", "cv_empirical", "cv_source",
+                 "sdc_status", "sca_class", "similarity", "n_seasons",
+                 "n_peak_years", "peak_swe_mm"}
+    assert not (set(entry["fill_columns"]) & forbidden)
+    assert "hru_deplcrv" in entry["fill_columns"]
+```
+
+If either config uses a top-level key other than `params:` for its entry list, adjust the
+accessor to match and note it in your report.
+
+- [ ] **Step 3: Run to verify they fail**
+
+```bash
+srun -p cpu -A impd --mem=8G --time=00:15:00 \
+  pixi run -e dev pytest tests/test_merge_and_fill_params.py -q -k "fill_columns or provenance"
+```
+
+- [ ] **Step 4: Implement all-params mode**
+
+In `main()`, when `--param_file` is NOT given, iterate every declared param instead of defaulting to `nhm_ssflux_params.csv`. For each: resolve its merged file under `{data_root}/{fabric}/params/merged/`, skip with an INFO line if absent, otherwise run `resolve_fill_plan` → `fill_missing_values_knn` (declared columns only) → `write_filled_in_place`.
+
+Emit `logger.warning` for every entry in `plan.undeclared_with_nan`:
+
+```python
+        for col, n in plan.undeclared_with_nan.items():
+            logger.warning(
+                "  %s: column '%s' has %d NaN cell(s) but is NOT declared in "
+                "`fill_columns` — left untouched. If it is a PRMS parameter rather than "
+                "provenance, add it to the config; if it is provenance, this is correct.",
+                merged_file.name, col, n,
+            )
+```
+
+Delete the `filled_param_file = output_dir / f"filled_{param_file.name}"` line and every use of it. Keep `--param_file` working for single-param runs, routed through the same three functions.
+
+- [ ] **Step 5: Run the full suite**
+
+```bash
+srun -p cpu -A impd --mem=16G --time=00:30:00 pixi run -e dev pytest tests/ -q
+```
+
+Expected: all pass. If `tests/test_viz.py` fails on a missing `filled_nhm_ssflux_params.csv`, that is Task 4's job — note it and continue.
+
+- [ ] **Step 6: Lint and commit**
+
+```bash
+pixi run -e dev pre-commit run --files scripts/merge_and_fill_params.py \
+  configs/zonal/zonal_params.yml configs/depstor/depstor_params.yml tests/test_merge_and_fill_params.py
+git add scripts/merge_and_fill_params.py configs/zonal/zonal_params.yml \
+        configs/depstor/depstor_params.yml tests/test_merge_and_fill_params.py
+git commit -m "feat(params): fill every declared param by default, not just ssflux
+
+The step filled ONE file per invocation and hardcoded nhm_ssflux_params.csv, so
+a param was filled only if someone remembered to pass --param_file for it. The
+canonical set therefore differed per fabric: gfv2 had 2 filled files, oregon 4,
+with nothing recording which was authoritative.
+
+Every param declaring a merged_file now declares fill_columns, and the default
+run covers all of them. Undeclared columns carrying NaN are warned about by
+name so a missing declaration cannot hide."
+```
+
+---
+
+## Task 4: Migration script and `viz.py`
+
+**Files:**
+- Create: `scripts/migrate_filled_params.py`, `tests/test_migrate_filled_params.py`
+- Modify: `src/gfv2_params/viz.py`
+
+**Interfaces:**
+- Consumes: `UNFILLED_DIRNAME` from Task 2.
+- Produces: `plan_migration(merged_dir) -> list[tuple[Path, Path, Path]]` returning `(filled_file, canonical_target, raw_target)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+def test_plan_migration_pairs_filled_with_canonical(tmp_path):
+    (tmp_path / "filled_nhm_ssflux_params.csv").write_text("hru_id,v\n1,1\n")
+    (tmp_path / "nhm_ssflux_params.csv").write_text("hru_id,v\n1,\n")
+    (tmp_path / "nhm_slope_params.csv").write_text("hru_id,v\n1,2\n")   # no filled_ pair
+
+    plan = mig.plan_migration(tmp_path)
+
+    assert len(plan) == 1
+    filled, canonical, raw = plan[0]
+    assert filled.name == "filled_nhm_ssflux_params.csv"
+    assert canonical.name == "nhm_ssflux_params.csv"
+    assert raw == tmp_path / "_unfilled" / "nhm_ssflux_params.csv"
+
+
+def test_migration_is_idempotent(tmp_path):
+    (tmp_path / "filled_nhm_ssflux_params.csv").write_text("hru_id,v\n1,1\n")
+    (tmp_path / "nhm_ssflux_params.csv").write_text("hru_id,v\n1,\n")
+
+    mig.apply_migration(mig.plan_migration(tmp_path))
+    raw_after_first = (tmp_path / "_unfilled" / "nhm_ssflux_params.csv").read_text()
+    mig.apply_migration(mig.plan_migration(tmp_path))   # second run: nothing left to do
+
+    assert (tmp_path / "_unfilled" / "nhm_ssflux_params.csv").read_text() == raw_after_first
+    assert not (tmp_path / "filled_nhm_ssflux_params.csv").exists()
+    assert (tmp_path / "nhm_ssflux_params.csv").read_text() == "hru_id,v\n1,1\n"
+
+
+def test_migration_refuses_when_raw_already_preserved(tmp_path):
+    """Never overwrite an existing _unfilled/ copy — that is the irreversible mistake."""
+    (tmp_path / "filled_nhm_ssflux_params.csv").write_text("hru_id,v\n1,1\n")
+    (tmp_path / "nhm_ssflux_params.csv").write_text("hru_id,v\n1,\n")
+    (tmp_path / "_unfilled").mkdir()
+    (tmp_path / "_unfilled" / "nhm_ssflux_params.csv").write_text("ORIGINAL\n")
+
+    mig.apply_migration(mig.plan_migration(tmp_path))
+
+    assert (tmp_path / "_unfilled" / "nhm_ssflux_params.csv").read_text() == "ORIGINAL\n"
+```
+
+Bind `mig` with the same `importlib` loader pattern used for `maf`.
+
+- [ ] **Step 2: Run to verify they fail**
+
+```bash
+srun -p cpu -A impd --mem=8G --time=00:15:00 pixi run -e dev pytest tests/test_migrate_filled_params.py -q
+```
+
+- [ ] **Step 3: Write the migration script**
+
+Create `scripts/migrate_filled_params.py`. It must default to `--dry-run` and require an explicit `--apply`, print every move before making it, and never overwrite an existing `_unfilled/` entry. Reuse `UNFILLED_DIRNAME` by importing it from `merge_and_fill_params` if convenient, or redefine the literal `"_unfilled"` with a comment naming the source of truth.
+
+`plan_migration(merged_dir)` globs `filled_*.csv`, pairs each with its canonical name (strip the `filled_` prefix), and returns the triples. `apply_migration(plan)` performs, per triple: move canonical → `_unfilled/` (skip if the target exists), then move filled → canonical.
+
+- [ ] **Step 4: Point `viz.py` at the canonical files**
+
+Replace all 7 occurrences of `filled_nhm_ssflux_params.csv` with `nhm_ssflux_params.csv` in `src/gfv2_params/viz.py`. Verify with:
+
+```bash
+grep -c "filled_" src/gfv2_params/viz.py   # expect 0
+```
+
+- [ ] **Step 5: Run the tests**
+
+```bash
+srun -p cpu -A impd --mem=16G --time=00:30:00 \
+  pixi run -e dev pytest tests/test_migrate_filled_params.py tests/test_viz.py tests/test_merge_and_fill_params.py -q
+```
+
+- [ ] **Step 6: Dry-run the migration against BOTH real fabrics, and report the output**
+
+```bash
+DR=/caldera/hovenweep/projects/usgs/water/impd/nhgf/gfv2_param_v2
+for f in gfv2 oregon; do
+  echo "=== $f ==="
+  pixi run --as-is python scripts/migrate_filled_params.py --merged_dir "$DR/$f/params/merged"
+done
+```
+
+Expected: `gfv2` lists 2 moves (`ssflux`, `soil_moist_max`); `oregon` lists 4 (those plus `lulc_nalcms`, `lulc_nhm_v11`). **Do NOT pass `--apply`** — the controller decides when to migrate real products. Paste the dry-run output verbatim into your report.
+
+- [ ] **Step 7: Lint and commit**
+
+```bash
+pixi run -e dev pre-commit run --files scripts/migrate_filled_params.py \
+  tests/test_migrate_filled_params.py src/gfv2_params/viz.py
+git add scripts/migrate_filled_params.py tests/test_migrate_filled_params.py src/gfv2_params/viz.py
+git commit -m "feat(params): migration to the canonical convention + repoint viz.py
+
+One-time, dry-run by default, --apply required. Per filled_X.csv: move X.csv to
+_unfilled/X.csv (skipped if already preserved), then filled_X.csv to X.csv.
+
+viz.py was the ONLY consumer encoding the filled_ convention -- 7 hardcoded
+references to filled_nhm_ssflux_params.csv -- so it moves to the canonical name."
+```
+
+---
+
+## Task 5: Documentation
+
+**Files:**
+- Modify: `slurm_batch/RUNME.md`, `docs/ARCHITECTURE.md`, `slurm_batch/HPC_REFERENCE.md`
+
+- [ ] **Step 1: Rewrite RUNME §5**
+
+It is currently three lines that say "KNN-fills any missing per-HRU parameter values" and show one `sbatch`. Replace with content covering: the step now fills **every** param declaring `fill_columns` (not just ssflux); `merged/*.csv` is canonical and always gap-filled, so **consumers read `merged/`**; pre-fill copies live in `merged/_unfilled/`; the run logs per-param filled counts and **warns** for undeclared columns carrying NaN; and that an absent HRU row in a param with no `fill_columns` **raises** rather than passing silently.
+
+State plainly that the `filled_` prefix is retired, since anyone with an older checkout will look for it.
+
+- [ ] **Step 2: Update `docs/ARCHITECTURE.md`**
+
+Add `fill_columns` to the per-key required-field table, and document `merged/` (canonical, gap-filled) vs `merged/_unfilled/` (pre-fill copies) alongside the existing `merged/_intermediates/` description.
+
+- [ ] **Step 3: Update `slurm_batch/HPC_REFERENCE.md`**
+
+Wherever the param-file inventory names outputs, state that `merged/*.csv` is the canonical set.
+
+- [ ] **Step 4: Verify no stale reference survives**
+
+```bash
+grep -rn "filled_nhm\|filled_" --include=*.md --include=*.py --include=*.yml \
+  docs/ slurm_batch/ src/ scripts/ configs/ | grep -v superpowers/specs | grep -v superpowers/plans
+```
+
+Expected: only `_unfilled` matches and `merge_and_fill_params.py`'s own docstrings. Anything else is a stale reference to fix.
+
+- [ ] **Step 5: Full suite, lint, commit**
+
+```bash
+srun -p cpu -A impd --mem=16G --time=00:30:00 pixi run -e dev pytest tests/ -q
+pixi run -e dev pre-commit run --all-files
+git add docs/ slurm_batch/
+git commit -m "docs(params): document the canonical merged/ convention and gap-filling
+
+RUNME §5 described the step in three lines and mentioned neither that it filled
+ONE file per run nor that it emitted a filled_ prefix -- which is why four
+params on oregon went unfilled until someone audited them by hand."
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| spec section | task |
+| --- | --- |
+| Consumer contract (`merged/` canonical) | 2 |
+| `fill_columns` declaration | 3 |
+| Guard: undeclared NaN warns | 1 (detection) + 3 (warning emission) |
+| Guard: absent row raises | 1 |
+| All-params default mode | 3 |
+| In-place write + `_unfilled/` | 2 |
+| Idempotency rule | 2 (+ 4 for the migration) |
+| dtype restore | 2 |
+| `viz.py` repoint | 4 |
+| Migration script | 4 |
+| Docs (RUNME/ARCHITECTURE/HPC_REFERENCE) | 5 |
+
+No spec section is unimplemented. The spec's "out of scope" items (KNN behaviour, the
+non-per-HRU snarea files, choosing between the two LULC products) have no task, correctly.
+
+**Placeholder scan:** no TBD/TODO. Two steps deliberately require the implementer to read
+real data rather than transcribe: Task 3 Step 1's exact value-column names per param
+(guessing them would produce a `fill_columns` typo that Task 1's guard then raises on),
+and Task 5's grep sweep. Both say so explicitly and both have a verification command.
+
+**Type consistency:** `resolve_fill_plan` / `FillPlan.fill_columns` / `FillPlan.undeclared_with_nan`
+are used identically in Tasks 1 and 3. `write_filled_in_place(complete_df, param_file,
+original_df, dtypes, logger=None)` matches between Tasks 2 and 3. `UNFILLED_DIRNAME` is
+defined in Task 2 and consumed in Task 4. `plan_migration` / `apply_migration` are
+consistent within Task 4.
+
+**Risk worth naming:** Task 4 Step 6 runs the migration against real products in dry-run
+only. Applying it is a controller decision, taken after the dry-run output has been read —
+it is the one step in this plan that can lose data.

--- a/docs/superpowers/plans/2026-07-25-param-fill-convention.md
+++ b/docs/superpowers/plans/2026-07-25-param-fill-convention.md
@@ -430,20 +430,40 @@ In `configs/depstor/depstor_params.yml`, add `fill_columns` to each of the 6 rat
 - [ ] **Step 2: Write the failing tests**
 
 ```python
+# The two configs use DIFFERENT top-level list keys — zonal has `params:`, depstor has
+# `fractions:` / `means:` / `ratios:`. Iterating only "params" would silently return []
+# for depstor and make this test pass vacuously.
+_PARAM_LIST_KEYS = ("params", "fractions", "means", "ratios")
+
+
+def _configured_entries(doc):
+    for key in _PARAM_LIST_KEYS:
+        for entry in doc.get(key, []) or []:
+            if isinstance(entry, dict):
+                yield key, entry
+
+
 def test_every_configured_param_declares_fill_columns():
     """A param with no fill_columns cannot be gap-filled — catch it at config time."""
     import yaml
     root = Path(__file__).resolve().parent.parent
+    checked = 0
     for cfg in [root / "configs/zonal/zonal_params.yml",
                 root / "configs/depstor/depstor_params.yml"]:
         doc = yaml.safe_load(cfg.read_text())
-        for entry in doc.get("params", []):
+        for key, entry in _configured_entries(doc):
+            # Only files landing in merged/ are canonical consumer-facing params;
+            # depstor `fractions` go to merged/_intermediates/ and are not filled.
             if not entry.get("merged_file"):
                 continue
+            checked += 1
             assert entry.get("fill_columns"), (
-                f"{entry['name']} in {cfg.name} has a merged_file but no fill_columns, so "
-                f"the gap-fill step would skip it and any missing HRU row would raise."
+                f"{entry['name']} (under '{key}' in {cfg.name}) has a merged_file but no "
+                f"fill_columns, so the gap-fill step would skip it and any missing HRU "
+                f"row would raise."
             )
+    # Guard against the whole test passing because nothing was found.
+    assert checked >= 7, f"expected to check at least 7 merged params, checked {checked}"
 
 
 def test_snarea_curve_does_not_declare_provenance_columns():
@@ -584,10 +604,14 @@ Create `scripts/migrate_filled_params.py`. It must default to `--dry-run` and re
 
 - [ ] **Step 4: Point `viz.py` at the canonical files**
 
-Replace all 7 occurrences of `filled_nhm_ssflux_params.csv` with `nhm_ssflux_params.csv` in `src/gfv2_params/viz.py`. Verify with:
+Replace all 7 occurrences of `filled_nhm_ssflux_params.csv` with `nhm_ssflux_params.csv` in `src/gfv2_params/viz.py`.
+
+**`tests/test_viz.py:186` asserts the old filename** (`assert by_name[n].csv_name == "filled_nhm_ssflux_params.csv"`) and must be updated to `nhm_ssflux_params.csv` in the same commit — otherwise the suite fails and it looks like the repoint broke something.
+
+Verify with:
 
 ```bash
-grep -c "filled_" src/gfv2_params/viz.py   # expect 0
+grep -c "filled_" src/gfv2_params/viz.py tests/test_viz.py   # expect 0 for both
 ```
 
 - [ ] **Step 5: Run the tests**

--- a/docs/superpowers/specs/2026-07-25-param-fill-convention-design.md
+++ b/docs/superpowers/specs/2026-07-25-param-fill-convention-design.md
@@ -1,0 +1,181 @@
+# Parameter gap-fill convention — design
+
+**Date:** 2026-07-25
+**Status:** design, awaiting review
+**Issue:** file on approval
+
+Makes `{fabric}/params/merged/nhm_*_params.csv` the single canonical per-HRU parameter
+set — always gap-filled — and retires the `filled_` prefix. Declares which columns are
+fillable per param, so provenance columns are never overwritten.
+
+## Problem
+
+Gap-filling today is a per-file manual step, and the result is a directory a consumer
+cannot read without prior knowledge.
+
+`scripts/merge_and_fill_params.py` fills **one file per invocation** and hardcodes
+`nhm_ssflux_params.csv` as its default (line 162); `slurm_batch/merge_and_fill_params.batch`
+passes only `--fabric`. So a param gets filled if and only if someone remembered to pass
+`--param_file` for it. The observable result on 2026-07-25:
+
+| fabric | filled files present |
+| --- | --- |
+| `gfv2` | `ssflux`, `soil_moist_max` |
+| `oregon` | `ssflux`, `soil_moist_max`, `lulc_nalcms`, `lulc_nhm_v11` |
+
+**The canonical set differs per fabric, and nothing records which file is authoritative.**
+A consumer cannot learn the rule from one fabric and apply it to another. The only code
+that knows the convention is `src/gfv2_params/viz.py`, which hardcodes
+`filled_nhm_ssflux_params.csv` for 7 parameters — a convention encoded in exactly one
+consumer and nowhere else.
+
+Measured gaps on `oregon` (16,814 HRUs), which is what prompted this:
+
+| param | gap | was it filled? |
+| --- | --- | --- |
+| `nhm_ssflux` | 10 absent HRU rows | yes |
+| `nhm_soil_moist_max` | 65 NaN cells | only after being asked for |
+| `nhm_lulc_nalcms` | 1 absent HRU row | only after being asked for |
+| `nhm_lulc_nhm_v11` | 1 absent HRU row | only after being asked for |
+
+RUNME §5 documents the whole step in three lines ("KNN-fills any missing per-HRU
+parameter values") and mentions neither the one-file-per-run behaviour nor the `filled_`
+output.
+
+### The trap that shapes the design
+
+`nhm_snarea_curve_params.csv` reports 7,891 of 16,814 rows containing NaN — but every one
+is in a **provenance** column, not a parameter:
+
+* `cv_empirical` (7,891 NaN) — the empirical CV is derivable for only ~42% of HRUs by
+  design; `cv_subgrid` exists precisely to rescue the rest. NaN is the *result*.
+* `cv_assign`, `cv_subgrid`, `similarity`, `peak_swe_mm` — 20 NaN each.
+* Every actual PRMS parameter — `hru_deplcrv`, `snarea_thresh`, `snarea_curve_0..10` —
+  is **complete**.
+
+A naive "fill everything with a gap" would overwrite `cv_empirical` with interpolated
+values and destroy the record of how each curve was derived. So the fill cannot be
+driven by "is there a NaN"; it must be told what a parameter is.
+
+## The convention
+
+**Consumer contract, one line:** read `{fabric}/params/merged/nhm_*_params.csv`. Always
+canonical, always gap-filled. The `filled_` prefix ceases to exist.
+
+The pre-fill copy moves to `{fabric}/params/merged/_unfilled/`, mirroring the repo's
+existing `merged/` (canonical) vs `merged/_intermediates/` (working) split.
+
+## What gets filled
+
+Each param entry in `configs/zonal/zonal_params.yml` and `configs/depstor/depstor_params.yml`
+declares its fillable columns:
+
+```yaml
+  - name: snarea_curve
+    fill_columns:
+      - hru_deplcrv
+      - snarea_thresh
+      - snarea_curve_0
+      # ... snarea_curve_1 .. snarea_curve_10
+    # cv_empirical / cv_assign / cv_subgrid / cv_source / sdc_status / similarity /
+    # peak_swe_mm / n_seasons / n_peak_years / sca_class are DELIBERATELY absent:
+    # NaN in those is "not derivable", a result rather than a gap.
+```
+
+Params needing the key: `ssflux` (7 columns), `snarea_curve` (13), `lulc_nalcms` and
+`lulc_nhm_v11` (7 each), `soil_moist_max`, `elevation`, `slope`, `aspect`, `soils`, and
+the single-column depstor params (`dprst_frac`, `carea_max`, `smidx_coef`,
+`sro_to_dprst_perv`, `sro_to_dprst_imperv`, `hru_percent_imperv`, `dprst_depth_avg`).
+
+## The guard
+
+An undeclared column is never touched — the safe direction, since it cannot destroy
+provenance. But "don't fill" must never be silent, or this design just trades a
+consumer-side ambiguity for a producer-side one. So the step audits **every** column
+regardless of what it fills:
+
+| finding | response |
+| --- | --- |
+| declared column, gap present | fill (KNN, `k=1`) |
+| **undeclared column with NaN cells** | **WARNING** naming column + count |
+| **undeclared param with an absent HRU row** | **RAISE** |
+
+The asymmetry is deliberate. A NaN cell is ambiguous — it may be a legitimate "not
+derivable", as `cv_empirical` is. An **absent row** is not ambiguous: the HRU is either
+in the file or it isn't, and no provenance reading makes a missing HRU correct. So a
+missing row in a param nobody declared fillable is a configuration error and fails loud.
+
+This is the same failure mode as the three defects found during the 2026-07-25 oregon
+rebuild — a step that reports success while quietly doing nothing. The design makes
+"I found a gap I was not told to fill" impossible to miss.
+
+## Components
+
+### `scripts/merge_and_fill_params.py`
+
+* **Default mode becomes all-params**: iterate every param declared in the zonal +
+  depstor configs for the active fabric. `--param_file` is retained for single-param runs.
+* **Write in place** at `merged/<name>.csv`; move the pre-fill copy to `merged/_unfilled/<name>.csv`.
+* **Restore the original column dtype after filling.** The 2026-07-25 oregon fill turned
+  `cov_type` from `int64` into `float64` (values `0.0/1.0/2.0/3.0`). With `k=1` no
+  averaging occurs so the classes stayed integral, but the dtype change is visible to any
+  consumer that does not cast. A declared categorical must come back as the integer class
+  it was.
+
+**Idempotency rule, load-bearing:** `_unfilled/<name>.csv` is written **only if it does
+not already exist**. Without that, a second run moves the *already-filled* file into
+`_unfilled/` and the true pre-fill version is destroyed — a one-way data loss on a shared
+filesystem with no version control. This gets a dedicated test; it is precisely the
+re-run-shaped hazard that produced the stale-`dprst_depth` bug the same day.
+
+### `src/gfv2_params/viz.py`
+
+Its 7 hardcoded `filled_nhm_ssflux_params.csv` references become `nhm_ssflux_params.csv`.
+It is the only consumer that encodes the old convention.
+
+### Migration
+
+One-time, touching real products on both fabrics (`gfv2`: `ssflux`, `soil_moist_max`;
+`oregon`: those plus `lulc_nalcms`, `lulc_nhm_v11`). A script with `--dry-run` first —
+not hand-run `mv`s. Per existing `filled_X.csv`:
+
+1. `X.csv` → `_unfilled/X.csv` (skip if `_unfilled/X.csv` exists)
+2. `filled_X.csv` → `X.csv`
+
+Idempotent and reversible.
+
+## Testing
+
+Synthetic, CI-safe (no data root):
+
+* declared columns filled; undeclared columns byte-identical afterwards
+* undeclared column with NaN → warning naming the column
+* undeclared param with an absent HRU row → raises
+* in-place write lands at `merged/<name>.csv`, pre-fill copy at `merged/_unfilled/<name>.csv`
+* **running twice does not clobber `_unfilled/`** — the second run's `_unfilled/` still
+  holds the original pre-fill content
+* a declared categorical column keeps its integer dtype after filling
+* a param with no gaps at all is a no-op (no `_unfilled/` entry created)
+
+## Docs
+
+* **`slurm_batch/RUNME.md` §5** — currently three lines. Must state: the step now covers
+  every declared param rather than one; `merged/` is canonical and gap-filled; the raw
+  pre-fill copies live in `merged/_unfilled/`; and how to see what was filled (the run log
+  reports per-param filled counts, plus the warnings for undeclared gaps).
+* **`docs/ARCHITECTURE.md`** — add `fill_columns` to the per-key required-field table and
+  document the `merged/` vs `merged/_unfilled/` split alongside the existing
+  `merged/_intermediates/` description.
+* **`slurm_batch/HPC_REFERENCE.md`** — the param-file inventory should name
+  `merged/*.csv` as canonical.
+
+## Out of scope
+
+* Changing *what* KNN fill does (still `k=1` nearest-neighbour). Only what it is run
+  against, where it writes, and what it refuses to touch.
+* `nhm_snarea_curve_library.csv` (9 rows) and `nhm_snarea_curve_validation.csv` (1 row) —
+  not per-HRU files; they are not params and are not filled.
+* Whether `lulc_nalcms` or `lulc_nhm_v11` should be preferred downstream. They are
+  different products from different source rasters, not two versions of one thing; the
+  crosswalk provenance favours `nhm_v11`, but selecting between them is a modelling
+  decision, not a fill-convention one.

--- a/scripts/merge_and_fill_params.py
+++ b/scripts/merge_and_fill_params.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import geopandas as gpd
 import numpy as np
 import pandas as pd
+import yaml
 from sklearn.neighbors import NearestNeighbors
 from tqdm import tqdm
 
@@ -249,13 +250,103 @@ def write_filled_in_place(complete_df, param_file, original_df, dtypes, logger=N
     return param_file
 
 
+# Repo-relative config paths consumed by `iter_declared_params`. Only the
+# static `name`/`merged_file`/`output_file`/`fill_columns` fields are read
+# here (none are {data_root}/{fabric}-templated), so a bare yaml.safe_load is
+# enough -- no need for gfv2_params.config.load_config's fabric-profile
+# resolution, which keeps this read safe with no data root (the CI contract:
+# tests may parse these files but must not touch a real data root).
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+ZONAL_PARAMS_CONFIG = _REPO_ROOT / "configs" / "zonal" / "zonal_params.yml"
+DEPSTOR_PARAMS_CONFIG = _REPO_ROOT / "configs" / "depstor" / "depstor_params.yml"
+SNAREA_LIBRARY_CONFIG = _REPO_ROOT / "configs" / "snarea" / "snarea_library.yml"
+
+
+def _load_yaml_doc(path: Path) -> dict:
+    """Bare `yaml.safe_load` of a config file, no placeholder resolution."""
+    doc = yaml.safe_load(path.read_text())
+    return doc or {}
+
+
+def iter_declared_params(
+    zonal_cfg: dict, depstor_cfg: dict, snarea_cfg: dict | None = None
+) -> list[tuple[str, str, list[str]]]:
+    """Every param with a canonical `merged/` output and its declared `fill_columns`.
+
+    Returns `(param_name, merged_filename, fill_columns)` tuples.
+
+    `zonal_cfg["params"]` and `depstor_cfg["means"]` name their canonical file
+    `merged_file`; `depstor_cfg["ratios"]` names it `output_file` instead (see
+    `derive_depstor_params.py`'s `run_mean_finalize` / `run_ratios`).
+    `depstor_cfg["fractions"]` is DELIBERATELY EXCLUDED: every fraction entry
+    also happens to carry a `merged_file` key, but that key names the
+    per-fraction COUNT csv written to `merged/_intermediates/` (`run_merge`),
+    never a `merged/` output -- fractions are intermediates, not
+    consumer-facing params, and are never filled.
+
+    `snarea_cfg` is optional and does NOT share either config's
+    list-of-entries shape. `snarea_curve` is not a `zonal_params.yml` entry at
+    all -- it comes from the separate 3-stage SNODAS pipeline
+    (`configs/snarea/snarea_library.yml`, Stage 3), a flat single-param config
+    whose `params_file` names the real `nhm_snarea_curve_params.csv`. A
+    synthetic `snarea_curve` entry could not live in `zonal_params.yml`
+    instead: `slurm_batch/submit_zonal_params.sh` loops that exact `params:`
+    list to submit one SLURM array job per param, and a phantom entry with no
+    `source_raster`/`script:` would break that orchestration. Hence the
+    separate optional argument rather than a fourth zonal-shaped list.
+    """
+    declared: list[tuple[str, str, list[str]]] = []
+
+    for entry in zonal_cfg.get("params", []) or []:
+        merged_file = entry.get("merged_file")
+        if merged_file:
+            declared.append((entry["name"], merged_file, list(entry.get("fill_columns") or [])))
+
+    for entry in depstor_cfg.get("means", []) or []:
+        merged_file = entry.get("merged_file")
+        if merged_file:
+            declared.append((entry["name"], merged_file, list(entry.get("fill_columns") or [])))
+
+    for entry in depstor_cfg.get("ratios", []) or []:
+        merged_file = entry.get("output_file")
+        if merged_file:
+            declared.append((entry["name"], merged_file, list(entry.get("fill_columns") or [])))
+
+    if snarea_cfg:
+        merged_file = snarea_cfg.get("params_file")
+        if merged_file:
+            declared.append(("snarea_curve", merged_file, list(snarea_cfg.get("fill_columns") or [])))
+
+    return declared
+
+
+def _load_declared_params() -> list[tuple[str, str, list[str]]]:
+    """`iter_declared_params` over the real in-repo configs."""
+    zonal_cfg = _load_yaml_doc(ZONAL_PARAMS_CONFIG)
+    depstor_cfg = _load_yaml_doc(DEPSTOR_PARAMS_CONFIG)
+    snarea_cfg = _load_yaml_doc(SNAREA_LIBRARY_CONFIG)
+    return iter_declared_params(zonal_cfg, depstor_cfg, snarea_cfg)
+
+
 def main():
     parser = argparse.ArgumentParser(description="Fill missing parameter values using KNN interpolation.")
     parser.add_argument("--base_config", default=None, help="Path to base_config.yml")
     parser.add_argument("--fabric", default=None, help="Fabric name (overrides FABRIC env / default_fabric)")
     parser.add_argument("--merged_gpkg", default=None, help="Path to merged nhru geopackage")
-    parser.add_argument("--param_file", default=None, help="Path to merged parameter CSV to fill")
-    parser.add_argument("--output_dir", default=None, help="Output directory for filled file")
+    parser.add_argument(
+        "--param_file", default=None,
+        help="Path to ONE merged parameter CSV to fill (single-param mode). Its "
+             "filename must be declared (merged_file/output_file/params_file) in "
+             "configs/zonal/zonal_params.yml, configs/depstor/depstor_params.yml, or "
+             "configs/snarea/snarea_library.yml. Omit to fill every declared param "
+             "for the active fabric whose merged file already exists (default).",
+    )
+    parser.add_argument(
+        "--output_dir", default=None,
+        help="Unused. Filling now writes in place at merged/<name>.csv (see "
+             "write_filled_in_place) -- kept only so a caller still passing this "
+             "flag does not break.",
+    )
     parser.add_argument("--k_neighbors", type=int, default=1)
     args = parser.parse_args()
 
@@ -276,21 +367,9 @@ def main():
     hru_layer = base.get("hru_layer", "nhru")
     if args.merged_gpkg is None:
         args.merged_gpkg = require_config_key(base, "hru_gpkg", "merge_and_fill_params")
-    if args.param_file is None:
-        args.param_file = f"{data_root}/{fabric}/params/merged/nhm_ssflux_params.csv"
-    if args.output_dir is None:
-        args.output_dir = f"{data_root}/{fabric}/params/merged"
 
     merged_gpkg = Path(args.merged_gpkg)
-    param_file = Path(args.param_file)
-    output_dir = Path(args.output_dir)
-    output_dir.mkdir(parents=True, exist_ok=True)
-
-    if not param_file.exists():
-        raise FileNotFoundError(
-            f"Parameter file not found: {param_file}\n"
-            "Run scripts/derive_zonal_params.py --mode merge --param <name> for this parameter type first."
-        )
+    merged_dir = Path(data_root) / fabric / "params" / "merged"
 
     if not merged_gpkg.exists():
         raise FileNotFoundError(
@@ -310,35 +389,79 @@ def main():
         ) from exc
     logger.info("Loaded %d features", len(merged_gdf))
 
-    filled_param_file = output_dir / f"filled_{param_file.name}"
+    declared_params = _load_declared_params()
 
-    param_df, missing_ids = find_missing_ids(param_file, expected_max, id_feature, logger)
+    if args.param_file is not None:
+        # Single-param mode: fill exactly the file named on the CLI, routed
+        # through the same resolve_fill_plan / fill_missing_values_knn /
+        # write_filled_in_place path as the default all-params mode below.
+        param_file = Path(args.param_file)
+        if not param_file.exists():
+            raise FileNotFoundError(
+                f"Parameter file not found: {param_file}\n"
+                "Run scripts/derive_zonal_params.py --mode merge --param <name> (or the "
+                "matching depstor/snarea step) for this parameter type first."
+            )
+        match = next((d for d in declared_params if d[1] == param_file.name), None)
+        if match is None:
+            raise ValueError(
+                f"'{param_file.name}' is not declared in configs/zonal/zonal_params.yml, "
+                "configs/depstor/depstor_params.yml, or configs/snarea/snarea_library.yml "
+                "-- add a `fill_columns` entry for it before filling."
+            )
+        name, _merged_file, fill_columns = match
+        targets = [(name, param_file, fill_columns)]
+    else:
+        # All-params mode (default): every declared param whose merged file has
+        # already been produced for this fabric. A param not yet produced
+        # (e.g. lulc_nlcd/lulc_foresce -- inputs unstaged) is skipped with an
+        # INFO line, not an error.
+        targets = []
+        for name, merged_file, fill_columns in declared_params:
+            pf = merged_dir / merged_file
+            if not pf.exists():
+                logger.info("Skipping %s: %s not found (not yet produced for this fabric)", name, pf)
+                continue
+            targets.append((name, pf, fill_columns))
+        if not targets:
+            logger.warning("No declared params' merged files were found under %s", merged_dir)
+            return
 
-    param_columns = [col for col in param_df.columns if col not in {id_feature, "hru_id", "nat_hru_id", "vpu"}]
-    if not param_columns:
-        raise ValueError("No parameter columns found in the data")
+    for name, param_file, declared_columns in targets:
+        logger.info("=== %s (%s) ===", name, param_file.name)
 
-    needs_fill = bool(missing_ids) or param_df[param_columns].isna().to_numpy().any()
+        param_df, missing_ids = find_missing_ids(param_file, expected_max, id_feature, logger)
+        plan = resolve_fill_plan(param_df, declared_columns, missing_ids, id_feature, name)
 
-    if needs_fill:
-        logger.info("Filling parameter columns: %s", param_columns)
+        for col, n in plan.undeclared_with_nan.items():
+            logger.warning(
+                "  %s: column '%s' has %d NaN cell(s) but is NOT declared in "
+                "`fill_columns` — left untouched. If it is a PRMS parameter rather than "
+                "provenance, add it to the config; if it is provenance, this is correct.",
+                param_file.name, col, n,
+            )
+
+        if not plan.fill_columns:
+            logger.info("  No fill_columns declared for %s; nothing to fill", name)
+            continue
+
+        # Capture dtypes on the pristine pre-fill frame; fill_missing_values_knn
+        # does not mutate param_df in place (it rebinds through pd.concat/merge),
+        # so it also doubles as the "original" frame write_filled_in_place needs.
+        dtypes = param_df.dtypes.to_dict()
 
         complete_df = fill_missing_values_knn(
-            param_df, missing_ids, merged_gdf, param_columns, args.k_neighbors, id_feature, logger
+            param_df, missing_ids, merged_gdf, plan.fill_columns, args.k_neighbors, id_feature, logger,
         )
-        complete_df.to_csv(filled_param_file, index=False)
-        logger.info("Filled parameter file saved to: %s", filled_param_file)
+        write_filled_in_place(complete_df, param_file, param_df, dtypes, logger=logger)
 
         final_ids = set(complete_df[id_feature])
         expected_ids = set(range(1, expected_max + 1))
         still_missing = expected_ids - final_ids
-
         if still_missing:
-            logger.warning("%d IDs are still missing", len(still_missing))
+            logger.warning("  %d IDs are still missing", len(still_missing))
         else:
-            logger.info("All missing values have been filled successfully!")
-    else:
-        logger.info("No missing values found in the parameter file")
+            logger.info("  All missing values have been filled successfully!")
 
 
 if __name__ == "__main__":

--- a/scripts/merge_and_fill_params.py
+++ b/scripts/merge_and_fill_params.py
@@ -9,6 +9,7 @@ profile.
 """
 
 import argparse
+import fnmatch
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -63,6 +64,17 @@ def resolve_fill_plan(param_df, declared, missing_ids, id_feature, param_name) -
     existed the column list was "everything except the id columns", which would have
     done exactly that.
 
+    Each entry in `declared` is normally a plain column name, but MAY instead be a
+    list/tuple of alias alternatives -- e.g. `[retention, rad_trncf]` for
+    `lulc_nhm_v11`, whose `lulc_prederived` builder renamed the same computed quantity
+    from `retention` to `rad_trncf` ("There is no `retention` column: it was only ever
+    a stand-in for rad_trncf", zonal_runners/lulc_prederived.py). Fabrics built before
+    the rename (gfv2, oregon) still carry `retention` on disk; fabrics built after it
+    (tjc) carry `rad_trncf`. The first alternative present in `param_df` wins; this is
+    NOT a generic "optional column" mechanism -- if NONE of the alternatives are
+    present, that still raises exactly like a plain missing column would, so a
+    genuinely absent column cannot silently skip filling.
+
     Two asymmetric guards, because the two kinds of gap differ in what they can mean:
 
       * an undeclared column with NaN CELLS is ambiguous -- it may be a legitimate
@@ -73,10 +85,24 @@ def resolve_fill_plan(param_df, declared, missing_ids, id_feature, param_name) -
     """
     declared = list(declared or [])
 
-    absent = [c for c in declared if c not in param_df.columns]
-    if absent:
+    resolved: list[str] = []
+    unresolved: list[str] = []
+    for item in declared:
+        if isinstance(item, (list, tuple)):
+            alternatives = list(item)
+            match = next((alt for alt in alternatives if alt in param_df.columns), None)
+            if match is None:
+                unresolved.append(" or ".join(alternatives))
+            else:
+                resolved.append(match)
+        elif item not in param_df.columns:
+            unresolved.append(item)
+        else:
+            resolved.append(item)
+
+    if unresolved:
         raise ValueError(
-            f"`fill_columns` for '{param_name}' names {absent}, which are not present in "
+            f"`fill_columns` for '{param_name}' names {unresolved}, which are not present in "
             f"the parameter file (columns: {sorted(param_df.columns)}). Fix the config -- "
             f"a typo here would silently fill nothing."
         )
@@ -92,13 +118,13 @@ def resolve_fill_plan(param_df, declared, missing_ids, id_feature, param_name) -
 
     undeclared_with_nan = {}
     for col in param_df.columns:
-        if col in declared or col in ID_COLUMNS or col == id_feature:
+        if col in resolved or col in ID_COLUMNS or col == id_feature:
             continue
         n_nan = int(param_df[col].isna().sum())
         if n_nan:
             undeclared_with_nan[col] = n_nan
 
-    return FillPlan(fill_columns=declared, undeclared_with_nan=undeclared_with_nan)
+    return FillPlan(fill_columns=resolved, undeclared_with_nan=undeclared_with_nan)
 
 
 def fill_missing_values_knn(param_df, missing_ids, merged_gdf, param_columns, k, id_feature, logger):
@@ -141,9 +167,15 @@ def fill_missing_values_knn(param_df, missing_ids, merged_gdf, param_columns, k,
     # Step 1: append all-NaN rows for absent ids so every expected id is present.
     if missing_ids:
         absent_rows = pd.DataFrame({id_feature: missing_ids})
-        # gfv2 CSVs carry a secondary local hru_id; populate it for appended rows.
-        # When id_feature is already hru_id (e.g. oregon) this is a harmless self-assignment.
-        absent_rows["hru_id"] = absent_rows[id_feature]
+        # Some fabrics' CSVs carry a secondary local hru_id column; populate it for
+        # appended rows ONLY if the frame already has one. gfv2's id_feature is
+        # nat_hru_id with NO hru_id column at all -- unconditionally adding one here
+        # would introduce a spurious, all-empty trailing hru_id column into the
+        # canonical output for every param with an absent row (lulc_nhm_v11,
+        # lulc_nalcms, ssflux on gfv2). When id_feature is already hru_id (e.g.
+        # oregon) the column already exists, so this is a harmless self-assignment.
+        if "hru_id" in param_df.columns:
+            absent_rows["hru_id"] = absent_rows[id_feature]
         param_df = pd.concat([param_df, absent_rows], ignore_index=True)
 
     # Step 2: attach centroid x,y to every row (left join preserves all ids).
@@ -328,6 +360,112 @@ def _load_declared_params() -> list[tuple[str, str, list[str]]]:
     return iter_declared_params(zonal_cfg, depstor_cfg, snarea_cfg)
 
 
+def check_param_file_in_fabric(param_file: Path, merged_dir: Path) -> None:
+    """Refuse a `--param_file` that does not live under the active fabric's
+    own `merged/` directory.
+
+    `--fabric gfv2 --param_file <gfv2_vpu01 path>` would otherwise write in
+    place into a DIFFERENT fabric's canonical parameter file -- the CLI takes
+    `--fabric` and `--param_file` as two independent flags with nothing tying
+    them together, so nothing else catches a mismatched pair.
+    """
+    if param_file.parent.resolve() != merged_dir.resolve():
+        raise ValueError(
+            f"--param_file {param_file} is not under the active fabric's merged "
+            f"directory ({merged_dir}). Refusing to write in place into what looks "
+            f"like a different fabric's canonical parameter file -- pass a path "
+            f"under {merged_dir}, or check --fabric."
+        )
+
+
+# Allowlist for warn_undeclared_merged_files: on-disk artifacts under merged/
+# that legitimately have no fill_columns declaration because they are not a
+# per-HRU consumer param (e.g. a *_library.csv reference table).
+_UNDECLARED_ALLOW_PATTERNS = ("*_library*", "*_validation*")
+
+
+def warn_undeclared_merged_files(merged_dir: Path, declared_params, logger) -> list[str]:
+    """Warn about any `merged/nhm_*_params.csv` that no config entry declares.
+
+    All-params mode iterates the DECLARATION, so a merged file with no config
+    entry is otherwise never filled and never flagged -- there is nothing
+    enforcing the reverse direction (declaration -> disk is covered by the
+    per-target skip warning; disk -> declaration was not, until now).
+
+    Returns the sorted list of undeclared filenames warned about (for tests).
+    """
+    declared_filenames = {merged_file for _, merged_file, _ in declared_params}
+    undeclared = []
+    for on_disk in sorted(merged_dir.glob("nhm_*_params.csv")):
+        if on_disk.name in declared_filenames:
+            continue
+        if any(fnmatch.fnmatch(on_disk.name, pat) for pat in _UNDECLARED_ALLOW_PATTERNS):
+            continue
+        undeclared.append(on_disk.name)
+        logger.warning(
+            "%s exists under %s but is not declared in any fill_columns config "
+            "(configs/zonal/zonal_params.yml, configs/depstor/depstor_params.yml, or "
+            "configs/snarea/snarea_library.yml) -- it will never be gap-filled by this "
+            "step.", on_disk.name, merged_dir,
+        )
+    return undeclared
+
+
+def run_fill_sweep(targets, merged_gdf, expected_max, id_feature, k_neighbors, logger) -> list[str]:
+    """Fill every `(name, param_file, declared_columns)` in `targets`, isolating
+    per-param failures.
+
+    One param's config drift (e.g. a column rename that resolve_fill_plan can't
+    resolve) must not starve every OTHER declared param of its fill -- a
+    partially-applied canonical set from an aborted sweep is worse than a
+    param that stays unfilled with a named, logged cause. Catches per-param,
+    logs the full traceback, records the failure, and continues; the caller
+    decides the process exit code from the returned failure list.
+    """
+    failed_params: list[str] = []
+    for name, param_file, declared_columns in targets:
+        logger.info("=== %s (%s) ===", name, param_file.name)
+        try:
+            param_df, missing_ids = find_missing_ids(param_file, expected_max, id_feature, logger)
+            plan = resolve_fill_plan(param_df, declared_columns, missing_ids, id_feature, name)
+
+            for col, n in plan.undeclared_with_nan.items():
+                logger.warning(
+                    "  %s: column '%s' has %d NaN cell(s) but is NOT declared in "
+                    "`fill_columns` — left untouched. If it is a PRMS parameter rather than "
+                    "provenance, add it to the config; if it is provenance, this is correct.",
+                    param_file.name, col, n,
+                )
+
+            if not plan.fill_columns:
+                logger.info("  No fill_columns declared for %s; nothing to fill", name)
+                continue
+
+            # Capture dtypes on the pristine pre-fill frame; fill_missing_values_knn
+            # does not mutate param_df in place (it rebinds through pd.concat/merge),
+            # so it also doubles as the "original" frame write_filled_in_place needs.
+            dtypes = param_df.dtypes.to_dict()
+
+            complete_df = fill_missing_values_knn(
+                param_df, missing_ids, merged_gdf, plan.fill_columns, k_neighbors, id_feature, logger,
+            )
+            write_filled_in_place(complete_df, param_file, param_df, dtypes, logger=logger)
+
+            final_ids = set(complete_df[id_feature])
+            expected_ids = set(range(1, expected_max + 1))
+            still_missing = expected_ids - final_ids
+            if still_missing:
+                logger.warning("  %d IDs are still missing", len(still_missing))
+            else:
+                logger.info("  All missing values have been filled successfully!")
+        except Exception:
+            # See docstring: isolate this param's failure, keep going.
+            logger.exception("  %s: FAILED to fill -- continuing with remaining params", name)
+            failed_params.append(name)
+
+    return failed_params
+
+
 def main():
     parser = argparse.ArgumentParser(description="Fill missing parameter values using KNN interpolation.")
     parser.add_argument("--base_config", default=None, help="Path to base_config.yml")
@@ -396,6 +534,7 @@ def main():
         # through the same resolve_fill_plan / fill_missing_values_knn /
         # write_filled_in_place path as the default all-params mode below.
         param_file = Path(args.param_file)
+        check_param_file_in_fabric(param_file, merged_dir)
         if not param_file.exists():
             raise FileNotFoundError(
                 f"Parameter file not found: {param_file}\n"
@@ -414,55 +553,37 @@ def main():
     else:
         # All-params mode (default): every declared param whose merged file has
         # already been produced for this fabric. A param not yet produced
-        # (e.g. lulc_nlcd/lulc_foresce -- inputs unstaged) is skipped with an
-        # INFO line, not an error.
+        # (e.g. lulc_nlcd/lulc_foresce -- inputs unstaged) is skipped with a
+        # WARNING (not silently at INFO -- an operator scanning the log for
+        # problems should see it).
         targets = []
         for name, merged_file, fill_columns in declared_params:
             pf = merged_dir / merged_file
             if not pf.exists():
-                logger.info("Skipping %s: %s not found (not yet produced for this fabric)", name, pf)
+                logger.warning("Skipping %s: %s not found (not yet produced for this fabric)", name, pf)
                 continue
             targets.append((name, pf, fill_columns))
         if not targets:
             logger.warning("No declared params' merged files were found under %s", merged_dir)
-            return
+            return 0
 
-    for name, param_file, declared_columns in targets:
-        logger.info("=== %s (%s) ===", name, param_file.name)
+        # The reverse direction: warn about a merged/nhm_*_params.csv on disk that
+        # no config entry declares at all -- see warn_undeclared_merged_files.
+        warn_undeclared_merged_files(merged_dir, declared_params, logger)
 
-        param_df, missing_ids = find_missing_ids(param_file, expected_max, id_feature, logger)
-        plan = resolve_fill_plan(param_df, declared_columns, missing_ids, id_feature, name)
+    failed_params = run_fill_sweep(
+        targets, merged_gdf, expected_max, id_feature, args.k_neighbors, logger,
+    )
 
-        for col, n in plan.undeclared_with_nan.items():
-            logger.warning(
-                "  %s: column '%s' has %d NaN cell(s) but is NOT declared in "
-                "`fill_columns` — left untouched. If it is a PRMS parameter rather than "
-                "provenance, add it to the config; if it is provenance, this is correct.",
-                param_file.name, col, n,
-            )
-
-        if not plan.fill_columns:
-            logger.info("  No fill_columns declared for %s; nothing to fill", name)
-            continue
-
-        # Capture dtypes on the pristine pre-fill frame; fill_missing_values_knn
-        # does not mutate param_df in place (it rebinds through pd.concat/merge),
-        # so it also doubles as the "original" frame write_filled_in_place needs.
-        dtypes = param_df.dtypes.to_dict()
-
-        complete_df = fill_missing_values_knn(
-            param_df, missing_ids, merged_gdf, plan.fill_columns, args.k_neighbors, id_feature, logger,
+    if failed_params:
+        logger.error(
+            "%d of %d param(s) FAILED to fill: %s. The canonical set is only PARTIALLY "
+            "applied -- fix the cause(s) above and re-run.",
+            len(failed_params), len(targets), ", ".join(failed_params),
         )
-        write_filled_in_place(complete_df, param_file, param_df, dtypes, logger=logger)
-
-        final_ids = set(complete_df[id_feature])
-        expected_ids = set(range(1, expected_max + 1))
-        still_missing = expected_ids - final_ids
-        if still_missing:
-            logger.warning("  %d IDs are still missing", len(still_missing))
-        else:
-            logger.info("  All missing values have been filled successfully!")
+        return 1
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/scripts/merge_and_fill_params.py
+++ b/scripts/merge_and_fill_params.py
@@ -9,6 +9,7 @@ profile.
 """
 
 import argparse
+from dataclasses import dataclass, field
 from pathlib import Path
 
 import geopandas as gpd
@@ -29,6 +30,74 @@ def find_missing_ids(param_file, expected_max, id_feature, logger):
     missing_ids = sorted(expected_ids - existing_ids)
     logger.info("Found %d missing %s values out of %d", len(missing_ids), id_feature, expected_max)
     return param_df, missing_ids
+
+
+@dataclass
+class FillPlan:
+    """What a param's fill run may touch, and what it found but must not touch.
+
+    `fill_columns` is exactly the caller's declared list, intersected with nothing —
+    a declared column missing from the frame is an error, not a silent skip.
+    `undeclared_with_nan` is the caller's warning material: columns carrying NaN that
+    nobody declared fillable.
+    """
+
+    fill_columns: list[str] = field(default_factory=list)
+    undeclared_with_nan: dict[str, int] = field(default_factory=dict)
+
+
+# Columns that identify an HRU rather than parameterise it. Never fillable, and never
+# reported as an undeclared gap.
+ID_COLUMNS = {"hru_id", "nat_hru_id", "model_hru_idx", "vpu"}
+
+
+def resolve_fill_plan(param_df, declared, missing_ids, id_feature, param_name) -> FillPlan:
+    """Decide what to fill for one param, and what to surface without filling.
+
+    The selection is DECLARATION-driven, not gap-driven, because "has a NaN" does not
+    mean "is missing". `nhm_snarea_curve_params.csv` carries 7,891 rows with NaN, every
+    one in a provenance column -- `cv_empirical` is derivable for only ~42% of HRUs BY
+    DESIGN, and `cv_subgrid` exists to rescue the rest. Filling it would overwrite the
+    record of how each curve was derived with interpolated noise. Before this function
+    existed the column list was "everything except the id columns", which would have
+    done exactly that.
+
+    Two asymmetric guards, because the two kinds of gap differ in what they can mean:
+
+      * an undeclared column with NaN CELLS is ambiguous -- it may be a legitimate
+        "not derivable" -- so it is reported for the caller to WARN about;
+      * an absent HRU ROW is not ambiguous. The HRU is in the file or it is not, and no
+        provenance reading makes a missing HRU correct. With nothing declared fillable,
+        that is a configuration error and RAISES.
+    """
+    declared = list(declared or [])
+
+    absent = [c for c in declared if c not in param_df.columns]
+    if absent:
+        raise ValueError(
+            f"`fill_columns` for '{param_name}' names {absent}, which are not present in "
+            f"the parameter file (columns: {sorted(param_df.columns)}). Fix the config -- "
+            f"a typo here would silently fill nothing."
+        )
+
+    if missing_ids and not declared:
+        raise ValueError(
+            f"'{param_name}' is missing {len(missing_ids)} HRU row(s) but declares no "
+            f"`fill_columns`, so nothing would be filled and the gap would persist "
+            f"unnoticed. An absent HRU row is unambiguous -- unlike a NaN cell, it cannot "
+            f"be a legitimate 'not derivable' result. Add `fill_columns` for this param in "
+            f"its config entry."
+        )
+
+    undeclared_with_nan = {}
+    for col in param_df.columns:
+        if col in declared or col in ID_COLUMNS or col == id_feature:
+            continue
+        n_nan = int(param_df[col].isna().sum())
+        if n_nan:
+            undeclared_with_nan[col] = n_nan
+
+    return FillPlan(fill_columns=declared, undeclared_with_nan=undeclared_with_nan)
 
 
 def fill_missing_values_knn(param_df, missing_ids, merged_gdf, param_columns, k, id_feature, logger):

--- a/scripts/merge_and_fill_params.py
+++ b/scripts/merge_and_fill_params.py
@@ -200,6 +200,55 @@ def fill_missing_values_knn(param_df, missing_ids, merged_gdf, param_columns, k,
     return full_df
 
 
+UNFILLED_DIRNAME = "_unfilled"
+
+
+def write_filled_in_place(complete_df, param_file, original_df, dtypes, logger=None):
+    """Write the filled frame OVER `param_file`, preserving the pre-fill copy.
+
+    `merged/<name>.csv` is the single canonical per-HRU parameter file -- always
+    gap-filled -- so a consumer's rule is one line: read `merged/*.csv`. The retired
+    `filled_` prefix required a consumer to know, per param AND per fabric, which of two
+    files was authoritative; the set differed between gfv2 (2 filled) and oregon (4), and
+    only `viz.py` encoded the rule.
+
+    The pre-fill copy goes to `merged/_unfilled/`, mirroring `merged/_intermediates/`.
+
+    IDEMPOTENCY, load-bearing: `_unfilled/<name>.csv` is written ONLY if it does not
+    already exist. On a re-run the on-disk file is ALREADY filled, so overwriting the
+    preserved copy with it would destroy the true raw version -- irreversibly, on a
+    shared filesystem with no version control.
+
+    `dtypes` restores each column's pre-fill dtype. KNN returns float64 even at k=1, which
+    silently turned `cov_type` (an integer class 0-3) into 0.0/1.0/2.0/3.0. No averaging
+    occurs at k=1, so the classes are correct -- but the dtype change is visible to any
+    consumer that does not cast.
+    """
+    unfilled_dir = param_file.parent / UNFILLED_DIRNAME
+    unfilled_dir.mkdir(parents=True, exist_ok=True)
+    raw_copy = unfilled_dir / param_file.name
+
+    if raw_copy.exists():
+        if logger:
+            logger.info(
+                "  %s already preserved at %s — not overwriting (a re-run's input is "
+                "already filled)", param_file.name, raw_copy,
+            )
+    else:
+        original_df.to_csv(raw_copy, index=False)
+        if logger:
+            logger.info("  pre-fill copy preserved -> %s", raw_copy)
+
+    out = complete_df.copy()
+    for col, dt in (dtypes or {}).items():
+        if col in out.columns and dt.kind in "iu" and out[col].notna().all():
+            out[col] = out[col].round().astype(dt)
+    out.to_csv(param_file, index=False)
+    if logger:
+        logger.info("  canonical parameter file written -> %s", param_file)
+    return param_file
+
+
 def main():
     parser = argparse.ArgumentParser(description="Fill missing parameter values using KNN interpolation.")
     parser.add_argument("--base_config", default=None, help="Path to base_config.yml")

--- a/scripts/migrate_filled_params.py
+++ b/scripts/migrate_filled_params.py
@@ -1,0 +1,127 @@
+"""One-time migration off the retired `filled_` prefix onto the canonical convention.
+
+`merged/<name>.csv` is now the single canonical, always-gap-filled per-HRU file
+(see scripts/merge_and_fill_params.py's write_filled_in_place), with the
+pre-fill copy preserved at `merged/_unfilled/<name>.csv`. Existing products
+(gfv2, oregon) still have some params split across `<name>.csv` (pre-fill) and
+`filled_<name>.csv` (the actual filled product) from before that convention
+existed. This script moves each pair onto the new layout:
+
+    1. `<name>.csv`        -> `_unfilled/<name>.csv`   (skipped if already there)
+    2. `filled_<name>.csv` -> `<name>.csv`
+
+Step 1's skip is load-bearing: if `_unfilled/<name>.csv` already exists (e.g. a
+previous run of this script, or merge_and_fill_params.py has already run once
+since), the on-disk `<name>.csv` is ALREADY the filled product -- moving it
+over the preserved copy would destroy the true pre-fill version irreversibly,
+on a shared filesystem with no version control. See
+test_migration_refuses_when_raw_already_preserved.
+
+Defaults to --dry-run (prints the plan, moves nothing); pass --apply to
+execute it. Always prints every move before making it.
+
+    pixi run --as-is python scripts/migrate_filled_params.py --merged_dir <path>          # dry-run
+    pixi run --as-is python scripts/migrate_filled_params.py --merged_dir <path> --apply   # execute
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+from pathlib import Path
+
+# Source of truth: scripts/merge_and_fill_params.py's UNFILLED_DIRNAME.
+try:
+    from merge_and_fill_params import UNFILLED_DIRNAME
+except ImportError:
+    # Fallback for contexts where scripts/ isn't on sys.path (e.g. this module
+    # loaded standalone via importlib, as tests do) -- must match the literal
+    # in scripts/merge_and_fill_params.py.
+    UNFILLED_DIRNAME = "_unfilled"
+
+FILLED_PREFIX = "filled_"
+
+
+def plan_migration(merged_dir: Path) -> list[tuple[Path, Path, Path]]:
+    """Pair every `filled_*.csv` under `merged_dir` with its canonical/raw targets.
+
+    Returns `(filled_file, canonical_target, raw_target)` triples, one per
+    `filled_*.csv` found. Does not touch the filesystem.
+    """
+    merged_dir = Path(merged_dir)
+    plan = []
+    for filled_file in sorted(merged_dir.glob(f"{FILLED_PREFIX}*.csv")):
+        canonical_name = filled_file.name[len(FILLED_PREFIX):]
+        canonical_target = merged_dir / canonical_name
+        raw_target = merged_dir / UNFILLED_DIRNAME / canonical_name
+        plan.append((filled_file, canonical_target, raw_target))
+    return plan
+
+
+def apply_migration(plan: list[tuple[Path, Path, Path]]) -> None:
+    """Execute a migration plan from `plan_migration`.
+
+    Per triple: move the canonical (pre-fill) file to `_unfilled/` -- skipped
+    if that target already exists, see module docstring -- then move the
+    `filled_` file onto the now-vacated canonical name. Prints every move (or
+    skip) before performing it.
+    """
+    for filled_file, canonical_target, raw_target in plan:
+        if raw_target.exists():
+            print(f"  SKIP  {canonical_target} -> {raw_target} (already preserved)")
+        elif canonical_target.exists():
+            raw_target.parent.mkdir(parents=True, exist_ok=True)
+            print(f"  MOVE  {canonical_target} -> {raw_target}")
+            shutil.move(str(canonical_target), str(raw_target))
+        else:
+            print(f"  SKIP  {canonical_target} does not exist -- nothing to preserve")
+
+        print(f"  MOVE  {filled_file} -> {canonical_target}")
+        shutil.move(str(filled_file), str(canonical_target))
+
+
+def print_plan(plan: list[tuple[Path, Path, Path]]) -> None:
+    """Print what `apply_migration` would do, without touching the filesystem."""
+    for filled_file, canonical_target, raw_target in plan:
+        note = " (already preserved -- would SKIP)" if raw_target.exists() else ""
+        print(f"  {filled_file.name}")
+        print(f"    {canonical_target.name} -> {raw_target.parent.name}/{raw_target.name}{note}")
+        print(f"    {filled_file.name} -> {canonical_target.name}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--merged_dir", required=True,
+        help="Path to a fabric's params/merged/ directory to migrate.",
+    )
+    parser.add_argument(
+        "--apply", action="store_true",
+        help="Execute the migration. Without this flag, only prints the plan.",
+    )
+    args = parser.parse_args()
+
+    merged_dir = Path(args.merged_dir)
+    if not merged_dir.is_dir():
+        raise FileNotFoundError(f"Not a directory: {merged_dir}")
+
+    plan = plan_migration(merged_dir)
+    if not plan:
+        print(f"No filled_*.csv found under {merged_dir}; nothing to migrate.")
+        return 0
+
+    print(f"{'APPLYING' if args.apply else 'DRY RUN'}: {len(plan)} move(s) planned under {merged_dir}")
+    print_plan(plan)
+
+    if not args.apply:
+        print("\nDry run only -- pass --apply to execute.")
+        return 0
+
+    print("\nApplying...")
+    apply_migration(plan)
+    print("Done.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/migrate_filled_params.py
+++ b/scripts/migrate_filled_params.py
@@ -14,8 +14,21 @@ Step 1's skip is load-bearing: if `_unfilled/<name>.csv` already exists (e.g. a
 previous run of this script, or merge_and_fill_params.py has already run once
 since), the on-disk `<name>.csv` is ALREADY the filled product -- moving it
 over the preserved copy would destroy the true pre-fill version irreversibly,
-on a shared filesystem with no version control. See
-test_migration_refuses_when_raw_already_preserved.
+on a shared filesystem with no version control.
+
+Step 2 is NOT unconditional, even though step 1 may have been skipped. If
+`_unfilled/<name>.csv` (raw_target) already exists AND `<name>.csv`
+(canonical_target) ALSO already exists, the canonical file is already on the
+new convention (e.g. produced by a fresh `merge_and_fill_params.py` run) and
+`filled_<name>.csv` is a stale leftover from before that -- moving it over the
+canonical file would silently REVERT today's correct fill to whatever
+pre-branch product the `filled_` file still holds, with exit code 0 and no
+warning. That case refuses loudly instead of moving. Only when raw_target
+exists but canonical_target does NOT (a previous run of this script died
+between step 1 and step 2) does step 2 proceed, resuming the partial
+migration. See test_migration_resumes_when_raw_preserved_but_canonical_missing
+and test_migration_raises_when_canonical_already_filled_and_raw_preserved.
+`print_plan` mirrors this exact decision so a dry run matches --apply.
 
 Defaults to --dry-run (prints the plan, moves nothing); pass --apply to
 execute it. Always prints every move before making it.
@@ -58,6 +71,24 @@ def plan_migration(merged_dir: Path) -> list[tuple[Path, Path, Path]]:
     return plan
 
 
+class AlreadyMigratedError(RuntimeError):
+    """Raised when both the canonical file and its preserved raw copy already
+    exist -- moving the `filled_` file over the canonical would silently
+    revert an already-correct fill. See the module docstring."""
+
+
+def _refusal_message(filled_file: Path, canonical_target: Path, raw_target: Path) -> str:
+    return (
+        f"Refusing to migrate {filled_file.name}: both {canonical_target} (the canonical "
+        f"file, already on the new convention) and {raw_target} (its preserved pre-fill "
+        f"copy) already exist. This means {filled_file.name} is a stale leftover from "
+        f"before the canonical file was (re)filled -- moving it over {canonical_target.name} "
+        f"would silently REVERT today's correct fill to whatever pre-branch product "
+        f"{filled_file.name} still holds, with no warning. Inspect both files by hand; do "
+        f"not simply re-run --apply."
+    )
+
+
 def apply_migration(plan: list[tuple[Path, Path, Path]]) -> None:
     """Execute a migration plan from `plan_migration`.
 
@@ -65,10 +96,17 @@ def apply_migration(plan: list[tuple[Path, Path, Path]]) -> None:
     if that target already exists, see module docstring -- then move the
     `filled_` file onto the now-vacated canonical name. Prints every move (or
     skip) before performing it.
+
+    Raises `AlreadyMigratedError` (stopping the whole run) if a triple's
+    raw_target AND canonical_target both already exist -- see module
+    docstring. That case is NOT a resumable partial migration; the `filled_`
+    file must not be moved.
     """
     for filled_file, canonical_target, raw_target in plan:
         if raw_target.exists():
-            print(f"  SKIP  {canonical_target} -> {raw_target} (already preserved)")
+            if canonical_target.exists():
+                raise AlreadyMigratedError(_refusal_message(filled_file, canonical_target, raw_target))
+            print(f"  SKIP  {canonical_target} -> {raw_target} (already preserved; resuming partial migration)")
         elif canonical_target.exists():
             raw_target.parent.mkdir(parents=True, exist_ok=True)
             print(f"  MOVE  {canonical_target} -> {raw_target}")
@@ -81,10 +119,18 @@ def apply_migration(plan: list[tuple[Path, Path, Path]]) -> None:
 
 
 def print_plan(plan: list[tuple[Path, Path, Path]]) -> None:
-    """Print what `apply_migration` would do, without touching the filesystem."""
+    """Print what `apply_migration` would do, without touching the filesystem.
+
+    Mirrors apply_migration's decision exactly, including the refuse case --
+    a dry run that disagreed with --apply on a data-moving script would be
+    worse than no dry run at all.
+    """
     for filled_file, canonical_target, raw_target in plan:
-        note = " (already preserved -- would SKIP)" if raw_target.exists() else ""
         print(f"  {filled_file.name}")
+        if raw_target.exists() and canonical_target.exists():
+            print(f"    REFUSE -- {_refusal_message(filled_file, canonical_target, raw_target)}")
+            continue
+        note = " (already preserved -- would SKIP)" if raw_target.exists() else ""
         print(f"    {canonical_target.name} -> {raw_target.parent.name}/{raw_target.name}{note}")
         print(f"    {filled_file.name} -> {canonical_target.name}")
 

--- a/slurm_batch/HPC_REFERENCE.md
+++ b/slurm_batch/HPC_REFERENCE.md
@@ -81,7 +81,9 @@ gfv2_param/
     ├── fabric/             # Merged fabric gpkg
     ├── batches/            # Per-batch gpkgs + manifest
     ├── depstor_rasters/    # Depression-storage intermediate rasters (per fabric)
-    └── params/             # Parameter outputs + merged + filled
+    └── params/             # Parameter outputs; merged/ (canonical, gap-filled)
+                             #   + merged/_unfilled/ (pre-fill copies)
+                             #   + merged/_intermediates/
 ```
 
 > **Upgrading an existing `data_root` from the legacy `work/` layout?** Run
@@ -910,18 +912,25 @@ Env knobs (both wrappers):
   (e.g. omit `lulc_nlcd`/`lulc_foresce` when their CONUS rasters aren't present).
   Keep `slope` before `ssflux` in the list.
 
-**Depstor outputs** land in two subdirectories under `{fabric}/params/merged/`:
+**Depstor outputs** land in subdirectories under `{fabric}/params/merged/`:
 
-- `{fabric}/params/merged/` — **6 final PRMS-ready ratio CSVs**, dimensionless
+- `{fabric}/params/merged/` — the canonical parameter set, dimensionless
   and bounded in [0, 1]: `sro_to_dprst_perv`, `sro_to_dprst_imperv`,
-  `carea_max`, `smidx_coef`, `hru_percent_imperv`, `dprst_frac`.
+  `carea_max`, `smidx_coef`, `hru_percent_imperv`, `dprst_frac`. Not final
+  until Stage 7's gap-fill has run over each — Stage 7 fills every one of
+  these in place (each declares `fill_columns` in
+  `configs/depstor/depstor_params.yml`), so `merged/*.csv` is the single
+  file to read regardless of whether a given HRU needed KNN-filling.
 - `{fabric}/params/merged/_intermediates/` — **10 per-fraction count CSVs**
   (`nhm_<name>_frac_params.csv` and `nhm_hru_total_count_params.csv`). Each
   row's `count` column is the partial-pixel-weighted sum of `1`-valued cells
   per HRU — **not** a [0, 1] fraction. Inputs to ratio derivation; not direct
-  PRMS parameters. To get a true area fraction divide by the HRU pixel count
-  (e.g. `areasqkm * 1e6 / 900` for the 30 m template grid; the `hru_total`
-  fraction aggregates `land_mask.tif` to give that denominator).
+  PRMS parameters, never filled (`depstor_params.yml`'s `fractions:` entries
+  declare no `fill_columns`). To get a true area fraction divide by the HRU
+  pixel count (e.g. `areasqkm * 1e6 / 900` for the 30 m template grid; the
+  `hru_total` fraction aggregates `land_mask.tif` to give that denominator).
+- `{fabric}/params/merged/_unfilled/` — the pre-fill (raw) copy of each ratio
+  CSV above, preserved once by Stage 7 and never overwritten on a re-run.
 
 ---
 
@@ -953,14 +962,37 @@ Idempotent — skips if the matrix already exists; pass `FORCE=1` to overwrite.
 
 ### Stage 7 — KNN gap-fill
 
-Fits sklearn NearestNeighbors over every HRU and fills all param columns. Loads
-the full fabric into memory; submit via the batch:
+Fits sklearn NearestNeighbors over every HRU's centroid. Default (all-params)
+mode loops **every param that declares `fill_columns`** in
+`configs/zonal/zonal_params.yml`, `configs/depstor/depstor_params.yml`, or
+`configs/snarea/snarea_library.yml` and whose `merged/` CSV already exists for
+the active fabric — not one hardcoded file per invocation, which is the
+pre-fix behaviour that let 4 `oregon` params go unfilled unnoticed. Pass
+`--param_file <path>` to fill exactly one declared file instead. Loads the
+full fabric into memory; submit via the batch:
 
 ```bash
 sbatch slurm_batch/merge_and_fill_params.batch
 # Other fabrics:
 FABRIC=<name> sbatch slurm_batch/merge_and_fill_params.batch
+# Single-param mode:
+sbatch slurm_batch/merge_and_fill_params.batch --param_file <path-to-merged-csv>
 ```
+
+`merge_and_fill_params.py` writes the filled frame **in place** over
+`merged/<name>.csv` — the single canonical, always-gap-filled per-HRU file;
+the retired `filled_` prefix no longer exists, so **consumers read
+`merged/*.csv`**. The pre-fill (raw) copy is preserved once at
+`merged/_unfilled/<name>.csv` (never overwritten on a re-run — by then the
+on-disk file is already filled). The job log reports, per param, how many
+absent rows and NaN cells it filled, and applies two asymmetric guards: a
+column *not* declared in that param's `fill_columns` but carrying NaN cells
+only **warns** (a NaN cell may be a legitimate "not derivable" result); a
+param that is missing an HRU row entirely but declares no `fill_columns`
+**raises** (an absent row admits no such reading). Migrating an existing
+`filled_`-prefixed product onto this layout is a separate one-time step —
+`scripts/migrate_filled_params.py --merged_dir <path>` (dry-run by default,
+`--apply` to execute).
 
 ### Stage 8 — Merge NHM defaults
 
@@ -1096,7 +1128,11 @@ per `deplcrv_id`), `nhm_snarea_curve_params.csv` (one row per HRU:
 `nhm_snarea_curve_validation.csv` (calibration report: reconstruction error
 before/after, bias, `n_estimable`), and `nhm_snarea_curve.nc` (the pyWatershed
 parameter file — `snarea_curve` flat ascending, `hru_deplcrv`,
-`snarea_thresh`).
+`snarea_thresh`). Of these, only `nhm_snarea_curve_params.csv` declares
+`fill_columns` (`configs/snarea/snarea_library.yml`) and is gap-filled by
+Stage 7 — its curve/threshold columns, not the `cv_*`/provenance columns,
+which stay NaN by design; `nhm_snarea_curve_library.csv`/`_validation.csv`/
+`.nc` are never touched by Stage 7.
 
 **Cost profile:** Stage 1's gdptools weight-generation (`WeightGen`, one
 polygon/cell intersection pass per batch) is the expensive step; each batch's

--- a/slurm_batch/HPC_REFERENCE.md
+++ b/slurm_batch/HPC_REFERENCE.md
@@ -994,6 +994,13 @@ param that is missing an HRU row entirely but declares no `fill_columns`
 `scripts/migrate_filled_params.py --merged_dir <path>` (dry-run by default,
 `--apply` to execute).
 
+**Run the migration BEFORE the first Stage 7 run on an existing product.** A
+fabric whose `merged/` directory still has `filled_*.csv` leftovers must be
+migrated first. Filling then migrating (the wrong order) would have the
+migration move a stale `filled_` file over today's already-correct canonical
+fill; that is refused loudly rather than silently reverted, but migrating
+first avoids hitting the refusal at all.
+
 ### Stage 8 — Merge NHM defaults
 
 ```bash

--- a/slurm_batch/RUNME.md
+++ b/slurm_batch/RUNME.md
@@ -344,6 +344,14 @@ Migrating an existing product off the old `filled_` layout is a one-time,
 separate step — see `scripts/migrate_filled_params.py` (dry-run by default,
 `--apply` to execute).
 
+> **Run the migration BEFORE the first Step 5 run on an existing product.**
+> If a fabric's `merged/` directory still has any `filled_*.csv` files from
+> before this convention existed, migrate it first. Running Step 5 (which
+> writes the new, correct fill in place) and only migrating afterward would
+> have the migration move the stale `filled_` file over top of today's
+> correct fill — refused loudly, not silently, as of the Finding-1 fix, but
+> the ordering above avoids hitting the refusal at all.
+
 **Wait for:** the job `COMPLETED`.
 
 ---

--- a/slurm_batch/RUNME.md
+++ b/slurm_batch/RUNME.md
@@ -309,7 +309,40 @@ ratios job `COMPLETED`.
 sbatch slurm_batch/merge_and_fill_params.batch
 ```
 
-**What it does:** KNN-fills any missing per-HRU parameter values.
+**What it does:** default (all-params) mode — loops **every** param that
+declares `fill_columns` in `configs/zonal/zonal_params.yml`,
+`configs/depstor/depstor_params.yml`, or `configs/snarea/snarea_library.yml`
+and whose `merged/` CSV already exists for this fabric, and KNN-fills it
+against the fabric's HRU centroids. This replaced an earlier version that
+filled exactly one hardcoded file (`nhm_ssflux_params.csv`) per invocation —
+which is why the canonical set silently differed per fabric (2 files on
+`gfv2`, 4 on `oregon`) and why four `oregon` params went unfilled until
+someone audited them by hand. Pass `--param_file <path>` to fill one file
+instead of the default sweep.
+
+**`merged/<name>.csv` is the single canonical, always-gap-filled per-HRU file
+— read `merged/*.csv`.** The `filled_` prefix is **retired**: there is no
+longer a separate `filled_nhm_*.csv` to look for (an older checkout's docs or
+memory may still mention it). The step writes the filled result **in place**
+over `merged/<name>.csv`; the pre-fill (raw) copy is preserved once at
+`merged/_unfilled/<name>.csv` (never overwritten on a re-run, since the
+on-disk file is by then already filled).
+
+The run logs, per param, how many absent HRU rows and NaN cells it filled.
+Two asymmetric guards fire per param:
+
+- A column **not** declared in that param's `fill_columns` but carrying NaN
+  cells only **warns** (names the column and the NaN count) — a NaN cell can
+  be a legitimate "not derivable" result (e.g. `cv_empirical`, derivable for
+  only ~42% of HRUs by design; `cv_subgrid` exists to rescue the rest), so it
+  is left untouched rather than silently filled.
+- A param that is missing an HRU **row** entirely but declares no
+  `fill_columns` **raises** instead of passing silently — an absent row
+  admits no "not derivable" reading, unlike a NaN cell.
+
+Migrating an existing product off the old `filled_` layout is a one-time,
+separate step — see `scripts/migrate_filled_params.py` (dry-run by default,
+`--apply` to execute).
 
 **Wait for:** the job `COMPLETED`.
 
@@ -406,13 +439,19 @@ tail -n 200 logs/job_<JOBID>.err
 
 ## Where outputs land
 
-- `{data_root}/gfv2/params/merged/` — final parameter CSVs, including the 6
-  depstor ratios (`sro_to_dprst_perv`, `sro_to_dprst_imperv`, `carea_max`,
-  `smidx_coef`, `hru_percent_imperv`, `dprst_frac`) and
+- `{data_root}/gfv2/params/merged/` — the canonical, always-gap-filled
+  per-HRU parameter CSVs (Step 5 fills every param declaring `fill_columns`
+  in place; consumers read `merged/*.csv`, never a `filled_` prefix — see
+  Step 5). Includes the 6 depstor ratios (`sro_to_dprst_perv`,
+  `sro_to_dprst_imperv`, `carea_max`, `smidx_coef`, `hru_percent_imperv`,
+  `dprst_frac`) and
   `nhm_dprst_depth_avg_params.csv` (issue #173 — derived, NOT the pyWatershed
   132 in default; see `docs/pywatershed_depression_storage_requirements.md`).
 - `{data_root}/gfv2/params/merged/_intermediates/` — 10 per-fraction count
   CSVs (inputs to ratio derivation; `count` is NOT a [0, 1] fraction).
+- `{data_root}/gfv2/params/merged/_unfilled/` — the pre-fill (raw) copy of
+  each `merged/<name>.csv` that Step 5 has gap-filled, preserved once and
+  never overwritten on a re-run.
 - `{data_root}/gfv2/depstor_rasters/dprst_depth.tif`,
   `op_flow_thres_params.csv` — Step 3's `dprst_depth` step output (per-cell
   V/A mean depth raster; `op_flow_thres_params.csv` is the constant-1.0

--- a/slurm_batch/merge_and_fill_params.batch
+++ b/slurm_batch/merge_and_fill_params.batch
@@ -10,8 +10,17 @@
 #SBATCH --mem=64G
 #
 # KNN gap-fill of missing parameter values against the fabric (Stage 7). Fits
-# sklearn NearestNeighbors over every HRU and fills all param columns, so it
-# runs as a SLURM job rather than on the login node.
+# sklearn NearestNeighbors over every HRU and fills every param that declares
+# `fill_columns` in configs/zonal/zonal_params.yml, configs/depstor/
+# depstor_params.yml, or configs/snarea/snarea_library.yml (NOT every column of
+# every param -- undeclared columns carrying NaN are left untouched and only
+# warned about, see RUNME.md Step 5), so it runs as a SLURM job rather than on
+# the login node.
+#
+# IMPORTANT: if this fabric's product still uses the retired `filled_` prefix
+# layout, run `scripts/migrate_filled_params.py --merged_dir <path> --apply`
+# BEFORE the first Step 5 run here -- see RUNME.md Step 5 / HPC_REFERENCE.md
+# Stage 7 for why the order matters.
 #   FABRIC=oregon sbatch slurm_batch/merge_and_fill_params.batch
 # --mem/--time are starting points; right-size from `sacct -j <id> -o MaxRSS`.
 cd "$SLURM_SUBMIT_DIR"

--- a/src/gfv2_params/viz.py
+++ b/src/gfv2_params/viz.py
@@ -526,13 +526,13 @@ _PARAM_ENTRIES = [
     ParamEntry(name="hru_percent_imperv", csv_name="nhm_hru_percent_imperv_params.csv", column="hru_percent_imperv", kind="continuous", units="fraction", cmap="OrRd"),
     ParamEntry(name="dprst_frac", csv_name="nhm_dprst_frac_params.csv", column="dprst_frac", kind="continuous", units="fraction", cmap="GnBu"),
     # ssflux PRMS params (from the gap-filled Stage 7 CSV — PRMS-ready values).
-    ParamEntry(name="soil2gw_max", csv_name="filled_nhm_ssflux_params.csv", column="soil2gw_max", kind="continuous", units="in/day", cmap="Blues"),
-    ParamEntry(name="ssr2gw_rate", csv_name="filled_nhm_ssflux_params.csv", column="ssr2gw_rate", kind="continuous", units="1/day", cmap="BuPu"),
-    ParamEntry(name="fastcoef_lin", csv_name="filled_nhm_ssflux_params.csv", column="fastcoef_lin", kind="continuous", units="1/day", cmap="YlOrRd"),
-    ParamEntry(name="slowcoef_lin", csv_name="filled_nhm_ssflux_params.csv", column="slowcoef_lin", kind="continuous", units="1/day", cmap="YlGn"),
-    ParamEntry(name="gwflow_coef", csv_name="filled_nhm_ssflux_params.csv", column="gwflow_coef", kind="continuous", units="1/day", cmap="Purples"),
-    ParamEntry(name="dprst_seep_rate_open", csv_name="filled_nhm_ssflux_params.csv", column="dprst_seep_rate_open", kind="continuous", units="1/day", cmap="PuBu"),
-    ParamEntry(name="dprst_flow_coef", csv_name="filled_nhm_ssflux_params.csv", column="dprst_flow_coef", kind="continuous", units="1/day", cmap="GnBu"),
+    ParamEntry(name="soil2gw_max", csv_name="nhm_ssflux_params.csv", column="soil2gw_max", kind="continuous", units="in/day", cmap="Blues"),
+    ParamEntry(name="ssr2gw_rate", csv_name="nhm_ssflux_params.csv", column="ssr2gw_rate", kind="continuous", units="1/day", cmap="BuPu"),
+    ParamEntry(name="fastcoef_lin", csv_name="nhm_ssflux_params.csv", column="fastcoef_lin", kind="continuous", units="1/day", cmap="YlOrRd"),
+    ParamEntry(name="slowcoef_lin", csv_name="nhm_ssflux_params.csv", column="slowcoef_lin", kind="continuous", units="1/day", cmap="YlGn"),
+    ParamEntry(name="gwflow_coef", csv_name="nhm_ssflux_params.csv", column="gwflow_coef", kind="continuous", units="1/day", cmap="Purples"),
+    ParamEntry(name="dprst_seep_rate_open", csv_name="nhm_ssflux_params.csv", column="dprst_seep_rate_open", kind="continuous", units="1/day", cmap="PuBu"),
+    ParamEntry(name="dprst_flow_coef", csv_name="nhm_ssflux_params.csv", column="dprst_flow_coef", kind="continuous", units="1/day", cmap="GnBu"),
 ]
 
 

--- a/tests/test_merge_and_fill_params.py
+++ b/tests/test_merge_and_fill_params.py
@@ -7,6 +7,7 @@ import geopandas as gpd
 import numpy as np
 import pandas as pd
 import pytest
+import yaml
 from shapely.geometry import Point
 
 _spec = importlib.util.spec_from_file_location(
@@ -371,3 +372,149 @@ def test_categorical_dtype_is_restored(tmp_path):
     got = pd.read_csv(p)
     assert got["cov_type"].dtype.kind == "i"
     assert got["cov_type"].tolist() == [1, 3]
+
+
+# ---------------------------------------------------------------------------
+# All-params default mode: every configured param declares fill_columns.
+#
+# The two configs use DIFFERENT top-level list keys — zonal has `params:`,
+# depstor has `fractions:` / `means:` / `ratios:`. Iterating only "params"
+# would silently return [] for depstor and make this test pass vacuously.
+#
+# NB deviation from the design brief: the brief assumed `snarea_curve` was a
+# configs/zonal/zonal_params.yml `params:` entry. It is not — snarea_curve
+# comes from the separate 3-stage SNODAS pipeline
+# (configs/snarea/snarea_library.yml, Stage 3), a FLAT single-param config
+# (no `params:`/`fractions:` list, no per-entry `name:`) whose `params_file`
+# names the real `nhm_snarea_curve_params.csv`. Folding a synthetic
+# `snarea_curve` entry into zonal_params.yml's `params:` list would also feed
+# slurm_batch/submit_zonal_params.sh, which loops that exact list to submit
+# one SLURM array job per param — a phantom entry with no `source_raster`/
+# `script:` would break that orchestration. So `snarea_curve` is checked
+# separately below, against its real config file.
+# ---------------------------------------------------------------------------
+
+_PARAM_LIST_KEYS = ("params", "fractions", "means", "ratios")
+
+
+def _configured_entries(doc):
+    for key in _PARAM_LIST_KEYS:
+        for entry in doc.get(key, []) or []:
+            if isinstance(entry, dict):
+                yield key, entry
+
+
+def _canonical_merged_filename(list_key, entry):
+    """The filename an entry writes to merged/ (canonical, consumer-facing),
+    or None if it does not land there.
+
+    zonal `params` and depstor `means` name their canonical file `merged_file`;
+    depstor `ratios` names it `output_file` instead (see
+    derive_depstor_params.py's run_mean_finalize / run_ratios). depstor
+    `fractions` are EXCLUDED even though every entry there also carries a
+    `merged_file` key — that key names the per-fraction COUNT csv written to
+    merged/_intermediates/ (run_merge), never a merged/ output. Fractions are
+    intermediates, not consumer-facing params, and are never filled.
+    """
+    if list_key == "fractions":
+        return None
+    if list_key == "ratios":
+        return entry.get("output_file")
+    return entry.get("merged_file")
+
+
+def test_every_configured_param_declares_fill_columns():
+    """A param with no fill_columns cannot be gap-filled — catch it at config time."""
+    root = Path(__file__).resolve().parent.parent
+    checked = 0
+    for cfg in [root / "configs/zonal/zonal_params.yml",
+                root / "configs/depstor/depstor_params.yml"]:
+        doc = yaml.safe_load(cfg.read_text())
+        for key, entry in _configured_entries(doc):
+            canonical = _canonical_merged_filename(key, entry)
+            if not canonical:
+                continue
+            checked += 1
+            assert entry.get("fill_columns"), (
+                f"{entry['name']} (under '{key}' in {cfg.name}) has a merged/ output but "
+                f"no fill_columns, so the gap-fill step would skip it and any missing HRU "
+                f"row would raise."
+            )
+
+    # snarea_curve: separate flat config, see the module-level note above.
+    snarea_doc = yaml.safe_load(
+        (root / "configs/snarea/snarea_library.yml").read_text()
+    )
+    assert snarea_doc.get("params_file"), "snarea_library.yml must declare params_file"
+    checked += 1
+    assert snarea_doc.get("fill_columns"), (
+        "configs/snarea/snarea_library.yml declares params_file but no fill_columns, so "
+        "snarea_curve would never be filled by the default all-params run."
+    )
+
+    # Guard against the whole test passing because nothing was found.
+    assert checked >= 7, f"expected to check at least 7 merged params, checked {checked}"
+
+
+def test_snarea_curve_does_not_declare_provenance_columns():
+    """Regression guard for the whole point of this change.
+
+    Reads configs/snarea/snarea_library.yml, not configs/zonal/zonal_params.yml
+    — see the module-level deviation note above.
+    """
+    root = Path(__file__).resolve().parent.parent
+    doc = yaml.safe_load((root / "configs/snarea/snarea_library.yml").read_text())
+    forbidden = {"cv_assign", "cv_subgrid", "cv_empirical", "cv_source",
+                 "sdc_status", "sca_class", "similarity", "n_seasons",
+                 "n_peak_years", "peak_swe_mm"}
+    assert not (set(doc["fill_columns"]) & forbidden)
+    assert "hru_deplcrv" in doc["fill_columns"]
+
+
+# ---------------------------------------------------------------------------
+# iter_declared_params: unit coverage on synthetic dicts (no data root, no
+# real config files) for the exclusion/inclusion rules exercised above.
+# ---------------------------------------------------------------------------
+
+def test_iter_declared_params_excludes_fractions_includes_means_and_ratios():
+    zonal_cfg = {
+        "params": [
+            {"name": "elevation", "merged_file": "nhm_elevation_params.csv",
+             "fill_columns": ["mean"]},
+        ],
+    }
+    depstor_cfg = {
+        "fractions": [
+            {"name": "perv_frac", "merged_file": "nhm_perv_frac_params.csv"},
+        ],
+        "means": [
+            {"name": "dprst_depth_avg", "merged_file": "nhm_dprst_depth_avg_params.csv",
+             "fill_columns": ["dprst_depth_avg"]},
+        ],
+        "ratios": [
+            {"name": "dprst_frac", "output_file": "nhm_dprst_frac_params.csv",
+             "fill_columns": ["dprst_frac"]},
+        ],
+    }
+
+    declared = maf.iter_declared_params(zonal_cfg, depstor_cfg)
+    names = {d[0] for d in declared}
+
+    assert names == {"elevation", "dprst_depth_avg", "dprst_frac"}
+    assert "perv_frac" not in names  # fraction excluded despite its merged_file key
+
+    by_name = {d[0]: d for d in declared}
+    assert by_name["dprst_frac"] == ("dprst_frac", "nhm_dprst_frac_params.csv", ["dprst_frac"])
+    assert by_name["elevation"] == ("elevation", "nhm_elevation_params.csv", ["mean"])
+
+
+def test_iter_declared_params_includes_snarea_when_given():
+    snarea_cfg = {"params_file": "nhm_snarea_curve_params.csv", "fill_columns": ["hru_deplcrv"]}
+    declared = maf.iter_declared_params({}, {}, snarea_cfg)
+    assert declared == [("snarea_curve", "nhm_snarea_curve_params.csv", ["hru_deplcrv"])]
+
+
+def test_iter_declared_params_snarea_optional():
+    """The 2-arg call the brief documented must still work (snarea omitted)."""
+    declared = maf.iter_declared_params({}, {})
+    assert declared == []

--- a/tests/test_merge_and_fill_params.py
+++ b/tests/test_merge_and_fill_params.py
@@ -329,6 +329,129 @@ def test_declared_column_absent_from_frame_raises():
         )
 
 
+# ---------------------------------------------------------------------------
+# Finding 2: retention/rad_trncf alias groups in fill_columns.
+#
+# lulc_prederived.py renamed the same computed quantity from `retention` to
+# `rad_trncf`; gfv2/oregon were built before the rename (still carry
+# `retention`), tjc was built after (carries `rad_trncf`). A declared
+# fill_columns entry may be a list/tuple of alias alternatives instead of a
+# plain string -- the first one present in the frame wins.
+# ---------------------------------------------------------------------------
+
+def _lulc_frame(column_name):
+    return pd.DataFrame({
+        "model_hru_idx": [1, 2, 3],
+        "cov_type": [1, 2, 3],
+        column_name: [0.1, 0.2, np.nan],
+    })
+
+
+def test_alias_resolves_to_first_alternative_present():
+    """Legacy header (gfv2/oregon): `retention` present, `rad_trncf` absent."""
+    plan = maf.resolve_fill_plan(
+        _lulc_frame("retention"), declared=["cov_type", ["retention", "rad_trncf"]],
+        missing_ids=set(), id_feature="model_hru_idx", param_name="lulc_nhm_v11",
+    )
+    assert plan.fill_columns == ["cov_type", "retention"]
+    assert "rad_trncf" not in plan.fill_columns
+
+
+def test_alias_resolves_to_second_alternative_present():
+    """Current header (tjc, post-rename): `rad_trncf` present, `retention` absent."""
+    plan = maf.resolve_fill_plan(
+        _lulc_frame("rad_trncf"), declared=["cov_type", ["retention", "rad_trncf"]],
+        missing_ids=set(), id_feature="model_hru_idx", param_name="lulc_nhm_v11",
+    )
+    assert plan.fill_columns == ["cov_type", "rad_trncf"]
+    assert "retention" not in plan.fill_columns
+
+
+def test_alias_raises_when_neither_alternative_present():
+    """Neither alias present must still raise -- this is NOT an optional-column
+    mechanism; a genuinely missing column cannot silently skip filling."""
+    frame = pd.DataFrame({"model_hru_idx": [1, 2], "cov_type": [1, 2]})
+    with pytest.raises(ValueError, match="not present"):
+        maf.resolve_fill_plan(
+            frame, declared=["cov_type", ["retention", "rad_trncf"]], missing_ids=set(),
+            id_feature="model_hru_idx", param_name="lulc_nhm_v11",
+        )
+
+
+def test_alias_column_excluded_from_undeclared_with_nan():
+    """Whichever alias actually resolves must not ALSO be reported as an
+    undeclared NaN-carrying column."""
+    plan = maf.resolve_fill_plan(
+        _lulc_frame("rad_trncf"), declared=["cov_type", ["retention", "rad_trncf"]],
+        missing_ids=set(), id_feature="model_hru_idx", param_name="lulc_nhm_v11",
+    )
+    assert "rad_trncf" not in plan.undeclared_with_nan
+
+
+# ---------------------------------------------------------------------------
+# Finding 3: appending an absent-id row must not invent an hru_id column that
+# was never in the original frame.
+# ---------------------------------------------------------------------------
+
+def test_knn_does_not_add_spurious_hru_id_column():
+    """gfv2's id_feature is nat_hru_id with NO hru_id column at all. Filling an
+    absent row must not manufacture an all-empty hru_id column in the output."""
+    import logging
+    logger = logging.getLogger("test")
+
+    merged_gdf = gpd.GeoDataFrame(
+        {"nat_hru_id": [1, 2, 3]},
+        geometry=[Point(0, 0), Point(10, 0), Point(5, 0)],
+        crs="EPSG:5070",
+    )
+    param_df = pd.DataFrame({
+        "nat_hru_id": [1, 2],
+        "my_param": [100.0, 200.0],
+    })
+
+    result = fill_missing_values_knn(param_df, [3], merged_gdf, "my_param", 1, "nat_hru_id", logger)
+    assert "hru_id" not in result.columns
+
+
+def test_knn_still_populates_hru_id_when_frame_already_has_it():
+    """Regression guard for the opposite direction: when hru_id genuinely IS a
+    secondary column in the frame, appended rows must still populate it (not
+    leave it NaN) -- this is the pre-existing, still-desired behavior."""
+    import logging
+    logger = logging.getLogger("test")
+
+    merged_gdf = gpd.GeoDataFrame(
+        {"nat_hru_id": [1, 2, 3]},
+        geometry=[Point(0, 0), Point(10, 0), Point(5, 0)],
+        crs="EPSG:5070",
+    )
+    param_df = pd.DataFrame({
+        "nat_hru_id": [1, 2],
+        "hru_id": [1, 2],
+        "my_param": [100.0, 200.0],
+    })
+
+    result = fill_missing_values_knn(param_df, [3], merged_gdf, "my_param", 1, "nat_hru_id", logger)
+    assert result.loc[result["nat_hru_id"] == 3, "hru_id"].iloc[0] == 3
+
+
+def test_id_column_with_nan_excluded_from_undeclared_with_nan():
+    """An ID column (hru_id, in ID_COLUMNS but NOT the active id_feature) that
+    carries NaN must never be reported/filled -- this exclusion is exactly the
+    branch that hid the spurious-hru_id regression (Finding 3): if it had
+    warned, the bug would have been visible in every gfv2 fill-run log."""
+    frame = pd.DataFrame({
+        "nat_hru_id": [1, 2, 3],
+        "hru_id": [1, 2, np.nan],
+        "hru_deplcrv": [1.0, 2.0, 3.0],
+    })
+    plan = maf.resolve_fill_plan(
+        frame, declared=["hru_deplcrv"], missing_ids=set(),
+        id_feature="nat_hru_id", param_name="mystery_param",
+    )
+    assert "hru_id" not in plan.undeclared_with_nan
+
+
 def test_writes_in_place_and_preserves_raw(tmp_path):
     p = tmp_path / "nhm_x_params.csv"
     pd.DataFrame({"hru_id": [1, 2], "v": [1.0, np.nan]}).to_csv(p, index=False)
@@ -518,3 +641,125 @@ def test_iter_declared_params_snarea_optional():
     """The 2-arg call the brief documented must still work (snarea omitted)."""
     declared = maf.iter_declared_params({}, {})
     assert declared == []
+
+
+# ---------------------------------------------------------------------------
+# Finding 2 (isolation half): run_fill_sweep must not let one param's config
+# drift starve every other declared param of its fill.
+# ---------------------------------------------------------------------------
+
+class TestRunFillSweep:
+    def _merged_gdf(self):
+        return gpd.GeoDataFrame(
+            {"hru_id": [1, 2, 3]},
+            geometry=[Point(0, 0), Point(10, 0), Point(5, 0)],
+            crs="EPSG:5070",
+        )
+
+    def test_one_param_failure_does_not_block_the_others(self, tmp_path):
+        """A param whose declared fill_columns names a column absent from its
+        own file (the tjc-vs-gfv2 rad_trncf/retention scenario, pre-fix) must
+        fail in isolation -- every OTHER param in the sweep still gets filled."""
+        import logging
+        logger = logging.getLogger("test")
+
+        good = tmp_path / "nhm_good_params.csv"
+        pd.DataFrame({"hru_id": [1, 2], "v": [10.0, 20.0]}).to_csv(good, index=False)
+
+        bad = tmp_path / "nhm_bad_params.csv"
+        pd.DataFrame({"hru_id": [1, 2], "v": [1.0, 2.0]}).to_csv(bad, index=False)
+
+        targets = [
+            ("good_param", good, ["v"]),
+            ("bad_param", bad, ["typo_column"]),  # not present -> resolve_fill_plan raises
+        ]
+
+        failed = maf.run_fill_sweep(
+            targets, self._merged_gdf(), expected_max=3, id_feature="hru_id",
+            k_neighbors=1, logger=logger,
+        )
+
+        assert failed == ["bad_param"]
+        # good_param was still filled despite bad_param's failure.
+        result = pd.read_csv(good)
+        assert result["hru_id"].tolist() == [1, 2, 3]
+
+    def test_no_failures_returns_empty_list(self, tmp_path):
+        import logging
+        logger = logging.getLogger("test")
+
+        good = tmp_path / "nhm_good_params.csv"
+        pd.DataFrame({"hru_id": [1, 2], "v": [10.0, 20.0]}).to_csv(good, index=False)
+
+        failed = maf.run_fill_sweep(
+            [("good_param", good, ["v"])], self._merged_gdf(), expected_max=3,
+            id_feature="hru_id", k_neighbors=1, logger=logger,
+        )
+        assert failed == []
+
+
+# ---------------------------------------------------------------------------
+# Finding 5: --param_file must be under the ACTIVE fabric's own merged/ dir.
+# ---------------------------------------------------------------------------
+
+def test_check_param_file_in_fabric_accepts_matching_dir(tmp_path):
+    merged_dir = tmp_path / "gfv2" / "params" / "merged"
+    merged_dir.mkdir(parents=True)
+    param_file = merged_dir / "nhm_x_params.csv"
+    maf.check_param_file_in_fabric(param_file, merged_dir)  # must not raise
+
+
+def test_check_param_file_in_fabric_rejects_foreign_fabric(tmp_path):
+    """--fabric gfv2 --param_file <gfv2_vpu01 path> must be refused, not
+    silently write into the wrong fabric's canonical file."""
+    merged_dir = tmp_path / "gfv2" / "params" / "merged"
+    merged_dir.mkdir(parents=True)
+    foreign_file = tmp_path / "gfv2_vpu01" / "params" / "merged" / "nhm_x_params.csv"
+
+    with pytest.raises(ValueError, match="not under the active fabric"):
+        maf.check_param_file_in_fabric(foreign_file, merged_dir)
+
+
+# ---------------------------------------------------------------------------
+# Finding 4: warn about a merged/nhm_*_params.csv that no config entry
+# declares (the reverse direction from the per-target skip warning).
+# ---------------------------------------------------------------------------
+
+class TestWarnUndeclaredMergedFiles:
+    def test_warns_on_undeclared_on_disk_file(self, tmp_path, caplog):
+        import logging
+        (tmp_path / "nhm_declared_params.csv").write_text("hru_id,v\n1,1\n")
+        (tmp_path / "nhm_mystery_params.csv").write_text("hru_id,v\n1,1\n")
+        logger = logging.getLogger("test_warn_undeclared")
+
+        with caplog.at_level(logging.WARNING, logger="test_warn_undeclared"):
+            undeclared = maf.warn_undeclared_merged_files(
+                tmp_path, [("declared", "nhm_declared_params.csv", ["v"])], logger,
+            )
+
+        assert undeclared == ["nhm_mystery_params.csv"]
+        assert any("nhm_mystery_params.csv" in rec.message for rec in caplog.records)
+
+    def test_allowlists_library_and_validation_files(self, tmp_path):
+        import logging
+        (tmp_path / "nhm_declared_params.csv").write_text("hru_id,v\n1,1\n")
+        (tmp_path / "nhm_foo_library_params.csv").write_text("a,b\n1,2\n")
+        (tmp_path / "nhm_bar_validation_params.csv").write_text("a,b\n1,2\n")
+        logger = logging.getLogger("test_warn_undeclared_allow")
+
+        undeclared = maf.warn_undeclared_merged_files(
+            tmp_path, [("declared", "nhm_declared_params.csv", ["v"])], logger,
+        )
+
+        assert undeclared == []
+
+    def test_no_undeclared_files_returns_empty(self, tmp_path):
+        import logging
+        (tmp_path / "nhm_declared_params.csv").write_text("hru_id,v\n1,1\n")
+        logger = logging.getLogger("test_warn_undeclared_none")
+
+        undeclared = maf.warn_undeclared_merged_files(
+            tmp_path, [("declared", "nhm_declared_params.csv", ["v"])], logger,
+        )
+
+        assert undeclared == []

--- a/tests/test_merge_and_fill_params.py
+++ b/tests/test_merge_and_fill_params.py
@@ -18,6 +18,7 @@ _spec.loader.exec_module(_mod)
 
 find_missing_ids = _mod.find_missing_ids
 fill_missing_values_knn = _mod.fill_missing_values_knn
+maf = _mod
 
 
 class TestFindMissingIds:
@@ -271,3 +272,57 @@ class TestFillMissingValuesKnn:
         # Only id=2 (val=5.0) is in the fit set — both NaN rows must get 5.0
         assert result.loc[result["nat_hru_id"] == 1, "my_param"].iloc[0] == 5.0
         assert result.loc[result["nat_hru_id"] == 3, "my_param"].iloc[0] == 5.0
+
+
+def _frame():
+    """A snarea_curve-shaped frame: real params complete, provenance partly NaN."""
+    return pd.DataFrame({
+        "hru_id": [1, 2, 3],
+        "hru_deplcrv": [1.0, 2.0, np.nan],      # declared param, has a gap
+        "snarea_thresh": [0.1, 0.2, 0.3],        # declared param, complete
+        "cv_empirical": [np.nan, np.nan, 0.4],   # UNDECLARED provenance, NaN by design
+    })
+
+
+def test_only_declared_columns_are_filled():
+    plan = maf.resolve_fill_plan(
+        _frame(), declared=["hru_deplcrv", "snarea_thresh"],
+        missing_ids=set(), id_feature="hru_id", param_name="snarea_curve",
+    )
+    assert plan.fill_columns == ["hru_deplcrv", "snarea_thresh"]
+    assert "cv_empirical" not in plan.fill_columns
+
+
+def test_undeclared_column_with_nan_is_reported_not_filled():
+    plan = maf.resolve_fill_plan(
+        _frame(), declared=["hru_deplcrv", "snarea_thresh"],
+        missing_ids=set(), id_feature="hru_id", param_name="snarea_curve",
+    )
+    # cv_empirical has 2 NaN — surfaced for the caller to warn about, never filled.
+    assert plan.undeclared_with_nan == {"cv_empirical": 2}
+
+
+def test_absent_hru_row_with_no_declaration_raises():
+    """A missing ROW admits no provenance reading — it is a config error, not a result."""
+    with pytest.raises(ValueError, match="fill_columns"):
+        maf.resolve_fill_plan(
+            _frame(), declared=[], missing_ids={4, 5},
+            id_feature="hru_id", param_name="mystery_param",
+        )
+
+
+def test_absent_hru_row_with_declaration_is_fine():
+    plan = maf.resolve_fill_plan(
+        _frame(), declared=["hru_deplcrv"], missing_ids={4},
+        id_feature="hru_id", param_name="snarea_curve",
+    )
+    assert plan.fill_columns == ["hru_deplcrv"]
+
+
+def test_declared_column_absent_from_frame_raises():
+    """A typo'd fill_columns entry must fail loud, not silently fill nothing."""
+    with pytest.raises(ValueError, match="not present"):
+        maf.resolve_fill_plan(
+            _frame(), declared=["hru_deplcrv", "typo_column"], missing_ids=set(),
+            id_feature="hru_id", param_name="snarea_curve",
+        )

--- a/tests/test_merge_and_fill_params.py
+++ b/tests/test_merge_and_fill_params.py
@@ -326,3 +326,48 @@ def test_declared_column_absent_from_frame_raises():
             _frame(), declared=["hru_deplcrv", "typo_column"], missing_ids=set(),
             id_feature="hru_id", param_name="snarea_curve",
         )
+
+
+def test_writes_in_place_and_preserves_raw(tmp_path):
+    p = tmp_path / "nhm_x_params.csv"
+    pd.DataFrame({"hru_id": [1, 2], "v": [1.0, np.nan]}).to_csv(p, index=False)
+    original = pd.read_csv(p)
+    filled = pd.DataFrame({"hru_id": [1, 2], "v": [1.0, 9.0]})
+
+    out = maf.write_filled_in_place(filled, p, original, {"v": np.dtype("float64")})
+
+    assert out == p
+    assert pd.read_csv(p)["v"].tolist() == [1.0, 9.0]          # canonical is filled
+    raw = pd.read_csv(tmp_path / "_unfilled" / "nhm_x_params.csv")
+    assert raw["v"].isna().sum() == 1                            # raw preserved
+
+
+def test_second_run_does_not_clobber_the_raw_copy(tmp_path):
+    """The irreversible one: a re-run must not move the FILLED file into _unfilled/."""
+    p = tmp_path / "nhm_x_params.csv"
+    pd.DataFrame({"hru_id": [1, 2], "v": [1.0, np.nan]}).to_csv(p, index=False)
+    original = pd.read_csv(p)
+    filled = pd.DataFrame({"hru_id": [1, 2], "v": [1.0, 9.0]})
+
+    maf.write_filled_in_place(filled, p, original, {"v": np.dtype("float64")})
+    # Run 2: the on-disk file is now already filled. Passing it as "original" is exactly
+    # what the orchestrator does on a re-run.
+    again = pd.read_csv(p)
+    maf.write_filled_in_place(filled, p, again, {"v": np.dtype("float64")})
+
+    raw = pd.read_csv(tmp_path / "_unfilled" / "nhm_x_params.csv")
+    assert raw["v"].isna().sum() == 1, "_unfilled/ must still hold the ORIGINAL raw frame"
+
+
+def test_categorical_dtype_is_restored(tmp_path):
+    """cov_type is an integer class (0-3). k=1 copies a real class, so it must stay int."""
+    p = tmp_path / "nhm_lulc_params.csv"
+    pd.DataFrame({"hru_id": [1, 2], "cov_type": [1, 3]}).to_csv(p, index=False)
+    original = pd.read_csv(p)
+    filled = pd.DataFrame({"hru_id": [1, 2], "cov_type": [1.0, 3.0]})  # KNN returns float
+
+    maf.write_filled_in_place(filled, p, original, {"cov_type": np.dtype("int64")})
+
+    got = pd.read_csv(p)
+    assert got["cov_type"].dtype.kind == "i"
+    assert got["cov_type"].tolist() == [1, 3]

--- a/tests/test_migrate_filled_params.py
+++ b/tests/test_migrate_filled_params.py
@@ -10,6 +10,8 @@ existing products onto.
 import importlib.util
 from pathlib import Path
 
+import pytest
+
 _spec = importlib.util.spec_from_file_location(
     "migrate_filled_params",
     Path(__file__).resolve().parent.parent / "scripts" / "migrate_filled_params.py",
@@ -47,13 +49,58 @@ def test_migration_is_idempotent(tmp_path):
     assert (tmp_path / "nhm_ssflux_params.csv").read_text() == "hru_id,v\n1,1\n"
 
 
-def test_migration_refuses_when_raw_already_preserved(tmp_path):
-    """Never overwrite an existing _unfilled/ copy — that is the irreversible mistake."""
+def test_migration_resumes_when_raw_preserved_but_canonical_missing(tmp_path):
+    """A previous run of this script died between step 1 (preserve) and step 2
+    (move filled_ onto canonical): raw_target already exists, but canonical_target
+    does not. This IS a resumable partial migration -- step 2 must proceed and the
+    preserved raw copy must be untouched."""
     (tmp_path / "filled_nhm_ssflux_params.csv").write_text("hru_id,v\n1,1\n")
-    (tmp_path / "nhm_ssflux_params.csv").write_text("hru_id,v\n1,\n")
     (tmp_path / "_unfilled").mkdir()
     (tmp_path / "_unfilled" / "nhm_ssflux_params.csv").write_text("ORIGINAL\n")
+    assert not (tmp_path / "nhm_ssflux_params.csv").exists()
 
     mig.apply_migration(mig.plan_migration(tmp_path))
 
     assert (tmp_path / "_unfilled" / "nhm_ssflux_params.csv").read_text() == "ORIGINAL\n"
+    assert (tmp_path / "nhm_ssflux_params.csv").read_text() == "hru_id,v\n1,1\n"
+    assert not (tmp_path / "filled_nhm_ssflux_params.csv").exists()
+
+
+def test_migration_raises_when_canonical_already_filled_and_raw_preserved(tmp_path):
+    """The Finding-1 regression: raw_target AND canonical_target BOTH already
+    exist -- the canonical file is already on the new convention (e.g. a fresh
+    merge_and_fill_params.py run) and filled_<name>.csv is a stale leftover.
+    Moving it over the canonical would silently revert today's correct fill.
+    Must raise, and must leave every file exactly as it was."""
+    (tmp_path / "filled_nhm_ssflux_params.csv").write_text("hru_id,v\n1,1\n")
+    todays_fill = "hru_id,v\n1,1.0\n2,42.0\n"
+    (tmp_path / "nhm_ssflux_params.csv").write_text(todays_fill)
+    (tmp_path / "_unfilled").mkdir()
+    (tmp_path / "_unfilled" / "nhm_ssflux_params.csv").write_text("ORIGINAL\n")
+
+    with pytest.raises(mig.AlreadyMigratedError, match="Refusing to migrate"):
+        mig.apply_migration(mig.plan_migration(tmp_path))
+
+    # Nothing moved: the canonical file must still hold TODAY's correct fill,
+    # not be silently reverted; filled_ and _unfilled/ are untouched too.
+    assert (tmp_path / "nhm_ssflux_params.csv").read_text() == todays_fill
+    assert (tmp_path / "filled_nhm_ssflux_params.csv").read_text() == "hru_id,v\n1,1\n"
+    assert (tmp_path / "_unfilled" / "nhm_ssflux_params.csv").read_text() == "ORIGINAL\n"
+
+
+def test_print_plan_matches_apply_for_refuse_case(tmp_path, capsys):
+    """A dry run must show REFUSE for exactly the triples apply_migration would
+    raise on -- not a plan implying the move would succeed."""
+    (tmp_path / "filled_nhm_ssflux_params.csv").write_text("hru_id,v\n1,1\n")
+    (tmp_path / "nhm_ssflux_params.csv").write_text("hru_id,v\n1,1.0\n2,42.0\n")
+    (tmp_path / "_unfilled").mkdir()
+    (tmp_path / "_unfilled" / "nhm_ssflux_params.csv").write_text("ORIGINAL\n")
+
+    plan = mig.plan_migration(tmp_path)
+    mig.print_plan(plan)
+    out = capsys.readouterr().out
+
+    assert "REFUSE" in out
+    # print_plan must not touch the filesystem regardless of what it prints.
+    assert (tmp_path / "filled_nhm_ssflux_params.csv").exists()
+    assert (tmp_path / "nhm_ssflux_params.csv").read_text() == "hru_id,v\n1,1.0\n2,42.0\n"

--- a/tests/test_migrate_filled_params.py
+++ b/tests/test_migrate_filled_params.py
@@ -1,0 +1,59 @@
+"""Tests for scripts/migrate_filled_params.py
+
+One-time migration off the retired `filled_` prefix onto the canonical
+convention (`merged/<name>.csv` always filled, pre-fill copy at
+`merged/_unfilled/<name>.csv`). See scripts/merge_and_fill_params.py's
+UNFILLED_DIRNAME / write_filled_in_place for the convention this migrates
+existing products onto.
+"""
+
+import importlib.util
+from pathlib import Path
+
+_spec = importlib.util.spec_from_file_location(
+    "migrate_filled_params",
+    Path(__file__).resolve().parent.parent / "scripts" / "migrate_filled_params.py",
+)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+mig = _mod
+
+
+def test_plan_migration_pairs_filled_with_canonical(tmp_path):
+    (tmp_path / "filled_nhm_ssflux_params.csv").write_text("hru_id,v\n1,1\n")
+    (tmp_path / "nhm_ssflux_params.csv").write_text("hru_id,v\n1,\n")
+    (tmp_path / "nhm_slope_params.csv").write_text("hru_id,v\n1,2\n")   # no filled_ pair
+
+    plan = mig.plan_migration(tmp_path)
+
+    assert len(plan) == 1
+    filled, canonical, raw = plan[0]
+    assert filled.name == "filled_nhm_ssflux_params.csv"
+    assert canonical.name == "nhm_ssflux_params.csv"
+    assert raw == tmp_path / "_unfilled" / "nhm_ssflux_params.csv"
+
+
+def test_migration_is_idempotent(tmp_path):
+    (tmp_path / "filled_nhm_ssflux_params.csv").write_text("hru_id,v\n1,1\n")
+    (tmp_path / "nhm_ssflux_params.csv").write_text("hru_id,v\n1,\n")
+
+    mig.apply_migration(mig.plan_migration(tmp_path))
+    raw_after_first = (tmp_path / "_unfilled" / "nhm_ssflux_params.csv").read_text()
+    mig.apply_migration(mig.plan_migration(tmp_path))   # second run: nothing left to do
+
+    assert (tmp_path / "_unfilled" / "nhm_ssflux_params.csv").read_text() == raw_after_first
+    assert not (tmp_path / "filled_nhm_ssflux_params.csv").exists()
+    assert (tmp_path / "nhm_ssflux_params.csv").read_text() == "hru_id,v\n1,1\n"
+
+
+def test_migration_refuses_when_raw_already_preserved(tmp_path):
+    """Never overwrite an existing _unfilled/ copy — that is the irreversible mistake."""
+    (tmp_path / "filled_nhm_ssflux_params.csv").write_text("hru_id,v\n1,1\n")
+    (tmp_path / "nhm_ssflux_params.csv").write_text("hru_id,v\n1,\n")
+    (tmp_path / "_unfilled").mkdir()
+    (tmp_path / "_unfilled" / "nhm_ssflux_params.csv").write_text("ORIGINAL\n")
+
+    mig.apply_migration(mig.plan_migration(tmp_path))
+
+    assert (tmp_path / "_unfilled" / "nhm_ssflux_params.csv").read_text() == "ORIGINAL\n"

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -183,7 +183,7 @@ def test_param_inventory_kinds():
     # ssflux PRMS params read from the gap-filled Stage 7 CSV
     for n in ("soil2gw_max", "ssr2gw_rate", "fastcoef_lin", "slowcoef_lin",
               "gwflow_coef", "dprst_seep_rate_open", "dprst_flow_coef"):
-        assert by_name[n].csv_name == "filled_nhm_ssflux_params.csv"
+        assert by_name[n].csv_name == "nhm_ssflux_params.csv"
         assert by_name[n].kind == "continuous"
 
 


### PR DESCRIPTION
## What changed

`{fabric}/params/merged/nhm_*_params.csv` is now the **single canonical per-HRU parameter set** — always gap-filled. The `filled_` prefix is retired; pre-fill copies live in `merged/_unfilled/`, mirroring the existing `merged/_intermediates/`.

**Consumer rule, one line:** read `merged/*.csv`.

## Why

`scripts/merge_and_fill_params.py` filled **one file per invocation** and hardcoded `nhm_ssflux_params.csv` as its default; the batch passed only `--fabric`. So a param was gap-filled if and only if someone remembered to pass `--param_file` for it. The canonical set therefore differed per fabric — **gfv2 had 2 filled files, oregon 4** — with nothing recording which was authoritative, and the only code encoding the convention was `viz.py` (7 hardcoded references).

Found by auditing oregon after a rebuild: `soil_moist_max` (65 NaN), `lulc_nalcms` and `lulc_nhm_v11` (1 absent HRU each) had never been filled at all.

## The trap that shaped the design

`nhm_snarea_curve_params.csv` has 7,891 of 16,814 rows containing NaN — but **every one is in a provenance column**. `cv_empirical` is derivable for only ~42% of HRUs *by design* (`cv_subgrid` exists to rescue the rest), while all 13 real PRMS parameter columns are complete. The pre-existing column selection was *"every column except the id columns"*, which would have overwritten that provenance with interpolated noise.

So selection is now **declaration-driven** — `fill_columns` per param in config — with **asymmetric guards**:

| finding | response |
| --- | --- |
| declared column, gap present | fill (KNN, k=1) |
| undeclared column with **NaN cells** | **WARNING** naming column + count |
| undeclared param with an **absent HRU row** | **RAISE** |

A NaN cell may be a legitimate "not derivable". An absent row admits no such reading — the HRU is in the file or it isn't.

## Also

- **dtype restore** — KNN returns float64 even at k=1, which silently turned `cov_type` (integer PRMS class 0–3) into `0.0/1.0/2.0/3.0`.
- **`scripts/migrate_filled_params.py`** — one-time migration, dry-run by default, `--apply` required. Dry-run verified against both fabrics: gfv2 2 moves, oregon 4.
- **`viz.py`** repointed off the retired prefix.

## Data-safety rules (both have dedicated tests)

- `_unfilled/<name>.csv` is written **only if absent**. On a re-run the on-disk file is already filled; overwriting the preserved copy with it would destroy the true pre-fill version irreversibly, on a filesystem with no version control.
- The migration **refuses loudly** when the canonical file is already on the new convention, rather than moving a stale `filled_` file over a fresh fill. `print_plan` and `apply_migration` agree across all four (raw × canonical) existence states.

## Found by the whole-branch review, not per-task review

Two composition defects only visible across tasks, both reproduced by simulating the real modules against on-disk products:

1. **The migration silently reverted a freshly-filled canonical file** — the `filled_ → canonical` move ran unconditionally. Fill-then-migrate restored the pre-branch product at exit 0. The existing test only asserted `_unfilled/` survived, never what happened to the canonical file.
2. **Step 5 aborted mid-sweep on `tjc`** — `lulc_nhm_v11` declared `retention` but tjc's header has `rad_trncf` (a rename). Unhandled in `main()`, so the sweep aborted with earlier params already written in place, leaving a partially-applied set. Fixed with alias-group resolution (a genuinely missing column still raises) plus per-param error isolation and a non-zero exit summarising failures.

Plus: a spurious all-empty `hru_id` column that would have landed in 3 canonical gfv2 files, an undeclared-on-disk-param blind spot, and a `--param_file` that accepted a foreign fabric's path.

## Testing

**832 passing.** New coverage for the guard asymmetry, idempotency (verified load-bearing by removing the guard and confirming the test fails), dtype preservation, alias resolution, migration refuse, and the four-state dry-run/apply agreement.

## Rollout — not done here

Run `scripts/migrate_filled_params.py --apply` on gfv2, oregon and tjc **before** the first Step 5 run on those products. No production file has been touched by this branch — oregon still shows its 4 `filled_*.csv` and no `_unfilled/` exists anywhere.

Spec: `docs/superpowers/specs/2026-07-25-param-fill-convention-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
