### PR TITLE
feat(config): add data-root pixi task; simplify RUNME.md BATCHES setup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ platforms = ["linux-64"]
 
 [tool.pixi.tasks]
 init-data-root = "python scripts/init_data_root.py"
+data-root = "python -c 'from gfv2_params.config import load_base_config; print(load_base_config()[\"data_root\"])'"
 
 [tool.pixi.dependencies]
 python = "3.12.*"

--- a/slurm_batch/RUNME.md
+++ b/slurm_batch/RUNME.md
@@ -66,8 +66,7 @@ sbatch slurm_batch/build_depstor_rasters.batch --step imperv
 sbatch slurm_batch/build_depstor_rasters.batch --step waterbody
 sbatch slurm_batch/build_depstor_rasters.batch --step wbody_connectivity
 sbatch slurm_batch/build_depstor_rasters.batch --step dprst
-BATCHES=$(pixi run --as-is python -c \
-  "import yaml;print(yaml.safe_load(open('configs/base_config.yml'))['data_root'])")/gfv2/batches
+BATCHES=$(pixi run data-root)/gfv2/batches
 slurm_batch/submit_dprst_depth.sh "$BATCHES" gfv2 configs/base_config.yml 150
 ```
 > Wait for `submit_dprst_depth.sh`'s final job (`mean_finalize`) `COMPLETED`, then:
@@ -238,8 +237,7 @@ sbatch slurm_batch/build_depstor_rasters.batch --step dprst
 # 3c. dprst_depth's own SLURM array (plan -> array -> build -> mean_zonal ->
 # mean_finalize) -- now burns against the FRESH `dprst_binary.tif` from 3b.
 # Wait for this to COMPLETE before 3d:
-BATCHES=$(pixi run --as-is python -c \
-  "import yaml;print(yaml.safe_load(open('configs/base_config.yml'))['data_root'])")/gfv2/batches
+BATCHES=$(pixi run data-root)/gfv2/batches
 slurm_batch/submit_dprst_depth.sh "$BATCHES" gfv2 configs/base_config.yml 150
 
 # 3d. the rest of the depstor raster stack (landmask + imperv + segment_wbody
@@ -321,8 +319,7 @@ merge before the next** — `slope` must merge before `ssflux`. First set the
 shared variables:
 
 ```bash
-BATCHES=$(pixi run --as-is python -c \
-  "import yaml;print(yaml.safe_load(open('configs/base_config.yml'))['data_root'])")/gfv2/batches
+BATCHES=$(pixi run data-root)/gfv2/batches
 FABRIC=gfv2
 BASE_CONFIG=configs/base_config.yml
 N=$(grep '^n_batches:' "$BATCHES/manifest.yml" | awk '{print $2}')   # array size


### PR DESCRIPTION
Closes #193

## What

- Adds `data-root` to `[tool.pixi.tasks]` in `pyproject.toml` — prints `data_root` from `base_config.yml` via the existing `load_base_config()` helper
- Replaces all three occurrences of the two-line Python one-liner in `slurm_batch/RUNME.md` with `BATCHES=$(pixi run data-root)/gfv2/batches`

## Before / After

```bash
# Before
BATCHES=$(pixi run --as-is python -c \
  "import yaml;print(yaml.safe_load(open('configs/base_config.yml'))['data_root'])")/gfv2/batches

# After
BATCHES=$(pixi run data-root)/gfv2/batches
```

## Changes

- `pyproject.toml`: +1 task
- `slurm_batch/RUNME.md`: 3 two-line blocks → 3 one-liners