### PR TITLE
fix(fill): copy fabric geometry.area for synthesized ssflux rows instead of KNN

### DIFF
--- a/configs/zonal/zonal_params.yml
+++ b/configs/zonal/zonal_params.yml
@@ -224,6 +224,12 @@ params:
       - gwflow_coef
       - dprst_seep_rate_open
       - dprst_flow_coef
+    # hru_area is geometry.area from the fabric — exact, not interpolatable.
+    # Synthesized rows get the true area rather than a neighbour's.
+    fabric_columns:
+      hru_area:
+        source: geometry
+        scale: 1.0
     # Lithology permeability + PRMS flux normalisation (lifted verbatim
     # from configs/zonal/ssflux_param.yml).
     k_perm_min: -16.48

--- a/configs/zonal/zonal_params.yml
+++ b/configs/zonal/zonal_params.yml
@@ -224,8 +224,22 @@ params:
       - gwflow_coef
       - dprst_seep_rate_open
       - dprst_flow_coef
-    # hru_area is geometry.area from the fabric — exact, not interpolatable.
-    # Synthesized rows get the true area rather than a neighbour's.
+    # hru_area is geometry.area from the fabric -- an exact fact already on disk,
+    # not something to interpolate. 77 gfv2 HRUs are absent from this file; without
+    # this declaration their hru_area lands NaN (it is an INPUT column above, so
+    # nobody declares it fillable), and under the retired "fill everything but the
+    # ids" regime it was KNN-copied from a neighbour at up to 11,109x the truth.
+    #
+    # `scale: 1.0` because geometry.area is in the fabric CRS's units, and every
+    # current fabric is a metre-based Albers (gfv2/oregon EPSG:5070, tjc
+    # ESRI:102039) -- so m², matching what zonal_runners/ssflux.py computes for
+    # every other row. A geographic-CRS fabric would yield degrees² with no error.
+    #
+    # NOT the PRMS `hru_area` parameter, which is acres (NHM_description TM6B9).
+    # This column is the raw divisor in the flux normalisation below -- do not
+    # reach for `scale` to "convert" it, or slowcoef_lin/fastcoef_lin/gwflow_coef
+    # all shift. `geometry` is preferred over the fabric's own `areasqkm` column
+    # so the synthesized value comes from the same computation as every other row.
     fabric_columns:
       hru_area:
         source: geometry

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -223,6 +223,39 @@ carries NaN cells only warns, naming the column and the NaN count — a NaN
 cell can be a legitimate "not derivable" result (`cv_empirical` is derivable
 for only ~42% of HRUs by design; `cv_subgrid` exists to rescue the rest).
 
+#### `fabric_columns` — exact values, not interpolated ones
+
+A param entry may also declare `fabric_columns`, a sibling of `fill_columns`
+for columns whose value is an exact fact already on disk in the fabric gpkg
+rather than something to interpolate:
+
+```yaml
+fabric_columns:
+  hru_area:
+    source: geometry   # or a fabric-GDF column name; `geometry` means geometry.area
+    scale: 1.0         # multiplier, in the fabric CRS's units
+```
+
+`apply_fabric_columns` copies these into **synthesized (previously absent)
+rows only** — existing rows keep their builder-computed value, so the
+mechanism cannot shift a canonical product it was not meant to touch. Today
+only `ssflux` declares one: `hru_area` is `geometry.area`, and the 77 gfv2
+HRUs absent from `nhm_ssflux_params.csv` would otherwise land NaN (it is a
+litho/slope *input*, so nobody declares it fillable) — or, under the retired
+"fill everything but the ids" regime, be KNN-copied from a neighbour at up to
+11,109× the true area.
+
+Both halves of the spec are validated eagerly and raise: the CSV column in
+`resolve_fill_plan`, the GDF `source` in `validate_fabric_sources` (before
+any fill runs, so a typo cannot lie dormant until the day a row goes
+missing). An id that the fabric cannot serve raises rather than warning, and
+a fabric column still NaN on a synthesized row raises *before* the write —
+`merged/<name>.csv` is read unconditionally by consumers, so a silent gap in
+it has no downstream reader to catch it. A `fabric_columns` column is **not**
+exempt from the undeclared-NaN warning: that census runs on the pre-append
+frame, so every NaN it counts is in an existing row, which this mechanism
+does not touch.
+
 `merged/<name>.csv` is the single canonical, always-gap-filled per-HRU file
 for every param that declares `fill_columns` — **consumers read
 `merged/*.csv`**. The retired `filled_` prefix required a consumer to know,

--- a/scripts/merge_and_fill_params.py
+++ b/scripts/merge_and_fill_params.py
@@ -10,6 +10,7 @@ profile.
 
 import argparse
 import fnmatch
+import math
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import NamedTuple
@@ -41,11 +42,16 @@ class FillPlan:
 
     `fill_columns` is exactly the caller's declared list, intersected with nothing —
     a declared column missing from the frame is an error, not a silent skip.
-    `fabric_columns` maps CSV column name -> (gdf_column, scale) for columns whose
-    value is a known geometric fact (e.g. hru_area = geometry.area) and must be
-    copied from the fabric GDF rather than KNN-interpolated.
+    `fabric_columns` maps CSV column name -> (source, scale), where `source` is either
+    a fabric-GDF column name or the SENTINEL "geometry", meaning `geometry.area` -- a
+    derived scalar, not a column read. These are columns whose value is an exact known
+    fact (`hru_area`), copied from the fabric rather than KNN-interpolated; see
+    `apply_fabric_columns`. Note the two lists are NOT peers in one respect: a param
+    may declare either, both, or neither, but `fabric_columns` alone only ever writes
+    the rows in `missing_ids`.
     `undeclared_with_nan` is the caller's warning material: columns carrying NaN that
-    nobody declared fillable.
+    nobody declared fillable. A `fabric_columns` column is NOT exempt from it -- see
+    the census comment in `resolve_fill_plan`.
     """
 
     fill_columns: list[str] = field(default_factory=list)
@@ -112,15 +118,60 @@ def resolve_fill_plan(param_df, declared, missing_ids, id_feature, param_name, f
             f"a typo here would silently fill nothing."
         )
 
-    if missing_ids and not declared:
+    # fabric_columns: {csv_col: {source: gdf_col_or_"geometry", scale: float}}
+    # Validated eagerly and completely, like fill_columns above, because the whole
+    # point of the mechanism is that a typo must RAISE rather than silently copy
+    # nothing. Narrower than fill_columns in one respect: there is no alias-list
+    # support here (fill_columns has it for the retention/rad_trncf rename), so a
+    # key is always a plain column name.
+    fabric_columns: dict[str, tuple[str, float]] = {}
+    bad_specs: list[str] = []
+    for csv_col, spec in (fabric_col_spec or {}).items():
+        if csv_col not in param_df.columns:
+            bad_specs.append(f"{csv_col!r} (not a column in the parameter file)")
+            continue
+        if not isinstance(spec, dict):
+            bad_specs.append(
+                f"{csv_col!r} (value must be a mapping with a `source` key, got {spec!r})"
+            )
+            continue
+        if "source" not in spec:
+            bad_specs.append(f"{csv_col!r} (mapping has no `source` key)")
+            continue
+        try:
+            scale = float(spec.get("scale", 1.0))
+        except (TypeError, ValueError):
+            bad_specs.append(f"{csv_col!r} (`scale` is not a number: {spec.get('scale')!r})")
+            continue
+        if not math.isfinite(scale) or scale == 0:
+            bad_specs.append(f"{csv_col!r} (`scale` must be finite and non-zero, got {scale!r})")
+            continue
+        fabric_columns[csv_col] = (spec["source"], scale)
+
+    if bad_specs:
         raise ValueError(
-            f"'{param_name}' is missing {len(missing_ids)} HRU row(s) but declares no "
-            f"`fill_columns`, so nothing would be filled and the gap would persist "
-            f"unnoticed. An absent HRU row is unambiguous -- unlike a NaN cell, it cannot "
-            f"be a legitimate 'not derivable' result. Add `fill_columns` for this param in "
-            f"its config entry."
+            f"`fabric_columns` for '{param_name}' is malformed: {bad_specs}. Expected "
+            f"`{{<csv column>: {{source: <gdf column> | geometry, scale: <number>}}}}`, "
+            f"where the csv column is one of {sorted(param_df.columns)}. Fix the config -- "
+            f"a typo here would silently copy nothing."
         )
 
+    if missing_ids and not declared and not fabric_columns:
+        raise ValueError(
+            f"'{param_name}' is missing {len(missing_ids)} HRU row(s) but declares no "
+            f"`fill_columns` or `fabric_columns`, so nothing would be filled and the gap "
+            f"would persist unnoticed. An absent HRU row is unambiguous -- unlike a NaN "
+            f"cell, it cannot be a legitimate 'not derivable' result. Add `fill_columns` "
+            f"for this param in its config entry."
+        )
+
+    # NaN census. A fabric column is NOT exempted here, even though
+    # `apply_fabric_columns` will write into it: this census runs on the frame as
+    # read from disk, BEFORE the absent rows are appended, so every NaN it counts is
+    # in a row that already exists -- and `apply_fabric_columns` only ever writes
+    # rows in `missing_ids`. Exempting them (as this originally did, on the reasoning
+    # that "it will be filled from the fabric") suppressed the warning for exactly
+    # the population the mechanism cannot reach.
     undeclared_with_nan = {}
     for col in param_df.columns:
         if col in resolved or col in ID_COLUMNS or col == id_feature:
@@ -128,20 +179,6 @@ def resolve_fill_plan(param_df, declared, missing_ids, id_feature, param_name, f
         n_nan = int(param_df[col].isna().sum())
         if n_nan:
             undeclared_with_nan[col] = n_nan
-
-    # fabric_columns: {csv_col: {source: gdf_col_or_"geometry", scale: float}}
-    # Validate that declared fabric columns are present in the frame (same contract
-    # as fill_columns — a typo must raise, not silently copy nothing).
-    fabric_columns: dict[str, tuple[str, float]] = {}
-    for csv_col, spec in (fabric_col_spec or {}).items():
-        if csv_col not in param_df.columns:
-            raise ValueError(
-                f"`fabric_columns` for '{param_name}' names '{csv_col}', which is not "
-                f"present in the parameter file. Fix the config."
-            )
-        fabric_columns[csv_col] = (spec["source"], float(spec.get("scale", 1.0)))
-        # Exclude from undeclared_with_nan — it will be filled from the fabric.
-        undeclared_with_nan.pop(csv_col, None)
 
     return FillPlan(fill_columns=resolved, fabric_columns=fabric_columns, undeclared_with_nan=undeclared_with_nan)
 
@@ -467,32 +504,98 @@ def warn_undeclared_merged_files(merged_dir: Path, declared_params, logger) -> l
     return undeclared
 
 
+def validate_fabric_sources(fabric_columns, merged_gdf, param_name) -> None:
+    """Check every `fabric_columns` source against the fabric GDF, before any fill runs.
+
+    The config half of the spec is validated in `resolve_fill_plan`, which has the
+    parameter frame but not the GDF. This is the other half, and it must be EAGER: a
+    typo'd `source` would otherwise surface only as a bare `KeyError` deep inside
+    `apply_fabric_columns`, and only on the runs where a row happens to be absent --
+    so a broken config could validate as fine indefinitely and fail on the exact day
+    the mechanism was needed.
+    """
+    bad = []
+    for csv_col, (source, _scale) in fabric_columns.items():
+        if source == "geometry":
+            if "geometry" not in merged_gdf.columns:
+                bad.append(f"{csv_col!r} -> geometry (the fabric GDF has no geometry column)")
+        elif source not in merged_gdf.columns:
+            bad.append(f"{csv_col!r} -> {source!r} (not a column in the fabric GDF)")
+    if bad:
+        raise ValueError(
+            f"`fabric_columns` for '{param_name}' names sources absent from the fabric "
+            f"geopackage: {bad}. Available columns: {sorted(merged_gdf.columns)}. Fix the "
+            f"config, or check that the profile's hru_gpkg is the fabric you meant."
+        )
+
+
 def apply_fabric_columns(complete_df, missing_ids, merged_gdf, fabric_columns, id_feature, logger):
     """Copy exact values from the fabric GDF into synthesized rows for declared fabric_columns.
 
+    WHY this exists: `hru_area` is `geometry.area` -- an exact fact already on disk in
+    the fabric gpkg, not a field to interpolate. Under the pre-`resolve_fill_plan`
+    regime ("fill everything except the id columns") the 77 HRUs absent from gfv2's
+    `nhm_ssflux_params.csv` had it KNN(k=1)-copied from whichever neighbour was
+    nearest: median 2.45x the true area, worst case 11,109x. Under the current
+    declaration-driven regime the same rows would instead land silently NaN, because
+    `hru_area` is a litho/slope INPUT that nobody declares fillable and the
+    `undeclared_with_nan` census runs before the absent rows are appended. Neither
+    outcome is acceptable when the true value is one attribute lookup away.
+
     For each column in `fabric_columns`, the value is read from the GDF column named
-    `source` (or computed as `geometry.area` when source == "geometry") and multiplied
-    by `scale`. Only synthesized (previously absent) rows are updated — existing rows
-    already carry the builder-computed value and must not be overwritten.
+    `source` (or computed as `geometry.area` when `source` is the sentinel "geometry")
+    and multiplied by `scale`.
+
+    Only synthesized (previously absent) rows are updated. For `hru_area` the existing
+    rows' values are `geometry.area` too (`zonal_runners/ssflux.py`), so this is about
+    blast radius rather than divergence: a mechanism that rewrote all 361,471 rows
+    from a second code path could silently shift the canonical product, and there is
+    no reason to take that risk to fix 77 rows.
+
+    RAISES rather than warns when an id cannot be served -- absent from the GDF, or
+    absent from the frame. Every other unrecoverable gap in this module raises (see
+    `fill_missing_values_knn`'s null-geometry guard and `resolve_fill_plan`), and the
+    failure mode of a warn-and-continue here is silent: the cell keeps its NaN, the
+    param is written to the canonical file, and `main()` exits 0.
     """
     if not missing_ids:
         return complete_df
 
-    gdf_indexed = merged_gdf.set_index(id_feature)
+    # A duplicated id makes `.loc[id]` return a DataFrame, `row.geometry.area` a
+    # Series, and the assignment below index-align into NaN instead of raising.
+    gdf_indexed = merged_gdf.set_index(id_feature, verify_integrity=True)
     df = complete_df.copy()
 
+    absent_from_gdf = [i for i in missing_ids if i not in gdf_indexed.index]
+    if absent_from_gdf:
+        raise ValueError(
+            f"fabric_columns: {len(absent_from_gdf)} id(s) needing fill are absent from "
+            f"the fabric geopackage (first few: {absent_from_gdf[:10]}). Every id in "
+            f"`missing_ids` comes from range(1, expected_max_hru_id + 1), so this means "
+            f"the fabric gpkg and expected_max_hru_id disagree -- a configuration error, "
+            f"not a data condition."
+        )
+
+    n_written = 0
     for csv_col, (source, scale) in fabric_columns.items():
         for hru_id in missing_ids:
-            if hru_id not in gdf_indexed.index:
-                logger.warning("  fabric_columns: %s not found in GDF for id %s", csv_col, hru_id)
-                continue
             row = gdf_indexed.loc[hru_id]
             val = row.geometry.area if source == "geometry" else row[source]
-            df.loc[df[id_feature] == hru_id, csv_col] = val * scale
+            target = df[id_feature] == hru_id
+            if not target.any():
+                raise ValueError(
+                    f"fabric_columns: id {hru_id} has no row in '{csv_col}'s frame to "
+                    f"write into. Synthesized rows are appended by fill_missing_values_knn "
+                    f"-- this means it did not run, or ran on a different id set."
+                )
+            df.loc[target, csv_col] = val * scale
+            n_written += 1
 
+    # Count actual writes, not len(missing_ids): a summary that reports the ATTEMPT
+    # count reads as an unqualified success in a SLURM log even when nothing landed.
     logger.info(
-        "  fabric_columns: copied exact values for %s into %d synthesized row(s)",
-        list(fabric_columns), len(missing_ids),
+        "  fabric_columns: copied exact values for %s into %d synthesized row(s) (%d cell(s))",
+        list(fabric_columns), len(missing_ids), n_written,
     )
     return df
 
@@ -523,7 +626,12 @@ def run_fill_sweep(targets, merged_gdf, expected_max, id_feature, k_neighbors, l
                     param_file.name, col, n,
                 )
 
-            if not plan.fill_columns:
+            validate_fabric_sources(plan.fabric_columns, merged_gdf, name)
+
+            # `fabric_columns` counts as work: a param declaring ONLY fabric columns
+            # must not be short-circuited here (this guard tested `fill_columns` alone
+            # and made `apply_fabric_columns` below unreachable for such a param).
+            if not plan.fill_columns and not plan.fabric_columns:
                 logger.info("  No fill_columns declared for %s; nothing to fill", name)
                 continue
 
@@ -540,6 +648,21 @@ def run_fill_sweep(targets, merged_gdf, expected_max, id_feature, k_neighbors, l
                 complete_df = apply_fabric_columns(
                     complete_df, missing_ids, merged_gdf, plan.fabric_columns, id_feature, logger,
                 )
+                # Post-condition, checked BEFORE the write: a fabric column that came
+                # out NaN on a synthesized row means the copy silently did not land,
+                # and nothing downstream would ever report it -- `merged/<name>.csv` is
+                # the always-filled canonical artifact consumers read unconditionally.
+                if missing_ids:
+                    synthesized = complete_df[id_feature].isin(missing_ids)
+                    for csv_col in plan.fabric_columns:
+                        n_nan = int(complete_df.loc[synthesized, csv_col].isna().sum())
+                        if n_nan:
+                            raise ValueError(
+                                f"fabric_columns: '{csv_col}' is still NaN on {n_nan} of "
+                                f"{len(missing_ids)} synthesized row(s) after copying from "
+                                f"the fabric. Refusing to write a canonical parameter file "
+                                f"with an unfilled gap."
+                            )
 
             write_filled_in_place(complete_df, param_file, param_df, dtypes, logger=logger)
 

--- a/scripts/merge_and_fill_params.py
+++ b/scripts/merge_and_fill_params.py
@@ -12,6 +12,7 @@ import argparse
 import fnmatch
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import NamedTuple
 
 import geopandas as gpd
 import numpy as np
@@ -318,12 +319,38 @@ def _load_yaml_doc(path: Path) -> dict:
     return doc or {}
 
 
+class DeclaredParam(NamedTuple):
+    """One config entry's fill contract: what file, and what may be written into it.
+
+    A NamedTuple rather than a bare tuple because this record has now been widened
+    twice (`fill_columns`, then `fabric_columns`) and each widening has to reach FOUR
+    consumption sites. The `fabric_columns` widening missed one of them --
+    `warn_undeclared_merged_files`, whose `for _, merged_file, _ in ...` then raised
+    `ValueError: too many values to unpack` in all-params mode, the DEFAULT and the
+    only mode `slurm_batch/merge_and_fill_params.batch` runs. It aborted `main()`
+    outside `run_fill_sweep`'s per-param guard, so nothing was filled at all, while
+    the test suite stayed green because its fixtures hand-built the OLD 3-tuple shape
+    -- test and implementation wrong in the same direction, agreeing with each other.
+
+    Attribute access cannot drift that way: a fifth field is invisible to every
+    consumer that does not ask for it.
+    """
+
+    name: str
+    merged_file: str
+    fill_columns: list[str]
+    fabric_columns: dict
+
+
 def iter_declared_params(
     zonal_cfg: dict, depstor_cfg: dict, snarea_cfg: dict | None = None
-) -> list[tuple[str, str, list[str], dict]]:
-    """Every param with a canonical `merged/` output and its declared `fill_columns`.
+) -> list[DeclaredParam]:
+    """Every param with a canonical `merged/` output, and what it declares fillable.
 
-    Returns `(param_name, merged_filename, fill_columns, fabric_columns)` tuples.
+    Returns `DeclaredParam(name, merged_file, fill_columns, fabric_columns)` records.
+    `fill_columns` is KNN-interpolated; `fabric_columns` is copied verbatim from the
+    fabric GDF (see `apply_fabric_columns`). Both default to empty for the params that
+    declare neither -- today every param but `ssflux` has an empty `fabric_columns`.
 
     `zonal_cfg["params"]` and `depstor_cfg["means"]` name their canonical file
     `merged_file`; `depstor_cfg["ratios"]` names it `output_file` instead (see
@@ -345,32 +372,40 @@ def iter_declared_params(
     `source_raster`/`script:` would break that orchestration. Hence the
     separate optional argument rather than a fourth zonal-shaped list.
     """
-    declared: list[tuple[str, str, list[str], dict]] = []
+    def _record(name: str, merged_file: str, entry: dict) -> DeclaredParam:
+        return DeclaredParam(
+            name=name,
+            merged_file=merged_file,
+            fill_columns=list(entry.get("fill_columns") or []),
+            fabric_columns=dict(entry.get("fabric_columns") or {}),
+        )
+
+    declared: list[DeclaredParam] = []
 
     for entry in zonal_cfg.get("params", []) or []:
         merged_file = entry.get("merged_file")
         if merged_file:
-            declared.append((entry["name"], merged_file, list(entry.get("fill_columns") or []), dict(entry.get("fabric_columns") or {})))
+            declared.append(_record(entry["name"], merged_file, entry))
 
     for entry in depstor_cfg.get("means", []) or []:
         merged_file = entry.get("merged_file")
         if merged_file:
-            declared.append((entry["name"], merged_file, list(entry.get("fill_columns") or []), dict(entry.get("fabric_columns") or {})))
+            declared.append(_record(entry["name"], merged_file, entry))
 
     for entry in depstor_cfg.get("ratios", []) or []:
         merged_file = entry.get("output_file")
         if merged_file:
-            declared.append((entry["name"], merged_file, list(entry.get("fill_columns") or []), dict(entry.get("fabric_columns") or {})))
+            declared.append(_record(entry["name"], merged_file, entry))
 
     if snarea_cfg:
         merged_file = snarea_cfg.get("params_file")
         if merged_file:
-            declared.append(("snarea_curve", merged_file, list(snarea_cfg.get("fill_columns") or []), dict(snarea_cfg.get("fabric_columns") or {})))
+            declared.append(_record("snarea_curve", merged_file, snarea_cfg))
 
     return declared
 
 
-def _load_declared_params() -> list[tuple[str, str, list[str]]]:
+def _load_declared_params() -> list[DeclaredParam]:
     """`iter_declared_params` over the real in-repo configs."""
     zonal_cfg = _load_yaml_doc(ZONAL_PARAMS_CONFIG)
     depstor_cfg = _load_yaml_doc(DEPSTOR_PARAMS_CONFIG)
@@ -412,7 +447,10 @@ def warn_undeclared_merged_files(merged_dir: Path, declared_params, logger) -> l
 
     Returns the sorted list of undeclared filenames warned about (for tests).
     """
-    declared_filenames = {merged_file for _, merged_file, _ in declared_params}
+    # Read by NAME, not by position: this set is the only thing this function needs
+    # from the record, and a positional unpack here is exactly what broke when
+    # `fabric_columns` widened it (see DeclaredParam).
+    declared_filenames = {d.merged_file for d in declared_params}
     undeclared = []
     for on_disk in sorted(merged_dir.glob("nhm_*_params.csv")):
         if on_disk.name in declared_filenames:
@@ -460,8 +498,8 @@ def apply_fabric_columns(complete_df, missing_ids, merged_gdf, fabric_columns, i
 
 
 def run_fill_sweep(targets, merged_gdf, expected_max, id_feature, k_neighbors, logger) -> list[str]:
-    """Fill every `(name, param_file, declared_columns)` in `targets`, isolating
-    per-param failures.
+    """Fill every `(name, param_file, fill_columns, fabric_col_spec)` in `targets`,
+    isolating per-param failures.
 
     One param's config drift (e.g. a column rename that resolve_fill_plan can't
     resolve) must not starve every OTHER declared param of its fill -- a
@@ -595,15 +633,14 @@ def main():
                 "Run scripts/derive_zonal_params.py --mode merge --param <name> (or the "
                 "matching depstor/snarea step) for this parameter type first."
             )
-        match = next((d for d in declared_params if d[1] == param_file.name), None)
+        match = next((d for d in declared_params if d.merged_file == param_file.name), None)
         if match is None:
             raise ValueError(
                 f"'{param_file.name}' is not declared in configs/zonal/zonal_params.yml, "
                 "configs/depstor/depstor_params.yml, or configs/snarea/snarea_library.yml "
                 "-- add a `fill_columns` entry for it before filling."
             )
-        name, _merged_file, fill_columns, fabric_col_spec = match
-        targets = [(name, param_file, fill_columns, fabric_col_spec)]
+        targets = [(match.name, param_file, match.fill_columns, match.fabric_columns)]
     else:
         # All-params mode (default): every declared param whose merged file has
         # already been produced for this fabric. A param not yet produced
@@ -611,12 +648,12 @@ def main():
         # WARNING (not silently at INFO -- an operator scanning the log for
         # problems should see it).
         targets = []
-        for name, merged_file, fill_columns, fabric_col_spec in declared_params:
-            pf = merged_dir / merged_file
+        for d in declared_params:
+            pf = merged_dir / d.merged_file
             if not pf.exists():
-                logger.warning("Skipping %s: %s not found (not yet produced for this fabric)", name, pf)
+                logger.warning("Skipping %s: %s not found (not yet produced for this fabric)", d.name, pf)
                 continue
-            targets.append((name, pf, fill_columns, fabric_col_spec))
+            targets.append((d.name, pf, d.fill_columns, d.fabric_columns))
         if not targets:
             logger.warning("No declared params' merged files were found under %s", merged_dir)
             return 0

--- a/scripts/merge_and_fill_params.py
+++ b/scripts/merge_and_fill_params.py
@@ -40,11 +40,15 @@ class FillPlan:
 
     `fill_columns` is exactly the caller's declared list, intersected with nothing —
     a declared column missing from the frame is an error, not a silent skip.
+    `fabric_columns` maps CSV column name -> (gdf_column, scale) for columns whose
+    value is a known geometric fact (e.g. hru_area = geometry.area) and must be
+    copied from the fabric GDF rather than KNN-interpolated.
     `undeclared_with_nan` is the caller's warning material: columns carrying NaN that
     nobody declared fillable.
     """
 
     fill_columns: list[str] = field(default_factory=list)
+    fabric_columns: dict[str, tuple[str, float]] = field(default_factory=dict)
     undeclared_with_nan: dict[str, int] = field(default_factory=dict)
 
 
@@ -53,7 +57,7 @@ class FillPlan:
 ID_COLUMNS = {"hru_id", "nat_hru_id", "model_hru_idx", "vpu"}
 
 
-def resolve_fill_plan(param_df, declared, missing_ids, id_feature, param_name) -> FillPlan:
+def resolve_fill_plan(param_df, declared, missing_ids, id_feature, param_name, fabric_col_spec=None) -> FillPlan:
     """Decide what to fill for one param, and what to surface without filling.
 
     The selection is DECLARATION-driven, not gap-driven, because "has a NaN" does not
@@ -124,7 +128,21 @@ def resolve_fill_plan(param_df, declared, missing_ids, id_feature, param_name) -
         if n_nan:
             undeclared_with_nan[col] = n_nan
 
-    return FillPlan(fill_columns=resolved, undeclared_with_nan=undeclared_with_nan)
+    # fabric_columns: {csv_col: {source: gdf_col_or_"geometry", scale: float}}
+    # Validate that declared fabric columns are present in the frame (same contract
+    # as fill_columns — a typo must raise, not silently copy nothing).
+    fabric_columns: dict[str, tuple[str, float]] = {}
+    for csv_col, spec in (fabric_col_spec or {}).items():
+        if csv_col not in param_df.columns:
+            raise ValueError(
+                f"`fabric_columns` for '{param_name}' names '{csv_col}', which is not "
+                f"present in the parameter file. Fix the config."
+            )
+        fabric_columns[csv_col] = (spec["source"], float(spec.get("scale", 1.0)))
+        # Exclude from undeclared_with_nan — it will be filled from the fabric.
+        undeclared_with_nan.pop(csv_col, None)
+
+    return FillPlan(fill_columns=resolved, fabric_columns=fabric_columns, undeclared_with_nan=undeclared_with_nan)
 
 
 def fill_missing_values_knn(param_df, missing_ids, merged_gdf, param_columns, k, id_feature, logger):
@@ -302,10 +320,10 @@ def _load_yaml_doc(path: Path) -> dict:
 
 def iter_declared_params(
     zonal_cfg: dict, depstor_cfg: dict, snarea_cfg: dict | None = None
-) -> list[tuple[str, str, list[str]]]:
+) -> list[tuple[str, str, list[str], dict]]:
     """Every param with a canonical `merged/` output and its declared `fill_columns`.
 
-    Returns `(param_name, merged_filename, fill_columns)` tuples.
+    Returns `(param_name, merged_filename, fill_columns, fabric_columns)` tuples.
 
     `zonal_cfg["params"]` and `depstor_cfg["means"]` name their canonical file
     `merged_file`; `depstor_cfg["ratios"]` names it `output_file` instead (see
@@ -327,27 +345,27 @@ def iter_declared_params(
     `source_raster`/`script:` would break that orchestration. Hence the
     separate optional argument rather than a fourth zonal-shaped list.
     """
-    declared: list[tuple[str, str, list[str]]] = []
+    declared: list[tuple[str, str, list[str], dict]] = []
 
     for entry in zonal_cfg.get("params", []) or []:
         merged_file = entry.get("merged_file")
         if merged_file:
-            declared.append((entry["name"], merged_file, list(entry.get("fill_columns") or [])))
+            declared.append((entry["name"], merged_file, list(entry.get("fill_columns") or []), dict(entry.get("fabric_columns") or {})))
 
     for entry in depstor_cfg.get("means", []) or []:
         merged_file = entry.get("merged_file")
         if merged_file:
-            declared.append((entry["name"], merged_file, list(entry.get("fill_columns") or [])))
+            declared.append((entry["name"], merged_file, list(entry.get("fill_columns") or []), dict(entry.get("fabric_columns") or {})))
 
     for entry in depstor_cfg.get("ratios", []) or []:
         merged_file = entry.get("output_file")
         if merged_file:
-            declared.append((entry["name"], merged_file, list(entry.get("fill_columns") or [])))
+            declared.append((entry["name"], merged_file, list(entry.get("fill_columns") or []), dict(entry.get("fabric_columns") or {})))
 
     if snarea_cfg:
         merged_file = snarea_cfg.get("params_file")
         if merged_file:
-            declared.append(("snarea_curve", merged_file, list(snarea_cfg.get("fill_columns") or [])))
+            declared.append(("snarea_curve", merged_file, list(snarea_cfg.get("fill_columns") or []), dict(snarea_cfg.get("fabric_columns") or {})))
 
     return declared
 
@@ -411,6 +429,36 @@ def warn_undeclared_merged_files(merged_dir: Path, declared_params, logger) -> l
     return undeclared
 
 
+def apply_fabric_columns(complete_df, missing_ids, merged_gdf, fabric_columns, id_feature, logger):
+    """Copy exact values from the fabric GDF into synthesized rows for declared fabric_columns.
+
+    For each column in `fabric_columns`, the value is read from the GDF column named
+    `source` (or computed as `geometry.area` when source == "geometry") and multiplied
+    by `scale`. Only synthesized (previously absent) rows are updated — existing rows
+    already carry the builder-computed value and must not be overwritten.
+    """
+    if not missing_ids:
+        return complete_df
+
+    gdf_indexed = merged_gdf.set_index(id_feature)
+    df = complete_df.copy()
+
+    for csv_col, (source, scale) in fabric_columns.items():
+        for hru_id in missing_ids:
+            if hru_id not in gdf_indexed.index:
+                logger.warning("  fabric_columns: %s not found in GDF for id %s", csv_col, hru_id)
+                continue
+            row = gdf_indexed.loc[hru_id]
+            val = row.geometry.area if source == "geometry" else row[source]
+            df.loc[df[id_feature] == hru_id, csv_col] = val * scale
+
+    logger.info(
+        "  fabric_columns: copied exact values for %s into %d synthesized row(s)",
+        list(fabric_columns), len(missing_ids),
+    )
+    return df
+
+
 def run_fill_sweep(targets, merged_gdf, expected_max, id_feature, k_neighbors, logger) -> list[str]:
     """Fill every `(name, param_file, declared_columns)` in `targets`, isolating
     per-param failures.
@@ -423,11 +471,11 @@ def run_fill_sweep(targets, merged_gdf, expected_max, id_feature, k_neighbors, l
     decides the process exit code from the returned failure list.
     """
     failed_params: list[str] = []
-    for name, param_file, declared_columns in targets:
+    for name, param_file, declared_columns, fabric_col_spec in targets:
         logger.info("=== %s (%s) ===", name, param_file.name)
         try:
             param_df, missing_ids = find_missing_ids(param_file, expected_max, id_feature, logger)
-            plan = resolve_fill_plan(param_df, declared_columns, missing_ids, id_feature, name)
+            plan = resolve_fill_plan(param_df, declared_columns, missing_ids, id_feature, name, fabric_col_spec)
 
             for col, n in plan.undeclared_with_nan.items():
                 logger.warning(
@@ -449,6 +497,12 @@ def run_fill_sweep(targets, merged_gdf, expected_max, id_feature, k_neighbors, l
             complete_df = fill_missing_values_knn(
                 param_df, missing_ids, merged_gdf, plan.fill_columns, k_neighbors, id_feature, logger,
             )
+
+            if plan.fabric_columns:
+                complete_df = apply_fabric_columns(
+                    complete_df, missing_ids, merged_gdf, plan.fabric_columns, id_feature, logger,
+                )
+
             write_filled_in_place(complete_df, param_file, param_df, dtypes, logger=logger)
 
             final_ids = set(complete_df[id_feature])
@@ -548,8 +602,8 @@ def main():
                 "configs/depstor/depstor_params.yml, or configs/snarea/snarea_library.yml "
                 "-- add a `fill_columns` entry for it before filling."
             )
-        name, _merged_file, fill_columns = match
-        targets = [(name, param_file, fill_columns)]
+        name, _merged_file, fill_columns, fabric_col_spec = match
+        targets = [(name, param_file, fill_columns, fabric_col_spec)]
     else:
         # All-params mode (default): every declared param whose merged file has
         # already been produced for this fabric. A param not yet produced
@@ -557,12 +611,12 @@ def main():
         # WARNING (not silently at INFO -- an operator scanning the log for
         # problems should see it).
         targets = []
-        for name, merged_file, fill_columns in declared_params:
+        for name, merged_file, fill_columns, fabric_col_spec in declared_params:
             pf = merged_dir / merged_file
             if not pf.exists():
                 logger.warning("Skipping %s: %s not found (not yet produced for this fabric)", name, pf)
                 continue
-            targets.append((name, pf, fill_columns))
+            targets.append((name, pf, fill_columns, fabric_col_spec))
         if not targets:
             logger.warning("No declared params' merged files were found under %s", merged_dir)
             return 0

--- a/slurm_batch/HPC_REFERENCE.md
+++ b/slurm_batch/HPC_REFERENCE.md
@@ -989,7 +989,11 @@ absent rows and NaN cells it filled, and applies two asymmetric guards: a
 column *not* declared in that param's `fill_columns` but carrying NaN cells
 only **warns** (a NaN cell may be a legitimate "not derivable" result); a
 param that is missing an HRU row entirely but declares no `fill_columns`
-**raises** (an absent row admits no such reading). Migrating an existing
+**raises** (an absent row admits no such reading). A param may additionally
+declare `fabric_columns` — values copied verbatim from the fabric gpkg into
+synthesized rows instead of being interpolated (`ssflux`'s `hru_area` is
+`geometry.area`); every failure in that path raises rather than warns, and
+the copy is checked for residual NaN *before* the file is written. Migrating an existing
 `filled_`-prefixed product onto this layout is a separate one-time step —
 `scripts/migrate_filled_params.py --merged_dir <path>` (dry-run by default,
 `--apply` to execute).

--- a/slurm_batch/RUNME.md
+++ b/slurm_batch/RUNME.md
@@ -429,8 +429,18 @@ Two asymmetric guards fire per param:
   only ~42% of HRUs by design; `cv_subgrid` exists to rescue the rest), so it
   is left untouched rather than silently filled.
 - A param that is missing an HRU **row** entirely but declares no
-  `fill_columns` **raises** instead of passing silently — an absent row
-  admits no "not derivable" reading, unlike a NaN cell.
+  `fill_columns` (or `fabric_columns`) **raises** instead of passing silently
+  — an absent row admits no "not derivable" reading, unlike a NaN cell.
+
+A param may also declare **`fabric_columns`** for values that are exact facts
+already on disk in the fabric gpkg rather than things to interpolate. These
+are copied verbatim from the fabric into synthesized rows only — never
+KNN-filled, never applied to rows that already exist. Today only `ssflux`
+declares one (`hru_area: {source: geometry, scale: 1.0}`, i.e.
+`geometry.area` in the fabric CRS's units). Unlike the NaN-cell warning
+above, every `fabric_columns` failure **raises**: a malformed spec, a
+`source` absent from the fabric gpkg, an id the fabric cannot serve, or a
+value still NaN after the copy. See `docs/ARCHITECTURE.md`.
 
 Migrating an existing product off the old `filled_` layout is a one-time,
 separate step — see `scripts/migrate_filled_params.py` (dry-run by default,

--- a/tests/test_merge_and_fill_params.py
+++ b/tests/test_merge_and_fill_params.py
@@ -627,14 +627,14 @@ def test_iter_declared_params_excludes_fractions_includes_means_and_ratios():
     assert "perv_frac" not in names  # fraction excluded despite its merged_file key
 
     by_name = {d[0]: d for d in declared}
-    assert by_name["dprst_frac"] == ("dprst_frac", "nhm_dprst_frac_params.csv", ["dprst_frac"])
-    assert by_name["elevation"] == ("elevation", "nhm_elevation_params.csv", ["mean"])
+    assert by_name["dprst_frac"] == ("dprst_frac", "nhm_dprst_frac_params.csv", ["dprst_frac"], {})
+    assert by_name["elevation"] == ("elevation", "nhm_elevation_params.csv", ["mean"], {})
 
 
 def test_iter_declared_params_includes_snarea_when_given():
     snarea_cfg = {"params_file": "nhm_snarea_curve_params.csv", "fill_columns": ["hru_deplcrv"]}
     declared = maf.iter_declared_params({}, {}, snarea_cfg)
-    assert declared == [("snarea_curve", "nhm_snarea_curve_params.csv", ["hru_deplcrv"])]
+    assert declared == [("snarea_curve", "nhm_snarea_curve_params.csv", ["hru_deplcrv"], {})]
 
 
 def test_iter_declared_params_snarea_optional():
@@ -670,8 +670,8 @@ class TestRunFillSweep:
         pd.DataFrame({"hru_id": [1, 2], "v": [1.0, 2.0]}).to_csv(bad, index=False)
 
         targets = [
-            ("good_param", good, ["v"]),
-            ("bad_param", bad, ["typo_column"]),  # not present -> resolve_fill_plan raises
+            ("good_param", good, ["v"], {}),
+            ("bad_param", bad, ["typo_column"], {}),  # not present -> resolve_fill_plan raises
         ]
 
         failed = maf.run_fill_sweep(
@@ -692,7 +692,7 @@ class TestRunFillSweep:
         pd.DataFrame({"hru_id": [1, 2], "v": [10.0, 20.0]}).to_csv(good, index=False)
 
         failed = maf.run_fill_sweep(
-            [("good_param", good, ["v"])], self._merged_gdf(), expected_max=3,
+            [("good_param", good, ["v"], {})], self._merged_gdf(), expected_max=3,
             id_feature="hru_id", k_neighbors=1, logger=logger,
         )
         assert failed == []
@@ -763,3 +763,110 @@ class TestWarnUndeclaredMergedFiles:
         )
 
         assert undeclared == []
+
+
+# ---------------------------------------------------------------------------
+# fabric_columns: exact values copied from the GDF for synthesized rows.
+# ---------------------------------------------------------------------------
+
+class TestApplyFabricColumns:
+    def _gdf(self):
+        from shapely.geometry import box
+        # id=1: 100m x 100m = 10000 m²; id=2: 200m x 200m = 40000 m²; id=3: 50m x 50m = 2500 m²
+        return gpd.GeoDataFrame(
+            {"nat_hru_id": [1, 2, 3]},
+            geometry=[box(0, 0, 100, 100), box(0, 0, 200, 200), box(0, 0, 50, 50)],
+            crs="EPSG:5070",
+        )
+
+    def test_geometry_area_copied_for_synthesized_rows(self):
+        import logging
+        logger = logging.getLogger("test")
+        gdf = self._gdf()
+        # id=3 is synthesized (absent from original CSV)
+        df = pd.DataFrame({
+            "nat_hru_id": [1, 2, 3],
+            "hru_area": [10000.0, 40000.0, 99999.0],  # id=3 has wrong neighbour value
+            "my_param": [1.0, 2.0, 3.0],
+        })
+        result = maf.apply_fabric_columns(
+            df, missing_ids=[3], merged_gdf=gdf,
+            fabric_columns={"hru_area": ("geometry", 1.0)},
+            id_feature="nat_hru_id", logger=logger,
+        )
+        assert result.loc[result["nat_hru_id"] == 3, "hru_area"].iloc[0] == pytest.approx(2500.0)
+        # Existing rows must not be touched
+        assert result.loc[result["nat_hru_id"] == 1, "hru_area"].iloc[0] == pytest.approx(10000.0)
+        assert result.loc[result["nat_hru_id"] == 2, "hru_area"].iloc[0] == pytest.approx(40000.0)
+
+    def test_scale_applied(self):
+        import logging
+        logger = logging.getLogger("test")
+        from shapely.geometry import box
+        gdf = gpd.GeoDataFrame(
+            {"nat_hru_id": [1]},
+            geometry=[box(0, 0, 1000, 1000)],  # 1e6 m²
+            crs="EPSG:5070",
+        )
+        df = pd.DataFrame({"nat_hru_id": [1], "hru_area": [0.0]})
+        result = maf.apply_fabric_columns(
+            df, missing_ids=[1], merged_gdf=gdf,
+            fabric_columns={"hru_area": ("geometry", 1e-6)},  # m² -> km²
+            id_feature="nat_hru_id", logger=logger,
+        )
+        assert result.loc[result["nat_hru_id"] == 1, "hru_area"].iloc[0] == pytest.approx(1.0)
+
+    def test_no_missing_ids_returns_unchanged(self):
+        import logging
+        logger = logging.getLogger("test")
+        gdf = self._gdf()
+        df = pd.DataFrame({"nat_hru_id": [1, 2], "hru_area": [10000.0, 40000.0]})
+        result = maf.apply_fabric_columns(
+            df, missing_ids=[], merged_gdf=gdf,
+            fabric_columns={"hru_area": ("geometry", 1.0)},
+            id_feature="nat_hru_id", logger=logger,
+        )
+        pd.testing.assert_frame_equal(result, df)
+
+
+def test_resolve_fill_plan_parses_fabric_columns():
+    """fabric_columns spec is parsed into (source, scale) tuples and excluded from undeclared_with_nan."""
+    frame = pd.DataFrame({
+        "nat_hru_id": [1, 2],
+        "hru_area": [10000.0, np.nan],
+        "my_param": [1.0, 2.0],
+    })
+    plan = maf.resolve_fill_plan(
+        frame,
+        declared=["my_param"],
+        missing_ids=set(),
+        id_feature="nat_hru_id",
+        param_name="ssflux",
+        fabric_col_spec={"hru_area": {"source": "geometry", "scale": 1.0}},
+    )
+    assert plan.fabric_columns == {"hru_area": ("geometry", 1.0)}
+    # hru_area has a NaN but is a fabric column — must NOT appear in undeclared_with_nan
+    assert "hru_area" not in plan.undeclared_with_nan
+
+
+def test_resolve_fill_plan_fabric_column_absent_from_frame_raises():
+    frame = pd.DataFrame({"nat_hru_id": [1], "my_param": [1.0]})
+    with pytest.raises(ValueError, match="fabric_columns"):
+        maf.resolve_fill_plan(
+            frame,
+            declared=["my_param"],
+            missing_ids=set(),
+            id_feature="nat_hru_id",
+            param_name="ssflux",
+            fabric_col_spec={"hru_area": {"source": "geometry", "scale": 1.0}},
+        )
+
+
+def test_ssflux_config_declares_fabric_columns():
+    """Regression guard: ssflux must declare hru_area as a fabric_column."""
+    root = Path(__file__).resolve().parent.parent
+    doc = yaml.safe_load((root / "configs/zonal/zonal_params.yml").read_text())
+    ssflux = next(e for e in doc["params"] if e["name"] == "ssflux")
+    assert "fabric_columns" in ssflux, "ssflux must declare fabric_columns"
+    assert "hru_area" in ssflux["fabric_columns"], "hru_area must be a fabric_column for ssflux"
+    assert ssflux["fabric_columns"]["hru_area"]["source"] == "geometry"

--- a/tests/test_merge_and_fill_params.py
+++ b/tests/test_merge_and_fill_params.py
@@ -734,7 +734,7 @@ class TestWarnUndeclaredMergedFiles:
 
         with caplog.at_level(logging.WARNING, logger="test_warn_undeclared"):
             undeclared = maf.warn_undeclared_merged_files(
-                tmp_path, [("declared", "nhm_declared_params.csv", ["v"])], logger,
+                tmp_path, [maf.DeclaredParam("declared", "nhm_declared_params.csv", ["v"], {})], logger,
             )
 
         assert undeclared == ["nhm_mystery_params.csv"]
@@ -748,7 +748,7 @@ class TestWarnUndeclaredMergedFiles:
         logger = logging.getLogger("test_warn_undeclared_allow")
 
         undeclared = maf.warn_undeclared_merged_files(
-            tmp_path, [("declared", "nhm_declared_params.csv", ["v"])], logger,
+            tmp_path, [maf.DeclaredParam("declared", "nhm_declared_params.csv", ["v"], {})], logger,
         )
 
         assert undeclared == []
@@ -759,10 +759,31 @@ class TestWarnUndeclaredMergedFiles:
         logger = logging.getLogger("test_warn_undeclared_none")
 
         undeclared = maf.warn_undeclared_merged_files(
-            tmp_path, [("declared", "nhm_declared_params.csv", ["v"])], logger,
+            tmp_path, [maf.DeclaredParam("declared", "nhm_declared_params.csv", ["v"], {})], logger,
         )
 
         assert undeclared == []
+
+    def test_consumes_the_real_producers_output(self, tmp_path):
+        """Feed `_load_declared_params()`'s ACTUAL records in, not a hand-built literal.
+
+        Regression guard for the `fabric_columns` widening: this function read the
+        record positionally (`for _, merged_file, _ in ...`) and raised
+        `ValueError: too many values to unpack` on every all-params run -- the default
+        mode, and the only one slurm_batch/merge_and_fill_params.batch uses. The three
+        tests above did not catch it because they hand-built the record, so they
+        asserted the shape the implementation still expected rather than the shape
+        production actually supplies. A fixture can never catch a producer/consumer
+        contract change; consuming the producer can.
+        """
+        import logging
+        (tmp_path / "nhm_mystery_params.csv").write_text("hru_id,v\n1,1\n")
+
+        undeclared = maf.warn_undeclared_merged_files(
+            tmp_path, maf._load_declared_params(), logging.getLogger("test_warn_undeclared_real"),
+        )
+
+        assert undeclared == ["nhm_mystery_params.csv"]
 
 
 # ---------------------------------------------------------------------------
@@ -772,6 +793,7 @@ class TestWarnUndeclaredMergedFiles:
 class TestApplyFabricColumns:
     def _gdf(self):
         from shapely.geometry import box
+
         # id=1: 100m x 100m = 10000 m²; id=2: 200m x 200m = 40000 m²; id=3: 50m x 50m = 2500 m²
         return gpd.GeoDataFrame(
             {"nat_hru_id": [1, 2, 3]},

--- a/tests/test_merge_and_fill_params.py
+++ b/tests/test_merge_and_fill_params.py
@@ -806,9 +806,14 @@ class TestApplyFabricColumns:
         logger = logging.getLogger("test")
         gdf = self._gdf()
         # id=3 is synthesized (absent from original CSV)
+        # Existing rows carry SENTINEL values that deliberately differ from their own
+        # geometry.area (10000.0 / 40000.0). If this test used the true areas, an
+        # implementation that overwrote every row -- not just the synthesized ones --
+        # would still pass, and the "must not be overwritten" assertion below would
+        # prove nothing.
         df = pd.DataFrame({
             "nat_hru_id": [1, 2, 3],
-            "hru_area": [10000.0, 40000.0, 99999.0],  # id=3 has wrong neighbour value
+            "hru_area": [111.0, 222.0, 99999.0],  # id=3 has wrong neighbour value
             "my_param": [1.0, 2.0, 3.0],
         })
         result = maf.apply_fabric_columns(
@@ -817,9 +822,9 @@ class TestApplyFabricColumns:
             id_feature="nat_hru_id", logger=logger,
         )
         assert result.loc[result["nat_hru_id"] == 3, "hru_area"].iloc[0] == pytest.approx(2500.0)
-        # Existing rows must not be touched
-        assert result.loc[result["nat_hru_id"] == 1, "hru_area"].iloc[0] == pytest.approx(10000.0)
-        assert result.loc[result["nat_hru_id"] == 2, "hru_area"].iloc[0] == pytest.approx(40000.0)
+        # Existing rows must not be touched -- these are the sentinels, not the areas.
+        assert result.loc[result["nat_hru_id"] == 1, "hru_area"].iloc[0] == pytest.approx(111.0)
+        assert result.loc[result["nat_hru_id"] == 2, "hru_area"].iloc[0] == pytest.approx(222.0)
 
     def test_scale_applied(self):
         import logging
@@ -850,9 +855,157 @@ class TestApplyFabricColumns:
         )
         pd.testing.assert_frame_equal(result, df)
 
+    def test_plain_gdf_column_source(self):
+        """The non-`geometry` half of the mechanism: copy an ordinary GDF attribute."""
+        import logging
+        gdf = self._gdf()
+        gdf["areasqkm"] = [0.01, 0.04, 0.0025]
+        df = pd.DataFrame({"nat_hru_id": [1, 2, 3], "hru_area": [111.0, 222.0, np.nan]})
+        result = maf.apply_fabric_columns(
+            df, missing_ids=[3], merged_gdf=gdf,
+            fabric_columns={"hru_area": ("areasqkm", 1e6)},  # km² -> m²
+            id_feature="nat_hru_id", logger=logging.getLogger("test"),
+        )
+        assert result.loc[result["nat_hru_id"] == 3, "hru_area"].iloc[0] == pytest.approx(2500.0)
+
+    def test_id_absent_from_gdf_raises(self):
+        """An id needing fill that the fabric cannot serve must RAISE, not warn.
+
+        Warn-and-continue left the cell NaN, wrote it into the canonical parameter
+        file, and exited 0 -- while the summary log still reported a successful copy.
+        Every other unrecoverable gap in this module raises.
+        """
+        import logging
+        df = pd.DataFrame({"nat_hru_id": [1, 2, 4], "hru_area": [111.0, 222.0, np.nan]})
+        with pytest.raises(ValueError, match="absent from the fabric geopackage"):
+            maf.apply_fabric_columns(
+                df, missing_ids=[4], merged_gdf=self._gdf(),  # gdf has ids 1,2,3 only
+                fabric_columns={"hru_area": ("geometry", 1.0)},
+                id_feature="nat_hru_id", logger=logging.getLogger("test"),
+            )
+
+    def test_duplicate_id_in_gdf_raises(self):
+        """A duplicated id would make `.loc` return a frame and the write align to NaN."""
+        import logging
+
+        from shapely.geometry import box
+        gdf = gpd.GeoDataFrame(
+            {"nat_hru_id": [1, 2, 2]},
+            geometry=[box(0, 0, 10, 10), box(0, 0, 20, 20), box(0, 0, 30, 30)],
+            crs="EPSG:5070",
+        )
+        df = pd.DataFrame({"nat_hru_id": [1, 2], "hru_area": [111.0, np.nan]})
+        with pytest.raises(ValueError):
+            maf.apply_fabric_columns(
+                df, missing_ids=[2], merged_gdf=gdf,
+                fabric_columns={"hru_area": ("geometry", 1.0)},
+                id_feature="nat_hru_id", logger=logging.getLogger("test"),
+            )
+
+
+class TestFabricColumnsThroughRunFillSweep:
+    """The seam: `fabric_columns` must actually reach the on-disk file.
+
+    Every other fabric_columns test calls `apply_fabric_columns` directly. Without
+    this one, `run_fill_sweep`'s call to it could be deleted outright and the suite
+    would stay green -- the feature would ship inert. This also pins the ORDERING
+    (synthesize rows via KNN -> copy fabric values -> write), which nothing else does.
+    """
+
+    def _gdf(self):
+        from shapely.geometry import box
+        return gpd.GeoDataFrame(
+            {"hru_id": [1, 2, 3]},
+            geometry=[box(0, 0, 100, 100), box(0, 0, 200, 200), box(0, 0, 50, 50)],
+            crs="EPSG:5070",
+        )
+
+    def test_fabric_column_lands_in_the_written_file(self, tmp_path):
+        import logging
+        pf = tmp_path / "nhm_ssflux_params.csv"
+        # id=3 absent entirely; the existing rows' hru_area are sentinels, not areas.
+        pd.DataFrame({"hru_id": [1, 2], "hru_area": [111.0, 222.0], "v": [10.0, 20.0]}).to_csv(pf, index=False)
+
+        failed = maf.run_fill_sweep(
+            [("ssflux", pf, ["v"], {"hru_area": {"source": "geometry", "scale": 1.0}})],
+            self._gdf(), expected_max=3, id_feature="hru_id", k_neighbors=1,
+            logger=logging.getLogger("test"),
+        )
+
+        assert failed == []
+        result = pd.read_csv(pf).set_index("hru_id")
+        assert result.loc[3, "hru_area"] == pytest.approx(2500.0)  # exact, not a neighbour's
+        # KNN still filled the ordinary column: id=3's centroid (25,25) is nearest
+        # id=1's (50,50), not id=2's (100,100).
+        assert result.loc[3, "v"] == pytest.approx(10.0)
+        assert result.loc[1, "hru_area"] == pytest.approx(111.0)   # existing rows untouched
+        assert result.loc[2, "hru_area"] == pytest.approx(222.0)
+
+    def test_fabric_columns_only_param_is_not_short_circuited(self, tmp_path):
+        """A param declaring ONLY fabric_columns must still fill.
+
+        `if not plan.fill_columns: continue` made `apply_fabric_columns` unreachable
+        for such a param -- silently doing nothing rather than failing.
+        """
+        import logging
+        pf = tmp_path / "nhm_areaonly_params.csv"
+        pd.DataFrame({"hru_id": [1, 2], "hru_area": [111.0, 222.0]}).to_csv(pf, index=False)
+
+        failed = maf.run_fill_sweep(
+            [("areaonly", pf, [], {"hru_area": {"source": "geometry", "scale": 1.0}})],
+            self._gdf(), expected_max=3, id_feature="hru_id", k_neighbors=1,
+            logger=logging.getLogger("test"),
+        )
+
+        assert failed == []
+        result = pd.read_csv(pf).set_index("hru_id")
+        assert result.index.tolist() == [1, 2, 3]
+        assert result.loc[3, "hru_area"] == pytest.approx(2500.0)
+
+    def test_bad_source_fails_this_param_without_writing(self, tmp_path):
+        """A `source` absent from the GDF is caught eagerly, before any write."""
+        import logging
+        pf = tmp_path / "nhm_ssflux_params.csv"
+        pd.DataFrame({"hru_id": [1, 2], "hru_area": [111.0, 222.0], "v": [10.0, 20.0]}).to_csv(pf, index=False)
+
+        failed = maf.run_fill_sweep(
+            [("ssflux", pf, ["v"], {"hru_area": {"source": "typo_col", "scale": 1.0}})],
+            self._gdf(), expected_max=3, id_feature="hru_id", k_neighbors=1,
+            logger=logging.getLogger("test"),
+        )
+
+        assert failed == ["ssflux"]
+        # The canonical file is untouched -- no partial write.
+        assert pd.read_csv(pf)["hru_id"].tolist() == [1, 2]
+
 
 def test_resolve_fill_plan_parses_fabric_columns():
-    """fabric_columns spec is parsed into (source, scale) tuples and excluded from undeclared_with_nan."""
+    """fabric_columns spec is parsed into (source, scale) tuples."""
+    frame = pd.DataFrame({
+        "nat_hru_id": [1, 2],
+        "hru_area": [10000.0, 20000.0],
+        "my_param": [1.0, 2.0],
+    })
+    plan = maf.resolve_fill_plan(
+        frame,
+        declared=["my_param"],
+        missing_ids=set(),
+        id_feature="nat_hru_id",
+        param_name="ssflux",
+        fabric_col_spec={"hru_area": {"source": "geometry", "scale": 1.0}},
+    )
+    assert plan.fabric_columns == {"hru_area": ("geometry", 1.0)}
+
+
+def test_resolve_fill_plan_still_warns_on_nan_in_an_existing_fabric_column_row():
+    """A NaN in an EXISTING row of a fabric column must still be surfaced.
+
+    `apply_fabric_columns` writes only rows in `missing_ids`, and this census runs on
+    the pre-append frame -- so every NaN it sees is in a row the mechanism structurally
+    cannot reach. Exempting fabric columns from the census (the original behaviour,
+    justified as "it will be filled from the fabric") suppressed the module's only
+    warning for a gap that nothing fills.
+    """
     frame = pd.DataFrame({
         "nat_hru_id": [1, 2],
         "hru_area": [10000.0, np.nan],
@@ -866,9 +1019,39 @@ def test_resolve_fill_plan_parses_fabric_columns():
         param_name="ssflux",
         fabric_col_spec={"hru_area": {"source": "geometry", "scale": 1.0}},
     )
+    assert plan.undeclared_with_nan == {"hru_area": 1}
+
+
+def test_resolve_fill_plan_defaults_scale_to_one():
+    frame = pd.DataFrame({"nat_hru_id": [1], "hru_area": [10000.0], "my_param": [1.0]})
+    plan = maf.resolve_fill_plan(
+        frame, declared=["my_param"], missing_ids=set(), id_feature="nat_hru_id",
+        param_name="ssflux", fabric_col_spec={"hru_area": {"source": "geometry"}},
+    )
     assert plan.fabric_columns == {"hru_area": ("geometry", 1.0)}
-    # hru_area has a NaN but is a fabric column — must NOT appear in undeclared_with_nan
-    assert "hru_area" not in plan.undeclared_with_nan
+
+
+@pytest.mark.parametrize("spec", [
+    {"scale": 1.0},              # no `source`
+    "geometry",                  # scalar shorthand -- not a mapping
+    None,                        # empty YAML value
+    {"source": "geometry", "scale": "1e-6x"},   # unparseable scale
+    {"source": "geometry", "scale": 0},         # would zero every synthesized value
+])
+def test_resolve_fill_plan_malformed_fabric_spec_raises_with_context(spec):
+    """A malformed spec must raise the module's own instructive ValueError.
+
+    Each of these previously produced a context-free builtin (KeyError, TypeError,
+    ValueError) from `spec["source"]` / `float(...)`, five lines below a raise that
+    names the param, the column, and the remedy. In a SLURM log that surfaces only as
+    a truncated line inside `logger.exception`.
+    """
+    frame = pd.DataFrame({"nat_hru_id": [1], "hru_area": [10000.0], "my_param": [1.0]})
+    with pytest.raises(ValueError, match="malformed"):
+        maf.resolve_fill_plan(
+            frame, declared=["my_param"], missing_ids=set(), id_feature="nat_hru_id",
+            param_name="ssflux", fabric_col_spec={"hru_area": spec},
+        )
 
 
 def test_resolve_fill_plan_fabric_column_absent_from_frame_raises():
@@ -892,3 +1075,9 @@ def test_ssflux_config_declares_fabric_columns():
     assert "fabric_columns" in ssflux, "ssflux must declare fabric_columns"
     assert "hru_area" in ssflux["fabric_columns"], "hru_area must be a fabric_column for ssflux"
     assert ssflux["fabric_columns"]["hru_area"]["source"] == "geometry"
+    # The two lists must stay disjoint: declaring hru_area in BOTH would have KNN
+    # interpolate it and then the fabric copy overwrite -- harmless only by accident
+    # of ordering, and an interpolated hru_area is the bug this declaration fixes.
+    assert "hru_area" not in ssflux["fill_columns"], (
+        "hru_area must be a fabric_column ONLY -- KNN must never touch it"
+    )


### PR DESCRIPTION
Closes #190

## Problem

77 HRUs absent from `nhm_ssflux_params.csv` had their `hru_area` filled by KNN (k=1), copying a neighbour's area. Median ratio to truth: 2.45×; worst case: 11,109×. `hru_area` is `geometry.area` — exact and already on disk in the fabric gpkg.

## Solution

Adds a `fabric_columns` mechanism to the gap-fill step. Columns declared as `fabric_columns` are copied from the fabric GDF for synthesized rows rather than KNN-interpolated. Only synthesized (previously absent) rows are updated — existing rows already carry the builder-computed value.

Config declaration (ssflux):
```yaml
fabric_columns:
  hru_area:
    source: geometry   # geometry.area in the CRS units (m², EPSG:5070)
    scale: 1.0
```

## Changes

- `scripts/merge_and_fill_params.py`: `FillPlan` + `resolve_fill_plan` + new `apply_fabric_columns` + `iter_declared_params` / `run_fill_sweep` threading
- `configs/zonal/zonal_params.yml`: ssflux `fabric_columns` declaration
- `tests/test_merge_and_fill_params.py`: 6 new tests; 4 existing tests updated for 3→4 tuple

All 47 tests pass.