### PR TITLE
feat(diagnose): run the #147 FDR-conditioning A/B; record the result

### DIFF
--- a/.amazonq/rules/workflow.md
+++ b/.amazonq/rules/workflow.md
@@ -58,6 +58,10 @@ Configuration (CFG-*), Code Quality (CODE-*), Hygiene (HYG-*), Architecture (ARC
 - Default branch: `main`
 - CI runs `pytest tests/` on push to main and every PR
 - Do not run pytest on the HPC login node
+- `sbatch slurm_batch/ab_drains_to_dprst.batch [VPU] [FABRIC]` — the #147 FDR
+  A/B (production vs fill vs breach) on one VPU; defaults VPU 16 / gfv2_dev.
+  Already run; result recorded in CLAUDE.md's FDR bullet (production ≈ breach,
+  so do not swap the FDR chasing contributing-area magnitude)
 - Environment: pixi (`pyproject.toml`); SLURM batches use `pixi run --as-is`
 - `pixi run data-root` — prints `data_root` from base_config.yml (added PR #194)
 - `pixi run init-data-root` — scaffolds the data directory tree

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,19 @@ These are hard-won; violating them silently corrupts outputs.
   construction. See `docs/ARCHITECTURE.md`,
   `docs/superpowers/specs/2026-07-12-endorheic-dprst-classifier-design.md`, and
   issue #147 (depression-respecting FDR investigation) for the provenance/tradeoff.
+  **The #147 A/B has now been run** (VPU 16, `slurm_batch/ab_drains_to_dprst.batch`):
+  `drains_to_dprst` land coverage is 0.4401 under the production FdrFac vs 0.4388
+  under a breached DEM — a 0.3% difference — while a richdem **fill-all** on the same
+  DEM gives 0.8079, nearly double, inflating 1,009 of 2,605 depressions by >2x and 411
+  by >10x. So the fill pathology #147 feared is real but **we are not exposed to it**:
+  stream-burning and walling already give water defined exits, so the FdrFac behaves
+  like a depression-respecting DEM. Do not swap the FDR chasing contributing-area
+  magnitude — there is nothing to win. (Open sub-question: production and breach agree
+  on the total but disagree on *attribution*, reshuffling 31% of contributing area
+  between depressions, 415 of them by >2x. Which is correct is not decided by that
+  A/B.) Note also that `Fdr_breached` sets `BREACH_FILL=True` and therefore has **no
+  interior code-0 cells**, so it can never serve as an endorheic-classifier input —
+  Signal A would go silently dark.
 - **Endorheic demotion is a STRICT SUBTRACTION, and its input is the FDR — not a
   vector sink file.** `wbody_connectivity` subtracts an endorheic COMID set from
   the on-stream union; the subtraction can only ever remove COMIDs, never add

--- a/slurm_batch/ab_drains_to_dprst.batch
+++ b/slurm_batch/ab_drains_to_dprst.batch
@@ -1,0 +1,72 @@
+#!/bin/bash
+#SBATCH -p cpu
+#SBATCH -A impd
+#SBATCH --job-name=ab_drains_to_dprst
+#SBATCH --output=logs/job_%j.out
+#SBATCH --error=logs/job_%j.err
+#SBATCH --time=12:00:00
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=128G
+
+# The #147 A/B: drains_to_dprst on ONE VPU across all three FDR conditionings.
+#
+#   production : the fabric fdr.vrt (NHDPlus FdrFac -- stream-burned + filled
+#                except at NHD's own curated sinks)
+#   fill       : Fdr_hydrodem_<vpu>.tif (richdem fill-all on the same Hydrodem)
+#   breach     : Fdr_breached_<vpu>.tif (WBT BreachDepressionsLeastCost)
+#
+# production-vs-fill isolates the DEM/stream-burn difference; fill-vs-breach
+# isolates the conditioning. This is the investigation #147 asked for and
+# PR #148 built the harness for but never ran.
+#
+# VPU 16 (Great Basin) is the default test domain: it carries the terminal
+# lakes the endorheic classifier exists for AND the closed basins whose
+# contributing areas #147 suspects are inflated, so one VPU exercises both
+# questions. Fdr_breached_16.tif is already staged.
+#
+# Memory: the harness reads the FULL CONUS vpu_id raster (~17 GB as uint8) and
+# warps the FDR onto the whole dprst grid before windowing to the VPU, so this
+# is NOT sized by the VPU -- 128G. Raise if it OOMs.
+#
+# Usage:
+#   sbatch slurm_batch/ab_drains_to_dprst.batch [VPU] [FABRIC]
+# Defaults: VPU=16, FABRIC=gfv2_dev (the Jul-25 segment-driven run).
+
+set -euo pipefail
+
+VPU="${1:-16}"
+FABRIC="${2:-gfv2_dev}"
+
+DATA_ROOT="$(pixi run --as-is data-root | tail -1)"
+DEPSTOR="${DATA_ROOT}/${FABRIC}/depstor_rasters"
+OUT_DIR="${DATA_ROOT}/${FABRIC}/diagnose/ab_drains_to_dprst_vpu${VPU}"
+
+# The fabric-bounds FDR clip doubles as the grid template (see CLAUDE.md:
+# template/fdr both come from the fdr.vrt clip, on the hydrology lattice).
+FDR_VRT="${DATA_ROOT}/gfv2/shared/gfv2_fdr.vrt"
+
+mkdir -p "${OUT_DIR}"
+
+echo "=== A/B drains_to_dprst | VPU ${VPU} | fabric ${FABRIC} ==="
+echo "data_root=${DATA_ROOT}"
+echo "out_dir=${OUT_DIR}"
+
+for VARIANT in production fill breach; do
+  echo ""
+  echo "--- FDR variant: ${VARIANT} ---"
+  pixi run --as-is python scripts/diagnose/ab_drains_to_dprst.py \
+    --vpu "${VPU}" \
+    --fdr "${VARIANT}" \
+    --fdr-vrt "${FDR_VRT}" \
+    --per-vpu-dir "${DATA_ROOT}/shared/per_vpu" \
+    --dprst "${DEPSTOR}/dprst_binary.tif" \
+    --vpu-id "${DEPSTOR}/vpu_id.tif" \
+    --template "${FDR_VRT}" \
+    --labels "${DEPSTOR}/wbody_regions.tif" \
+    --out-dir "${OUT_DIR}"
+done
+
+echo ""
+echo "=== done; outputs in ${OUT_DIR} ==="
+ls -la "${OUT_DIR}"

--- a/src/gfv2_params/shared_rasters/compute_breached_fdr.py
+++ b/src/gfv2_params/shared_rasters/compute_breached_fdr.py
@@ -38,9 +38,20 @@ from .context import SharedRastersContext
 # over-connection); too large -> over-carves real depressions. Start at 100 and
 # tune on VPU 09 (see #147), then pin the chosen value here with rationale.
 BREACH_DIST = 100
-# --fill: fill any pit not breachable within --dist, so the FDR has no interior
-# 0-sinks the routing kernel cannot leave. Keep True (a breach-or-fill hybrid is
-# still far less over-connecting than a global fill).
+# --fill: fill any pit not breachable within --dist. NOTE the consequence: the
+# resulting FDR has NO interior code-0 cells at all. The original rationale here
+# was that the routing kernel "cannot leave" an interior sink, which is wrong for
+# this pipeline -- `d8_routing` treats code 0 as a TERMINUS by design, and that is
+# the entire basis of the endorheic classifier's Signal A (terminus-inside-itself)
+# and of the classifier/router agreement CLAUDE.md relies on. Interior sinks are
+# the signal here, not a hazard.
+#
+# Keep True anyway, for the narrow purpose this raster serves: it exists only for
+# the #147 A/B on contributing area, where a breach-or-fill hybrid is the right
+# comparator against a global fill. But do NOT reach for `Fdr_breached` as an
+# endorheic-classifier input -- Signal A would find nothing to read and would go
+# silently dark. A depression-PRESERVING variant (fill=False plus a depth/area
+# threshold) would be a different raster with a different purpose.
 BREACH_FILL = True
 
 


### PR DESCRIPTION
Runs the investigation #147 asked for and PR #148 built the harness for but never executed, and records what it found.

## Result: the current FDR is already right

VPU 16 (Great Basin), 10.5 min, 38.7 GB peak:

| FDR variant | fraction of land draining to dprst |
| --- | --- |
| production (NHDPlus FdrFac) | **0.4401** |
| fill (richdem fill-all, same DEM) | **0.8079** |
| breach (WBT least-cost, same DEM) | **0.4388** |

`fill` vs `breach` is the clean comparison — same DEM, conditioning only. **Conditioning alone nearly doubles contributing area**, inflating 1,009 of 2,605 depressions by >2× and 411 by >10×. So #147's physical reasoning was right.

But production lands within **0.3%** of breach. The premise that `fdr.vrt` is "a filled HydroDEM" is functionally wrong — stream-burning and walling give water defined exits, so it never ponds and over-connects. **The stream-burn is already doing the work breaching would do**, which argues for keeping it rather than replacing it.

Practical upshot, now in CLAUDE.md: do not swap the FDR chasing contributing-area magnitude. Recorded so nobody spends a CONUS breach build finding out.

## Left open, deliberately

Production and breach agree on the total but disagree on **attribution** — 415 of 2,605 depressions change by >2×, and 31% of contributing area is reshuffled between depressions. That matters because `sro_to_dprst_*` are per-HRU ratios. The A/B shows they disagree; it cannot show which is right, and deciding needs ground truth we do not have. Flagged on #147, not chased.

## `BREACH_FILL` correction

The constant justified itself as protecting the routing kernel from interior 0-sinks. That is wrong here — `d8_routing` treats code 0 as a **terminus by design**, which is the whole basis of the endorheic classifier's Signal A. The value stays `True` (right for this raster's narrow purpose) but the comment now warns that `Fdr_breached` can never be an endorheic-classifier input: Signal A would find no code-0 cells and go silently dark.

## Changes

- `slurm_batch/ab_drains_to_dprst.batch` (new) — wraps the existing harness so the A/B is one `sbatch` rather than three hand-assembled invocations; defaults VPU 16 / `gfv2_dev`. Sized 128G because the harness reads the full CONUS `vpu_id` (~17 GB) and warps the FDR onto the whole dprst grid before windowing.
- `compute_breached_fdr.py` — corrected `BREACH_FILL` rationale (comment only; no behaviour change).
- `CLAUDE.md` — the measured result in the FDR bullet.
- `.amazonq/rules/workflow.md` — batch entry, per the two-way sync contract.

No pipeline behaviour changes. No test changes — the batch is a wrapper around already-tested code and the other edits are comments/docs.

Related: closed #188 as not-a-defect in the course of this (Alvord Lake's terminus is the adjacent playa, so Signal A correctly declined to flag it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)