### PR TITLE
docs: PRMS parameter index + close the add-a-param trap

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,8 +250,8 @@ via (highest precedence first):
 3. Run `prepare_fabric.py --fabric oregon` (reads `hru_gpkg` from the profile —
    no `--fabric_gpkg` needed), then submit Part 2 jobs via
    `slurm_batch/submit_zonal_params.sh $BATCHES oregon configs/base_config.yml`
-   (loops every entry in `configs/zonal/zonal_params.yml` and chains array
-   + merge per param). For Part 1 raster prep, `sbatch slurm_batch/build_shared_rasters.batch`.
+   (submits an array + merge per param in its hardcoded `PARAMS` array, which
+   mirrors `configs/zonal/zonal_params.yml`). For Part 1 raster prep, `sbatch slurm_batch/build_shared_rasters.batch`.
    The Part 2 zonal pass (and depstor) read the CONUS shared rasters from Part 1,
    so scope Part 1 to the VPUs your fabric overlaps — Oregon HRUs fall in VPU 17
    (incidental), so `VPUS=17 sbatch slurm_batch/build_shared_rasters.batch`
@@ -336,8 +336,10 @@ prereq).
 
 The slurm wrapper
 [`slurm_batch/submit_zonal_params.sh`](slurm_batch/submit_zonal_params.sh)
-loops every entry in `params:` and chains per-param array + merge jobs via
-`afterok`. When an entry carries `depends_on: build_weights` (typically
+does **not** read the YAML — it carries a hardcoded `PARAMS` bash array mirroring
+the `params:` list, and chains per-param array + merge jobs via `afterok`. Adding a
+param to the YAML without adding it to that array silently skips it;
+`tests/test_submit_wrapper_param_lists.py` guards the pair. When an entry carries `depends_on: build_weights` (typically
 `ssflux`), the wrapper first submits `build_zonal_weights.batch` and
 chains ssflux on its `afterok`.
 

--- a/docs/ADDING_A_PARAMETER.md
+++ b/docs/ADDING_A_PARAMETER.md
@@ -230,10 +230,25 @@ For `elevation` that is
        --fabric gfv2_vpu01
    ```
    Check the per-batch CSV under `{data_root}/{fabric}/params/<newname>/`.
-5. **Submit the full SLURM array** via
+5. **Add the param to the submit wrapper's `PARAMS` array.**
    [`slurm_batch/submit_zonal_params.sh`](../slurm_batch/submit_zonal_params.sh)
-   from a shell that has `pixi` on `PATH`. This loops every param in the
-   YAML and chains array zonal -> merge per param.
+   does **not** read the YAML — it carries a hardcoded bash array
+   (`PARAMS`, lines 68-79) and exports `PARAM=<name>` per element.
+   A param present in the YAML but absent from that array is silently
+   **not run**, and the wrapper still exits 0.
+
+   Order matters: keep `slope` before `ssflux`, which reads the merged
+   slope CSV at zonal time. If your param needs the CONUS weight matrix or
+   an upstream merge, add it to `NEEDS_WEIGHTS` (line 94) or
+   `NEEDS_MERGE_OF` (line 101) as well.
+
+   [`tests/test_submit_wrapper_param_lists.py`](../tests/test_submit_wrapper_param_lists.py)
+   guards this, so CI will catch a forgotten entry — but only after you push.
+
+6. **Submit the full SLURM array** via
+   [`slurm_batch/submit_zonal_params.sh`](../slurm_batch/submit_zonal_params.sh)
+   from a shell that has `pixi` on `PATH`. It submits an array zonal job
+   plus a chained merge for each param in `PARAMS`.
 
 ## See also
 

--- a/docs/ADDING_A_PARAMETER.md
+++ b/docs/ADDING_A_PARAMETER.md
@@ -233,17 +233,24 @@ For `elevation` that is
 5. **Add the param to the submit wrapper's `PARAMS` array.**
    [`slurm_batch/submit_zonal_params.sh`](../slurm_batch/submit_zonal_params.sh)
    does **not** read the YAML — it carries a hardcoded bash array
-   (`PARAMS`, lines 68-79) and exports `PARAM=<name>` per element.
+   (`PARAMS`) and exports `PARAM=<name>` per element.
    A param present in the YAML but absent from that array is silently
    **not run**, and the wrapper still exits 0.
 
    Order matters: keep `slope` before `ssflux`, which reads the merged
    slope CSV at zonal time. If your param needs the CONUS weight matrix or
-   an upstream merge, add it to `NEEDS_WEIGHTS` (line 94) or
-   `NEEDS_MERGE_OF` (line 101) as well.
+   an upstream merge, add it to `NEEDS_WEIGHTS` or
+   `NEEDS_MERGE_OF` in the same file as well.
 
    [`tests/test_submit_wrapper_param_lists.py`](../tests/test_submit_wrapper_param_lists.py)
-   guards this, so CI will catch a forgotten entry — but only after you push.
+   guards this — it asserts the array and the YAML match exactly, **including
+   order** — so CI catches a forgotten or misplaced entry, but only after you push.
+   It does **not** cover `NEEDS_WEIGHTS`/`NEEDS_MERGE_OF`; verify those by hand.
+
+   Note the wrapper also honours a `ZONAL_PARAMS` environment override that
+   replaces the array wholesale at runtime — the documented way to run a subset
+   on fabrics with unstaged sources. If you submit from a shell exporting it,
+   your new param must be in *that* list too, or it still will not run.
 
 6. **Submit the full SLURM array** via
    [`slurm_batch/submit_zonal_params.sh`](../slurm_batch/submit_zonal_params.sh)

--- a/docs/ADDING_A_PARAMETER.md
+++ b/docs/ADDING_A_PARAMETER.md
@@ -38,8 +38,9 @@ pixi run -e dev python scripts/derive_zonal_params.py \
 
 This is exactly what one SLURM array task runs. The submit wrapper
 [`slurm_batch/submit_zonal_params.sh`](../slurm_batch/submit_zonal_params.sh)
-loops every entry in `zonal_params.yml` and submits an array zonal job +
-chained merge per param.
+submits an array zonal job + chained merge for each param in its hardcoded
+`PARAMS` array — it does **not** read `zonal_params.yml`. See step 5 of
+[To add a new param](#to-add-a-new-param).
 
 ### Hop 2 — Orchestrator dispatch
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -650,6 +650,16 @@ zonal param family):
 2. **Register in the package's `__init__.py`** — add to the `BUILDERS` /
    `STEP_ORDER` / `BATCH_RUNNERS` registries as appropriate.
 3. **Add a config block** in the matching unified config under `configs/`.
+   For **depstor** this is mandatory and enforced: `build_depstor_rasters.py`
+   raises if a `STEP_ORDER` step has no block in `depstor_rasters.yml`, and
+   `tests/test_expected_outputs.py` asserts the two agree. (It used to be
+   silent — a registered-but-unconfigured step was skipped, and
+   `_hydrate_existing_outputs` then served the previous run's artifact for its
+   output key, so a `--from` rebuild re-emitted stale CONUS product at exit 0.)
+   **`shared_rasters` is deliberately different**: its config omits the opt-in
+   `compute_dem_derivatives` and `compute_breached_fdr` steps, so its
+   orchestrator tolerates registered-but-unconfigured steps by design. Don't
+   copy the depstor guard there.
 4. **Add a test** under `tests/test_<name>.py`. CI (`.github/workflows/ci.yml`)
    gates the merge; the head-node-pytest prohibition (see CLAUDE.md) does
    not apply to PR-driven CI.

--- a/docs/depstor_workflow.md
+++ b/docs/depstor_workflow.md
@@ -437,9 +437,10 @@ produce, per fabric:
     └── nhm_hru_total_count_params.csv    # NEW in PR #72; denominator for the area-fraction ratios
 ```
 
-The 13 PRMS depstor parameters not produced here (`dprst_frac_open`,
-`dprst_frac_clos`, `dprst_depth_avg`, `dprst_seep_rate_clos`,
-`dprst_et_coef`, `op_flow_thres`, `va_open_exp`, `va_clos_exp`,
+`dprst_depth_avg` and `op_flow_thres` ARE produced as of #173 — see
+[`docs/parameter_index.md`](parameter_index.md). The remaining PRMS depstor
+parameters not produced here (`dprst_frac_open`, `dprst_frac_clos`,
+`dprst_seep_rate_clos`, `dprst_et_coef`, `va_open_exp`, `va_clos_exp`,
 `dprst_frac_init`, `imperv_stor_max`, `smidx_exp`) come from NHM defaults
 or a separate sourcing decision — see the "Out-of-scope PRMS dprst params"
 cell in `notebooks/qaqc_depstor_vpu01.ipynb`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,8 +21,8 @@ USGS HPC cluster.
   end-to-end. The pattern transfers.
 - **Which parameters feed a given PRMS process?** →
   [Parameter index](parameter_index.md) maps every emitted parameter to its
-  PRMS process, config entry, and builder — and flags the three columns whose
-  emitted name is not the PRMS quantity.
+  PRMS process, config entry, and builder — and flags every column whose
+  emitted name is not the PRMS quantity, plus one that is outright defective.
 - **Hit an unfamiliar Python idiom?** →
   [Python patterns](python-patterns.md) explains the 10 non-obvious idioms
   this codebase uses (placeholder strings, `require_config_key`, the

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,10 @@ USGS HPC cluster.
 - **Adding a new HRU parameter?** →
   [Adding a parameter](ADDING_A_PARAMETER.md) traces `--param elevation`
   end-to-end. The pattern transfers.
+- **Which parameters feed a given PRMS process?** →
+  [Parameter index](parameter_index.md) maps every emitted parameter to its
+  PRMS process, config entry, and builder — and flags the three columns whose
+  emitted name is not the PRMS quantity.
 - **Hit an unfamiliar Python idiom?** →
   [Python patterns](python-patterns.md) explains the 10 non-obvious idioms
   this codebase uses (placeholder strings, `require_config_key`, the

--- a/docs/parameter_index.md
+++ b/docs/parameter_index.md
@@ -1,0 +1,283 @@
+# PRMS parameter index
+
+Every parameter this pipeline emits to `{fabric}/params/merged/`, mapped to the PRMS
+process that consumes it, the config entry that declares it, and the builder that computes
+it.
+
+Process membership is from `pywatershed.<Process>.get_parameters()` (pywatershed 2.0.4, the
+`reference` pixi env), not inference. Column lists are observed on-disk headers from
+`gfv2/params/merged/`.
+
+> **Hand-maintained as of 2026-08-04.** Generated from `configs/` once
+> `scripts/build_parameter_index.py` lands — see
+> `docs/superpowers/specs/2026-08-04-prms-parameter-index-design.md` in the repo
+> (the `superpowers/` tree is excluded from this site).
+
+## Reading this index
+
+- ⚠️ marks a column whose **emitted name is not the PRMS parameter name**. You must
+  translate it before feeding PRMS.
+- **DEFECTIVE** marks a column that does not currently represent the PRMS parameter at all.
+  Do not use it.
+- *provenance* marks an emitted column that is not a PRMS parameter — a diagnostic, an
+  intermediate, or a raw statistic.
+
+Three columns need care before use. Each is explained in [Known gaps](#known-gaps):
+
+| Emitted | Reality |
+| --- | --- |
+| `nhm_slope_params.csv:mean` | degrees, not PRMS rise/run — **~57× if copied verbatim** |
+| `nhm_aspect_params.csv:mean` | **DEFECTIVE** — arithmetic mean of a circular variable ([#201](https://github.com/rmcd-mscb/gfv2-params/issues/201)) |
+| `op_flow_thres_params.csv` | a PRMSRunoff parameter that is **not in `merged/`** |
+
+---
+
+## By PRMS process
+
+### PRMSRunoff (`srunoff_smidx`) — 11 parameters
+
+| PRMS parameter | Emitted file | Column | Config entry | Builder |
+| --- | --- | --- | --- | --- |
+| `soil_moist_max` | `nhm_soil_moist_max_params.csv` | `soil_moist_max` | `zonal_params.yml:81` | `zonal_runners/soils.py` |
+| `dprst_seep_rate_open` | `nhm_ssflux_params.csv` | `dprst_seep_rate_open` | `zonal_params.yml:208` | `zonal_runners/ssflux.py` |
+| `dprst_flow_coef` | `nhm_ssflux_params.csv` | `dprst_flow_coef` | `zonal_params.yml:208` | `zonal_runners/ssflux.py` |
+| `sro_to_dprst_perv` | `nhm_sro_to_dprst_perv_params.csv` | `sro_to_dprst_perv` | `depstor_params.yml:134` | `depstor_builders/same_hru_drains.py` + `perv.py` → `depstor_ratios.py` |
+| `sro_to_dprst_imperv` | `nhm_sro_to_dprst_imperv_params.csv` | `sro_to_dprst_imperv` | `depstor_params.yml:141` | `depstor_builders/same_hru_drains.py` + `imperv.py` → `depstor_ratios.py` |
+| `carea_max` | `nhm_carea_max_params.csv` | `carea_max` | `depstor_params.yml:148` | `depstor_builders/carea_map.py` |
+| `smidx_coef` | `nhm_smidx_coef_params.csv` | `smidx_coef` | `depstor_params.yml:155` | `depstor_builders/carea_map.py` |
+| `hru_percent_imperv` | `nhm_hru_percent_imperv_params.csv` | `hru_percent_imperv` | `depstor_params.yml:164` | `depstor_builders/imperv.py` + `landmask.py` |
+| `dprst_frac` | `nhm_dprst_frac_params.csv` | `dprst_frac` | `depstor_params.yml:177` | `depstor_builders/dprst.py` + `landmask.py` |
+| `dprst_depth_avg` | `nhm_dprst_depth_avg_params.csv` | `dprst_depth_avg` | `depstor_params.yml:107` (`means:`) | `depstor_builders/dprst_depth.py` + `dprst_depth/aggregate.py` |
+| `op_flow_thres` ⚠️ | **`op_flow_thres_params.csv`** — in `depstor_rasters/`, **not** `merged/` | `op_flow_thres` | `depstor_rasters.yml:83` | `depstor_builders/dprst_depth.py:361` |
+
+`dprst_frac` also appears in `merged/_intermediates/` under the same filename — that copy is
+a partial-pixel **count**, not a `[0, 1]` fraction. The PRMS parameter is the one in
+`merged/`.
+
+### PRMSSoilzone — 9 parameters
+
+| PRMS parameter | Emitted file | Column | Config entry | Builder |
+| --- | --- | --- | --- | --- |
+| `soil_type` ⚠️ | `nhm_soils_params.csv` | `soils` | `zonal_params.yml:74` | `zonal_runners/soils.py:78` |
+| `soil_moist_max` | `nhm_soil_moist_max_params.csv` | `soil_moist_max` | `zonal_params.yml:81` | `zonal_runners/soils.py` |
+| `cov_type` | `nhm_lulc_nhm_v11_params.csv` | `cov_type` | `zonal_params.yml:96` | `zonal_runners/lulc_prederived.py` |
+| `soil2gw_max` | `nhm_ssflux_params.csv` | `soil2gw_max` | `zonal_params.yml:208` | `zonal_runners/ssflux.py` |
+| `ssr2gw_rate` | `nhm_ssflux_params.csv` | `ssr2gw_rate` | `zonal_params.yml:208` | `zonal_runners/ssflux.py` |
+| `fastcoef_lin` | `nhm_ssflux_params.csv` | `fastcoef_lin` | `zonal_params.yml:208` | `zonal_runners/ssflux.py` |
+| `slowcoef_lin` | `nhm_ssflux_params.csv` | `slowcoef_lin` | `zonal_params.yml:208` | `zonal_runners/ssflux.py` |
+| `hru_percent_imperv` | `nhm_hru_percent_imperv_params.csv` | `hru_percent_imperv` | `depstor_params.yml:164` | `depstor_builders/imperv.py` + `landmask.py` |
+| `dprst_frac` | `nhm_dprst_frac_params.csv` | `dprst_frac` | `depstor_params.yml:177` | `depstor_builders/dprst.py` + `landmask.py` |
+
+### PRMSSnow — 7 parameters
+
+| PRMS parameter | Emitted file | Column | Config entry | Builder |
+| --- | --- | --- | --- | --- |
+| `cov_type` | `nhm_lulc_nhm_v11_params.csv` | `cov_type` | `zonal_params.yml:96` | `zonal_runners/lulc_prederived.py` |
+| `covden_sum` | `nhm_lulc_nhm_v11_params.csv` | `covden_sum` | `zonal_params.yml:96` | `zonal_runners/lulc_prederived.py` |
+| `covden_win` | `nhm_lulc_nhm_v11_params.csv` | `covden_win` | `zonal_params.yml:96` | `zonal_runners/lulc_prederived.py` |
+| `rad_trncf` ⚠️ | `nhm_lulc_nhm_v11_params.csv` | `retention` (gfv2, oregon) \| `rad_trncf` (tjc) | `zonal_params.yml:96` | `zonal_runners/lulc_prederived.py` |
+| `hru_deplcrv` | `nhm_snarea_curve_params.csv` | `hru_deplcrv` | `snarea_library.yml` | `snarea/library.py` |
+| `snarea_thresh` | `nhm_snarea_curve_params.csv` | `snarea_thresh` | `snarea_library.yml` | `snarea/library.py` |
+| `snarea_curve` | `nhm_snarea_curve_params.csv` | `snarea_curve_0` … `snarea_curve_10` | `snarea_library.yml` | `snarea/library.py` |
+
+### PRMSCanopy — 6 parameters
+
+| PRMS parameter | Emitted file | Column | Config entry | Builder |
+| --- | --- | --- | --- | --- |
+| `cov_type` | `nhm_lulc_nhm_v11_params.csv` | `cov_type` | `zonal_params.yml:96` | `zonal_runners/lulc_prederived.py` |
+| `covden_sum` | `nhm_lulc_nhm_v11_params.csv` | `covden_sum` | `zonal_params.yml:96` | `zonal_runners/lulc_prederived.py` |
+| `covden_win` | `nhm_lulc_nhm_v11_params.csv` | `covden_win` | `zonal_params.yml:96` | `zonal_runners/lulc_prederived.py` |
+| `srain_intcp` | `nhm_lulc_nhm_v11_params.csv` | `srain_intcp` | `zonal_params.yml:96` | `zonal_runners/lulc_prederived.py` |
+| `wrain_intcp` | `nhm_lulc_nhm_v11_params.csv` | `wrain_intcp` | `zonal_params.yml:96` | `zonal_runners/lulc_prederived.py` |
+| `snow_intcp` | `nhm_lulc_nhm_v11_params.csv` | `snow_intcp` | `zonal_params.yml:96` | `zonal_runners/lulc_prederived.py` |
+
+### PRMSGroundwater — 1 parameter
+
+| PRMS parameter | Emitted file | Column | Config entry | Builder |
+| --- | --- | --- | --- | --- |
+| `gwflow_coef` | `nhm_ssflux_params.csv` | `gwflow_coef` | `zonal_params.yml:208` | `zonal_runners/ssflux.py` |
+
+### PRMSEt — 2 parameters
+
+| PRMS parameter | Emitted file | Column | Config entry | Builder |
+| --- | --- | --- | --- | --- |
+| `hru_percent_imperv` | `nhm_hru_percent_imperv_params.csv` | `hru_percent_imperv` | `depstor_params.yml:164` | `depstor_builders/imperv.py` + `landmask.py` |
+| `dprst_frac` | `nhm_dprst_frac_params.csv` | `dprst_frac` | `depstor_params.yml:177` | `depstor_builders/dprst.py` + `landmask.py` |
+
+### PRMSSolarGeometry / PRMSAtmosphere — 2 parameters
+
+| PRMS parameter | Emitted file | Column | Config entry | Builder |
+| --- | --- | --- | --- | --- |
+| `hru_slope` ⚠️ | `nhm_slope_params.csv` | `tan(radians(mean))` — `mean` is **degrees** | `zonal_params.yml:56` | `zonal_runners/zonal.py` |
+| `hru_aspect` | `nhm_aspect_params.csv` | **DEFECTIVE** — see [#201](https://github.com/rmcd-mscb/gfv2-params/issues/201) | `zonal_params.yml:64` | `zonal_runners/zonal.py` |
+
+### Not consumed by any pywatershed process — 1 parameter
+
+| PRMS parameter | Emitted file | Column | Config entry | Builder |
+| --- | --- | --- | --- | --- |
+| `hru_elev` ⚠️ | `nhm_elevation_params.csv` | `mean` (metres) | `zonal_params.yml:43` | `zonal_runners/zonal.py` |
+
+`hru_elev` appears in no pywatershed `Process.get_parameters()` list. It is used by PRMS's
+temperature/precipitation distribution modules — which pywatershed handles by reading CBH
+files — and by the `cov_type` reset rule at
+[TM6B9:707](NHM_description_Regan_2018_TM6B9.md) (HRUs above 11,500 ft).
+
+---
+
+## By config entry
+
+### `configs/zonal/zonal_params.yml`
+
+| Entry | Merged file | PRMS parameters | Provenance columns |
+| --- | --- | --- | --- |
+| `elevation` `:43` | `nhm_elevation_params.csv` | `hru_elev` ⚠️ (from `mean`) | `count`, `std`, `min`, `25%`, `50%`, `75%`, `max`, `sum` |
+| `slope` `:56` | `nhm_slope_params.csv` | `hru_slope` ⚠️ (from `tan(radians(mean))`) | same 8 stats, plus `mean` itself |
+| `aspect` `:64` | `nhm_aspect_params.csv` | **none — DEFECTIVE** | all 9 columns |
+| `soils` `:74` | `nhm_soils_params.csv` | `soil_type` ⚠️ (from `soils`) | — |
+| `soil_moist_max` `:81` | `nhm_soil_moist_max_params.csv` | `soil_moist_max` | — |
+| `lulc_nhm_v11` `:96` | `nhm_lulc_nhm_v11_params.csv` | `cov_type`, `covden_sum`, `covden_win`, `srain_intcp`, `wrain_intcp`, `snow_intcp`, `rad_trncf` ⚠️ | — |
+| `lulc_nalcms` `:133` | `nhm_lulc_nalcms_params.csv` | `cov_type`, `covden_sum`, `covden_win`, `srain_intcp`, `wrain_intcp`, `snow_intcp` | `retention` — **unverified**, not `rad_trncf` |
+| `lulc_nlcd` `:154` | *never built* — `input/lulc_veg/nlcd/` absent | as `lulc_nalcms` | `retention` |
+| `lulc_foresce` `:179` | *never built* — `input/lulc_veg/foresce/` absent | as `lulc_nalcms` | `retention` |
+| `ssflux` `:208` | `nhm_ssflux_params.csv` | `soil2gw_max`, `ssr2gw_rate`, `fastcoef_lin`, `slowcoef_lin`, `gwflow_coef`, `dprst_seep_rate_open`, `dprst_flow_coef` | `k_perm_wtd`, `mean_slope_fraction`, `hru_area` |
+
+### `configs/depstor/depstor_params.yml`
+
+| Entry | Merged file | PRMS parameter | Provenance |
+| --- | --- | --- | --- |
+| `dprst_depth_avg` `:107` (`means:`) | `nhm_dprst_depth_avg_params.csv` | `dprst_depth_avg` | `dprst_depth_provenance` |
+| `sro_to_dprst_perv` `:134` (`ratios:`) | `nhm_sro_to_dprst_perv_params.csv` | `sro_to_dprst_perv` | — |
+| `sro_to_dprst_imperv` `:141` | `nhm_sro_to_dprst_imperv_params.csv` | `sro_to_dprst_imperv` | — |
+| `carea_max` `:148` | `nhm_carea_max_params.csv` | `carea_max` | — |
+| `smidx_coef` `:155` | `nhm_smidx_coef_params.csv` | `smidx_coef` | — |
+| `hru_percent_imperv` `:164` | `nhm_hru_percent_imperv_params.csv` | `hru_percent_imperv` | — |
+| `dprst_frac` `:177` | `nhm_dprst_frac_params.csv` | `dprst_frac` | — |
+
+The 10 `fractions:` entries are **intermediates**, not parameters. They write
+partial-pixel-weighted count CSVs to `merged/_intermediates/` and feed the ratios above.
+
+### `configs/depstor/depstor_rasters.yml`
+
+| Entry | Output | PRMS parameter |
+| --- | --- | --- |
+| `dprst_depth` `:70`, output name `:83` | `depstor_rasters/op_flow_thres_params.csv` | `op_flow_thres` — **not in `merged/`** |
+
+### `configs/snarea/snarea_library.yml`
+
+| Merged file | PRMS parameters | Provenance |
+| --- | --- | --- |
+| `nhm_snarea_curve_params.csv` | `hru_deplcrv`, `snarea_thresh`, `snarea_curve` (11 columns) | `cv_assign`, `cv_subgrid`, `cv_empirical`, `cv_source`, `sdc_status`, `sca_class`, `similarity`, `n_seasons`, `n_peak_years`, `peak_swe_mm` |
+
+The `cv_*` columns are **derivable for only ~42% of HRUs by design** — `cv_subgrid` rescues
+the rest. A NaN there is a result, not a gap, which is why they are excluded from
+`fill_columns`.
+
+---
+
+## By builder
+
+| Builder module | PRMS parameters produced |
+| --- | --- |
+| `zonal_runners/zonal.py` | `hru_elev`, `hru_slope` ⚠️, `hru_aspect` (DEFECTIVE) |
+| `zonal_runners/soils.py` | `soil_type` ⚠️, `soil_moist_max` |
+| `zonal_runners/lulc_prederived.py` | `cov_type`, `covden_sum`, `covden_win`, `srain_intcp`, `wrain_intcp`, `snow_intcp`, `rad_trncf` ⚠️ |
+| `zonal_runners/lulc.py` | `cov_type`, `covden_sum`, `covden_win`, `srain_intcp`, `wrain_intcp`, `snow_intcp` (+ unverified `retention`) |
+| `zonal_runners/ssflux.py` | `soil2gw_max`, `ssr2gw_rate`, `fastcoef_lin`, `slowcoef_lin`, `gwflow_coef`, `dprst_seep_rate_open`, `dprst_flow_coef` |
+| `depstor_builders/carea_map.py` | `carea_max`, `smidx_coef` |
+| `depstor_builders/imperv.py` + `landmask.py` | `hru_percent_imperv` |
+| `depstor_builders/dprst.py` + `landmask.py` | `dprst_frac` |
+| `depstor_builders/same_hru_drains.py` (+ `perv.py` / `imperv.py`) | `sro_to_dprst_perv`, `sro_to_dprst_imperv` |
+| `depstor_builders/dprst_depth.py` + `dprst_depth/aggregate.py` | `dprst_depth_avg`, `op_flow_thres` |
+| `snarea/library.py` (← `snarea/build.py` ← `aggregate/`) | `hru_deplcrv`, `snarea_thresh`, `snarea_curve` |
+
+The depstor ratios are finalised by `gfv2_params/depstor_ratios.py` (a top-level module, not
+part of `depstor_builders/`), driven by `scripts/derive_depstor_params.py --mode ratios`.
+
+---
+
+## Known gaps
+
+### `hru_slope` is degrees on disk; PRMS wants rise/run
+
+`slope.vrt` is built as `rd.TerrainAttribute(dem, attrib="slope_degrees")`
+(`shared_rasters/compute_slope_aspect.py:72`), so `nhm_slope_params.csv:mean` is **degrees**.
+PRMS `hru_slope` is a decimal fraction rise/run ([TM6B9:536](NHM_description_Regan_2018_TM6B9.md)).
+
+For small angles the discrepancy is 180/π ≈ **57×**. gfv2 HRU 1: `mean = 4.4252` →
+`hru_slope = 0.0774`. Copied verbatim, that declares a 77° cliff instead of a 4.4° hillslope.
+
+**The pipeline is not wrong** — `zonal_runners/ssflux.py:63` applies
+`raster_ops.deg_to_fraction` before deriving `ssr2gw_rate`/`slowcoef_lin`, so the flux
+parameters are correct. But nothing currently *emits* `hru_slope`. Apply
+`tan(radians(mean))` yourself until the pipeline emits it directly.
+
+Known approximation once it does: `tan(mean θ) ≠ mean(tan θ)`, and `tan` is convex, so the
+conversion systematically underestimates. Measured over all 361,471 gfv2 HRUs: median
+**0.2%**, p90 2.4%, p99 5.6%.
+
+### `hru_aspect` is DEFECTIVE — do not use `nhm_aspect_params.csv:mean`
+
+It is an **arithmetic** mean of a **circular** variable.
+[TM6B9:603](NHM_description_Regan_2018_TM6B9.md) requires
+`atan2(mean(sin(aspect)), mean(cos(aspect)))`; the `aspect` entry runs the generic `zonal`
+script instead.
+
+Across all 361,471 gfv2 HRUs: median `mean` = **179.4°** (due south), IQR 151.7°–207.5°,
+median within-HRU `std` 91.3° (uniform-circular ≈ 104°). Half of CONUS reporting a mean
+orientation between 152° and 208° is not terrain — it is what arithmetic-averaging wrapped
+directions produces.
+
+The circularity rule *was* applied at every raster boundary
+(`compute_slope_aspect.py:68`, `build_vrt.py:74`, `build_border_dem.py:224`, `cog.py:84`,
+with tests). The zonal-side limitation was recorded at the time as a known simplification;
+what was never done is measure it. Unlike `hru_slope`, this **cannot be repaired from what
+is on disk** — a circular mean is not recoverable from an arithmetic one.
+
+Tracked as [#201](https://github.com/rmcd-mscb/gfv2-params/issues/201).
+
+### `op_flow_thres` is not in `merged/`
+
+A PRMSRunoff parameter written by a depstor builder to
+`{fabric}/depstor_rasters/op_flow_thres_params.csv`. Because it never reaches `merged/`, the
+gap-fill sweep never sees it and the "undeclared merged file" guard cannot flag it. If you
+assemble a parameter file by globbing `merged/nhm_*_params.csv`, **you will silently drop
+it**. It is a constant 1.0 for every HRU.
+
+### `retention` means two different things
+
+On `lulc_nhm_v11` it is PRMS `rad_trncf` — `lulc_prederived.py:176-181` computes a Beer's-law
+transform, and the column was renamed to `rad_trncf` after gfv2/oregon were built.
+
+On `lulc_nalcms` / `lulc_nlcd` / `lulc_foresce` it is **not** `rad_trncf`.
+`lulc.py:186-193` computes `zonal_mean(keep)/100` or the crosswalk's `evergreen_retention`
+column — no Beer's-law step, and no `radtrn_raster` is configured for those entries. What
+PRMS parameter it corresponds to, if any, is unverified.
+
+### Unverified mappings
+
+- **`soils` → `soil_type`** — inferred from the source raster (`TEXT_PRMS.tif`, soil texture)
+  plus [TM6B9:786](NHM_description_Regan_2018_TM6B9.md). No repo artifact asserts it.
+- **`mean` → `hru_elev`** — inferred from `viz.py:505-507` plus
+  [TM6B9:601](NHM_description_Regan_2018_TM6B9.md). Elevation is neither circular nor
+  transformed, so the arithmetic zonal mean is the right statistic; only the *name* is
+  undocumented.
+- **pywatershed's process lists are pywatershed's view of PRMS**, not TM6B9's NHM module set.
+  They agreed everywhere spot-checked, but `hru_elev` appears in no pywatershed process at
+  all, so the two are not identical.
+
+### Not built on any fabric
+
+`lulc_nlcd` and `lulc_foresce` are declared in `zonal_params.yml` but their source
+directories (`input/lulc_veg/nlcd/`, `input/lulc_veg/foresce/`) do not exist. A CONUS run
+submits them and they fail; the other eight params merge normally.
+
+---
+
+## See also
+
+- [Adding a parameter](ADDING_A_PARAMETER.md) — end-to-end trace of `--param elevation`.
+- [Architecture](ARCHITECTURE.md) — the orchestrator + builder + unified-config pattern.
+- [`docs/nhm_source_crosscheck_2026-07.md`](nhm_source_crosscheck_2026-07.md) — TM 6-B9 and
+  Driscoll 2020 vs. this pipeline, including where `ssflux` deviates from TM 6-B9.
+- [NHM description (Regan 2018, TM 6-B9)](NHM_description_Regan_2018_TM6B9.md) — the
+  authoritative parameter definitions.

--- a/docs/parameter_index.md
+++ b/docs/parameter_index.md
@@ -70,7 +70,7 @@ a partial-pixel **count**, not a `[0, 1]` fraction. The PRMS parameter is the on
 
 | PRMS parameter | Emitted file | Column | Config entry | Builder |
 | --- | --- | --- | --- | --- |
-| `soil_type` ⚠️ | `nhm_soils_params.csv` | `soils` — identity, **1=sand, 2=loam, 3=clay**; the source metadata is wrong, see [Known gaps](#soils--soil_type-is-an-identity-mapping--and-the-source-metadata-says-otherwise) | `zonal_params.yml:74` | `zonal_runners/soils.py:78` |
+| `soil_type` ⚠️ | `nhm_soils_params.csv` | `soils` — identity, **1=sand, 2=loam, 3=clay**; the source metadata is wrong, see [Known gaps](#soils-soil_type-is-an-identity-mapping-and-the-source-metadata-says-otherwise) | `zonal_params.yml:74` | `zonal_runners/soils.py:78` |
 | `soil_moist_max` | `nhm_soil_moist_max_params.csv` | `soil_moist_max` | `zonal_params.yml:81` | `zonal_runners/soils.py` |
 | `cov_type` | `nhm_lulc_nhm_v11_params.csv` | `cov_type` | `zonal_params.yml:96` | `zonal_runners/lulc_prederived.py` |
 | `soil2gw_max` | `nhm_ssflux_params.csv` | `soil2gw_max` | `zonal_params.yml:208` | `zonal_runners/ssflux.py` |

--- a/docs/parameter_index.md
+++ b/docs/parameter_index.md
@@ -70,7 +70,7 @@ a partial-pixel **count**, not a `[0, 1]` fraction. The PRMS parameter is the on
 
 | PRMS parameter | Emitted file | Column | Config entry | Builder |
 | --- | --- | --- | --- | --- |
-| `soil_type` ⚠️ | `nhm_soils_params.csv` | `soils` | `zonal_params.yml:74` | `zonal_runners/soils.py:78` |
+| `soil_type` ⚠️ | `nhm_soils_params.csv` | `soils` — identity, **1=sand, 2=loam, 3=clay**; the source metadata is wrong, see [Known gaps](#soils--soil_type-is-an-identity-mapping--and-the-source-metadata-says-otherwise) | `zonal_params.yml:74` | `zonal_runners/soils.py:78` |
 | `soil_moist_max` | `nhm_soil_moist_max_params.csv` | `soil_moist_max` | `zonal_params.yml:81` | `zonal_runners/soils.py` |
 | `cov_type` | `nhm_lulc_nhm_v11_params.csv` | `cov_type` | `zonal_params.yml:96` | `zonal_runners/lulc_prederived.py` |
 | `soil2gw_max` | `nhm_ssflux_params.csv` | `soil2gw_max` | `zonal_params.yml:208` | `zonal_runners/ssflux.py` |
@@ -269,10 +269,42 @@ gated on `radtrn_raster`, which is configured for none of these three entries
 (`zonal_params.yml:163-165` says so) — so it never runs for them. What
 PRMS parameter it corresponds to, if any, is unverified.
 
+### `soils` → `soil_type` is an identity mapping — and the source metadata says otherwise
+
+**Verified 2026-08-05.** `TEXT_PRMS.tif` is already in PRMS `soil_type` encoding
+(**1 = sand, 2 = loam, 3 = clay**), so `nhm_soils_params.csv:soils` can be used as
+`soil_type` unchanged. Only the *name* differs.
+
+⚠️ **The ScienceBase metadata for `TEXT_PRMS.tif` contradicts this, and it is wrong.** Its
+`edom` block describes value 1 as "Percent clay greater than 40", value 2 as sand, value 3
+as loam — i.e. clay and sand transposed relative to PRMS. Anyone who follows it and remaps
+1↔3 will **silently invert sand and clay for every HRU**.
+
+The raster's own values settle it. Observed cell counts (`rasterio`, full CONUS grid,
+27317×15906 uint8):
+
+| Value | Cells | % of valid | metadata `edom` claims | actual |
+| --- | --- | --- | --- | --- |
+| 1 | 38,489,559 | 29.4% | clay > 40% | **sand** |
+| 2 | 91,238,514 | 69.6% | sand | **loam** |
+| 3 | 1,288,556 | 1.0% | loam | **clay** |
+
+Three independent reasons the data, not the metadata, is right:
+
+1. The metadata's own `Count` range — min **1,288,556**, max **91,238,514** — matches values
+   3 and 2 exactly, so this is the raster the metadata describes; only its class
+   *descriptions* are transposed.
+2. 29.4% of CONUS exceeding 40% clay is not credible; 1.0% is. Loam at 1.0% is absurd;
+   69.6% is right.
+3. [TM6B9:786](NHM_description_Regan_2018_TM6B9.md) assigns the **residual** to class 2
+   ("*or 2 for the remaining cells*"), and a residual category is naturally the majority —
+   which class 2 is.
+
+Cross-check against the delivered product: `nhm_soils_params.csv` gives 30.5% / 69.0% / 0.4%
+across 361,471 HRUs — the same shape, as expected for per-HRU dominant class.
+
 ### Unverified mappings
 
-- **`soils` → `soil_type`** — inferred from the source raster (`TEXT_PRMS.tif`, soil texture)
-  plus [TM6B9:786](NHM_description_Regan_2018_TM6B9.md). No repo artifact asserts it.
 - **`mean` → `hru_elev`** — inferred from `viz.py:505-507` plus
   [TM6B9:601](NHM_description_Regan_2018_TM6B9.md). Elevation is neither circular nor
   transformed, so the arithmetic zonal mean is the right statistic; only the *name* is

--- a/docs/parameter_index.md
+++ b/docs/parameter_index.md
@@ -8,6 +8,10 @@ Process membership is from `pywatershed.<Process>.get_parameters()` (pywatershed
 `reference` pixi env), not inference. Column lists are observed on-disk headers from
 `gfv2/params/merged/`.
 
+The 16 `nhm_*_params.csv` files below are the complete set. Note `gfv2/params/merged/` also
+still holds two `filled_nhm_*.csv` files from the retired `filled_` prefix convention
+(PR #189) — they are superseded, not parameters, and are not listed here.
+
 > **Hand-maintained as of 2026-08-04.** Generated from `configs/` once
 > `scripts/build_parameter_index.py` lands — see
 > `docs/superpowers/specs/2026-08-04-prms-parameter-index-design.md` in the repo
@@ -22,13 +26,21 @@ Process membership is from `pywatershed.<Process>.get_parameters()` (pywatershed
 - *provenance* marks an emitted column that is not a PRMS parameter — a diagnostic, an
   intermediate, or a raw statistic.
 
-Three columns need care before use. Each is explained in [Known gaps](#known-gaps):
+**Five columns are renames** (⚠️): `mean`→`hru_elev`, `mean`→`hru_slope`, `soils`→`soil_type`,
+`retention`→`rad_trncf`, and `op_flow_thres` (right name, wrong directory). Feed any of them
+to PRMS under its emitted name and PRMS will not recognise it.
+
+Three of those are *actively dangerous* rather than merely misnamed — they produce wrong
+numbers or silent omission. Each is explained in [Known gaps](#known-gaps):
 
 | Emitted | Reality |
 | --- | --- |
 | `nhm_slope_params.csv:mean` | degrees, not PRMS rise/run — **~57× if copied verbatim** |
 | `nhm_aspect_params.csv:mean` | **DEFECTIVE** — arithmetic mean of a circular variable ([#201](https://github.com/rmcd-mscb/gfv2-params/issues/201)) |
 | `op_flow_thres_params.csv` | a PRMSRunoff parameter that is **not in `merged/`** |
+
+The other two renames (`soils`→`soil_type`, `retention`→`rad_trncf`) are safe once you know
+them; the per-process tables below mark every one with ⚠️.
 
 ---
 
@@ -48,7 +60,7 @@ Three columns need care before use. Each is explained in [Known gaps](#known-gap
 | `hru_percent_imperv` | `nhm_hru_percent_imperv_params.csv` | `hru_percent_imperv` | `depstor_params.yml:164` | `depstor_builders/imperv.py` + `landmask.py` |
 | `dprst_frac` | `nhm_dprst_frac_params.csv` | `dprst_frac` | `depstor_params.yml:177` | `depstor_builders/dprst.py` + `landmask.py` |
 | `dprst_depth_avg` | `nhm_dprst_depth_avg_params.csv` | `dprst_depth_avg` | `depstor_params.yml:107` (`means:`) | `depstor_builders/dprst_depth.py` + `dprst_depth/aggregate.py` |
-| `op_flow_thres` ⚠️ | **`op_flow_thres_params.csv`** — in `depstor_rasters/`, **not** `merged/` | `op_flow_thres` | `depstor_rasters.yml:83` | `depstor_builders/dprst_depth.py:361` |
+| `op_flow_thres` ⚠️ | **`op_flow_thres_params.csv`** — in `depstor_rasters/`, **not** `merged/` | `op_flow_thres` | `depstor_rasters.yml:77` | `depstor_builders/dprst_depth.py:361` |
 
 `dprst_frac` also appears in `merged/_intermediates/` under the same filename — that copy is
 a partial-pixel **count**, not a `[0, 1]` fraction. The PRMS parameter is the one in
@@ -160,7 +172,7 @@ partial-pixel-weighted count CSVs to `merged/_intermediates/` and feed the ratio
 
 | Entry | Output | PRMS parameter |
 | --- | --- | --- |
-| `dprst_depth` `:70`, output name `:83` | `depstor_rasters/op_flow_thres_params.csv` | `op_flow_thres` — **not in `merged/`** |
+| `dprst_depth` `:70`, output name `:77` | `depstor_rasters/op_flow_thres_params.csv` | `op_flow_thres` — **not in `merged/`** |
 
 ### `configs/snarea/snarea_library.yml`
 
@@ -178,7 +190,7 @@ the rest. A NaN there is a result, not a gap, which is why they are excluded fro
 
 | Builder module | PRMS parameters produced |
 | --- | --- |
-| `zonal_runners/zonal.py` | `hru_elev`, `hru_slope` ⚠️, `hru_aspect` (DEFECTIVE) |
+| `zonal_runners/zonal.py` | `hru_elev` ⚠️, `hru_slope` ⚠️, `hru_aspect` (DEFECTIVE) |
 | `zonal_runners/soils.py` | `soil_type` ⚠️, `soil_moist_max` |
 | `zonal_runners/lulc_prederived.py` | `cov_type`, `covden_sum`, `covden_win`, `srain_intcp`, `wrain_intcp`, `snow_intcp`, `rad_trncf` ⚠️ |
 | `zonal_runners/lulc.py` | `cov_type`, `covden_sum`, `covden_win`, `srain_intcp`, `wrain_intcp`, `snow_intcp` (+ unverified `retention`) |
@@ -212,7 +224,9 @@ parameters are correct. But nothing currently *emits* `hru_slope`. Apply
 `tan(radians(mean))` yourself until the pipeline emits it directly.
 
 Known approximation once it does: `tan(mean θ) ≠ mean(tan θ)`, and `tan` is convex, so the
-conversion systematically underestimates. Measured over all 361,471 gfv2 HRUs: median
+conversion systematically underestimates. Estimated (second-order Taylor from the
+on-disk `mean`/`std` — `mean(tan θ)` is not recoverable from summary statistics) over all
+361,471 gfv2 HRUs: median
 **0.2%**, p90 2.4%, p99 5.6%.
 
 ### `hru_aspect` is DEFECTIVE — do not use `nhm_aspect_params.csv:mean`
@@ -250,7 +264,9 @@ transform, and the column was renamed to `rad_trncf` after gfv2/oregon were buil
 
 On `lulc_nalcms` / `lulc_nlcd` / `lulc_foresce` it is **not** `rad_trncf`.
 `lulc.py:186-193` computes `zonal_mean(keep)/100` or the crosswalk's `evergreen_retention`
-column — no Beer's-law step, and no `radtrn_raster` is configured for those entries. What
+column. The module *does* carry a Beer's-law `rad_trncf` path (`lulc.py:194-239`), but it is
+gated on `radtrn_raster`, which is configured for none of these three entries
+(`zonal_params.yml:163-165` says so) — so it never runs for them. What
 PRMS parameter it corresponds to, if any, is unverified.
 
 ### Unverified mappings

--- a/docs/superpowers/plans/2026-08-04-prms-parameter-index.md
+++ b/docs/superpowers/plans/2026-08-04-prms-parameter-index.md
@@ -1,0 +1,1144 @@
+# PRMS Parameter Index Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make "which parameters feed PRMS runoff?" answerable from the repo, by adding a PRMS-metadata axis to the existing per-stage configs and generating an index from it.
+
+**Architecture:** Every parameter file already flows through one function — `iter_declared_params` in `scripts/merge_and_fill_params.py` — which unions four configs. That function moves into the package, gains a `prms:` block per config entry mapping *emitted column → PRMS parameter → consuming process*, and two guards keep the declaration honest. A generator renders the index from it. **No source file moves**: the by-process view is a metadata gap, not a layout gap.
+
+**Tech Stack:** Python 3.12/3.13, PyYAML, pandas, pytest, mkdocs-material, pixi.
+
+**Spec:** `docs/superpowers/specs/2026-08-04-prms-parameter-index-design.md`
+**Branch:** `docs/prms-parameter-index-spec`
+
+## Global Constraints
+
+- **Never run `pytest` on the HPC head node** (CLAUDE.md). Concurrent geo-library imports trigger shared-FS metadata storms. Local verification is `python -m py_compile` and bare `yaml.safe_load` only. **The authoritative test gate is CI** (`.github/workflows/ci.yml`, `runs-on: ubuntu-latest`, fires on push to `main` and every PR). Where a step below says "verify the test fails/passes", that means *push the branch and read the CI result*, unless the step explicitly says the check is import-free.
+- **CI has no data root.** Any test touching `{data_root}` must `pytest.skip` when absent. `scripts/merge_and_fill_params.py:341-346` records this contract: "tests may parse these files but must not touch a real data root."
+- **`params:` stays a flat list and every `name:` value stays stable.** `slurm_batch/submit_zonal_params.sh:68-79` carries a hardcoded bash array and `derive_zonal_params.py:64-71` does a flat linear scan. Adding keys *inside* an entry is invisible to both. Adding a new element to `means:`/`ratios:`/`constants:` is safe (no bash array mirrors them); adding one to `params:` or `fractions:` is **not**.
+- **Add deps via `pyproject.toml`**, then `pixi install` — not `environment.yml`.
+- **Run `pixi run -e dev pre-commit run --all-files` before pushing.**
+- **Atomic commits.** Split combined fixes before pushing.
+- **Every code change needs a docs check** — audit `docs/`, `README.md`, `slurm_batch/RUNME.md`, `HPC_REFERENCE.md`.
+- **Fabric-agnostic:** read paths via `require_config_key` against the active profile; never hardcode `/caldera/...`.
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| `docs/parameter_index.md` | The deliverable. Three views over the mapping: by PRMS process, by config entry, by builder. Hand-written in Task 1, generated from Task 7 on. |
+| `src/gfv2_params/params_index.py` | **New.** `DeclaredParam`, `iter_declared_params`, `load_declared_params`, `params_for_process`. Pure YAML — no geo imports, no data root. |
+| `scripts/merge_and_fill_params.py` | Loses `iter_declared_params`/`DeclaredParam`/`_load_declared_params`; imports them instead. Behaviour unchanged. |
+| `configs/zonal/zonal_params.yml` | Gains `prms:` per entry; `slope` also gains `derived_columns:`. |
+| `configs/depstor/depstor_params.yml` | Gains `prms:` on `means:`/`ratios:`; gains a `constants:` list. |
+| `configs/snarea/snarea_library.yml` | Gains a top-level `prms:`. |
+| `scripts/derive_depstor_params.py` | Gains `--mode copy_constants`. |
+| `src/gfv2_params/zonal_runners/merge.py` | Applies `derived_columns:` after concat. |
+| `tests/test_params_index.py` | **New.** Guard 1 (declaration superset) + unit coverage ported from `test_merge_and_fill_params.py`. |
+| `tests/test_params_index_ondisk.py` | **New.** Guard 2, data-root-gated, skips in CI. |
+| `scripts/build_parameter_index.py` | **New.** Renders `docs/parameter_index.md`. |
+
+---
+
+### Task 1: Hand-write `docs/parameter_index.md` (PR 1 — standalone)
+
+Ships the answer before any schema work, and becomes the acceptance target for Task 7's generator. Reviewed row-by-row by a hydrologist: this is the step that removes the need to trust the mapping.
+
+**Files:**
+- Create: `docs/parameter_index.md`
+- Modify: `mkdocs.yml` (nav, after line 113 `- API reference: api.md`)
+- Modify: `docs/index.md` (the "Where to start" list, after the "Adding a new HRU parameter?" bullet)
+
+**Interfaces:**
+- Consumes: Deliverable 1 of the spec (the 19-row mapping table) — the authoritative row data.
+- Produces: `docs/parameter_index.md` with three `##` sections whose headings Task 7 must reproduce exactly: `## By PRMS process`, `## By config entry`, `## By builder`.
+
+- [ ] **Step 1: Create `docs/parameter_index.md`**
+
+Transcribe the spec's Deliverable 1 table into three views. Required frontmatter paragraph and section skeleton:
+
+```markdown
+# PRMS parameter index
+
+Every parameter this pipeline emits to `{fabric}/params/merged/`, mapped to the PRMS
+process that consumes it, the config entry that declares it, and the builder that computes
+it.
+
+Process membership is from `pywatershed.<Process>.get_parameters()` (pywatershed 2.0.4, the
+`reference` pixi env), not inference. Column lists are observed on-disk headers from
+`gfv2/params/merged/`.
+
+> **Hand-maintained as of 2026-08-04.** Generated from `configs/` once
+> `scripts/build_parameter_index.py` lands — see
+> `docs/superpowers/specs/2026-08-04-prms-parameter-index-design.md`.
+
+## Reading this index
+
+- ⚠️ marks a column whose **emitted name is not the PRMS parameter name**.
+- **DEFECTIVE** marks a column that does not currently represent the PRMS parameter at all.
+- *provenance* marks an emitted column that is not a PRMS parameter — a diagnostic or an
+  intermediate.
+
+## By PRMS process
+
+### PRMSRunoff (`srunoff_smidx`) — 11 parameters
+
+| PRMS parameter | Emitted file | Column | Config entry | Builder |
+| --- | --- | --- | --- | --- |
+| `soil_moist_max` | `nhm_soil_moist_max_params.csv` | `soil_moist_max` | `zonal_params.yml:81` | `zonal_runners/soils.py` |
+| `dprst_seep_rate_open` | `nhm_ssflux_params.csv` | `dprst_seep_rate_open` | `zonal_params.yml:208` | `zonal_runners/ssflux.py` |
+| `dprst_flow_coef` | `nhm_ssflux_params.csv` | `dprst_flow_coef` | `zonal_params.yml:208` | `zonal_runners/ssflux.py` |
+| `sro_to_dprst_perv` | `nhm_sro_to_dprst_perv_params.csv` | `sro_to_dprst_perv` | `depstor_params.yml:134` | `same_hru_drains.py` + `perv.py` |
+| `sro_to_dprst_imperv` | `nhm_sro_to_dprst_imperv_params.csv` | `sro_to_dprst_imperv` | `depstor_params.yml:141` | `same_hru_drains.py` + `imperv.py` |
+| `carea_max` | `nhm_carea_max_params.csv` | `carea_max` | `depstor_params.yml:148` | `carea_map.py` |
+| `smidx_coef` | `nhm_smidx_coef_params.csv` | `smidx_coef` | `depstor_params.yml:155` | `carea_map.py` |
+| `hru_percent_imperv` | `nhm_hru_percent_imperv_params.csv` | `hru_percent_imperv` | `depstor_params.yml:164` | `imperv.py` + `landmask.py` |
+| `dprst_frac` | `nhm_dprst_frac_params.csv` | `dprst_frac` | `depstor_params.yml:177` | `dprst.py` + `landmask.py` |
+| `dprst_depth_avg` | `nhm_dprst_depth_avg_params.csv` | `dprst_depth_avg` | `depstor_params.yml:107` | `dprst_depth.py` + `dprst_depth/aggregate.py` |
+| `op_flow_thres` | **`op_flow_thres_params.csv`** (not in `merged/`) | `op_flow_thres` | `depstor_rasters.yml:83` | `dprst_depth.py:361` |
+
+### PRMSSoilzone — 8 parameters
+### PRMSSnow — 7 parameters
+### PRMSCanopy — 6 parameters
+### PRMSGroundwater — 1 parameter
+### PRMSSolarGeometry / PRMSAtmosphere — 2 parameters
+### Not consumed by any pywatershed process
+```
+
+Fill the remaining `###` sections from the spec's Deliverable 1 rows using the identical
+column layout. Three rows need their specific wording carried over verbatim:
+
+- **`hru_slope`** — currently emitted as `mean` in **degrees**; PRMS wants decimal fraction
+  rise/run. State the required conversion `tan(radians(mean))` and that Task 6 will emit it
+  directly. Include the worked example: gfv2 HRU 1, `mean = 4.4252` → `hru_slope = 0.0774`.
+- **`hru_aspect`** — mark **DEFECTIVE — not `hru_aspect`**. Arithmetic mean of a circular
+  variable; TM6B9:603 requires `atan2(mean(sin), mean(cos))`. Link issue #201.
+- **`retention`** on `lulc_nalcms`/`nlcd`/`foresce` — mark **unverified**, *not*
+  `rad_trncf`. The alias applies only to `lulc_nhm_v11`.
+
+Then `## By config entry` (rows grouped by the four configs) and `## By builder` (rows
+grouped by module path), same source data, and close with a `## Known gaps` section
+transcribing the spec's "Could not verify" list.
+
+- [ ] **Step 2: Add the mkdocs nav entry**
+
+In `mkdocs.yml`, insert after the `- API reference: api.md` line:
+
+```yaml
+  - Parameter index: parameter_index.md
+```
+
+- [ ] **Step 3: Add the `docs/index.md` pointer**
+
+In the "Where to start" list, after the "Adding a new HRU parameter?" bullet:
+
+```markdown
+- **Which parameters feed a given PRMS process?** →
+  [Parameter index](parameter_index.md) maps every emitted parameter to its
+  PRMS process, config entry, and builder.
+```
+
+- [ ] **Step 4: Verify the docs build (login-node safe — mkdocs imports no geo libs)**
+
+Run: `pixi run -e docs docs-build`
+Expected: exits 0; `site/parameter_index/index.html` exists; no `WARNING - Doc file ... contains a link to ... which is not found`.
+
+- [ ] **Step 5: Run pre-commit**
+
+Run: `pixi run -e dev pre-commit run --files docs/parameter_index.md mkdocs.yml docs/index.md`
+Expected: all hooks pass (prettier may reformat the markdown; re-stage if so).
+
+- [ ] **Step 6: Commit and open PR 1**
+
+```bash
+git add docs/parameter_index.md mkdocs.yml docs/index.md
+git commit -m "docs: add the PRMS parameter index
+
+Maps every parameter emitted to {fabric}/params/merged/ to its PRMS process,
+config entry, and builder. Hand-written; generated from configs/ once
+scripts/build_parameter_index.py lands.
+
+Flags three rows a consumer would otherwise get wrong: hru_slope is degrees
+on disk (PRMS wants rise/run, ~57x), hru_aspect is an arithmetic mean of a
+circular variable (issue #201), and op_flow_thres is a PRMSRunoff parameter
+written outside merged/."
+git push -u origin docs/prms-parameter-index-spec
+```
+
+**PR 1 stops here.** Tasks 2-7 continue on the same branch after review, or on a follow-up branch.
+
+---
+
+### Task 2: `params_index.py` — move `iter_declared_params`, widen `DeclaredParam`
+
+**Files:**
+- Create: `src/gfv2_params/params_index.py`
+- Create: `tests/test_params_index.py`
+- Modify: `scripts/merge_and_fill_params.py:341-450` (delete the moved block, import instead)
+- Modify: `tests/test_merge_and_fill_params.py:630`, `:631`, `:634`
+
+**Interfaces:**
+- Produces: `DeclaredParam(name: str, merged_file: str, fill_columns: list, fabric_columns: dict, prms: dict)` — a `NamedTuple` with `prms` defaulting to `{}`; `iter_declared_params(zonal_cfg, depstor_cfg, snarea_cfg=None) -> list[DeclaredParam]`; `load_declared_params() -> list[DeclaredParam]` reading the four repo configs.
+- Consumed by: Tasks 3, 4, 5, 6, 7 and `scripts/merge_and_fill_params.py`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_params_index.py`:
+
+```python
+"""Unit coverage for gfv2_params.params_index.
+
+Pure YAML parsing -- no geo imports, no data root. Safe on CI's ubuntu-latest.
+"""
+from __future__ import annotations
+
+from gfv2_params import params_index as pi
+
+
+def test_declared_param_has_prms_field_defaulting_to_empty():
+    d = pi.DeclaredParam("elevation", "nhm_elevation_params.csv", ["mean"], {})
+    assert d.prms == {}
+    assert d.name == "elevation"
+
+
+def test_iter_declared_params_unions_four_config_families():
+    zonal = {"params": [{"name": "elevation", "merged_file": "nhm_elevation_params.csv",
+                         "fill_columns": ["mean"]}]}
+    depstor = {
+        "fractions": [{"name": "perv_frac", "merged_file": "nhm_perv_frac_params.csv"}],
+        "means": [{"name": "dprst_depth_avg", "merged_file": "nhm_dprst_depth_avg_params.csv",
+                   "fill_columns": ["dprst_depth_avg"]}],
+        "ratios": [{"name": "dprst_frac", "output_file": "nhm_dprst_frac_params.csv",
+                    "fill_columns": ["dprst_frac"]}],
+    }
+    declared = pi.iter_declared_params(zonal, depstor)
+    names = {d.name for d in declared}
+    assert names == {"elevation", "dprst_depth_avg", "dprst_frac"}
+    # fractions are intermediates -- excluded despite carrying a merged_file key
+    assert "perv_frac" not in names
+
+
+def test_iter_declared_params_carries_prms_block():
+    zonal = {"params": [{
+        "name": "slope", "merged_file": "nhm_slope_params.csv", "fill_columns": ["mean"],
+        "prms": {"columns": {"hru_slope": {"prms": "hru_slope",
+                                           "processes": ["PRMSSolarGeometry"]}}},
+    }]}
+    declared = pi.iter_declared_params(zonal, {})
+    assert declared[0].prms["columns"]["hru_slope"]["prms"] == "hru_slope"
+```
+
+- [ ] **Step 2: Verify it fails (import-free check — login-node safe)**
+
+Run: `pixi run --as-is python -c "import gfv2_params.params_index"`
+Expected: `ModuleNotFoundError: No module named 'gfv2_params.params_index'`
+
+- [ ] **Step 3: Create `src/gfv2_params/params_index.py`**
+
+Move the block verbatim from `scripts/merge_and_fill_params.py:341-450`, adding the fifth field and its default:
+
+```python
+"""Every parameter with a canonical `merged/` output, and what it declares.
+
+Moved here from scripts/merge_and_fill_params.py so the declaration is importable
+by the index generator and the guards, not only by the fill sweep.
+
+Pure YAML: only the static name/merged_file/output_file/fill_columns/fabric_columns/
+prms fields are read, none of which are {data_root}/{fabric}-templated. That keeps
+this import safe with no data root -- the CI contract recorded at
+scripts/merge_and_fill_params.py's config-path block.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import NamedTuple
+
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+ZONAL_PARAMS_CONFIG = _REPO_ROOT / "configs" / "zonal" / "zonal_params.yml"
+DEPSTOR_PARAMS_CONFIG = _REPO_ROOT / "configs" / "depstor" / "depstor_params.yml"
+SNAREA_LIBRARY_CONFIG = _REPO_ROOT / "configs" / "snarea" / "snarea_library.yml"
+
+
+class DeclaredParam(NamedTuple):
+    """One config entry's contract: what file, what may be filled, what PRMS calls it.
+
+    A NamedTuple rather than a bare tuple because this record has now been widened
+    three times (fill_columns, fabric_columns, prms) and each widening reaches
+    several consumption sites. `prms` carries a default so positional construction
+    in existing tests keeps working; tuple-EQUALITY assertions do not survive and
+    must be rewritten to attribute access.
+    """
+
+    name: str
+    merged_file: str
+    fill_columns: list
+    fabric_columns: dict
+    prms: dict = {}
+
+
+def _load_yaml_doc(path: Path) -> dict:
+    """Bare yaml.safe_load of a config file, no placeholder resolution."""
+    return yaml.safe_load(path.read_text()) or {}
+
+
+def iter_declared_params(
+    zonal_cfg: dict, depstor_cfg: dict, snarea_cfg: dict | None = None
+) -> list[DeclaredParam]:
+    """Every param with a canonical `merged/` output.
+
+    `zonal_cfg["params"]` and `depstor_cfg["means"]` name their file `merged_file`;
+    `depstor_cfg["ratios"]` names it `output_file`. `depstor_cfg["fractions"]` is
+    DELIBERATELY EXCLUDED: its merged_file key names a per-fraction COUNT csv under
+    merged/_intermediates/, never a merged/ output.
+
+    `snarea_cfg` does not share the list-of-entries shape -- the whole document IS
+    the entry, so a `prms:` block there is a top-level key.
+    """
+    def _record(name: str, merged_file: str, entry: dict) -> DeclaredParam:
+        return DeclaredParam(
+            name=name,
+            merged_file=merged_file,
+            fill_columns=list(entry.get("fill_columns") or []),
+            fabric_columns=dict(entry.get("fabric_columns") or {}),
+            prms=dict(entry.get("prms") or {}),
+        )
+
+    declared: list[DeclaredParam] = []
+
+    for entry in zonal_cfg.get("params", []) or []:
+        if entry.get("merged_file"):
+            declared.append(_record(entry["name"], entry["merged_file"], entry))
+
+    for entry in depstor_cfg.get("means", []) or []:
+        if entry.get("merged_file"):
+            declared.append(_record(entry["name"], entry["merged_file"], entry))
+
+    for entry in depstor_cfg.get("ratios", []) or []:
+        if entry.get("output_file"):
+            declared.append(_record(entry["name"], entry["output_file"], entry))
+
+    for entry in depstor_cfg.get("constants", []) or []:
+        if entry.get("merged_file"):
+            declared.append(_record(entry["name"], entry["merged_file"], entry))
+
+    if snarea_cfg and snarea_cfg.get("params_file"):
+        declared.append(_record("snarea_curve", snarea_cfg["params_file"], snarea_cfg))
+
+    return declared
+
+
+def load_declared_params() -> list[DeclaredParam]:
+    """iter_declared_params over the real in-repo configs."""
+    return iter_declared_params(
+        _load_yaml_doc(ZONAL_PARAMS_CONFIG),
+        _load_yaml_doc(DEPSTOR_PARAMS_CONFIG),
+        _load_yaml_doc(SNAREA_LIBRARY_CONFIG),
+    )
+```
+
+The `constants:` loop is included now so Task 5 adds only config plus a copy mode. It is a
+no-op until then.
+
+- [ ] **Step 4: Rewrite `scripts/merge_and_fill_params.py` to import**
+
+Delete lines 341-450 (the `_REPO_ROOT`/config-path block, `_load_yaml_doc`, `DeclaredParam`, `iter_declared_params`, `_load_declared_params`). Add to the import block:
+
+```python
+from gfv2_params.params_index import DeclaredParam, iter_declared_params, load_declared_params
+```
+
+Replace the single call site `declared_params = _load_declared_params()` in `main()` with `declared_params = load_declared_params()`. `DeclaredParam` and `iter_declared_params` stay re-exported by that import so `tests/test_merge_and_fill_params.py`'s `maf.DeclaredParam` / `maf.iter_declared_params` references keep resolving.
+
+- [ ] **Step 5: Rewrite the three tuple-equality assertions**
+
+In `tests/test_merge_and_fill_params.py`, replace line 630:
+
+```python
+    assert by_name["dprst_frac"] == ("dprst_frac", "nhm_dprst_frac_params.csv", ["dprst_frac"], {})
+```
+
+with:
+
+```python
+    d = by_name["dprst_frac"]
+    assert (d.name, d.merged_file, d.fill_columns, d.fabric_columns) == (
+        "dprst_frac", "nhm_dprst_frac_params.csv", ["dprst_frac"], {})
+```
+
+Replace line 631 the same way for `elevation` / `nhm_elevation_params.csv` / `["mean"]`. Replace line 634:
+
+```python
+    assert declared == [("snarea_curve", "nhm_snarea_curve_params.csv", ["hru_deplcrv"], {})]
+```
+
+with:
+
+```python
+    assert len(declared) == 1
+    d = declared[0]
+    assert (d.name, d.merged_file, d.fill_columns, d.fabric_columns) == (
+        "snarea_curve", "nhm_snarea_curve_params.csv", ["hru_deplcrv"], {})
+```
+
+The positional `maf.DeclaredParam(...)` constructions at `:737`, `:751`, `:762` and the `d[0]` indexing at `:624`/`:629` need **no change** — a defaulted fifth field leaves both working.
+
+- [ ] **Step 6: Verify imports compile (login-node safe)**
+
+Run: `pixi run --as-is python -m py_compile src/gfv2_params/params_index.py scripts/merge_and_fill_params.py tests/test_params_index.py tests/test_merge_and_fill_params.py`
+Expected: exits 0, no output.
+
+Run: `pixi run --as-is python -c "from gfv2_params.params_index import load_declared_params; d=load_declared_params(); print(len(d)); print(sorted(x.name for x in d))"`
+Expected: prints `16` and the sorted names — `aspect, carea_max, dprst_depth_avg, dprst_frac, elevation, hru_percent_imperv, lulc_foresce, lulc_nalcms, lulc_nhm_v11, lulc_nlcd, slope, snarea_curve, soil_moist_max, soils, sro_to_dprst_imperv, sro_to_dprst_perv, ssflux`. (That is 17 names for 17 declared entries; adjust the printed count assertion to match what the configs actually hold — the point is that no entry vanished in the move.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/gfv2_params/params_index.py tests/test_params_index.py \
+        scripts/merge_and_fill_params.py tests/test_merge_and_fill_params.py
+git commit -m "refactor: move iter_declared_params into gfv2_params.params_index
+
+Widens DeclaredParam with a defaulted `prms` field. Tuple-equality assertions
+do not survive a NamedTuple widening, so the three at test_merge_and_fill_params
+:630/:631/:634 are rewritten to attribute access; the positional constructions
+at :737/:751/:762 and the d[0] indexing survive the default unchanged.
+
+The DeclaredParam docstring records why this matters: the last widening broke
+four consumption sites while the suite stayed green, because its fixtures
+hand-built the old tuple shape."
+```
+
+- [ ] **Step 8: Push and confirm CI is green**
+
+Run: `git push`
+Expected: `pytest tests/` passes on CI. `tests/test_params_index.py` runs; `tests/test_merge_and_fill_params.py` still passes with the rewritten assertions.
+
+---
+
+### Task 3: `prms:` metadata + Guard 1 (declaration superset)
+
+**Files:**
+- Modify: `configs/zonal/zonal_params.yml` (10 entries), `configs/depstor/depstor_params.yml` (1 mean + 6 ratios), `configs/snarea/snarea_library.yml` (top-level)
+- Modify: `tests/test_params_index.py`
+
+**Interfaces:**
+- Consumes: `DeclaredParam.prms` from Task 2.
+- Produces: `prms.columns: {emitted_column: {prms: str, processes: list[str]}}` and `prms.provenance: {emitted_column: str}` on every declared entry.
+
+- [ ] **Step 1: Write the failing guard**
+
+Append to `tests/test_params_index.py`:
+
+```python
+import pytest
+
+
+def _flatten(fill_columns):
+    """fill_columns entries may be a list of alias alternatives, not only a string.
+
+    zonal_params.yml's lulc_nhm_v11 carries [retention, rad_trncf] because
+    lulc_prederived.py renamed the same computed quantity; fabrics built before the
+    rename carry `retention`, after carry `rad_trncf`. EVERY alternative must be
+    declared, so a fabric of either vintage is covered.
+    """
+    out = []
+    for item in fill_columns:
+        if isinstance(item, (list, tuple)):
+            out.extend(item)
+        else:
+            out.append(item)
+    return out
+
+
+@pytest.mark.parametrize("declared", pi.load_declared_params(), ids=lambda d: d.name)
+def test_guard1_prms_declares_every_fillable_column(declared):
+    """prms.columns | prms.provenance is the DECLARED COMPLETE column list.
+
+    Guard 1 only proves the declaration is self-consistent -- it is declaration ->
+    declaration and cannot see disk. Guard 2 (test_params_index_ondisk.py) is the
+    one that catches a new column appearing with no PRMS decision recorded.
+    """
+    assert declared.prms, (
+        f"{declared.name} has no `prms:` block. It is mandatory, not optional -- "
+        f"without it this guard passes vacuously."
+    )
+    known = set(declared.prms.get("columns") or {}) | set(declared.prms.get("provenance") or {})
+    required = set(_flatten(declared.fill_columns)) | set(declared.fabric_columns or {})
+    missing = required - known
+    assert not missing, (
+        f"{declared.name}: {sorted(missing)} are declared fillable but appear in neither "
+        f"prms.columns nor prms.provenance. Every emitted column needs a PRMS decision."
+    )
+```
+
+- [ ] **Step 2: Verify it fails (login-node safe — pure YAML, no geo imports)**
+
+Run: `pixi run --as-is python -c "
+from gfv2_params.params_index import load_declared_params
+for d in load_declared_params():
+    if not d.prms: print('NO prms block:', d.name)
+"`
+Expected: lists all 17 entries — none has a `prms:` block yet.
+
+- [ ] **Step 3: Add `prms:` to `configs/zonal/zonal_params.yml`**
+
+For `elevation` (and identically for `slope`/`aspect`, changing only the mapped name and processes):
+
+```yaml
+    prms:
+      columns:
+        mean: {prms: hru_elev, processes: [temp_distribution]}
+      provenance:
+        count: exactextract cell count
+        std: within-HRU standard deviation
+        min: within-HRU minimum
+        "25%": within-HRU 25th percentile
+        "50%": within-HRU median
+        "75%": within-HRU 75th percentile
+        max: within-HRU maximum
+        sum: within-HRU sum
+```
+
+`provenance` here is **not** a restatement of "unfilled" — these eight ARE in `fill_columns`, and `zonal_params.yml:50-54` states explicitly they are not provenance in the "not derivable by design" sense. `prms.provenance` answers a different question: *is this a PRMS parameter?* They are filled and they are not PRMS parameters.
+
+For `aspect`, mark the defect rather than a mapping:
+
+```yaml
+    prms:
+      columns: {}   # DEFECTIVE -- `mean` is an arithmetic mean of a circular variable.
+                    # TM6B9:603 requires atan2(mean(sin), mean(cos)). See issue #201.
+      provenance:
+        mean: arithmetic mean of a circular field -- NOT hru_aspect, see issue #201
+        count: exactextract cell count
+        std: within-HRU standard deviation
+        min: within-HRU minimum
+        "25%": within-HRU 25th percentile
+        "50%": within-HRU median
+        "75%": within-HRU 75th percentile
+        max: within-HRU maximum
+        sum: within-HRU sum
+```
+
+For `ssflux`, note `hru_area` comes from `fabric_columns`, not `fill_columns`, and is **not** PRMS `hru_area`:
+
+```yaml
+    prms:
+      columns:
+        soil2gw_max:          {prms: soil2gw_max,          processes: [PRMSSoilzone]}
+        ssr2gw_rate:          {prms: ssr2gw_rate,          processes: [PRMSSoilzone]}
+        fastcoef_lin:         {prms: fastcoef_lin,         processes: [PRMSSoilzone]}
+        slowcoef_lin:         {prms: slowcoef_lin,         processes: [PRMSSoilzone]}
+        gwflow_coef:          {prms: gwflow_coef,          processes: [PRMSGroundwater]}
+        dprst_seep_rate_open: {prms: dprst_seep_rate_open, processes: [PRMSRunoff]}
+        dprst_flow_coef:      {prms: dprst_flow_coef,      processes: [PRMSRunoff]}
+      provenance:
+        k_perm_wtd: litho-weighted permeability, flux-normalisation input
+        mean_slope_fraction: tan(radians(slope mean)), flux-normalisation input
+        hru_area: fabric geometry.area in m2 -- NOT PRMS hru_area, which is acres
+```
+
+For `lulc_nhm_v11`, both alias alternatives map to the same PRMS name:
+
+```yaml
+    prms:
+      columns:
+        cov_type:    {prms: cov_type,    processes: [PRMSCanopy, PRMSSnow, PRMSSoilzone]}
+        covden_sum:  {prms: covden_sum,  processes: [PRMSCanopy, PRMSSnow]}
+        covden_win:  {prms: covden_win,  processes: [PRMSCanopy, PRMSSnow]}
+        srain_intcp: {prms: srain_intcp, processes: [PRMSCanopy]}
+        wrain_intcp: {prms: wrain_intcp, processes: [PRMSCanopy]}
+        snow_intcp:  {prms: snow_intcp,  processes: [PRMSCanopy]}
+        retention:   {prms: rad_trncf,   processes: [PRMSSnow]}
+        rad_trncf:   {prms: rad_trncf,   processes: [PRMSSnow]}
+      provenance: {}
+```
+
+For `lulc_nalcms` / `lulc_nlcd` / `lulc_foresce`, `retention` is **unverified** — `lulc.py:186-193` computes `keep/100` or a crosswalk column, not `lulc_prederived.py`'s Beer's-law `rad_trncf`:
+
+```yaml
+    prms:
+      columns:
+        cov_type:    {prms: cov_type,    processes: [PRMSCanopy, PRMSSnow, PRMSSoilzone]}
+        covden_sum:  {prms: covden_sum,  processes: [PRMSCanopy, PRMSSnow]}
+        covden_win:  {prms: covden_win,  processes: [PRMSCanopy, PRMSSnow]}
+        srain_intcp: {prms: srain_intcp, processes: [PRMSCanopy]}
+        wrain_intcp: {prms: wrain_intcp, processes: [PRMSCanopy]}
+        snow_intcp:  {prms: snow_intcp,  processes: [PRMSCanopy]}
+      provenance:
+        retention: UNVERIFIED -- lulc.py's derivation differs from lulc_prederived.py's
+                   Beer's-law rad_trncf; do not assume they are the same parameter
+```
+
+`soils` → `{prms: soil_type, processes: [PRMSSoilzone]}`; `soil_moist_max` → `{prms: soil_moist_max, processes: [PRMSRunoff, PRMSSoilzone]}`.
+
+- [ ] **Step 4: Add `prms:` to `configs/depstor/depstor_params.yml`**
+
+On the `dprst_depth_avg` mean entry:
+
+```yaml
+    prms:
+      columns:
+        dprst_depth_avg: {prms: dprst_depth_avg, processes: [PRMSRunoff]}
+      provenance:
+        dprst_depth_provenance: how each HRU's depth was derived (3dep_raw /
+                                hollister_flat / calibrated / no_dprst_cells)
+```
+
+On each of the six ratios, a single mapped column and empty provenance — e.g.:
+
+```yaml
+    prms:
+      columns:
+        carea_max: {prms: carea_max, processes: [PRMSRunoff]}
+      provenance: {}
+```
+
+`hru_percent_imperv` and `dprst_frac` take `processes: [PRMSRunoff, PRMSSoilzone, PRMSEt]`; `sro_to_dprst_perv`/`sro_to_dprst_imperv`/`smidx_coef` take `[PRMSRunoff]`.
+
+Leave `fractions:` untouched — `iter_declared_params` excludes them.
+
+- [ ] **Step 5: Add the top-level `prms:` to `configs/snarea/snarea_library.yml`**
+
+`iter_declared_params` passes the whole document as the entry, so this is a top-level key beside `library_file`/`params_file`:
+
+```yaml
+prms:
+  columns:
+    hru_deplcrv:     {prms: hru_deplcrv,   processes: [PRMSSnow]}
+    snarea_thresh:   {prms: snarea_thresh, processes: [PRMSSnow]}
+    snarea_curve_0:  {prms: snarea_curve,  processes: [PRMSSnow]}
+    snarea_curve_1:  {prms: snarea_curve,  processes: [PRMSSnow]}
+    snarea_curve_2:  {prms: snarea_curve,  processes: [PRMSSnow]}
+    snarea_curve_3:  {prms: snarea_curve,  processes: [PRMSSnow]}
+    snarea_curve_4:  {prms: snarea_curve,  processes: [PRMSSnow]}
+    snarea_curve_5:  {prms: snarea_curve,  processes: [PRMSSnow]}
+    snarea_curve_6:  {prms: snarea_curve,  processes: [PRMSSnow]}
+    snarea_curve_7:  {prms: snarea_curve,  processes: [PRMSSnow]}
+    snarea_curve_8:  {prms: snarea_curve,  processes: [PRMSSnow]}
+    snarea_curve_9:  {prms: snarea_curve,  processes: [PRMSSnow]}
+    snarea_curve_10: {prms: snarea_curve,  processes: [PRMSSnow]}
+  provenance:
+    cv_assign: assigned CV bin
+    cv_subgrid: sub-grid CV estimate
+    cv_empirical: empirical CV -- derivable for only ~42% of HRUs BY DESIGN
+    cv_source: which CV estimate was used
+    sdc_status: derivation status
+    sca_class: snow-covered-area class
+    similarity: scale-free SDC similarity metric
+    n_seasons: seasons contributing
+    n_peak_years: peak years contributing
+    peak_swe_mm: peak SWE driving snarea_thresh
+```
+
+- [ ] **Step 6: Verify the guard now passes (login-node safe)**
+
+Run: `pixi run --as-is python -c "
+from gfv2_params.params_index import load_declared_params
+bad = 0
+for d in load_declared_params():
+    known = set((d.prms.get('columns') or {})) | set((d.prms.get('provenance') or {}))
+    req = set()
+    for i in d.fill_columns:
+        req.update(i if isinstance(i, (list, tuple)) else [i])
+    req |= set(d.fabric_columns or {})
+    missing = req - known
+    if not d.prms or missing:
+        print('FAIL', d.name, sorted(missing)); bad += 1
+print('failures:', bad)
+"`
+Expected: `failures: 0`
+
+- [ ] **Step 7: Run pre-commit (yamllint will check the configs)**
+
+Run: `pixi run -e dev pre-commit run --files configs/zonal/zonal_params.yml configs/depstor/depstor_params.yml configs/snarea/snarea_library.yml tests/test_params_index.py`
+Expected: all hooks pass.
+
+- [ ] **Step 8: Commit and push**
+
+```bash
+git add configs/ tests/test_params_index.py
+git commit -m "feat(config): declare PRMS metadata per emitted column + Guard 1
+
+Adds a prms: block to every declared config entry, mapping emitted column ->
+PRMS parameter -> consuming process. processes: is PER-COLUMN, not per-entry:
+ssflux alone spans PRMSSoilzone, PRMSGroundwater and PRMSRunoff across
+different columns, so an entry-level key would report 5 non-runoff parameters
+as feeding runoff.
+
+prms.provenance is ORTHOGONAL to fill_columns, not a restatement of it.
+fill_columns asks 'is this KNN-interpolable?'; prms.provenance asks 'is this a
+PRMS parameter?'. The elevation/slope/aspect stats are the load-bearing case:
+filled AND not PRMS parameters.
+
+Guard 1 asserts prms.columns | prms.provenance is a superset of
+fill_columns | fabric_columns, flattening alias lists so both alternatives of
+lulc_nhm_v11's [retention, rad_trncf] must be declared.
+
+Additive to entry bodies only: params: stays a flat list and every name: is
+unchanged, so submit_zonal_params.sh and submit_depstor_params.sh are
+untouched."
+git push
+```
+
+---
+
+### Task 4: Guard 2 — on-disk header check (data-root-gated)
+
+Guard 1 is declaration → declaration and **cannot** catch the D2/D3 class it was written for. Guard 2 is the one that sees disk.
+
+**Files:**
+- Create: `tests/test_params_index_ondisk.py`
+
+**Interfaces:**
+- Consumes: `load_declared_params()` from Task 2, `load_base_config`/`require_config_key` from `gfv2_params.config`.
+
+- [ ] **Step 1: Write the test**
+
+```python
+"""Guard 2: the declared column list must equal the on-disk header.
+
+DATA-ROOT-GATED. CI (ubuntu-latest) has no data root, so every case SKIPS there
+and CI reports green while proving nothing -- record this test's result by SLURM
+job id, never infer it from a CI badge. See the companion spec's Testing section.
+
+Pure pandas + yaml: no rasterio/GDAL/pyogrio, so it is head-node safe.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from gfv2_params.config import load_base_config, require_config_key
+from gfv2_params.params_index import load_declared_params
+
+_DECLARED = load_declared_params()
+
+
+def _merged_dir():
+    base = load_base_config(None, fabric=None)
+    return Path(base["data_root"]) / base["fabric"] / "params" / "merged", \
+        require_config_key(base, "id_feature", "test_params_index_ondisk")
+
+
+@pytest.mark.parametrize("declared", _DECLARED, ids=lambda d: d.name)
+def test_guard2_declared_columns_match_disk(declared):
+    merged_dir, id_feature = _merged_dir()
+    path = merged_dir / declared.merged_file
+    if not path.exists():
+        pytest.skip(f"not built for this fabric: {path}")
+
+    header = set(pd.read_csv(path, nrows=0).columns)
+    declared_cols = set(declared.prms.get("columns") or {}) | set(
+        declared.prms.get("provenance") or {})
+
+    # Alias columns: only one alternative is present on any given fabric, so
+    # declared-but-absent is expected. Absent-but-undeclared is the failure.
+    undeclared = header - declared_cols - {id_feature}
+    assert not undeclared, (
+        f"{declared.name}: {sorted(undeclared)} exist in {path.name} but are declared "
+        f"in neither prms.columns nor prms.provenance. A new column reached disk with "
+        f"no PRMS decision recorded -- that is exactly how the hru_slope and hru_aspect "
+        f"defects arose."
+    )
+```
+
+- [ ] **Step 2: Verify it compiles and skips cleanly without a data root**
+
+Run: `pixi run --as-is python -m py_compile tests/test_params_index_ondisk.py`
+Expected: exits 0.
+
+- [ ] **Step 3: Run it once against the real data root — on a COMPUTE NODE, never the login node**
+
+```bash
+srun -p cpu -A impd --time=00:20:00 --ntasks=1 --cpus-per-task=2 --mem=16G \
+  pixi run --as-is python -m pytest tests/test_params_index_ondisk.py -v
+```
+Expected: passes for every built param, skips `lulc_nlcd`/`lulc_foresce` (inputs unstaged). Any failure names a real undeclared column — fix the config, not the test. **Record the job id.**
+
+- [ ] **Step 4: Commit and push**
+
+```bash
+git add tests/test_params_index_ondisk.py
+git commit -m "test: Guard 2 -- declared columns must match the on-disk header
+
+Guard 1 is declaration -> declaration and is a tautology on 12 entries, vacuous
+on 3 (ssflux declares 7 of 10 columns, snarea 13 of 23, dprst_depth_avg 1 of 2).
+Guard 2 is the one that catches a new column reaching disk with no PRMS
+decision recorded.
+
+Data-root-gated, so it SKIPS on CI and reports green while proving nothing --
+its result must be recorded by SLURM job id."
+git push
+```
+
+---
+
+### Task 5: `constants:` + `op_flow_thres` into `merged/` (D1)
+
+**Files:**
+- Modify: `configs/depstor/depstor_params.yml` (new top-level `constants:` list)
+- Modify: `scripts/derive_depstor_params.py` (new `--mode copy_constants`)
+- Modify: `tests/test_params_index.py`
+
+**Interfaces:**
+- Consumes: the `constants:` loop already present in `iter_declared_params` (Task 2).
+- Produces: `merged/nhm_op_flow_thres_params.csv`.
+
+- [ ] **Step 1: Add the config block**
+
+Append to `configs/depstor/depstor_params.yml`:
+
+```yaml
+# Constant per-HRU params a depstor BUILDER writes directly, with no zonal pass.
+# Copied into merged/ by `--mode copy_constants` so the "everything a consumer
+# needs is in merged/" invariant holds. NOT a `means:` entry: run_mean_zonal does
+# Path(spec["source_raster"]) unconditionally and _find_mean advertises every
+# means[].name as a runnable --mean target, so a raster-less means entry is a
+# KeyError waiting for the first operator who types --mean op_flow_thres.
+constants:
+  - name: op_flow_thres
+    source: "{data_root}/{fabric}/depstor_rasters/op_flow_thres_params.csv"
+    merged_file: nhm_op_flow_thres_params.csv
+    fill_columns: [op_flow_thres]
+    prms:
+      columns:
+        op_flow_thres: {prms: op_flow_thres, processes: [PRMSRunoff]}
+      provenance: {}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Append to `tests/test_params_index.py`:
+
+```python
+def test_op_flow_thres_is_declared_with_a_merged_file():
+    """D1: op_flow_thres is a PRMSRunoff param that was written outside merged/,
+    so iter_declared_params and warn_undeclared_merged_files both missed it."""
+    declared = {d.name: d for d in pi.load_declared_params()}
+    assert "op_flow_thres" in declared
+    assert declared["op_flow_thres"].merged_file == "nhm_op_flow_thres_params.csv"
+    assert declared["op_flow_thres"].prms["columns"]["op_flow_thres"]["processes"] == ["PRMSRunoff"]
+```
+
+- [ ] **Step 3: Verify it fails, then passes (login-node safe)**
+
+Run before Step 1's edit: `pixi run --as-is python -c "
+from gfv2_params.params_index import load_declared_params
+print('op_flow_thres' in {d.name for d in load_declared_params()})"`
+Expected before: `False`. Expected after Step 1: `True`.
+
+- [ ] **Step 4: Add `--mode copy_constants` to `scripts/derive_depstor_params.py`**
+
+Add to the `--mode` choices list, and add the handler:
+
+```python
+def run_copy_constants(args, logger) -> None:
+    """Copy each `constants:` source into merged/ under its canonical name.
+
+    A straight copy, not a computation: the builder already wrote one row per HRU
+    (depstor_builders/dprst_depth.py builds the id column from ctx.hru_gpkg), so
+    there is nothing to aggregate and the fill declaration is a no-op.
+    """
+    config = _load_resolved_config(args)
+    merged_dir = Path(config["output_dir"]) / config["merged_subdir"]
+    merged_dir.mkdir(parents=True, exist_ok=True)
+
+    for entry in config.get("constants", []) or []:
+        src = Path(entry["source"])
+        if not src.exists():
+            raise FileNotFoundError(
+                f"constants entry '{entry['name']}' source not found: {src}. "
+                f"Run the depstor raster build first -- this file is written by a "
+                f"builder, not by a zonal pass."
+            )
+        dst = merged_dir / entry["merged_file"]
+        df = pd.read_csv(src)
+        df.to_csv(dst, index=False)
+        logger.info("copy_constants: %s -> %s (%d rows)", src, dst, len(df))
+```
+
+Wire it into the `main()` dispatch alongside the existing modes.
+
+- [ ] **Step 5: Verify it compiles**
+
+Run: `pixi run --as-is python -m py_compile scripts/derive_depstor_params.py`
+Expected: exits 0.
+
+- [ ] **Step 6: Run it against gfv2 — compute node**
+
+```bash
+srun -p cpu -A impd --time=00:10:00 --ntasks=1 --cpus-per-task=2 --mem=8G \
+  pixi run --as-is python scripts/derive_depstor_params.py \
+    --config configs/depstor/depstor_params.yml \
+    --base_config configs/base_config.yml --fabric gfv2 --mode copy_constants
+```
+Expected: logs one copy, 361471 rows. Verify: `head -2 $(pixi run data-root)/gfv2/params/merged/nhm_op_flow_thres_params.csv` shows `nat_hru_id,op_flow_thres` then `1,1.0`.
+
+- [ ] **Step 7: Docs check + commit**
+
+Add a `copy_constants` line to `slurm_batch/RUNME.md`'s Step 4 and `HPC_REFERENCE.md`'s mode table.
+
+```bash
+git add configs/depstor/depstor_params.yml scripts/derive_depstor_params.py \
+        tests/test_params_index.py slurm_batch/RUNME.md slurm_batch/HPC_REFERENCE.md
+git commit -m "feat(depstor): copy op_flow_thres into merged/ via a constants: list
+
+op_flow_thres is a PRMSRunoff parameter written to depstor_rasters/, so it was
+invisible to iter_declared_params AND to warn_undeclared_merged_files (which
+globs merged_dir). Anyone assembling a parameter file by globbing
+merged/nhm_*_params.csv silently dropped it.
+
+A constants: list rather than a means: entry -- run_mean_zonal reads
+spec['source_raster'] unconditionally and op_flow_thres has no raster."
+git push
+```
+
+---
+
+### Task 6: `derived_columns:` + emit `hru_slope` (D0a)
+
+**Files:**
+- Modify: `configs/zonal/zonal_params.yml` (the `slope` entry)
+- Modify: `src/gfv2_params/zonal_runners/merge.py`
+- Modify: `tests/test_params_index.py`
+
+**Interfaces:**
+- Consumes: `raster_ops.deg_to_fraction` (`np.tan(np.deg2rad(x))`, already exists at `raster_ops.py:264-266`).
+- Produces: an `hru_slope` column in `merged/nhm_slope_params.csv`.
+
+- [ ] **Step 1: Add the config block to the `slope` entry**
+
+```yaml
+    # PRMS hru_slope is a decimal fraction rise/run (TM6B9:536); slope.vrt is
+    # rd.TerrainAttribute(..., "slope_degrees"), so `mean` is DEGREES -- a ~57x
+    # discrepancy for small angles. Emit the PRMS quantity directly rather than
+    # leaving a footgun. ssflux.py:63 already applies this same conversion.
+    #
+    # KNOWN APPROXIMATION: tan(mean) != mean(tan), and tan is convex, so this
+    # underestimates. Measured over all 361,471 gfv2 HRUs (2nd-order Taylor from
+    # on-disk mean/std): median 0.2%, p90 2.4%, p99 5.6%. Too small to justify a
+    # CONUS fractional-slope VRT -- none exists.
+    derived_columns:
+      hru_slope: {from: mean, transform: deg_to_fraction}
+    prms:
+      columns:
+        hru_slope: {prms: hru_slope, processes: [PRMSSolarGeometry, PRMSAtmosphere]}
+      provenance:
+        mean: mean cell slope in DEGREES -- the raw stat hru_slope is derived from
+        count: exactextract cell count
+        std: within-HRU standard deviation
+        min: within-HRU minimum
+        "25%": within-HRU 25th percentile
+        "50%": within-HRU median
+        "75%": within-HRU 75th percentile
+        max: within-HRU maximum
+        sum: within-HRU sum
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Append to `tests/test_params_index.py`:
+
+```python
+import math
+
+from gfv2_params.zonal_runners.merge import apply_derived_columns
+
+
+def test_apply_derived_columns_converts_slope_degrees_to_rise_run():
+    import pandas as pd
+    df = pd.DataFrame({"nat_hru_id": [1, 2], "mean": [4.4252, 45.0]})
+    out = apply_derived_columns(df, {"hru_slope": {"from": "mean",
+                                                   "transform": "deg_to_fraction"}})
+    assert math.isclose(out["hru_slope"][0], 0.077398, rel_tol=1e-4)
+    assert math.isclose(out["hru_slope"][1], 1.0, rel_tol=1e-9)  # tan(45 deg) == 1
+    assert "mean" in out.columns  # the raw stat is kept as provenance
+
+
+def test_apply_derived_columns_rejects_an_unknown_transform():
+    import pandas as pd
+    import pytest
+    df = pd.DataFrame({"mean": [1.0]})
+    with pytest.raises(ValueError, match="not a known transform"):
+        apply_derived_columns(df, {"x": {"from": "mean", "transform": "nope"}})
+```
+
+- [ ] **Step 3: Implement `apply_derived_columns` in `src/gfv2_params/zonal_runners/merge.py`**
+
+```python
+from gfv2_params import raster_ops
+
+# Transforms a `derived_columns:` entry may name. Deliberately a whitelist rather
+# than getattr(raster_ops, name): a typo must raise, not silently resolve to some
+# other module-level function.
+_TRANSFORMS = {
+    "deg_to_fraction": raster_ops.deg_to_fraction,
+}
+
+
+def apply_derived_columns(df, derived_columns: dict | None):
+    """Add each declared derived column to a merged frame.
+
+    Applied AFTER concat so it runs once per param rather than once per batch.
+    The source column is kept -- it is declared provenance, not a temporary.
+    """
+    for out_col, spec in (derived_columns or {}).items():
+        src, tname = spec["from"], spec["transform"]
+        if tname not in _TRANSFORMS:
+            raise ValueError(
+                f"`{tname}` is not a known transform for derived column '{out_col}'. "
+                f"Known: {sorted(_TRANSFORMS)}."
+            )
+        if src not in df.columns:
+            raise ValueError(
+                f"derived column '{out_col}' reads '{src}', which is not in the merged "
+                f"frame (columns: {sorted(df.columns)})."
+            )
+        df[out_col] = df[src].astype(float).apply(_TRANSFORMS[tname])
+    return df
+```
+
+Call it in `run_merge` immediately after the per-batch concat and before the CSV write, passing `config.get("derived_columns")`.
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `pixi run --as-is python -m py_compile src/gfv2_params/zonal_runners/merge.py`
+Expected: exits 0. (Do not import it locally — `zonal_runners/__init__.py` pulls the geo stack.)
+
+- [ ] **Step 5: Re-run the slope merge — compute node. No zonal re-run needed.**
+
+```bash
+srun -p cpu -A impd --time=00:30:00 --ntasks=1 --cpus-per-task=4 --mem=32G \
+  pixi run --as-is python scripts/derive_zonal_params.py \
+    --config configs/zonal/zonal_params.yml --base_config configs/base_config.yml \
+    --fabric gfv2 --mode merge --param slope
+```
+Expected: `nhm_slope_params.csv` gains an `hru_slope` column. Verify:
+`head -2 $(pixi run data-root)/gfv2/params/merged/nhm_slope_params.csv` — header ends `...,sum,hru_slope`, and row 1's `hru_slope` ≈ 0.0774 against `mean` ≈ 4.4252.
+
+- [ ] **Step 6: Docs check + commit**
+
+Update `docs/parameter_index.md`'s slope row from "conversion required" to "emitted".
+
+```bash
+git add configs/zonal/zonal_params.yml src/gfv2_params/zonal_runners/merge.py \
+        tests/test_params_index.py docs/parameter_index.md
+git commit -m "feat(zonal): emit hru_slope in rise/run via derived_columns:
+
+slope.vrt is rd.TerrainAttribute(..., 'slope_degrees'), so nhm_slope_params.csv's
+`mean` is DEGREES while PRMS hru_slope is a decimal fraction rise/run
+(TM6B9:536) -- ~57x for small angles. gfv2 HRU 1: mean=4.4252, hru_slope=0.0774.
+
+Applied in run_merge, so no zonal re-run is needed. Reuses
+raster_ops.deg_to_fraction, which ssflux.py:63 already applies, so this makes
+the rest of the pipeline consistent with what ssflux assumed rather than
+introducing a new convention.
+
+Transforms are a whitelist, not getattr(raster_ops, name): a typo must raise."
+git push
+```
+
+---
+
+### Task 7: `build_parameter_index.py` — generate the index
+
+**Files:**
+- Create: `scripts/build_parameter_index.py`
+- Modify: `docs/parameter_index.md` (replaced by generated output)
+- Modify: `tests/test_params_index.py`
+
+**Interfaces:**
+- Consumes: `load_declared_params()`, and a new `params_for_process(process: str) -> list[tuple[str, DeclaredParam]]` added to `params_index.py`.
+
+- [ ] **Step 1: Add `params_for_process` to `src/gfv2_params/params_index.py`**
+
+```python
+def params_for_process(process: str, declared=None) -> list[tuple[str, DeclaredParam]]:
+    """Every (emitted_column, DeclaredParam) whose column feeds `process`.
+
+    Column-grained, not entry-grained: ssflux alone spans PRMSSoilzone,
+    PRMSGroundwater and PRMSRunoff across different columns, so returning whole
+    entries would report 5 non-runoff parameters as feeding runoff.
+    """
+    out = []
+    for d in declared if declared is not None else load_declared_params():
+        for col, spec in (d.prms.get("columns") or {}).items():
+            if process in (spec.get("processes") or []):
+                out.append((col, d))
+    return out
+```
+
+- [ ] **Step 2: Write the failing test**
+
+```python
+def test_params_for_process_is_column_grained_not_entry_grained():
+    """ssflux spans three processes; asking for PRMSRunoff must return only its
+    two runoff columns, not the whole 10-column file."""
+    hits = pi.params_for_process("PRMSRunoff")
+    ssflux_cols = {col for col, d in hits if d.name == "ssflux"}
+    assert ssflux_cols == {"dprst_seep_rate_open", "dprst_flow_coef"}
+    assert "gwflow_coef" not in ssflux_cols  # PRMSGroundwater
+    assert "soil2gw_max" not in ssflux_cols  # PRMSSoilzone
+
+
+def test_prms_runoff_has_the_expected_parameter_count():
+    hits = pi.params_for_process("PRMSRunoff")
+    assert len({spec_col for spec_col, _ in hits}) == 11
+```
+
+- [ ] **Step 3: Verify (login-node safe)**
+
+Run: `pixi run --as-is python -c "
+from gfv2_params.params_index import params_for_process
+h = params_for_process('PRMSRunoff')
+print(len(h)); print(sorted(c for c, _ in h))"`
+Expected: `11` and the sorted column list matching the spec's Deliverable 1 PRMSRunoff rows.
+
+- [ ] **Step 4: Write `scripts/build_parameter_index.py`**
+
+Render three sections whose `##` headings match Task 1's exactly (`## By PRMS process`, `## By config entry`, `## By builder`), plus the `## Reading this index` and `## Known gaps` preamble/postamble carried from Task 1's hand-written version. Emit the same table columns Task 1 used. Write to `docs/parameter_index.md`.
+
+Builder attribution is not in the configs, so add a `builder:` key to each `prms:` block in the same commit (e.g. `builder: zonal_runners/soils.py`) rather than hardcoding a lookup table in the script.
+
+- [ ] **Step 5: Regenerate and diff against the hand-written index**
+
+Run: `pixi run --as-is python scripts/build_parameter_index.py && git diff --stat docs/parameter_index.md`
+Expected: differences are formatting only. **Any row that changes meaning is a real finding** — reconcile before committing, because Task 1's version was hydrologist-reviewed and the generator's was not.
+
+- [ ] **Step 6: Verify the docs still build**
+
+Run: `pixi run -e docs docs-build`
+Expected: exits 0, no broken-link warnings.
+
+- [ ] **Step 7: Commit and push**
+
+```bash
+git add scripts/build_parameter_index.py src/gfv2_params/params_index.py \
+        configs/ docs/parameter_index.md tests/test_params_index.py
+git commit -m "feat(docs): generate the parameter index from configs/
+
+params_for_process is column-grained: ssflux spans PRMSSoilzone,
+PRMSGroundwater and PRMSRunoff across different columns, so an entry-grained
+query would report 5 non-runoff parameters as feeding runoff.
+
+The generated output is diffed against the hand-written, hydrologist-reviewed
+index from PR 1; only formatting may differ."
+git push
+```
+
+---
+
+## Self-Review
+
+**Spec coverage.** Design A (`prms:` metadata) → Task 3. Design B (`params_index.py`, `DeclaredParam` widening, the six affected test sites) → Task 2. Design C (two guards) → Tasks 3 and 4. Design D (`constants:`/`op_flow_thres`) → Task 5. Design E (generated index) → Tasks 1 and 7. Design F (`derived_columns:`/`hru_slope`) → Task 6. Deliverable 1 → Task 1. D0b is scoped out to issue #201 and appears only as the DEFECTIVE marking in Tasks 1 and 3 — intentional, per the spec's "Scoped out" section.
+
+**Gap found and closed while reviewing:** Task 7 needs builder attribution to render the "By builder" view, but that data lives in no config. Added a `builder:` key to Task 7 Step 4 rather than leaving the generator with a hardcoded lookup that would drift.
+
+**Placeholder scan.** No TBD/TODO. Every code step carries real code. Task 1 Step 1 cites the spec's Deliverable 1 for row data rather than repeating 19 rows — that data exists and is committed, so it is a citation, not a placeholder; the section skeleton and the three rows needing special wording are given in full.
+
+**Type consistency.** `DeclaredParam` is 5-field with `prms: dict = {}` throughout. `iter_declared_params(zonal_cfg, depstor_cfg, snarea_cfg=None)`, `load_declared_params()`, `params_for_process(process, declared=None)`, `apply_derived_columns(df, derived_columns)` are used with those exact signatures in every task that references them. `prms.columns` values are `{prms: str, processes: list[str]}` in Tasks 3, 5, 6 and read that way in Task 7.
+
+**Adaptation to this repo's constraints.** The skill's standard "run the test, watch it fail" cycle cannot run locally — CLAUDE.md forbids pytest on the head node. Every failing-test step is therefore either an import-free one-liner (pure YAML/`py_compile`) or an explicit `srun` on a compute node, with CI as the authoritative gate. This is stated in Global Constraints and applied per-step.

--- a/docs/superpowers/plans/2026-08-04-prms-parameter-index.md
+++ b/docs/superpowers/plans/2026-08-04-prms-parameter-index.md
@@ -313,7 +313,13 @@ with:
 
 - [ ] **Step 4: Check the same claim isn't repeated elsewhere**
 
-Run: `grep -rn "loops every param\|loops that exact\|loops the" --include=*.md --include=*.sh . | grep -v node_modules | grep -v "^./site/"`
+Run: `grep -rn "loops every\|loops that\|loops the" --include=*.md --include=*.sh --include=*.py . | grep -v node_modules | grep -v "^./site/"`
+
+**Match on the verb, not the phrase.** An earlier pattern here was
+`loops every param\|loops that exact\|loops the`, which missed six sites saying
+"loops every **entry**" — including `README.md` twice and `ADDING_A_PARAMETER.md:41`,
+Hop 1 of the very file being fixed. A too-specific grep reports clean and hides the
+biggest hits. Include `--include=*.py` too: `scripts/derive_zonal_params.py:17` carried it.
 Expected: remaining hits are in `slurm_batch/submit_zonal_params.sh`'s own header and `scripts/merge_and_fill_params.py`'s docstring, both of which describe the *intent* correctly ("if you add or remove entries there, also update PARAMS below"). Fix any other doc that repeats the false claim.
 
 - [ ] **Step 5: Run pre-commit**

--- a/docs/superpowers/plans/2026-08-04-prms-parameter-index.md
+++ b/docs/superpowers/plans/2026-08-04-prms-parameter-index.md
@@ -8,7 +8,7 @@
 
 **Tech Stack:** Python 3.12/3.13, PyYAML, pandas, pytest, mkdocs-material, pixi.
 
-**Spec:** `docs/superpowers/specs/2026-08-04-prms-parameter-index-design.md`
+**Spec:** `docs/superpowers/specs/2026-08-04-prms-parameter-index-design.md` (Task 2 is outside the spec — see Self-Review)
 **Branch:** `docs/prms-parameter-index-spec`
 
 ## Global Constraints
@@ -26,7 +26,7 @@
 
 | File | Responsibility |
 | --- | --- |
-| `docs/parameter_index.md` | The deliverable. Three views over the mapping: by PRMS process, by config entry, by builder. Hand-written in Task 1, generated from Task 7 on. |
+| `docs/parameter_index.md` | The deliverable. Three views over the mapping: by PRMS process, by config entry, by builder. Hand-written in Task 1, generated from Task 8 on. |
 | `src/gfv2_params/params_index.py` | **New.** `DeclaredParam`, `iter_declared_params`, `load_declared_params`, `params_for_process`. Pure YAML — no geo imports, no data root. |
 | `scripts/merge_and_fill_params.py` | Loses `iter_declared_params`/`DeclaredParam`/`_load_declared_params`; imports them instead. Behaviour unchanged. |
 | `configs/zonal/zonal_params.yml` | Gains `prms:` per entry; `slope` also gains `derived_columns:`. |
@@ -37,12 +37,14 @@
 | `tests/test_params_index.py` | **New.** Guard 1 (declaration superset) + unit coverage ported from `test_merge_and_fill_params.py`. |
 | `tests/test_params_index_ondisk.py` | **New.** Guard 2, data-root-gated, skips in CI. |
 | `scripts/build_parameter_index.py` | **New.** Renders `docs/parameter_index.md`. |
+| `docs/ADDING_A_PARAMETER.md` | Step 5 corrected — the submit wrapper does not read the YAML. |
+| `tests/test_submit_wrapper_param_lists.py` | **New.** Guards both wrappers' hardcoded arrays against their configs. Deleted when the Snakemake migration retires the wrappers. |
 
 ---
 
 ### Task 1: Hand-write `docs/parameter_index.md` (PR 1 — standalone)
 
-Ships the answer before any schema work, and becomes the acceptance target for Task 7's generator. Reviewed row-by-row by a hydrologist: this is the step that removes the need to trust the mapping.
+Ships the answer before any schema work, and becomes the acceptance target for Task 8's generator. Reviewed row-by-row by a hydrologist: this is the step that removes the need to trust the mapping.
 
 **Files:**
 - Create: `docs/parameter_index.md`
@@ -51,7 +53,7 @@ Ships the answer before any schema work, and becomes the acceptance target for T
 
 **Interfaces:**
 - Consumes: Deliverable 1 of the spec (the 19-row mapping table) — the authoritative row data.
-- Produces: `docs/parameter_index.md` with three `##` sections whose headings Task 7 must reproduce exactly: `## By PRMS process`, `## By config entry`, `## By builder`.
+- Produces: `docs/parameter_index.md` with three `##` sections whose headings Task 8 must reproduce exactly: `## By PRMS process`, `## By config entry`, `## By builder`.
 
 - [ ] **Step 1: Create `docs/parameter_index.md`**
 
@@ -109,7 +111,7 @@ Fill the remaining `###` sections from the spec's Deliverable 1 rows using the i
 column layout. Three rows need their specific wording carried over verbatim:
 
 - **`hru_slope`** — currently emitted as `mean` in **degrees**; PRMS wants decimal fraction
-  rise/run. State the required conversion `tan(radians(mean))` and that Task 6 will emit it
+  rise/run. State the required conversion `tan(radians(mean))` and that Task 7 will emit it
   directly. Include the worked example: gfv2 HRU 1, `mean = 4.4252` → `hru_slope = 0.0774`.
 - **`hru_aspect`** — mark **DEFECTIVE — not `hru_aspect`**. Arithmetic mean of a circular
   variable; TM6B9:603 requires `atan2(mean(sin), mean(cos))`. Link issue #201.
@@ -165,11 +167,186 @@ written outside merged/."
 git push -u origin docs/prms-parameter-index-spec
 ```
 
-**PR 1 stops here.** Tasks 2-7 continue on the same branch after review, or on a follow-up branch.
+---
+
+### Task 2: Close the add-a-param trap — doc fix + bash-array guard (also PR 1)
+
+Adding a param requires editing a hardcoded bash array that **no documentation mentions and
+no test guards**. Miss it and `submit_zonal_params.sh` runs the other params, skips yours,
+and **exits 0**. The walkthrough a newcomer follows currently states the opposite of the
+truth.
+
+This is the cheapest real-defect fix in the plan and it is independent of everything else,
+so it ships alongside Task 1.
+
+**Files:**
+- Modify: `docs/ADDING_A_PARAMETER.md:239-241`
+- Create: `tests/test_submit_wrapper_param_lists.py`
+
+**Interfaces:**
+- Consumes: nothing. Pure text + `yaml.safe_load`; no package imports, so it is unaffected by Task 3's refactor.
+- Produces: nothing other tasks consume. Deleted when the Snakemake migration retires the wrappers (see `docs/superpowers/specs/2026-08-04-snakemake-migration-design.md`).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_submit_wrapper_param_lists.py`:
+
+```python
+"""The submit wrappers retype the config's `name:` lists; nothing else checks them.
+
+`slurm_batch/submit_zonal_params.sh` does NOT read the YAML -- it carries a hardcoded
+bash array (`PARAMS`) and exports PARAM=<name> per element, and
+`scripts/derive_zonal_params.py` then does a flat linear scan for a matching `name:`.
+`submit_depstor_params.sh` has the same shape with `FRACTIONS`.
+
+So a param added to the YAML and forgotten in the array is silently NOT RUN, and the
+wrapper still exits 0. This test is the only thing that catches that.
+
+DELETE ME when the Snakemake migration retires the wrappers -- a Snakefile reads the
+YAML directly and the duplication disappears.
+
+Pure text + yaml.safe_load: no geo imports, CI-safe.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _bash_array(script: Path, name: str) -> list[str]:
+    """Extract a `NAME=( ... )` bash array, dropping comments and blank lines."""
+    text = script.read_text()
+    m = re.search(rf"^{name}=\((.*?)^\)", text, re.S | re.M)
+    assert m, f"could not find a {name}=( ... ) array in {script}"
+    return [
+        line.split("#")[0].strip()
+        for line in m.group(1).strip().splitlines()
+        if line.split("#")[0].strip()
+    ]
+
+
+@pytest.mark.parametrize(
+    ("script_rel", "array_name", "config_rel", "config_key"),
+    [
+        ("slurm_batch/submit_zonal_params.sh", "PARAMS",
+         "configs/zonal/zonal_params.yml", "params"),
+        ("slurm_batch/submit_depstor_params.sh", "FRACTIONS",
+         "configs/depstor/depstor_params.yml", "fractions"),
+    ],
+)
+def test_wrapper_array_matches_config_names(script_rel, array_name, config_rel, config_key):
+    script = _REPO_ROOT / script_rel
+    config = _REPO_ROOT / config_rel
+    if not script.exists():
+        pytest.skip(f"{script_rel} retired by the Snakemake migration -- delete this test")
+
+    from_bash = _bash_array(script, array_name)
+    from_yaml = [e["name"] for e in yaml.safe_load(config.read_text())[config_key]]
+
+    assert from_bash == from_yaml, (
+        f"{script_rel}'s {array_name} array has drifted from {config_rel}'s "
+        f"`{config_key}:` names.\n"
+        f"  bash: {from_bash}\n"
+        f"  yaml: {from_yaml}\n"
+        f"Order matters as well as membership: the wrapper submits in array order, and "
+        f"ssflux must follow slope because it reads the merged slope CSV at zonal time."
+    )
+```
+
+- [ ] **Step 2: Verify it passes today, and would catch a real drift (login-node safe)**
+
+Run: `pixi run --as-is python -c "
+import re, yaml, pathlib
+def arr(p, n):
+    m = re.search(rf'^{n}=\((.*?)^\)', pathlib.Path(p).read_text(), re.S|re.M)
+    return [l.split('#')[0].strip() for l in m.group(1).strip().splitlines() if l.split('#')[0].strip()]
+b = arr('slurm_batch/submit_zonal_params.sh','PARAMS')
+y = [e['name'] for e in yaml.safe_load(open('configs/zonal/zonal_params.yml'))['params']]
+print('zonal match:', b == y)
+b2 = arr('slurm_batch/submit_depstor_params.sh','FRACTIONS')
+y2 = [e['name'] for e in yaml.safe_load(open('configs/depstor/depstor_params.yml'))['fractions']]
+print('depstor match:', b2 == y2)
+"`
+Expected: `zonal match: True` and `depstor match: True`. Both arrays are in sync today — the drift this guards is latent, not actual, which is exactly why it needs a test rather than a fix.
+
+Now prove it fails on drift: temporarily append `  fake_param` inside the `PARAMS=( ... )` array, re-run, expect `zonal match: False`, then **revert the edit**.
+
+- [ ] **Step 3: Fix `docs/ADDING_A_PARAMETER.md`**
+
+Replace step 5 (lines 239-241), which currently reads:
+
+```markdown
+5. **Submit the full SLURM array** via
+   [`slurm_batch/submit_zonal_params.sh`](../slurm_batch/submit_zonal_params.sh)
+   from a shell that has `pixi` on `PATH`. This loops every param in the
+   YAML and chains array zonal -> merge per param.
+```
+
+with:
+
+```markdown
+5. **Add the param to the submit wrapper's `PARAMS` array.**
+   [`slurm_batch/submit_zonal_params.sh`](../slurm_batch/submit_zonal_params.sh)
+   does **not** read the YAML — it carries a hardcoded bash array
+   (`PARAMS`, lines 68-79) and exports `PARAM=<name>` per element.
+   A param present in the YAML but absent from that array is silently
+   **not run**, and the wrapper still exits 0.
+
+   Order matters: keep `slope` before `ssflux`, which reads the merged
+   slope CSV at zonal time. If your param needs the CONUS weight matrix or
+   an upstream merge, add it to `NEEDS_WEIGHTS` (line 94) or
+   `NEEDS_MERGE_OF` (line 101) as well.
+
+   `tests/test_submit_wrapper_param_lists.py` guards this, so CI will catch
+   a forgotten entry — but only after you push.
+
+6. **Submit the full SLURM array** via
+   [`slurm_batch/submit_zonal_params.sh`](../slurm_batch/submit_zonal_params.sh)
+   from a shell that has `pixi` on `PATH`. It submits an array zonal job
+   plus a chained merge for each param in `PARAMS`.
+```
+
+- [ ] **Step 4: Check the same claim isn't repeated elsewhere**
+
+Run: `grep -rn "loops every param\|loops that exact\|loops the" --include=*.md --include=*.sh . | grep -v node_modules | grep -v "^./site/"`
+Expected: remaining hits are in `slurm_batch/submit_zonal_params.sh`'s own header and `scripts/merge_and_fill_params.py`'s docstring, both of which describe the *intent* correctly ("if you add or remove entries there, also update PARAMS below"). Fix any other doc that repeats the false claim.
+
+- [ ] **Step 5: Run pre-commit**
+
+Run: `pixi run -e dev pre-commit run --files docs/ADDING_A_PARAMETER.md tests/test_submit_wrapper_param_lists.py`
+Expected: all hooks pass (shellcheck does not run on the test; ruff formats the Python).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/ADDING_A_PARAMETER.md tests/test_submit_wrapper_param_lists.py
+git commit -m "fix(docs): ADDING_A_PARAMETER wrongly said the submit wrapper loops the YAML
+
+It does not. submit_zonal_params.sh carries a hardcoded PARAMS bash array
+(:68-79) and exports PARAM=<name> per element; derive_zonal_params.py then
+does a flat linear scan for a matching name:. A param added to the YAML and
+forgotten in the array is silently NOT RUN, and the wrapper exits 0.
+
+The script's own header states the requirement, but the walkthrough a
+newcomer follows stated the opposite.
+
+Adds tests/test_submit_wrapper_param_lists.py, which asserts both wrappers'
+arrays match their configs' name: lists in membership AND order (ssflux must
+follow slope). Both are in sync today -- the drift is latent, which is why it
+needs a guard rather than a fix. Delete the test when the Snakemake migration
+retires the wrappers."
+```
+
+**PR 1 stops here** — Tasks 1 and 2 together. Tasks 3-8 continue on the same branch after review, or on a follow-up branch.
 
 ---
 
-### Task 2: `params_index.py` — move `iter_declared_params`, widen `DeclaredParam`
+### Task 3: `params_index.py` — move `iter_declared_params`, widen `DeclaredParam`
 
 **Files:**
 - Create: `src/gfv2_params/params_index.py`
@@ -179,7 +356,7 @@ git push -u origin docs/prms-parameter-index-spec
 
 **Interfaces:**
 - Produces: `DeclaredParam(name: str, merged_file: str, fill_columns: list, fabric_columns: dict, prms: dict)` — a `NamedTuple` with `prms` defaulting to `{}`; `iter_declared_params(zonal_cfg, depstor_cfg, snarea_cfg=None) -> list[DeclaredParam]`; `load_declared_params() -> list[DeclaredParam]` reading the four repo configs.
-- Consumed by: Tasks 3, 4, 5, 6, 7 and `scripts/merge_and_fill_params.py`.
+- Consumed by: Tasks 4, 5, 6, 7, 8 and `scripts/merge_and_fill_params.py`.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -338,7 +515,7 @@ def load_declared_params() -> list[DeclaredParam]:
     )
 ```
 
-The `constants:` loop is included now so Task 5 adds only config plus a copy mode. It is a
+The `constants:` loop is included now so Task 6 adds only config plus a copy mode. It is a
 no-op until then.
 
 - [ ] **Step 4: Rewrite `scripts/merge_and_fill_params.py` to import**
@@ -416,14 +593,14 @@ Expected: `pytest tests/` passes on CI. `tests/test_params_index.py` runs; `test
 
 ---
 
-### Task 3: `prms:` metadata + Guard 1 (declaration superset)
+### Task 4: `prms:` metadata + Guard 1 (declaration superset)
 
 **Files:**
 - Modify: `configs/zonal/zonal_params.yml` (10 entries), `configs/depstor/depstor_params.yml` (1 mean + 6 ratios), `configs/snarea/snarea_library.yml` (top-level)
 - Modify: `tests/test_params_index.py`
 
 **Interfaces:**
-- Consumes: `DeclaredParam.prms` from Task 2.
+- Consumes: `DeclaredParam.prms` from Task 3.
 - Produces: `prms.columns: {emitted_column: {prms: str, processes: list[str]}}` and `prms.provenance: {emitted_column: str}` on every declared entry.
 
 - [ ] **Step 1: Write the failing guard**
@@ -683,7 +860,7 @@ git push
 
 ---
 
-### Task 4: Guard 2 — on-disk header check (data-root-gated)
+### Task 5: Guard 2 — on-disk header check (data-root-gated)
 
 Guard 1 is declaration → declaration and **cannot** catch the D2/D3 class it was written for. Guard 2 is the one that sees disk.
 
@@ -691,7 +868,7 @@ Guard 1 is declaration → declaration and **cannot** catch the D2/D3 class it w
 - Create: `tests/test_params_index_ondisk.py`
 
 **Interfaces:**
-- Consumes: `load_declared_params()` from Task 2, `load_base_config`/`require_config_key` from `gfv2_params.config`.
+- Consumes: `load_declared_params()` from Task 3, `load_base_config`/`require_config_key` from `gfv2_params.config`.
 
 - [ ] **Step 1: Write the test**
 
@@ -776,7 +953,7 @@ git push
 
 ---
 
-### Task 5: `constants:` + `op_flow_thres` into `merged/` (D1)
+### Task 6: `constants:` + `op_flow_thres` into `merged/` (D1)
 
 **Files:**
 - Modify: `configs/depstor/depstor_params.yml` (new top-level `constants:` list)
@@ -784,7 +961,7 @@ git push
 - Modify: `tests/test_params_index.py`
 
 **Interfaces:**
-- Consumes: the `constants:` loop already present in `iter_declared_params` (Task 2).
+- Consumes: the `constants:` loop already present in `iter_declared_params` (Task 3).
 - Produces: `merged/nhm_op_flow_thres_params.csv`.
 
 - [ ] **Step 1: Add the config block**
@@ -898,7 +1075,7 @@ git push
 
 ---
 
-### Task 6: `derived_columns:` + emit `hru_slope` (D0a)
+### Task 7: `derived_columns:` + emit `hru_slope` (D0a)
 
 **Files:**
 - Modify: `configs/zonal/zonal_params.yml` (the `slope` entry)
@@ -1043,7 +1220,7 @@ git push
 
 ---
 
-### Task 7: `build_parameter_index.py` — generate the index
+### Task 8: `build_parameter_index.py` — generate the index
 
 **Files:**
 - Create: `scripts/build_parameter_index.py`
@@ -1133,12 +1310,14 @@ git push
 
 ## Self-Review
 
-**Spec coverage.** Design A (`prms:` metadata) → Task 3. Design B (`params_index.py`, `DeclaredParam` widening, the six affected test sites) → Task 2. Design C (two guards) → Tasks 3 and 4. Design D (`constants:`/`op_flow_thres`) → Task 5. Design E (generated index) → Tasks 1 and 7. Design F (`derived_columns:`/`hru_slope`) → Task 6. Deliverable 1 → Task 1. D0b is scoped out to issue #201 and appears only as the DEFECTIVE marking in Tasks 1 and 3 — intentional, per the spec's "Scoped out" section.
+**Spec coverage.** Design A (`prms:` metadata) → Task 4. Design B (`params_index.py`, `DeclaredParam` widening, the six affected test sites) → Task 3. Design C (two guards) → Tasks 4 and 5. Design D (`constants:`/`op_flow_thres`) → Task 6. Design E (generated index) → Tasks 1 and 8. Design F (`derived_columns:`/`hru_slope`) → Task 7. Deliverable 1 → Task 1. D0b is scoped out to issue #201 and appears only as the DEFECTIVE marking in Tasks 1 and 4 — intentional, per the spec's "Scoped out" section.
 
-**Gap found and closed while reviewing:** Task 7 needs builder attribution to render the "By builder" view, but that data lives in no config. Added a `builder:` key to Task 7 Step 4 rather than leaving the generator with a hardcoded lookup that would drift.
+**Task 2 is not from the spec.** It closes a live defect found while answering "what files must I modify to add a param?": the submit wrappers' hardcoded arrays are undocumented and unguarded, and `ADDING_A_PARAMETER.md:239-241` asserts the opposite of the truth. Independent of the index work, near-zero risk, and deleted when the Snakemake migration retires the wrappers — so it rides in PR 1 rather than waiting.
+
+**Gap found and closed while reviewing:** Task 8 needs builder attribution to render the "By builder" view, but that data lives in no config. Added a `builder:` key to Task 8 Step 4 rather than leaving the generator with a hardcoded lookup that would drift.
 
 **Placeholder scan.** No TBD/TODO. Every code step carries real code. Task 1 Step 1 cites the spec's Deliverable 1 for row data rather than repeating 19 rows — that data exists and is committed, so it is a citation, not a placeholder; the section skeleton and the three rows needing special wording are given in full.
 
-**Type consistency.** `DeclaredParam` is 5-field with `prms: dict = {}` throughout. `iter_declared_params(zonal_cfg, depstor_cfg, snarea_cfg=None)`, `load_declared_params()`, `params_for_process(process, declared=None)`, `apply_derived_columns(df, derived_columns)` are used with those exact signatures in every task that references them. `prms.columns` values are `{prms: str, processes: list[str]}` in Tasks 3, 5, 6 and read that way in Task 7.
+**Type consistency.** `DeclaredParam` is 5-field with `prms: dict = {}` throughout. `iter_declared_params(zonal_cfg, depstor_cfg, snarea_cfg=None)`, `load_declared_params()`, `params_for_process(process, declared=None)`, `apply_derived_columns(df, derived_columns)` are used with those exact signatures in every task that references them. `prms.columns` values are `{prms: str, processes: list[str]}` in Tasks 4, 6, 7 and read that way in Task 8.
 
 **Adaptation to this repo's constraints.** The skill's standard "run the test, watch it fail" cycle cannot run locally — CLAUDE.md forbids pytest on the head node. Every failing-test step is therefore either an import-free one-liner (pure YAML/`py_compile`) or an explicit `srun` on a compute node, with CI as the authoritative gate. This is stated in Global Constraints and applied per-step.

--- a/docs/superpowers/specs/2026-08-04-prms-parameter-index-design.md
+++ b/docs/superpowers/specs/2026-08-04-prms-parameter-index-design.md
@@ -1,0 +1,489 @@
+# PRMS parameter index — design
+
+**Date:** 2026-08-04
+**Status:** design, awaiting review
+**Issue:** file on approval
+**Companion:** `2026-08-04-snakemake-migration-design.md` (independent; this spec does not
+depend on it)
+
+A scientist asking *"which parameters feed PRMS runoff?"* cannot answer it from this repo.
+The layout is organised by HOW a parameter is computed (`zonal_runners/` /
+`depstor_builders/` / `snarea/` / `aggregate/`; one config per stage), which is the right
+axis for code and the wrong one for that question.
+
+This spec adds the missing metadata axis. It moves no source files.
+
+---
+
+## Problem
+
+### The question, answered by hand
+
+11 of the parameters we emit feed `PRMSRunoff` / `srunoff_smidx`. They are spread across
+**3 configs**, **4 builder packages**, and **2 output directories**:
+
+| Parameter | Config | Builder |
+| --- | --- | --- |
+| `soil_moist_max` | `zonal_params.yml:81` | `zonal_runners/soils.py` |
+| `dprst_seep_rate_open`, `dprst_flow_coef` | `zonal_params.yml:208` | `zonal_runners/ssflux.py` |
+| `sro_to_dprst_perv` | `depstor_params.yml:134` | `same_hru_drains.py` + `perv.py` |
+| `sro_to_dprst_imperv` | `depstor_params.yml:141` | `same_hru_drains.py` + `imperv.py` |
+| `carea_max` | `depstor_params.yml:148` | `carea_map.py` |
+| `smidx_coef` | `depstor_params.yml:155` | `carea_map.py` |
+| `hru_percent_imperv` | `depstor_params.yml:164` | `imperv.py` + `landmask.py` |
+| `dprst_frac` | `depstor_params.yml:177` | `dprst.py` + `landmask.py` |
+| `dprst_depth_avg` | `depstor_params.yml:107` (`means:`) | `dprst_depth.py` + `dprst_depth/aggregate.py` |
+| `op_flow_thres` | **`depstor_rasters.yml:77`** (output name at `:83`) | `dprst_depth.py:361` |
+
+Process membership throughout this spec is from `pywatershed.<Process>.get_parameters()`
+(pywatershed 2.0.4, `reference` pixi env), not inference.
+
+### Four defects the mapping surfaced
+
+**D0a — `hru_slope` is degrees on disk; PRMS wants a decimal fraction.** *(Decision made:
+the pipeline will emit rise/run — see Design F.)* Verified end to end:
+
+| Step | Evidence |
+| --- | --- |
+| `slope.vrt` is degrees | `shared_rasters/compute_slope_aspect.py:72` — `rd.TerrainAttribute(dem, attrib="slope_degrees")` |
+| so `nhm_slope_params.csv:mean` is degrees | zonal mean of that raster |
+| `viz.py:506` labels it `units="degrees"` | consistent |
+| PRMS `hru_slope` is decimal fraction rise/run | `docs/NHM_description_Regan_2018_TM6B9.md:536` |
+
+For small angles the discrepancy is 180/π ≈ **57×**: a 5° hillslope is `hru_slope = 0.087`,
+not `5`.
+
+**The pipeline is not wrong** — `zonal_runners/ssflux.py:63` applies
+`raster_ops.deg_to_fraction` (`np.tan(np.deg2rad(x))`, `:264-266`) before deriving
+`ssr2gw_rate`/`slowcoef_lin`, so the flux params are correct. But **nothing emits
+`hru_slope`**, and a consumer reading `merged/nhm_slope_params.csv` gets degrees under a
+column named `mean`. This is D2 (below) with a numeric consequence rather than a naming
+one, and it is the strongest single justification for this spec.
+
+Worked example from gfv2, HRU 1: the file says `mean = 4.4252`; PRMS `hru_slope` should be
+`0.0774`. Copied verbatim, that declares a 77° cliff instead of a 4.4° hillslope.
+
+**D0b — `hru_aspect` is an arithmetic mean of a circular variable, and cannot be repaired
+from what is on disk.** TM6B9:603 states the required derivation explicitly:
+
+> "the trigonometric sine and cosine of each cell's aspect are derived to create two new
+> rasters of values. The average value for both of these raster values is determined for
+> each HRU. The hru_aspect value is then set to the inverse tangent of these two values
+> `atan2[sin(aspect), cos(aspect)]`."
+
+The `aspect` entry (`zonal_params.yml:64`) instead runs the generic `zonal` script — a plain
+`exactextract` mean. Measured across all 361,471 gfv2 HRUs, the signature is unambiguous:
+
+| Statistic | Value |
+| --- | --- |
+| median aspect `mean` | **179.4°** (due south) |
+| IQR | 151.7° – 207.5° |
+| median within-HRU `std` | 91.3° (uniform-circular ≈ 104°) |
+
+Half of CONUS reporting a mean orientation between 152° and 208° is not terrain — it is what
+arithmetic-averaging wrapped directions produces. The column does not measure predominant
+orientation; it measures how symmetric each HRU's cell distribution is about 180°.
+
+**This was known, and the magnitude is the only new information.** The circularity rule was
+applied deliberately and testably at **every raster boundary**:
+
+| Location | What it guards |
+| --- | --- |
+| `shared_rasters/compute_slope_aspect.py:68` | COG overviews → `NEAREST` |
+| `shared_rasters/build_vrt.py:74` | VRT decimation → `NEAREST` |
+| `shared_rasters/build_border_dem.py:224` | border overviews → `NEAREST` |
+| `shared_rasters/cog.py:84` | the helper's stated contract |
+| `tests/test_compute_slope_aspect.py:90`, `tests/test_build_vrt.py:185` | two tests asserting it |
+
+And the zonal-side limitation was flagged at the time, in
+`notebooks/_archive/check_params.ipynb`:
+
+> "**Note:** Aspect is a circular variable; the arithmetic mean is a **simplification**.
+> North- and south-facing slopes (0°/360° vs 180°) are climatically opposite despite being
+> near-neighbours numerically."
+
+So this is not a defect nobody noticed. It is a **documented simplification whose magnitude
+was never measured** — and the measurement above is what changes the verdict. A few-percent
+bias would have vindicated the original call; a median of 179.4° means the column's central
+tendency is the artifact rather than the terrain.
+
+**Do not delete `notebooks/_archive/` before porting that note.** `repo_review_issues.md`
+CODE-4 proposes deleting the directory as exploratory noise; it is currently the only record
+of this known limitation, and it is the reason D0b can be framed accurately rather than as an
+oversight.
+
+**Why this differs from D0a in kind, not just degree.** D0a is a unit error: `tan(radians(mean))`
+recovers the correct value from data already on disk. D0b is information-destroying — a
+circular mean cannot be reconstructed from an arithmetic one. The fix requires sin/cos
+rasters and a second zonal pass, exactly as TM6B9 describes, plus a CONUS re-run. That is a
+builder change, not an index change, so **D0b is recorded here and filed separately** (see
+"Scoped out"). `hru_aspect` feeds PRMSSolarGeometry/PRMSAtmosphere, so a uniform southern
+bias is a systematic solar-radiation bias.
+
+**D1 — `op_flow_thres` is a PRMSRunoff parameter filed outside `merged/`.** Written to
+`{fabric}/depstor_rasters/op_flow_thres_params.csv` (`depstor_rasters.yml:83`,
+`dprst_depth.py:361`), confirmed on disk for gfv2. Because it never reaches `merged/`, it
+is invisible to `iter_declared_params` (`merge_and_fill_params.py:382`), never gap-filled,
+and `warn_undeclared_merged_files` (`:477`, which globs `merged_dir` at `:492`) cannot see
+it either. Anyone assembling a parameter file by globbing `merged/nhm_*_params.csv`
+silently drops it.
+
+**D2 — for four files the emitted column name is not the PRMS name, and nothing records
+the translation.** `nhm_elevation_params.csv` has a column named `mean`; so do slope and
+aspect. `nhm_soils_params.csv` emits `soils` (`soils.py:78`). Grepping the repo for
+`hru_elev` / `hru_slope` / `hru_aspect` / `soil_type` hits only
+`docs/NHM_description_Regan_2018_TM6B9.md` (the imported USGS report) and
+`docs/nhm_source_crosscheck_2026-07.md` — never a config, a builder, or the fill contract.
+
+**D3 — `retention` is PRMS `rad_trncf`, but only on `lulc_nhm_v11`.** That entry's
+`fill_columns` carries an alias group `[retention, rad_trncf]` (`zonal_params.yml:128`)
+because `lulc_prederived.py` renamed the same computed quantity; fabrics built before the
+rename (gfv2, oregon) carry `retention`, after (tjc) carry `rad_trncf`.
+
+**This does not generalise to the other three LULC entries**, which declare a bare
+`retention` (`zonal_params.yml:141-150`, `:166-175`, `:191-200`) — deliberately, because
+the builders compute different things:
+
+- `lulc_prederived.py:176-181` — `rad_trncf = rad_trncf_from_density(zonal_mean(radtrn_raster))`,
+  a Beer's-law transform. Its docstring (`:20`) states "There is no `retention` column: it
+  was only ever a stand-in for rad_trncf."
+- `lulc.py:186-193` — `retention` = `zonal_mean(keep)/100` **or** the crosswalk's
+  `evergreen_retention` column. No Beer's-law step; no `radtrn_raster` is configured for
+  those entries (`zonal_params.yml:161-165` says so).
+
+Mapping `retention → rad_trncf` for `lulc_nalcms`/`nlcd`/`foresce` would assert two
+different derivations are the same PRMS parameter. Scope D3 to `lulc_nhm_v11`; the other
+three get `retention` in `prms.provenance` pending verification.
+
+---
+
+## Non-goals
+
+- **Moving any source file.** `src/gfv2_params/`'s 7 subpackages and `configs/`'s 5
+  subdirectories stay exactly as they are. The by-process view is a metadata gap, not a
+  layout gap: a file lives in one directory, a parameter feeds several processes, and
+  directories cannot express a many-to-many relation. `carea_map.py` would still be wrong
+  for the HRUs where `smidx_coef` is the output rather than `carea_max`.
+- **Restructuring the `params:` list.** See "Hard constraint".
+- **Changing any derivation.** D0's conversion is an emit-or-document decision, not a
+  recomputation; the flux params that consume slope already convert correctly.
+
+---
+
+## Hard constraint
+
+`submit_zonal_params.sh` does not read the YAML. It carries a hardcoded bash array
+(`:68-79`) plus two name-keyed maps (`NEEDS_WEIGHTS` `:94`, `NEEDS_MERGE_OF` `:101`) and
+exports `PARAM=<name>`; the driver does a flat linear scan for a matching `name:`
+(`derive_zonal_params.py:64-71`). `submit_depstor_params.sh:63-74` has the same shape.
+
+The load-bearing contract: **`params:` stays a flat list, and every `name:` value stays
+stable.**
+
+| Change | Wrapper impact |
+| --- | --- |
+| Add a `prms:` key **inside** an existing entry | **None.** Neither the wrapper nor `_find_param` reads unknown keys. |
+| Reorder entries | None for the driver; the wrapper's array is the real order (slope must precede ssflux). Leave both alone. |
+| **Add a new element to a list** (Design D) | **None for `means:`/`ratios:`/`constants:`** — no bash array indexes them. **Would break `params:`** and `fractions:`, which the two wrappers mirror. Design D touches only `means:`-family lists. |
+| Nest `params:` under group keys | Breaks `_find_param` (`:67`), `iter_declared_params` (`:422`), both wrappers. Not proposed. |
+| Rename any `name:` | Breaks the hardcoded arrays and dependency maps. Not proposed. |
+
+---
+
+## Deliverable 1 — the mapping
+
+19 rows: **16** files currently in `gfv2/params/merged/`, **2** declared-but-unbuilt
+(`lulc_nlcd`, `lulc_foresce` — their `input/lulc_veg/{nlcd,foresce}/` source directories do
+not exist on disk), and **1** (`op_flow_thres`) outside `merged/` until D1 lands.
+
+Column lists are observed on-disk headers.
+
+| Emitted file | Column(s) | PRMS parameter | PRMS process | Config entry | Builder |
+| --- | --- | --- | --- | --- | --- |
+| `nhm_elevation_params.csv` | `mean` (+8 stats) | `hru_elev` ⚠️ | *no pywatershed process*; PRMS temp/precip distribution, `cov_type` reset (TM6B9:707) | `zonal_params.yml:43` | `zonal_runners/zonal.py` |
+| `nhm_slope_params.csv` | **`hru_slope`** *(new, D0a)* | `hru_slope` | PRMSSolarGeometry, PRMSAtmosphere | `zonal_params.yml:56` | `zonal_runners/zonal.py` + `derived_columns` |
+| ″ | `mean` (degrees) + 8 stats | *provenance* — the raw stat `hru_slope` is derived from | — | ″ | ″ |
+| `nhm_aspect_params.csv` | `mean` (+8 stats) | **DEFECTIVE — not `hru_aspect`** ⚠️**D0b** | PRMSSolarGeometry, PRMSAtmosphere | `zonal_params.yml:64` | `zonal_runners/zonal.py` |
+| `nhm_soils_params.csv` | `soils` | `soil_type` ⚠️ | PRMSSoilzone | `zonal_params.yml:74` | `zonal_runners/soils.py:78` |
+| `nhm_soil_moist_max_params.csv` | `soil_moist_max` | same | **PRMSRunoff**, PRMSSoilzone | `zonal_params.yml:81` | `zonal_runners/soils.py` |
+| `nhm_lulc_nhm_v11_params.csv` | `cov_type` | same | PRMSCanopy, PRMSSnow, PRMSSoilzone | `zonal_params.yml:96` | `lulc_prederived.py` |
+| ″ | `covden_sum`, `covden_win` | same | PRMSCanopy, PRMSSnow | ″ | ″ |
+| ″ | `srain_intcp`, `wrain_intcp`, `snow_intcp` | same | PRMSCanopy | ″ | ″ |
+| ″ | `retention` \| `rad_trncf` | `rad_trncf` ⚠️**D3** | PRMSSnow | ″ | ″ |
+| `nhm_lulc_nalcms_params.csv` | `cov_type`, 2 covden, 3 intcp | same | as above | `zonal_params.yml:133` | `lulc.py` |
+| ″ | `retention` | **unverified** — not `rad_trncf` (D3) | — | ″ | ″ |
+| `nhm_lulc_nlcd_params.csv` *(unbuilt)* | same 7 | same | same | `zonal_params.yml:154` | `lulc.py` |
+| `nhm_lulc_foresce_params.csv` *(unbuilt)* | same 7 | same | same | `zonal_params.yml:179` | `lulc.py` |
+| `nhm_ssflux_params.csv` | `soil2gw_max`, `ssr2gw_rate`, `fastcoef_lin`, `slowcoef_lin` | same | PRMSSoilzone | `zonal_params.yml:208` | `ssflux.py` |
+| ″ | `gwflow_coef` | same | PRMSGroundwater | ″ | ″ |
+| ″ | `dprst_seep_rate_open`, `dprst_flow_coef` | same | **PRMSRunoff** | ″ | ″ |
+| ″ | `k_perm_wtd`, `mean_slope_fraction`, `hru_area` | *inputs, not params* — `hru_area` here is m², **not** PRMS `hru_area` (acres); see `zonal_params.yml:238-242` | — | ″ | ″ |
+| `nhm_sro_to_dprst_perv_params.csv` | `sro_to_dprst_perv` | same | **PRMSRunoff** | `depstor_params.yml:134` | `same_hru_drains.py` + `perv.py` → `gfv2_params/depstor_ratios.py` |
+| `nhm_sro_to_dprst_imperv_params.csv` | `sro_to_dprst_imperv` | same | **PRMSRunoff** | `:141` | `same_hru_drains.py` + `imperv.py` |
+| `nhm_carea_max_params.csv` | `carea_max` | same | **PRMSRunoff** | `:148` | `carea_map.py` |
+| `nhm_smidx_coef_params.csv` | `smidx_coef` | same | **PRMSRunoff** | `:155` | `carea_map.py` |
+| `nhm_hru_percent_imperv_params.csv` | `hru_percent_imperv` | same | **PRMSRunoff**, PRMSSoilzone, PRMSEt | `:164` | `imperv.py` + `landmask.py` |
+| `nhm_dprst_frac_params.csv` | `dprst_frac` | same | **PRMSRunoff**, PRMSSoilzone, PRMSEt | `:177` (`ratios:`) | `dprst.py` + `landmask.py` |
+| `nhm_dprst_depth_avg_params.csv` | `dprst_depth_avg` | same | **PRMSRunoff** | `:107` (`means:`) | `dprst_depth.py` + `dprst_depth/aggregate.py` |
+| ″ | `dprst_depth_provenance` | *provenance* | — | ″ | ″ |
+| `nhm_snarea_curve_params.csv` | `hru_deplcrv`, `snarea_thresh`, `snarea_curve_0..10` | `hru_deplcrv`, `snarea_thresh`, `snarea_curve` | PRMSSnow | `snarea_library.yml` | `snarea/library.py` ← `snarea/build.py` ← `aggregate/` |
+| ″ | 10 `cv_*`/diagnostic columns | *provenance* | — | ″ | ″ |
+| **`op_flow_thres_params.csv`** | `op_flow_thres` | same | **PRMSRunoff** | `depstor_rasters.yml:83` | `dprst_depth.py:361` |
+
+⚠️ = emitted column name is not the PRMS parameter name.
+
+**Name collision to respect:** `dprst_frac` appears in both `fractions:` (`:50`, a count
+CSV in `merged/_intermediates/`) and `ratios:` (`:177`, the PRMS param in `merged/`). Any
+name-keyed index must key on the `ratios:`/`means:`/`params:` families only, as
+`iter_declared_params` already does by excluding `fractions:` (`:422-435`).
+
+---
+
+## Design
+
+### A. `prms:` metadata — column-level, additive
+
+```yaml
+- name: ssflux
+  # ... every existing key unchanged ...
+  prms:
+    columns:
+      soil2gw_max:          {prms: soil2gw_max,          processes: [PRMSSoilzone]}
+      ssr2gw_rate:          {prms: ssr2gw_rate,          processes: [PRMSSoilzone]}
+      fastcoef_lin:         {prms: fastcoef_lin,         processes: [PRMSSoilzone]}
+      slowcoef_lin:         {prms: slowcoef_lin,         processes: [PRMSSoilzone]}
+      gwflow_coef:          {prms: gwflow_coef,          processes: [PRMSGroundwater]}
+      dprst_seep_rate_open: {prms: dprst_seep_rate_open, processes: [PRMSRunoff]}
+      dprst_flow_coef:      {prms: dprst_flow_coef,      processes: [PRMSRunoff]}
+    provenance:
+      k_perm_wtd:          litho-weighted permeability, flux-normalisation input
+      mean_slope_fraction: tan(radians(slope mean)), flux-normalisation input
+      hru_area:            fabric geometry.area in m² — NOT PRMS hru_area (acres)
+```
+
+**`processes:` must be per-column, not per-entry.** `ssflux` alone spans three processes
+across different columns; a flat entry-level `processes: [PRMSRunoff]` would make
+`params_for_process("PRMSRunoff")` return the whole file and report 5 non-runoff parameters
+as feeding runoff. The same applies to `lulc_nhm_v11` (`cov_type` → three processes,
+`srain_intcp` → Canopy only, `rad_trncf` → Snow only).
+
+**`provenance` is orthogonal to `fill_columns`, not a restatement of it.** `fill_columns`
+answers *"is this KNN-interpolable?"*; `prms.provenance` answers *"is this a PRMS
+parameter?"*. All four quadrants exist today:
+
+| | filled | not filled |
+| --- | --- | --- |
+| **is a PRMS param** | `soil_moist_max` (`zonal_params.yml:86`) | `op_flow_thres` — D1's defect |
+| **not a PRMS param** | elevation/slope/aspect's 8 stats (`:54`, `:62`, `:70`) | `dprst_depth_provenance` (`depstor_params.yml:118-123`), snarea's `cv_*` (`snarea_library.yml:14-18`), ssflux's `k_perm_wtd` (`zonal_params.yml:214-218`) |
+
+The elevation/slope/aspect stats are the load-bearing case: `zonal_params.yml:50-54`
+states explicitly that `count/std/min/25%/50%/75%/max/sum` are **not** provenance — "plain
+exactextract zonal statistics with no 'not derivable by design' meaning… safe, and
+desirable, to fill". They are filled *and* they are not PRMS parameters, so they belong in
+`prms.provenance` while remaining in `fill_columns`.
+
+**Alias groups.** `fill_columns` entries may be a list of alternatives, not only a string
+(`zonal_params.yml:128`; handled at `merge_and_fill_params.py:101-112`). `prms.columns`
+must carry **every** alternative as its own key, both mapping to the same PRMS name:
+
+```yaml
+  prms:
+    columns:
+      retention:  {prms: rad_trncf, processes: [PRMSSnow]}
+      rad_trncf:  {prms: rad_trncf, processes: [PRMSSnow]}
+```
+
+**`prms:` is mandatory, not optional**, for every entry `iter_declared_params` returns —
+otherwise Design C's guard passes vacuously, including on day one when no entry has one.
+The implementing PR adds it to all declared entries in the same commit as the guard.
+
+**Placement for `snarea_curve`:** `iter_declared_params` passes the **entire
+`snarea_library.yml` document** as the entry (`merge_and_fill_params.py:437-440`), so
+`prms:` is a top-level key there, alongside `library_file`/`validation_file`/`netcdf_file`
+— which are outputs of the same stage but not per-HRU parameter files, and are not covered
+by this spec.
+
+### B. `gfv2_params/params_index.py`
+
+Move `iter_declared_params` (`merge_and_fill_params.py:382-442`) into the package, widen
+`DeclaredParam` with a `prms` field, and import it back.
+
+**`DeclaredParam` is a `NamedTuple`, so equality is tuple equality.** Widening it breaks
+existing assertions that compare against 4-tuples —
+`tests/test_merge_and_fill_params.py:630`, `:631`, `:634`, plus positional constructions at
+`:737`, `:751`, `:762`. These **must be rewritten to attribute access in the same commit**,
+and `prms` must carry a default. This is not hypothetical: the `DeclaredParam` docstring
+(`:359-380`) exists because the last widening broke four consumption sites while "the test
+suite stayed green because its fixtures hand-built the OLD 3-tuple shape".
+
+Promotion is import-safe: `src/gfv2_params/__init__.py` contains only `__version__`, so
+`import gfv2_params.params_index` pulls in no geo libraries.
+
+### C. Two guards, because one cannot work
+
+The naive guard — "every `fill_columns` column is in `prms.columns` or `prms.provenance`" —
+runs *declaration → declaration* and therefore **cannot catch the D2/D3 class it was
+written for**. Measured against real headers it is a tautology on 12 entries, vacuous on 3,
+and crashes on the alias list:
+
+| Entry | `fill_columns` | on-disk payload cols | invisible to a declaration-only guard |
+| --- | --- | --- | --- |
+| `ssflux` | 7 | 10 | `k_perm_wtd`, `mean_slope_fraction`, `hru_area` |
+| `snarea_curve` | 13 | 23 | 10 `cv_*`/diagnostic columns |
+| `dprst_depth_avg` | 1 | 2 | `dprst_depth_provenance` |
+
+**Guard 1 (CI, YAML-only, no data root).** `prms.columns ∪ prms.provenance` is the
+**declared complete column list**. Assert it is a superset of
+`flatten(fill_columns) ∪ fabric_columns.keys()`. Alias lists are flattened; every
+alternative must appear. This makes the declaration self-consistent and catches a typo, but
+does not see disk.
+
+**Guard 2 (data-root-gated, skip-if-absent).** For each declared file present under
+`{fabric}/params/merged/`, assert the on-disk header equals
+`prms.columns ∪ prms.provenance ∪ {id_feature}`. This is the one that catches a new column
+appearing with no PRMS decision recorded. It cannot run in CI — `merge_and_fill_params.py:341-346`
+records the contract that "tests may parse these files but must not touch a real data root"
+— so it runs where the parity tests run, not on `ubuntu-latest`.
+
+Dropping the claim from the previous draft that this "mirrors `warn_undeclared_merged_files`":
+that guard runs disk → declaration, and only Guard 2 resembles it.
+
+### D. `op_flow_thres` → `merged/`
+
+Add a `constants:` list to `depstor_params.yml` and a fifth loop to `iter_declared_params`:
+
+```yaml
+constants:
+  - name: op_flow_thres
+    source: "{data_root}/{fabric}/depstor_rasters/op_flow_thres_params.csv"
+    merged_file: nhm_op_flow_thres_params.csv
+    fill_columns: [op_flow_thres]
+    prms:
+      columns: {op_flow_thres: {prms: op_flow_thres, processes: [PRMSRunoff]}}
+```
+
+**Not a `means:` entry**, which the previous draft proposed: `run_mean_zonal` does
+`raster_path = Path(spec["source_raster"])` unconditionally
+(`scripts/derive_depstor_params.py:259`) and `_find_mean` advertises every `means[].name`
+as a runnable `--mean` target (`:113-119`). `op_flow_thres` is a constant 1.0 built from
+the fabric's id list with no raster at all (`dprst_depth.py:361-387`), so a raster-less
+`means:` entry is a `KeyError` waiting for the first operator who types
+`--mean op_flow_thres`.
+
+A new `--mode copy_constants` performs the copy. Per the Hard-constraint table, adding a
+list element to a non-`params:`/non-`fractions:` list has no wrapper impact.
+
+The file is already per-HRU-complete (`dprst_depth.py:367-380` builds the id column from
+`ctx.hru_gpkg`; verified on disk: `nat_hru_id,op_flow_thres` / `1,1.0`), so the fill
+declaration is a no-op rather than a KNN pass.
+
+### F. `derived_columns:` — emit `hru_slope` (D0a)
+
+The pipeline hands modelers the PRMS quantity rather than a raw statistic plus a footnote.
+Config-driven, on the existing entry:
+
+```yaml
+- name: slope
+  # ... unchanged ...
+  derived_columns:
+    hru_slope: {from: mean, transform: deg_to_fraction}
+  prms:
+    columns:
+      hru_slope: {prms: hru_slope, processes: [PRMSSolarGeometry, PRMSAtmosphere]}
+    provenance:
+      mean:  mean cell slope in DEGREES — the raw stat hru_slope is derived from
+      count: {}   # …and the other 7 exactextract stats
+```
+
+`transform` names a function in `gfv2_params.raster_ops`; `deg_to_fraction`
+(`np.tan(np.deg2rad(x))`, `:264-266`) already exists and is what `ssflux.py:63` uses, so
+this makes the rest of the pipeline consistent with what `ssflux` already assumes rather
+than introducing a new convention. Applied in `run_merge`, so **no zonal re-run is needed**
+— `mean` is already on disk for every fabric.
+
+This resolves D0a and D2-for-slope together: the PRMS parameter now carries the PRMS name,
+and `mean` is explicitly demoted to provenance so the two slope-like columns cannot be
+confused.
+
+**Known approximation, recorded not fixed.** `tan(mean θ) ≠ mean(tan θ)`, and `tan` is
+convex, so this systematically *under*estimates. Measured over all 361,471 gfv2 HRUs
+(second-order Taylor from the on-disk `mean`/`std`): median **0.2%**, p90 2.4%, p99 5.6%.
+Too small to justify building a CONUS fractional-slope VRT — none exists; only per-VPU
+`Slope_pct_hydrodem_<vpu>.tif` from the opt-in hydrodem path
+(`compute_dem_derivatives.py:351`). `ssflux` has carried the same approximation since it was
+written.
+
+The mechanism is not single-use: D0b's fix needs the same `derived_columns:` shape, with
+`atan2` over two zonal means instead of a one-argument transform.
+
+### E. Generated `docs/parameter_index.md`
+
+`scripts/build_parameter_index.py` renders three views — by PRMS process, by config entry,
+by builder — from `params_index.py`. Nav entry in `mkdocs.yml` and a link from
+`docs/index.md` land **in the same commit as the file**, not later.
+
+---
+
+## Sequence
+
+| Step | Work |
+| --- | --- |
+| 1 | Hand-write `docs/parameter_index.md` from Deliverable 1, with nav entry. Zero code risk; forces D0–D3 to surface as concrete decisions; becomes the generator's acceptance target. |
+| 2 | `params_index.py` + `DeclaredParam` widening + the six test rewrites (B). |
+| 3 | `prms:` blocks for every declared entry + Guard 1 (A, C). |
+| 4 | Guard 2, wired where parity tests run. |
+| 5 | `constants:` + `--mode copy_constants` + `op_flow_thres` (D). |
+| 6 | `derived_columns:` + `hru_slope` (F). No zonal re-run; re-runs `--mode merge` for `slope` only. |
+| 7 | `build_parameter_index.py` replaces the hand-written index (E). |
+
+Steps 1–4 are independent of the Snakemake migration. Step 6 is where a
+`snakemake prms_runoff` target group becomes possible, but nothing here requires it.
+
+---
+
+## Testing
+
+- **Guard 1** — YAML-only, CI-safe, runs on `ubuntu-latest`.
+- **Guard 2** — data-root-gated, `pytest.skip` when absent. **Note this means CI will
+  report it green while skipping**; it is only meaningful where a data root exists, so its
+  result must be recorded manually, not inferred from a green CI badge.
+- **`params_index.py`** — port the existing `iter_declared_params` coverage from
+  `tests/test_merge_and_fill_params.py`, extended for `prms:`, with the six tuple-equality
+  assertions rewritten.
+
+Per `CLAUDE.md`, no `pytest` on the HPC head node.
+
+---
+
+## Scoped out — filed separately
+
+**D0b — `hru_aspect` circular mean.** Recorded above with its evidence, but not implemented
+here. It requires two new shared rasters (`sin(aspect)`, `cos(aspect)`), a config entry, a
+second zonal pass, an `atan2` combine, and a CONUS re-run — a builder change with a compute
+cost, not an index change. Folding it in would block a small shippable spec behind a large
+one. File as its own issue, referencing this spec for the measurement and TM6B9:603 for the
+required method.
+
+Until it lands, the index must mark `nhm_aspect_params.csv:mean` as **defective — not
+`hru_aspect`**, not merely as an undocumented rename. That is the whole point of having an
+index: it is better for a consumer to read "this column is wrong" than to read nothing and
+infer it is right.
+
+---
+
+## Could not verify
+
+- **`soils` → `soil_type`** — inference from the source raster (`TEXT_PRMS.tif`, soil
+  texture) plus TM6B9:786. No repo artifact asserts it.
+- **`mean` → `hru_elev`** — inference from `viz.py:505-507` plus TM6B9:601. Elevation is
+  not a circular or transformed quantity, so the arithmetic zonal mean is the right
+  statistic; only the *name* is undocumented. (`hru_slope` and `hru_aspect` are no longer
+  inferences — see D0a/D0b.)
+- **`retention` on `lulc_nalcms`/`nlcd`/`foresce`** — what PRMS parameter, if any, it
+  corresponds to. `lulc.py`'s derivation differs from the Beer's-law path; see D3.
+- **Which LULC source is the delivered one** — both `nhm_v11` and `nalcms` are on disk for
+  gfv2.
+- **pywatershed's process→parameter lists are pywatershed's view of PRMS**, not TM6B9's NHM
+  module set. They agreed everywhere spot-checked, but `hru_elev` appears in no pywatershed
+  process at all, so the two are not identical.
+- No `pytest` was run (head-node prohibition).

--- a/docs/superpowers/specs/2026-08-04-prms-parameter-index-design.md
+++ b/docs/superpowers/specs/2026-08-04-prms-parameter-index-design.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-08-04
 **Status:** design, awaiting review
-**Issue:** file on approval
+**Issue:** file on approval; D0b scoped out as #201
 **Companion:** `2026-08-04-snakemake-migration-design.md` (independent; this spec does not
 depend on it)
 
@@ -461,8 +461,8 @@ Per `CLAUDE.md`, no `pytest` on the HPC head node.
 here. It requires two new shared rasters (`sin(aspect)`, `cos(aspect)`), a config entry, a
 second zonal pass, an `atan2` combine, and a CONUS re-run — a builder change with a compute
 cost, not an index change. Folding it in would block a small shippable spec behind a large
-one. File as its own issue, referencing this spec for the measurement and TM6B9:603 for the
-required method.
+one. **Filed as issue #201**, carrying the measurement, the raster-boundary evidence, and
+TM6B9:603's required method.
 
 Until it lands, the index must mark `nhm_aspect_params.csv:mean` as **defective — not
 `hru_aspect`**, not merely as an undocumented rename. That is the whole point of having an

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -110,5 +110,6 @@ nav:
       - Depstor port summary: depstor_port_summary.md
       - VPU 01 validation: depstor_vpu01_validation_results.md
       - dprst_depth Phase 0 spike (#173): dprst_depth_spike.md
+  - Parameter index: parameter_index.md
   - API reference: api.md
   - Project conventions: conventions.md

--- a/scripts/build_depstor_rasters.py
+++ b/scripts/build_depstor_rasters.py
@@ -214,7 +214,37 @@ def main():
     unknown = set(step_index) - set(STEP_ORDER)
     if unknown:
         raise ValueError(f"Unknown step(s) in config: {sorted(unknown)}; expected subset of {STEP_ORDER}")
-    ordered_steps = [step_index[n] for n in STEP_ORDER if n in step_index]
+
+    # The reverse direction is the dangerous one, and it used to be silent.
+    #
+    # `ordered_steps` was built with `if n in step_index`, so a step registered in
+    # STEP_ORDER but absent from the YAML was simply DROPPED: the orchestrator logged a
+    # plausible-looking step count, ran the rest, and exited 0. Worse than a no-op --
+    # `_hydrate_existing_outputs` then pulls that step's artifact off disk from a PREVIOUS
+    # run with no validation, so a `--from dprst` cascade rebuild silently re-emits stale
+    # CONUS product. Same failure shape as the `endorheic_wbody` hazard in CLAUDE.md:
+    # a stale output directory is never a legitimate configuration, so fail loud.
+    #
+    # This is safe to require here because `configs/depstor/depstor_rasters.yml` is the
+    # ONE depstor raster config -- it is fabric-independent ({fabric} is templated, not
+    # duplicated), so every fabric runs the full stack and an omission is always a bug.
+    #
+    # Do NOT copy this guard to scripts/build_shared_rasters.py. That orchestrator's
+    # matching `if n in step_index` IS load-bearing: `compute_dem_derivatives` and
+    # `compute_breached_fdr` are opt-in steps deliberately absent from
+    # shared_rasters.yml (docs/ARCHITECTURE.md:299-305), so a strict guard there would
+    # break the normal path.
+    missing = set(STEP_ORDER) - set(step_index)
+    if missing:
+        raise ValueError(
+            f"Step(s) registered in STEP_ORDER but missing from the config: {sorted(missing)}. "
+            f"Every STEP_ORDER step must have a block in configs/depstor/depstor_rasters.yml -- "
+            f"a missing one would be skipped silently, and any downstream step would then "
+            f"consume the PREVIOUS run's artifact off disk. Add the step block, or remove the "
+            f"name from STEP_ORDER in src/gfv2_params/depstor_builders/__init__.py."
+        )
+
+    ordered_steps = [step_index[n] for n in STEP_ORDER]
 
     run_steps = _select_steps(ordered_steps, args.step, args.from_step)
 

--- a/scripts/derive_zonal_params.py
+++ b/scripts/derive_zonal_params.py
@@ -14,9 +14,10 @@ Three modes:
         Compute the CONUS-wide P2P weight matrix that ssflux consumes.
         Honours --force.
 
-The slurm wrapper slurm_batch/submit_zonal_params.sh loops every entry in
-configs/zonal/zonal_params.yml's `params:` list and chains all three modes into a
-per-param afterok DAG (with build_weights submitted first for entries that
+The slurm wrapper slurm_batch/submit_zonal_params.sh carries a hardcoded PARAMS
+bash array mirroring configs/zonal/zonal_params.yml's `params:` list (it does NOT
+read the YAML; tests/test_submit_wrapper_param_lists.py guards the pair) and chains
+all three modes into a per-param afterok DAG (with build_weights submitted first for entries that
 carry `depends_on: build_weights`).
 
 Pattern mirrors scripts/derive_depstor_params.py (PR #72).

--- a/scripts/merge_and_fill_params.py
+++ b/scripts/merge_and_fill_params.py
@@ -405,7 +405,7 @@ def iter_declared_params(
     whose `params_file` names the real `nhm_snarea_curve_params.csv`. A
     synthetic `snarea_curve` entry could not live in `zonal_params.yml`
     instead. `slurm_batch/submit_zonal_params.sh` does not read the YAML -- it
-    carries a hardcoded `PARAMS` bash array (`:68-79`) mirroring that `params:`
+    carries a hardcoded `PARAMS` bash array mirroring that `params:`
     list -- and `tests/test_submit_wrapper_param_lists.py` requires the two to
     match. So a phantom entry would have to be added to the array too, and the
     wrapper would then submit a SLURM array job for an entry with no

--- a/scripts/merge_and_fill_params.py
+++ b/scripts/merge_and_fill_params.py
@@ -404,10 +404,13 @@ def iter_declared_params(
     (`configs/snarea/snarea_library.yml`, Stage 3), a flat single-param config
     whose `params_file` names the real `nhm_snarea_curve_params.csv`. A
     synthetic `snarea_curve` entry could not live in `zonal_params.yml`
-    instead: `slurm_batch/submit_zonal_params.sh` loops that exact `params:`
-    list to submit one SLURM array job per param, and a phantom entry with no
-    `source_raster`/`script:` would break that orchestration. Hence the
-    separate optional argument rather than a fourth zonal-shaped list.
+    instead. `slurm_batch/submit_zonal_params.sh` does not read the YAML -- it
+    carries a hardcoded `PARAMS` bash array (`:68-79`) mirroring that `params:`
+    list -- and `tests/test_submit_wrapper_param_lists.py` requires the two to
+    match. So a phantom entry would have to be added to the array too, and the
+    wrapper would then submit a SLURM array job for an entry with no
+    `source_raster`/`script:`. Hence the separate optional argument rather than
+    a fourth zonal-shaped list.
     """
     def _record(name: str, merged_file: str, entry: dict) -> DeclaredParam:
         return DeclaredParam(

--- a/slurm_batch/RUNME.md
+++ b/slurm_batch/RUNME.md
@@ -351,7 +351,12 @@ THROTTLE=4                                                            # concurre
 **Zonal parameters** — run this pair for each `P`, in order: `elevation`,
 `slope`, `aspect`, `soils`, `soil_moist_max`, `lulc_nhm_v11`, `lulc_nalcms`,
 `lulc_nlcd`, `lulc_foresce`, and `ssflux` (`ssflux` last — it has an extra
-prereq, see below):
+prereq, see below).
+
+> **Note:** `lulc_nlcd` and `lulc_foresce` have no staged CONUS inputs
+> (`input/lulc_veg/{nlcd,foresce}/` are absent), so they fail on a gfv2 run
+> while the other eight merge normally. Skip them with
+> `export ZONAL_PARAMS="elevation slope aspect soils soil_moist_max lulc_nhm_v11 lulc_nalcms ssflux"`.
 
 ```bash
 P=elevation     # change P and re-run for each parameter above, in order

--- a/slurm_batch/submit_jobs.sh
+++ b/slurm_batch/submit_jobs.sh
@@ -15,9 +15,9 @@
 #
 # For the chained-merge workflows (zonal + depstor params), use the
 # dedicated wrappers instead:
-#   slurm_batch/submit_zonal_params.sh   (loops every zonal param, chains
+#   slurm_batch/submit_zonal_params.sh   (loops its own PARAMS array, chains
 #                                         array -> merge per param)
-#   slurm_batch/submit_depstor_params.sh (loops every depstor fraction,
+#   slurm_batch/submit_depstor_params.sh (loops its own FRACTIONS array,
 #                                         chains array -> merge -> ratios)
 
 set -euo pipefail

--- a/tests/test_expected_outputs.py
+++ b/tests/test_expected_outputs.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 import yaml
 
+from gfv2_params.depstor_builders import BUILDERS, STEP_ORDER
 from scripts.build_depstor_rasters import _expected_outputs
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -32,3 +33,51 @@ def test_every_configured_step_has_expected_outputs():
             f"'{step['name']}' — every step in depstor_rasters.yml must be "
             f"mapped so --step/--from resume works without a KeyError."
         )
+
+
+def test_config_steps_and_step_order_agree():
+    """Every STEP_ORDER step must have a config block, and vice versa.
+
+    The orchestrator raises on both directions now (`build_depstor_rasters.main`), but
+    this catches the drift in CI at the moment someone edits either file, rather than on
+    a CONUS run hours later.
+
+    The dangerous direction is STEP_ORDER -> config. Before the guard, `ordered_steps`
+    was built with `if n in step_index`, so a registered-but-unconfigured step was
+    silently dropped and `_hydrate_existing_outputs` then served the PREVIOUS run's
+    artifact for its output key -- a `--from dprst` rebuild would re-emit stale CONUS
+    product at exit 0.
+
+    Set equality, not list: the YAML deliberately lists steps in a different order from
+    STEP_ORDER (`waterbody` and `segment_wbody` are swapped), which is fine because the
+    orchestrator re-sorts by STEP_ORDER. Only membership is a contract.
+
+    NB this assertion is correct for depstor and would be WRONG for shared_rasters,
+    whose config deliberately omits the opt-in `compute_dem_derivatives` and
+    `compute_breached_fdr` steps (docs/ARCHITECTURE.md:299-305).
+    """
+    config = yaml.safe_load(CONFIG_PATH.read_text())
+    configured = {s["name"] for s in config["steps"]}
+
+    assert configured == set(STEP_ORDER), (
+        f"depstor_rasters.yml and STEP_ORDER disagree.\n"
+        f"  registered but not configured (SILENTLY SKIPPED before the guard): "
+        f"{sorted(set(STEP_ORDER) - configured)}\n"
+        f"  configured but not registered (raises at startup): "
+        f"{sorted(configured - set(STEP_ORDER))}"
+    )
+
+
+def test_every_step_order_entry_has_a_builder():
+    """STEP_ORDER and BUILDERS must cover the same steps.
+
+    `build_depstor_rasters` does `BUILDERS[name]`, so a STEP_ORDER entry with no builder
+    raises KeyError -- but only after every prior step has already run, which at CONUS
+    scale is hours of wasted compute. `gfv2_params.shared_rasters` has had this
+    assertion since its orchestrator landed (tests/test_shared_rasters_orchestrator.py);
+    the depstor package never got one.
+    """
+    assert set(STEP_ORDER) == set(BUILDERS.keys()), (
+        f"STEP_ORDER without a builder: {sorted(set(STEP_ORDER) - set(BUILDERS))}; "
+        f"builders not in STEP_ORDER: {sorted(set(BUILDERS) - set(STEP_ORDER))}"
+    )

--- a/tests/test_merge_and_fill_params.py
+++ b/tests/test_merge_and_fill_params.py
@@ -510,11 +510,13 @@ def test_categorical_dtype_is_restored(tmp_path):
 # (configs/snarea/snarea_library.yml, Stage 3), a FLAT single-param config
 # (no `params:`/`fractions:` list, no per-entry `name:`) whose `params_file`
 # names the real `nhm_snarea_curve_params.csv`. Folding a synthetic
-# `snarea_curve` entry into zonal_params.yml's `params:` list would also feed
-# slurm_batch/submit_zonal_params.sh, which loops that exact list to submit
-# one SLURM array job per param — a phantom entry with no `source_raster`/
-# `script:` would break that orchestration. So `snarea_curve` is checked
-# separately below, against its real config file.
+# `snarea_curve` entry into zonal_params.yml's `params:` list would also reach
+# slurm_batch/submit_zonal_params.sh. That wrapper does not read the YAML — it
+# carries a hardcoded PARAMS bash array (:68-79) mirroring that list, and
+# tests/test_submit_wrapper_param_lists.py requires the two to match — so the
+# phantom would have to be added to the array as well, and the wrapper would
+# then submit a SLURM array job for an entry with no `source_raster`/`script:`.
+# So `snarea_curve` is checked separately below, against its real config file.
 # ---------------------------------------------------------------------------
 
 _PARAM_LIST_KEYS = ("params", "fractions", "means", "ratios")

--- a/tests/test_merge_and_fill_params.py
+++ b/tests/test_merge_and_fill_params.py
@@ -512,7 +512,7 @@ def test_categorical_dtype_is_restored(tmp_path):
 # names the real `nhm_snarea_curve_params.csv`. Folding a synthetic
 # `snarea_curve` entry into zonal_params.yml's `params:` list would also reach
 # slurm_batch/submit_zonal_params.sh. That wrapper does not read the YAML — it
-# carries a hardcoded PARAMS bash array (:68-79) mirroring that list, and
+# carries a hardcoded PARAMS bash array mirroring that list, and
 # tests/test_submit_wrapper_param_lists.py requires the two to match — so the
 # phantom would have to be added to the array as well, and the wrapper would
 # then submit a SLURM array job for an entry with no `source_raster`/`script:`.

--- a/tests/test_submit_wrapper_param_lists.py
+++ b/tests/test_submit_wrapper_param_lists.py
@@ -65,7 +65,9 @@ def _bash_array(script: Path, name: str) -> list[str]:
 def test_wrapper_array_matches_config_names(script_rel, array_name, config_rel, config_key):
     script = _REPO_ROOT / script_rel
     config = _REPO_ROOT / config_rel
-    if not script.exists():
+    # Guard BOTH sides: if the migration retires the config as well as the wrapper,
+    # `yaml.safe_load(...)[config_key]` would raise KeyError instead of skipping.
+    if not script.exists() or not config.exists():
         pytest.skip(f"{script_rel} retired by the Snakemake migration -- delete this test")
 
     from_bash = _bash_array(script, array_name)

--- a/tests/test_submit_wrapper_param_lists.py
+++ b/tests/test_submit_wrapper_param_lists.py
@@ -1,0 +1,75 @@
+"""The submit wrappers retype the config's `name:` lists; nothing else checks them.
+
+``slurm_batch/submit_zonal_params.sh`` does NOT read the YAML -- it carries a hardcoded
+bash array (``PARAMS``) and exports ``PARAM=<name>`` per element, and
+``scripts/derive_zonal_params.py`` then does a flat linear scan for a matching ``name:``.
+``submit_depstor_params.sh`` has the same shape with ``FRACTIONS``.
+
+So a param added to the YAML and forgotten in the array is silently NOT RUN, and the
+wrapper still exits 0. This test is the only thing that catches that.
+
+DELETE ME when the Snakemake migration retires the wrappers -- a Snakefile reads the YAML
+directly, so the duplication (and this guard) disappear. See
+``docs/superpowers/specs/2026-08-04-snakemake-migration-design.md``.
+
+Pure text + ``yaml.safe_load``: no geo imports, no data root, so it is CI-safe and
+head-node-safe.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _bash_array(script: Path, name: str) -> list[str]:
+    """Extract a ``NAME=( ... )`` bash array, dropping comments and blank lines."""
+    text = script.read_text()
+    match = re.search(rf"^{name}=\((.*?)^\)", text, re.S | re.M)
+    assert match, f"could not find a {name}=( ... ) array in {script}"
+    return [
+        line.split("#")[0].strip()
+        for line in match.group(1).strip().splitlines()
+        if line.split("#")[0].strip()
+    ]
+
+
+@pytest.mark.parametrize(
+    ("script_rel", "array_name", "config_rel", "config_key"),
+    [
+        (
+            "slurm_batch/submit_zonal_params.sh",
+            "PARAMS",
+            "configs/zonal/zonal_params.yml",
+            "params",
+        ),
+        (
+            "slurm_batch/submit_depstor_params.sh",
+            "FRACTIONS",
+            "configs/depstor/depstor_params.yml",
+            "fractions",
+        ),
+    ],
+)
+def test_wrapper_array_matches_config_names(script_rel, array_name, config_rel, config_key):
+    script = _REPO_ROOT / script_rel
+    config = _REPO_ROOT / config_rel
+    if not script.exists():
+        pytest.skip(f"{script_rel} retired by the Snakemake migration -- delete this test")
+
+    from_bash = _bash_array(script, array_name)
+    from_yaml = [entry["name"] for entry in yaml.safe_load(config.read_text())[config_key]]
+
+    assert from_bash == from_yaml, (
+        f"{script_rel}'s {array_name} array has drifted from {config_rel}'s "
+        f"`{config_key}:` names.\n"
+        f"  bash: {from_bash}\n"
+        f"  yaml: {from_yaml}\n"
+        f"Order matters as well as membership: the wrapper submits in array order, and "
+        f"ssflux must follow slope because it reads the merged slope CSV at zonal time."
+    )

--- a/tests/test_submit_wrapper_param_lists.py
+++ b/tests/test_submit_wrapper_param_lists.py
@@ -9,8 +9,14 @@ So a param added to the YAML and forgotten in the array is silently NOT RUN, and
 wrapper still exits 0. This test is the only thing that catches that.
 
 DELETE ME when the Snakemake migration retires the wrappers -- a Snakefile reads the YAML
-directly, so the duplication (and this guard) disappear. See
-``docs/superpowers/specs/2026-08-04-snakemake-migration-design.md``.
+directly, so the duplication (and this guard) disappear. Tracked as issue #141.
+
+Scope limit: this pins the DEFAULT ``PARAMS`` array only. ``submit_zonal_params.sh``
+supports a ``ZONAL_PARAMS`` environment override that replaces the array wholesale at
+runtime, and gfv2 in practice runs 8 of the 10 params because two LULC sources have
+unstaged inputs. So a green result here does NOT mean all declared params run on a given
+fabric -- it means the checked-in default and the config agree. Subsetting a run is what
+``ZONAL_PARAMS`` is for; commenting out array elements will fail this test, by design.
 
 Pure text + ``yaml.safe_load``: no geo imports, no data root, so it is CI-safe and
 head-node-safe.


### PR DESCRIPTION
Answers a question the repo could not: **which parameters feed PRMS runoff?**

The layout is organised by HOW a parameter is computed (`zonal_runners/` / `depstor_builders/` / `snarea/` / `aggregate/`; one config per stage) — the right axis for code, the wrong one for that question. This adds the missing metadata axis as documentation. **No source files move.**

## ⚠️ Scope expansion

Per CLAUDE.md, leading with this. The plan (`docs/superpowers/plans/2026-08-04-prms-parameter-index.md`) scoped PR 1 as Tasks 1–2 (docs + one guard test). Three things exceeded that:

1. **`6b7547a` is a depstor orchestrator fix**, not documentation — a silent-corruption guard found during review of this PR. Self-contained and small, but it is unrelated code on a docs branch. **Say the word and I'll move it to its own branch before merge.**
2. Task 2's grep found the false claim in **six** sites, not the two the plan anticipated — including `README.md` twice and `scripts/derive_zonal_params.py`.
3. Two existing docs contradicted the new index and needed correcting (`depstor_workflow.md`, `RUNME.md`).

## What lands

**`docs/parameter_index.md`** — every parameter emitted to `{fabric}/params/merged/`, in three views (by PRMS process, by config entry, by builder). Process membership is from `pywatershed.<Process>.get_parameters()` (2.0.4, `reference` env), not inference; column lists are observed on-disk headers.

**The answer: PRMSRunoff takes 11 parameters**, spread across 3 configs, 4 builder packages, and 2 output directories.

## Three product findings

| Finding | Status |
| --- | --- |
| **`hru_slope` is degrees; PRMS wants rise/run** — `slope.vrt` is `rd.TerrainAttribute(..., "slope_degrees")`, so `mean` is degrees. ~57×. gfv2 HRU 1: `mean=4.4252` → `hru_slope=0.0774`. The pipeline is fine (`ssflux.py:63` converts) but nothing *emits* `hru_slope`. | documented; emit decided, lands in Task 7 |
| **`hru_aspect` is DEFECTIVE** — arithmetic mean of a circular variable. TM6B9:603 requires `atan2(mean(sin), mean(cos))`. Median 179.4° across 361,471 HRUs (due south), IQR 152–208. Not repairable from disk. | scoped out → **#201** |
| **`op_flow_thres` is outside `merged/`** — a PRMSRunoff parameter in `depstor_rasters/`, invisible to `iter_declared_params` and `warn_undeclared_merged_files`. Globbing `merged/nhm_*_params.csv` silently drops it. | documented; moved in Task 6 |

The aspect one was a *known* simplification (recorded in `notebooks/_archive/check_params.ipynb`) whose magnitude was never measured. The measurement is what changes the verdict — which is also why CODE-4 must audit that directory before deleting it.

## The add-a-param trap

`ADDING_A_PARAMETER.md` told newcomers the submit wrapper "loops every entry in the YAML." It does not — it carries a hardcoded `PARAMS` bash array. A param added to the YAML and forgotten there is silently **not run**, and the wrapper exits 0.

Fixed in six sites, plus `tests/test_submit_wrapper_param_lists.py` guarding both wrappers' arrays against their configs (membership **and** order — `ssflux` must follow `slope`). Verified it fails on injected drift, not merely that it passes today.

## Depstor `STEP_ORDER` guard (`6b7547a`)

`build_depstor_rasters` used `[step_index[n] for n in STEP_ORDER if n in step_index]` — a step registered in `STEP_ORDER` but absent from `depstor_rasters.yml` was **silently dropped**, and `_hydrate_existing_outputs` then served the *previous* run's artifact for its output key. A `--from dprst` rebuild would re-emit stale CONUS product at exit 0.

**Deliberately not applied to `build_shared_rasters.py`**, which has the identical line. There it is load-bearing: `compute_dem_derivatives` and `compute_breached_fdr` are opt-in steps intentionally absent from the config (STEP_ORDER 11 vs config 9). Both the code comment and the test docstring record the asymmetry.

## Review

Three specialist agents (comment accuracy, test coverage, general/CLAUDE.md). They verified ~105 claims correct — all pywatershed memberships re-derived independently, all 16 on-disk headers, all TM 6-B9 cites, all measurements reproducing to stated precision. They also found, and this PR fixes:

- the front-door summary said "three columns" when five are renames, and named a *different* three
- `depstor_rasters.yml:83` → `:77` (I had taken `:83` from an automated audit without re-verifying)
- a Taylor **estimate** published as a **measurement**
- the test's "delete me when…" pointer citing a file on another branch
- the grep pattern that missed six sites

## Testing

- `pixi run -e docs docs-build` clean; `site/parameter_index/index.html` renders
- guard test green for both wrappers; verified it goes red on injected drift
- `STEP_ORDER` guard simulated: dropping `dprst_depth` or `wbody_connectivity` gave 15 silent steps before, raises now
- `py_compile` + pre-commit pass

**Not run:** `pytest` (CLAUDE.md head-node prohibition — CI is the gate), and the **shellcheck hook could not run locally** (requires docker, unavailable on this host). `submit_jobs.sh`'s change is comment-only and `bash -n` passes, but shellcheck will run for real in CI.

## Follow-ups

Tasks 3–8 (the `prms:` config schema, two guards, `constants:`/`op_flow_thres`, `derived_columns:`/`hru_slope`, generator) are planned but deliberately held until the index rows are reviewed — they commit to the mapping.

Two mappings remain inferences, flagged in "Unverified mappings": `soils`→`soil_type` and `mean`→`hru_elev`. Neither has a repo artifact asserting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
