### PR TITLE
PRMS parameter index: generate it from configs/ (plan Tasks 3-8)

### DIFF
--- a/configs/depstor/depstor_params.yml
+++ b/configs/depstor/depstor_params.yml
@@ -121,6 +121,16 @@ means:
     # not a PRMS parameter -- and is deliberately excluded, same reasoning as
     # snarea_curve's cv_* columns.
     fill_columns: [dprst_depth_avg]
+    prms:
+      builder: depstor_builders/dprst_depth.py + dprst_depth/aggregate.py
+      columns:
+        dprst_depth_avg:
+          prms: dprst_depth_avg
+          processes: [PRMSRunoff]
+      provenance:
+        dprst_depth_provenance:
+          how each HRU's depth was derived (3dep_raw / hollister_flat /
+          calibrated / no_dprst_cells)
 
 # Ratio derivations -- final PRMS parameters in {output_dir}/{merged_subdir}/.
 # numerator/denominator reference fraction `name`s above; derive_depstor_params
@@ -137,6 +147,13 @@ ratios:
     clamp_to_one: false
     output_file: nhm_sro_to_dprst_perv_params.csv
     fill_columns: [sro_to_dprst_perv]
+    prms:
+      builder: depstor_builders/same_hru_drains.py + perv.py
+      columns:
+        sro_to_dprst_perv:
+          prms: sro_to_dprst_perv
+          processes: [PRMSRunoff]
+      provenance: {}
 
   - name: sro_to_dprst_imperv
     numerator: drains_imperv_frac
@@ -144,6 +161,13 @@ ratios:
     clamp_to_one: false
     output_file: nhm_sro_to_dprst_imperv_params.csv
     fill_columns: [sro_to_dprst_imperv]
+    prms:
+      builder: depstor_builders/same_hru_drains.py + imperv.py
+      columns:
+        sro_to_dprst_imperv:
+          prms: sro_to_dprst_imperv
+          processes: [PRMSRunoff]
+      provenance: {}
 
   - name: carea_max
     numerator: carea_t8_frac
@@ -151,6 +175,13 @@ ratios:
     clamp_to_one: true
     output_file: nhm_carea_max_params.csv
     fill_columns: [carea_max]
+    prms:
+      builder: depstor_builders/carea_map.py
+      columns:
+        carea_max:
+          prms: carea_max
+          processes: [PRMSRunoff]
+      provenance: {}
 
   - name: smidx_coef
     numerator: carea_t156_frac
@@ -158,6 +189,13 @@ ratios:
     clamp_to_one: true
     output_file: nhm_smidx_coef_params.csv
     fill_columns: [smidx_coef]
+    prms:
+      builder: depstor_builders/carea_map.py
+      columns:
+        smidx_coef:
+          prms: smidx_coef
+          processes: [PRMSRunoff]
+      provenance: {}
 
   # imperv_count / hru_pixel_count -- per-HRU fraction of land area classified
   # as impervious. Bounded in [0, 1] by construction.
@@ -167,6 +205,15 @@ ratios:
     clamp_to_one: false
     output_file: nhm_hru_percent_imperv_params.csv
     fill_columns: [hru_percent_imperv]
+    prms:
+      builder: depstor_builders/imperv.py + landmask.py
+      columns:
+        hru_percent_imperv:
+          {
+            prms: hru_percent_imperv,
+            processes: [PRMSRunoff, PRMSSoilzone, PRMSEt],
+          }
+      provenance: {}
 
   # dprst_count / hru_pixel_count -- per-HRU fraction of land area classified
   # as depression storage. Bounded in [0, 1] by construction.
@@ -180,3 +227,10 @@ ratios:
     clamp_to_one: false
     output_file: nhm_dprst_frac_params.csv
     fill_columns: [dprst_frac]
+    prms:
+      builder: depstor_builders/dprst.py + landmask.py
+      columns:
+        dprst_frac:
+          prms: dprst_frac
+          processes: [PRMSRunoff, PRMSSoilzone, PRMSEt]
+      provenance: {}

--- a/configs/depstor/depstor_params.yml
+++ b/configs/depstor/depstor_params.yml
@@ -234,3 +234,32 @@ ratios:
           prms: dprst_frac
           processes: [PRMSRunoff, PRMSSoilzone, PRMSEt]
       provenance: {}
+
+# Constant per-HRU params a depstor BUILDER writes directly, with no zonal pass.
+# Copied into merged/ by `--mode copy_constants` so the "everything a consumer
+# needs is in merged/" invariant holds. Before this list existed, op_flow_thres
+# was invisible both to iter_declared_params AND to warn_undeclared_merged_files
+# (which globs merged_dir), so anyone assembling a parameter file by globbing
+# merged/nhm_*_params.csv silently dropped a PRMSRunoff parameter.
+#
+# NOT a `means:` entry: run_mean_zonal does Path(spec["source_raster"])
+# unconditionally and _find_mean advertises every means[].name as a runnable
+# --mean target, so a raster-less means entry is a KeyError waiting for the first
+# operator who types `--mean op_flow_thres`. op_flow_thres is a constant 1.0 built
+# from the fabric's id list (depstor_builders/dprst_depth.py:361-387) with no
+# raster at all.
+constants:
+  - name: op_flow_thres
+    source: "{data_root}/{fabric}/depstor_rasters/op_flow_thres_params.csv"
+    merged_file: nhm_op_flow_thres_params.csv
+    # A no-op rather than a KNN pass: the builder already writes one row per HRU
+    # (the id column comes from ctx.hru_gpkg), so there is no gap to fill. Declared
+    # anyway so the fill sweep's own guards see the file.
+    fill_columns: [op_flow_thres]
+    prms:
+      builder: depstor_builders/dprst_depth.py
+      columns:
+        op_flow_thres:
+          prms: op_flow_thres
+          processes: [PRMSRunoff]
+      provenance: {}

--- a/configs/snarea/snarea_library.yml
+++ b/configs/snarea/snarea_library.yml
@@ -31,6 +31,65 @@ fill_columns:
   - snarea_curve_9
   - snarea_curve_10
 
+# iter_declared_params passes this WHOLE document as the entry (snarea_curve is
+# not a zonal_params.yml `params:` element -- it comes from the separate 3-stage
+# SNODAS pipeline), so `prms:` is a top-level key here rather than a per-entry one.
+# The 11 snarea_curve_N columns are one PRMS parameter, snarea_curve, which is
+# dimensioned (ndeplval) in PRMS -- hence 11 columns mapping to one name.
+prms:
+  builder: snarea/library.py
+  columns:
+    hru_deplcrv:
+      prms: hru_deplcrv
+      processes: [PRMSSnow]
+    snarea_thresh:
+      prms: snarea_thresh
+      processes: [PRMSSnow]
+    snarea_curve_0:
+      prms: snarea_curve
+      processes: [PRMSSnow]
+    snarea_curve_1:
+      prms: snarea_curve
+      processes: [PRMSSnow]
+    snarea_curve_2:
+      prms: snarea_curve
+      processes: [PRMSSnow]
+    snarea_curve_3:
+      prms: snarea_curve
+      processes: [PRMSSnow]
+    snarea_curve_4:
+      prms: snarea_curve
+      processes: [PRMSSnow]
+    snarea_curve_5:
+      prms: snarea_curve
+      processes: [PRMSSnow]
+    snarea_curve_6:
+      prms: snarea_curve
+      processes: [PRMSSnow]
+    snarea_curve_7:
+      prms: snarea_curve
+      processes: [PRMSSnow]
+    snarea_curve_8:
+      prms: snarea_curve
+      processes: [PRMSSnow]
+    snarea_curve_9:
+      prms: snarea_curve
+      processes: [PRMSSnow]
+    snarea_curve_10:
+      prms: snarea_curve
+      processes: [PRMSSnow]
+  provenance:
+    cv_assign: assigned CV bin
+    cv_subgrid: sub-grid CV estimate
+    cv_empirical: empirical CV -- derivable for only ~42% of HRUs BY DESIGN
+    cv_source: which CV estimate was used
+    sdc_status: derivation status
+    sca_class: snow-covered-area class
+    similarity: scale-free SDC similarity metric
+    n_seasons: seasons contributing
+    n_peak_years: peak years contributing
+    peak_swe_mm: peak SWE driving snarea_thresh
+
 ndepl_cv: 8 # 8 CV bins + 1 reserved default = ndepl 9 (grouping memory: elbow 5-8)
 calibrate: auto # auto | on | off
 calibrate_bias_tol: 0.1 # |median(cv_subgrid) - median(cv_empirical)| trigger

--- a/configs/zonal/zonal_params.yml
+++ b/configs/zonal/zonal_params.yml
@@ -295,7 +295,7 @@ params:
 
     # `retention` here is NOT `rad_trncf`. lulc.py:186-193 computes
     # zonal_mean(keep)/100 or the crosswalk's evergreen_retention column -- no
-    # Beer's-law step. The module DOES carry a rad_trncf path (lulc.py:194-239),
+    # Beer's-law step. The module DOES carry a rad_trncf path (lulc.py:195-243),
     # but it is gated on `radtrn_raster`, which no `script: lulc` entry
     # configures, so it never runs for these three. Mapping it to rad_trncf would
     # assert two different derivations are the same PRMS parameter; it stays in
@@ -353,7 +353,7 @@ params:
 
     # `retention` here is NOT `rad_trncf`. lulc.py:186-193 computes
     # zonal_mean(keep)/100 or the crosswalk's evergreen_retention column -- no
-    # Beer's-law step. The module DOES carry a rad_trncf path (lulc.py:194-239),
+    # Beer's-law step. The module DOES carry a rad_trncf path (lulc.py:195-243),
     # but it is gated on `radtrn_raster`, which no `script: lulc` entry
     # configures, so it never runs for these three. Mapping it to rad_trncf would
     # assert two different derivations are the same PRMS parameter; it stays in
@@ -411,7 +411,7 @@ params:
 
     # `retention` here is NOT `rad_trncf`. lulc.py:186-193 computes
     # zonal_mean(keep)/100 or the crosswalk's evergreen_retention column -- no
-    # Beer's-law step. The module DOES carry a rad_trncf path (lulc.py:194-239),
+    # Beer's-law step. The module DOES carry a rad_trncf path (lulc.py:195-243),
     # but it is gated on `radtrn_raster`, which no `script: lulc` entry
     # configures, so it never runs for these three. Mapping it to rad_trncf would
     # assert two different derivations are the same PRMS parameter; it stays in

--- a/configs/zonal/zonal_params.yml
+++ b/configs/zonal/zonal_params.yml
@@ -52,6 +52,31 @@ params:
     # "not derivable by design" meaning, unlike snarea_curve's cv_* columns
     # below -- so all are safe, and desirable, to fill for a missing HRU.
     fill_columns: [count, mean, std, min, "25%", "50%", "75%", max, sum]
+    # `prms.provenance` here is NOT a restatement of the note above. These eight
+    # ARE in fill_columns and ARE safe to fill; provenance answers a DIFFERENT
+    # question -- "is this a PRMS parameter?" -- and they are not. All four
+    # quadrants of (filled / not filled) x (PRMS param / not) exist in this repo.
+    prms:
+      builder: zonal_runners/zonal.py
+      columns:
+        # processes: [] -- hru_elev appears in NO pywatershed Process.get_parameters()
+        # list. PRMS consumes it in the temperature/precipitation distribution
+        # modules, which pywatershed handles by reading CBH files instead, and in
+        # the cov_type reset rule at TM6B9:707 (HRUs above 11,500 ft). An empty
+        # list is the honest answer; naming a process pywatershed does not have
+        # would put a phantom heading in the generated index.
+        mean:
+          prms: hru_elev
+          processes: []
+      provenance:
+        count: exactextract cell count
+        std: within-HRU standard deviation
+        min: within-HRU minimum
+        "25%": within-HRU 25th percentile
+        "50%": within-HRU median
+        "75%": within-HRU 75th percentile
+        max: within-HRU maximum
+        sum: within-HRU sum
 
   - name: slope
     script: zonal
@@ -60,6 +85,30 @@ params:
     merged_file: nhm_slope_params.csv
     # Same value-column set as elevation (observed on-disk; same zonal script).
     fill_columns: [count, mean, std, min, "25%", "50%", "75%", max, sum]
+    prms:
+      builder: zonal_runners/zonal.py
+      columns: {}
+      # `mean` is DEGREES: slope.vrt is rd.TerrainAttribute(dem, "slope_degrees")
+      # (shared_rasters/compute_slope_aspect.py:72), while PRMS hru_slope is a
+      # decimal fraction rise/run (TM6B9:536) -- ~57x for small angles. Declared as
+      # a defect rather than as `mean: {prms: hru_slope}`, because that mapping
+      # would assert the degrees column IS the parameter, which is the defect.
+      # Unlike aspect below, this one is recoverable from what is on disk.
+      defects:
+        mean:
+          prms: hru_slope
+          processes: [PRMSSolarGeometry, PRMSAtmosphere]
+          reason: emitted in degrees; PRMS hru_slope is a decimal fraction rise/run
+          recovery: tan(radians(mean))
+      provenance:
+        count: exactextract cell count
+        std: within-HRU standard deviation
+        min: within-HRU minimum
+        "25%": within-HRU 25th percentile
+        "50%": within-HRU median
+        "75%": within-HRU 75th percentile
+        max: within-HRU maximum
+        sum: within-HRU sum
 
   - name: aspect
     script: zonal
@@ -68,6 +117,32 @@ params:
     merged_file: nhm_aspect_params.csv
     # Same value-column set as elevation (observed on-disk; same zonal script).
     fill_columns: [count, mean, std, min, "25%", "50%", "75%", max, sum]
+    prms:
+      builder: zonal_runners/zonal.py
+      columns: {}
+      # DEFECTIVE, not merely renamed. `mean` is an ARITHMETIC mean of a CIRCULAR
+      # variable; TM6B9:603 requires atan2(mean(sin), mean(cos)). Measured across
+      # all 361,471 gfv2 HRUs the median is 179.4 deg (due south), IQR 151.7-207.5
+      # -- that central tendency is the artifact, not the terrain. Unlike slope
+      # above there is no recovery: a circular mean cannot be reconstructed from
+      # an arithmetic one. Fixing it needs sin/cos rasters and a second zonal
+      # pass. Tracked as issue #201.
+      defects:
+        mean:
+          prms: hru_aspect
+          processes: [PRMSSolarGeometry, PRMSAtmosphere]
+          reason: arithmetic mean of a circular variable; TM6B9:603 requires atan2(mean(sin), mean(cos))
+          recovery: none -- not reconstructable from what is on disk
+          issue: 201
+      provenance:
+        count: exactextract cell count
+        std: within-HRU standard deviation
+        min: within-HRU minimum
+        "25%": within-HRU 25th percentile
+        "50%": within-HRU median
+        "75%": within-HRU 75th percentile
+        max: within-HRU maximum
+        sum: within-HRU sum
 
   # --- Soils (categorical + continuous via the same script dispatcher) ---
 
@@ -77,6 +152,17 @@ params:
     categorical: true
     merged_file: nhm_soils_params.csv
     fill_columns: [soils]
+    # IDENTITY mapping under a different name: TEXT_PRMS.tif is already in PRMS
+    # soil_type encoding (1=sand, 2=loam, 3=clay), verified against the raster's
+    # own cell counts. The ScienceBase metadata's edom block transposes sand and
+    # clay and is WRONG -- see docs/parameter_index.md's Known gaps.
+    prms:
+      builder: zonal_runners/soils.py
+      columns:
+        soils:
+          prms: soil_type
+          processes: [PRMSSoilzone]
+      provenance: {}
 
   - name: soil_moist_max
     script: soils
@@ -84,6 +170,13 @@ params:
     categorical: false
     merged_file: nhm_soil_moist_max_params.csv
     fill_columns: [soil_moist_max]
+    prms:
+      builder: zonal_runners/soils.py
+      columns:
+        soil_moist_max:
+          prms: soil_moist_max
+          processes: [PRMSRunoff, PRMSSoilzone]
+      provenance: {}
 
   # --- LULC sources (each derives cov_type / covden / interception + rad_trncf
   #     or retention) ---
@@ -127,6 +220,37 @@ params:
         covden_win,
         [retention, rad_trncf],
       ]
+    # BOTH alias alternatives are declared, mapping to the same PRMS name, so a
+    # fabric of either vintage is covered. Guard 1 flattens the alias group and
+    # requires every alternative, so declaring only one would fail.
+    prms:
+      builder: zonal_runners/lulc_prederived.py
+      columns:
+        cov_type:
+          prms: cov_type
+          processes: [PRMSCanopy, PRMSSnow, PRMSSoilzone]
+        covden_sum:
+          prms: covden_sum
+          processes: [PRMSCanopy, PRMSSnow]
+        covden_win:
+          prms: covden_win
+          processes: [PRMSCanopy, PRMSSnow]
+        srain_intcp:
+          prms: srain_intcp
+          processes: [PRMSCanopy]
+        wrain_intcp:
+          prms: wrain_intcp
+          processes: [PRMSCanopy]
+        snow_intcp:
+          prms: snow_intcp
+          processes: [PRMSCanopy]
+        retention:
+          prms: rad_trncf
+          processes: [PRMSSnow]
+        rad_trncf:
+          prms: rad_trncf
+          processes: [PRMSSnow]
+      provenance: {}
 
   # NALCMS 2020: no keep raster -> crosswalk evergreen_retention column.
 
@@ -148,6 +272,39 @@ params:
         covden_win,
         retention,
       ]
+
+    # `retention` here is NOT `rad_trncf`. lulc.py:186-193 computes
+    # zonal_mean(keep)/100 or the crosswalk's evergreen_retention column -- no
+    # Beer's-law step. The module DOES carry a rad_trncf path (lulc.py:194-239),
+    # but it is gated on `radtrn_raster`, which no `script: lulc` entry
+    # configures, so it never runs for these three. Mapping it to rad_trncf would
+    # assert two different derivations are the same PRMS parameter; it stays in
+    # provenance until someone verifies what, if anything, it corresponds to.
+    prms:
+      builder: zonal_runners/lulc.py
+      columns:
+        cov_type:
+          prms: cov_type
+          processes: [PRMSCanopy, PRMSSnow, PRMSSoilzone]
+        covden_sum:
+          prms: covden_sum
+          processes: [PRMSCanopy, PRMSSnow]
+        covden_win:
+          prms: covden_win
+          processes: [PRMSCanopy, PRMSSnow]
+        srain_intcp:
+          prms: srain_intcp
+          processes: [PRMSCanopy]
+        wrain_intcp:
+          prms: wrain_intcp
+          processes: [PRMSCanopy]
+        snow_intcp:
+          prms: snow_intcp
+          processes: [PRMSCanopy]
+      provenance:
+        retention: UNVERIFIED -- lulc.py's derivation differs from
+          lulc_prederived.py's Beer's-law rad_trncf; do not assume they are the
+          same parameter
 
   # NLCD 2021: no keep raster -> crosswalk evergreen_retention column.
 
@@ -174,6 +331,39 @@ params:
         retention,
       ]
 
+    # `retention` here is NOT `rad_trncf`. lulc.py:186-193 computes
+    # zonal_mean(keep)/100 or the crosswalk's evergreen_retention column -- no
+    # Beer's-law step. The module DOES carry a rad_trncf path (lulc.py:194-239),
+    # but it is gated on `radtrn_raster`, which no `script: lulc` entry
+    # configures, so it never runs for these three. Mapping it to rad_trncf would
+    # assert two different derivations are the same PRMS parameter; it stays in
+    # provenance until someone verifies what, if anything, it corresponds to.
+    prms:
+      builder: zonal_runners/lulc.py
+      columns:
+        cov_type:
+          prms: cov_type
+          processes: [PRMSCanopy, PRMSSnow, PRMSSoilzone]
+        covden_sum:
+          prms: covden_sum
+          processes: [PRMSCanopy, PRMSSnow]
+        covden_win:
+          prms: covden_win
+          processes: [PRMSCanopy, PRMSSnow]
+        srain_intcp:
+          prms: srain_intcp
+          processes: [PRMSCanopy]
+        wrain_intcp:
+          prms: wrain_intcp
+          processes: [PRMSCanopy]
+        snow_intcp:
+          prms: snow_intcp
+          processes: [PRMSCanopy]
+      provenance:
+        retention: UNVERIFIED -- lulc.py's derivation differs from
+          lulc_prederived.py's Beer's-law rad_trncf; do not assume they are the
+          same parameter
+
   # FORE-SCE bau_rcp45 2070: keep raster present -> raster-based retention.
 
   - name: lulc_foresce
@@ -198,6 +388,39 @@ params:
         covden_win,
         retention,
       ]
+
+    # `retention` here is NOT `rad_trncf`. lulc.py:186-193 computes
+    # zonal_mean(keep)/100 or the crosswalk's evergreen_retention column -- no
+    # Beer's-law step. The module DOES carry a rad_trncf path (lulc.py:194-239),
+    # but it is gated on `radtrn_raster`, which no `script: lulc` entry
+    # configures, so it never runs for these three. Mapping it to rad_trncf would
+    # assert two different derivations are the same PRMS parameter; it stays in
+    # provenance until someone verifies what, if anything, it corresponds to.
+    prms:
+      builder: zonal_runners/lulc.py
+      columns:
+        cov_type:
+          prms: cov_type
+          processes: [PRMSCanopy, PRMSSnow, PRMSSoilzone]
+        covden_sum:
+          prms: covden_sum
+          processes: [PRMSCanopy, PRMSSnow]
+        covden_win:
+          prms: covden_win
+          processes: [PRMSCanopy, PRMSSnow]
+        srain_intcp:
+          prms: srain_intcp
+          processes: [PRMSCanopy]
+        wrain_intcp:
+          prms: wrain_intcp
+          processes: [PRMSCanopy]
+        snow_intcp:
+          prms: snow_intcp
+          processes: [PRMSCanopy]
+      provenance:
+        retention: UNVERIFIED -- lulc.py's derivation differs from
+          lulc_prederived.py's Beer's-law rad_trncf; do not assume they are the
+          same parameter
 
   # --- ssflux (litho-weighted PRMS subsurface flux params) ---
   # Requires the CONUS-wide P2P weight matrix (build_weights mode) and a
@@ -244,6 +467,40 @@ params:
       hru_area:
         source: geometry
         scale: 1.0
+    # `processes:` is PER-COLUMN, and ssflux is why. This one entry spans
+    # PRMSSoilzone, PRMSGroundwater and PRMSRunoff across different columns, so an
+    # entry-level `processes: [PRMSRunoff]` would report 5 non-runoff parameters as
+    # feeding runoff. `hru_area` reaches here via fabric_columns, not fill_columns,
+    # and is still an emitted column that needs a PRMS decision -- Guard 1 unions
+    # both sources.
+    prms:
+      builder: zonal_runners/ssflux.py
+      columns:
+        soil2gw_max:
+          prms: soil2gw_max
+          processes: [PRMSSoilzone]
+        ssr2gw_rate:
+          prms: ssr2gw_rate
+          processes: [PRMSSoilzone]
+        fastcoef_lin:
+          prms: fastcoef_lin
+          processes: [PRMSSoilzone]
+        slowcoef_lin:
+          prms: slowcoef_lin
+          processes: [PRMSSoilzone]
+        gwflow_coef:
+          prms: gwflow_coef
+          processes: [PRMSGroundwater]
+        dprst_seep_rate_open:
+          prms: dprst_seep_rate_open
+          processes: [PRMSRunoff]
+        dprst_flow_coef:
+          prms: dprst_flow_coef
+          processes: [PRMSRunoff]
+      provenance:
+        k_perm_wtd: litho-weighted permeability, flux-normalisation input
+        mean_slope_fraction: tan(radians(slope mean)), flux-normalisation input
+        hru_area: fabric geometry.area in m2 -- NOT PRMS hru_area, which is acres
     # Lithology permeability + PRMS flux normalisation (lifted verbatim
     # from configs/zonal/ssflux_param.yml).
     k_perm_min: -16.48

--- a/configs/zonal/zonal_params.yml
+++ b/configs/zonal/zonal_params.yml
@@ -83,24 +83,44 @@ params:
     source_raster: "{data_root}/shared/conus/vrt/slope.vrt"
     categorical: false
     merged_file: nhm_slope_params.csv
-    # Same value-column set as elevation (observed on-disk; same zonal script).
-    fill_columns: [count, mean, std, min, "25%", "50%", "75%", max, sum]
+    # Same value-column set as elevation (observed on-disk; same zonal script),
+    # plus the derived hru_slope below. hru_slope IS declared fillable: without
+    # it, an HRU absent from the merged CSV would get `mean` KNN-filled but land
+    # NaN in the PRMS parameter itself. It is a monotone transform of `mean`, so
+    # interpolating it directly is exactly as defensible as interpolating `mean`.
+    #
+    # NB: this makes a re-merge a PREREQUISITE of the next fill sweep on any
+    # fabric -- resolve_fill_plan raises on a declared column the file does not
+    # have, so a slope CSV merged before this change must be re-merged with
+    # `derive_zonal_params.py --mode merge --param slope` first. That failure is
+    # loud and one command to fix; the alternative (silent NaN hru_slope for
+    # exactly the HRUs that were missing) is not.
+    fill_columns:
+      [count, mean, std, min, "25%", "50%", "75%", max, sum, hru_slope]
+    # PRMS hru_slope is a decimal fraction rise/run (TM6B9:536); slope.vrt is
+    # rd.TerrainAttribute(dem, "slope_degrees") (compute_slope_aspect.py:72), so
+    # `mean` is DEGREES -- a ~57x discrepancy for small angles. Emit the PRMS
+    # quantity directly rather than leaving a footgun. ssflux.py:63 already applies
+    # this same conversion to derive ssr2gw_rate/slowcoef_lin, so this makes the
+    # rest of the pipeline consistent with what ssflux already assumed rather than
+    # introducing a new convention. Applied in run_merge, so no zonal re-run.
+    #
+    # KNOWN APPROXIMATION: tan(mean) != mean(tan), and tan is convex, so this
+    # underestimates. Measured over all 361,471 gfv2 HRUs (2nd-order Taylor from
+    # on-disk mean/std): median 0.2%, p90 2.4%, p99 5.6%. Too small to justify a
+    # CONUS fractional-slope VRT -- none exists.
+    derived_columns:
+      hru_slope:
+        from: mean
+        transform: deg_to_fraction
     prms:
-      builder: zonal_runners/zonal.py
-      columns: {}
-      # `mean` is DEGREES: slope.vrt is rd.TerrainAttribute(dem, "slope_degrees")
-      # (shared_rasters/compute_slope_aspect.py:72), while PRMS hru_slope is a
-      # decimal fraction rise/run (TM6B9:536) -- ~57x for small angles. Declared as
-      # a defect rather than as `mean: {prms: hru_slope}`, because that mapping
-      # would assert the degrees column IS the parameter, which is the defect.
-      # Unlike aspect below, this one is recoverable from what is on disk.
-      defects:
-        mean:
+      builder: zonal_runners/zonal.py + zonal_runners/merge.py (derived_columns)
+      columns:
+        hru_slope:
           prms: hru_slope
           processes: [PRMSSolarGeometry, PRMSAtmosphere]
-          reason: emitted in degrees; PRMS hru_slope is a decimal fraction rise/run
-          recovery: tan(radians(mean))
       provenance:
+        mean: mean cell slope in DEGREES -- the raw stat hru_slope is derived from
         count: exactextract cell count
         std: within-HRU standard deviation
         min: within-HRU minimum

--- a/docs/ADDING_A_PARAMETER.md
+++ b/docs/ADDING_A_PARAMETER.md
@@ -215,6 +215,18 @@ raw `mean` (degrees), with no zonal re-run. See
    Mirror an existing entry of the same `script:` family — for a new
    continuous raster, copy the `elevation` block and change `name`,
    `source_raster`, and `merged_file`.
+
+   The entry needs a **`prms:` block**, and it is not optional: `builder:`,
+   plus every emitted column sorted into `columns:` (this IS the PRMS
+   parameter), `defects:` (this is *supposed* to be the PRMS parameter and
+   currently is not) or `provenance:` (this is not a PRMS parameter at all).
+   `processes:` is **per column**, not per entry — `ssflux` alone spans three
+   processes across different columns.
+   [`tests/test_params_index.py`](../tests/test_params_index.py)'s Guard 1
+   fails without it, and
+   [`tests/test_params_index_ondisk.py`](../tests/test_params_index_ondisk.py)'s
+   Guard 2 fails if a column reaches disk that none of the three buckets
+   declares. See the [Parameter index](parameter_index.md).
 2. **Confirm the source raster exists on disk.** Resolve any
    `{data_root}` placeholders by hand and `ls` the path.
 3. **Choose the `script:` tag** — `zonal` (continuous raster),
@@ -259,7 +271,17 @@ raw `mean` (degrees), with no zonal re-run. See
    on fabrics with unstaged sources. If you submit from a shell exporting it,
    your new param must be in *that* list too, or it still will not run.
 
-6. **Submit the full SLURM array** via
+6. **Regenerate the parameter index:**
+   ```bash
+   pixi run --as-is python scripts/build_parameter_index.py
+   ```
+   This rewrites the three generated tables in
+   [`docs/parameter_index.md`](parameter_index.md) from the `prms:` blocks and
+   nothing else; the surrounding prose is hand-maintained. CI fails if you skip
+   it — `test_generated_index_is_up_to_date` runs the same generator with
+   `--check`.
+
+7. **Submit the full SLURM array** via
    [`slurm_batch/submit_zonal_params.sh`](../slurm_batch/submit_zonal_params.sh)
    from a shell that has `pixi` on `PATH`. It submits an array zonal job
    plus a chained merge for each param in `PARAMS`.

--- a/docs/ADDING_A_PARAMETER.md
+++ b/docs/ADDING_A_PARAMETER.md
@@ -202,6 +202,12 @@ into `{output_dir}/merged/{merged_file}` (one row per HRU, sorted by
 For `elevation` that is
 `{data_root}/{fabric}/params/merged/nhm_elevation_params.csv`.
 
+If the entry declares `derived_columns:`, `--mode merge` also adds those columns
+after the concat — that is how `slope` emits `hru_slope` (rise/run) alongside the
+raw `mean` (degrees), with no zonal re-run. See
+[`docs/ARCHITECTURE.md`](ARCHITECTURE.md) and the
+[Parameter index](parameter_index.md).
+
 ## To add a new param
 
 1. **Add a YAML entry** under `params:` in

--- a/docs/ADDING_A_PARAMETER.md
+++ b/docs/ADDING_A_PARAMETER.md
@@ -198,7 +198,7 @@ Columns (continuous zonal, exactextract defaults):
 After the array job finishes, `--mode merge` concatenates every batch CSV
 into `{output_dir}/merged/{merged_file}` (one row per HRU, sorted by
 `id_feature`); see
-[`src/gfv2_params/zonal_runners/merge.py:15-75`](../src/gfv2_params/zonal_runners/merge.py#L15-L75).
+[`src/gfv2_params/zonal_runners/merge.py`](../src/gfv2_params/zonal_runners/merge.py)'s `run_merge`.
 For `elevation` that is
 `{data_root}/{fabric}/params/merged/nhm_elevation_params.csv`.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -256,6 +256,38 @@ exempt from the undeclared-NaN warning: that census runs on the pre-append
 frame, so every NaN it counts is in an existing row, which this mechanism
 does not touch.
 
+#### `derived_columns` — PRMS quantities computed at merge time
+
+A zonal param entry may also declare `derived_columns`, which adds a column to
+the merged frame by transforming one that is already there:
+
+```yaml
+derived_columns:
+  hru_slope: { from: mean, transform: deg_to_fraction }
+```
+
+`transform` names a function in a **whitelist** in
+`zonal_runners/merge.py` (`_TRANSFORMS`), not `getattr(gfv2_params.raster_ops,
+name)`: a typo must raise, not silently resolve to some other module-level
+function. `apply_derived_columns` runs in `run_merge`, after the per-batch
+concat and before the CSV write, so **adding one needs no zonal re-run** — only
+`--mode merge --param <name>`. The source column is kept, not consumed: it is
+declared `prms.provenance`, and a reader needs it to check the derivation.
+
+Today only `slope` declares one. `slope.vrt` is
+`rd.TerrainAttribute(dem, "slope_degrees")`, so `mean` is degrees while PRMS
+`hru_slope` is a decimal fraction rise/run (~57× for small angles); rather than
+ship a footgun, the pipeline emits the PRMS quantity directly, reusing the same
+`raster_ops.deg_to_fraction` that `ssflux.py:63` already applies. See
+[Parameter index](parameter_index.md).
+
+Note the ordering constraint with `fill_columns`: a derived column that is also
+declared fillable (as `hru_slope` is) makes a **re-merge a prerequisite of the
+next fill sweep** on any fabric whose CSV predates the declaration —
+`resolve_fill_plan` raises on a declared column the file does not have. That is
+deliberate: the alternative is a silent NaN in a PRMS parameter for exactly the
+HRUs that were missing.
+
 `merged/<name>.csv` is the single canonical, always-gap-filled per-HRU file
 for every param that declares `fill_columns` — **consumers read
 `merged/*.csv`**. The retired `filled_` prefix required a consumer to know,

--- a/docs/parameter_index.md
+++ b/docs/parameter_index.md
@@ -360,12 +360,39 @@ Three independent reasons the data, not the metadata, is right:
 Cross-check against the delivered product: `nhm_soils_params.csv` gives 30.5% / 69.0% / 0.4%
 across 361,471 HRUs — the same shape, as expected for per-HRU dominant class.
 
+### `mean` → `hru_elev` is verified — and it is **metres**
+
+**Verified 2026-08-05.** This was the last inferred mapping in the index. It is documented,
+not inferred: [TM6B9:534](NHM_description_Regan_2018_TM6B9.md) defines **`hru_elev`** as
+"Mean elevation for each HRU", dimension `nhru`, units **meters**, and
+[TM6B9:601](NHM_description_Regan_2018_TM6B9.md) states it "was derived using the outline of
+the GF-defined HRU and the Digital Elevation Model". That is exactly what
+`nhm_elevation_params.csv:mean` is — an arithmetic zonal mean over the HRU outline. Only the
+*name* differs.
+
+Checked against the data as well as the document, because the `TEXT_PRMS.tif` metadata
+turned out to be wrong (see below) and a metadata claim is not evidence on its own:
+
+| Check | Observed |
+| --- | --- |
+| `shared/conus/vrt/elevation.vrt` | float32, CRS linear units **metre**, scale 1.0 / offset 0.0 |
+| sampled raster range | −84.6 m … 4,028.8 m |
+| `mean` across 361,471 gfv2 HRUs | min −84.6, median 427.8, p99 2,940.3, max 3,851.2 |
+
+Metres, unambiguously. As feet the maximum HRU mean would be 3,851 ft ≈ 1,174 m and CONUS's
+high country would simply be absent; the p99 of 2,940 would be 896 m, which is not the
+Rockies. The 327 HRUs with a negative mean are Death Valley and the Salton Sea, matching the
+raster's own −84.6 m floor.
+
+⚠️ **Two unit traps that follow from this.**
+[TM6B9:707](NHM_description_Regan_2018_TM6B9.md)'s `cov_type` reset rule is stated in
+**feet** ("exceeds 11,500 feet") for a parameter carried in metres — that threshold is
+3,505 m. And TM6B9 derived NHM v1.1's `hru_elev` from the **NHDPlus v1.0** DEM, whereas this
+pipeline uses `elevation.vrt`; same quantity, same units, different source, so per-HRU values
+will not match NHM v1.1 exactly.
+
 ### Unverified mappings
 
-- **`mean` → `hru_elev`** — inferred from `viz.py:505-507` plus
-  [TM6B9:601](NHM_description_Regan_2018_TM6B9.md). Elevation is neither circular nor
-  transformed, so the arithmetic zonal mean is the right statistic; only the *name* is
-  undocumented.
 - **pywatershed's process lists are pywatershed's view of PRMS**, not TM6B9's NHM module set.
   They agreed everywhere spot-checked, but `hru_elev` appears in no pywatershed process at
   all, so the two are not identical.

--- a/docs/parameter_index.md
+++ b/docs/parameter_index.md
@@ -5,8 +5,9 @@ process that consumes it, the config entry that declares it, and the builder tha
 it.
 
 Process membership is from `pywatershed.<Process>.get_parameters()` (pywatershed 2.0.4, the
-`reference` pixi env), not inference. Column lists are observed on-disk headers from
-`gfv2/params/merged/`.
+`reference` pixi env), not inference. Column lists are observed on-disk headers from `gfv2/params/merged/`, except
+`lulc_nlcd` and `lulc_foresce`, which have never been built and are derived from the
+shared `script: lulc` builder.
 
 **19 config entries** are declared, of which **17** are built for gfv2 — `lulc_nlcd` and
 `lulc_foresce` have never been built on any fabric (see
@@ -321,10 +322,11 @@ transform, and the column was renamed to `rad_trncf` after gfv2/oregon were buil
 
 On `lulc_nalcms` / `lulc_nlcd` / `lulc_foresce` it is **not** `rad_trncf`.
 `lulc.py:186-193` computes `zonal_mean(keep)/100` or the crosswalk's `evergreen_retention`
-column. The module *does* carry a Beer's-law `rad_trncf` path (`lulc.py:194-239`), but it is
-gated on `radtrn_raster`, which is configured for none of these three entries
-(`zonal_params.yml:163-165` says so) — so it never runs for them. What
-PRMS parameter it corresponds to, if any, is unverified.
+column. The module *does* carry a Beer's-law `rad_trncf` path (`lulc.py:195-243`), but it is
+gated on `radtrn_raster`, which is configured for none of these three entries —
+each `script: lulc` entry in `zonal_params.yml` says so in its own comment, and
+`radtrn_raster` appears only on the `script: lulc_prederived` entry. So it never runs
+for them. What PRMS parameter it corresponds to, if any, is unverified.
 
 ### `soils` → `soil_type` is an identity mapping — and the source metadata says otherwise
 

--- a/docs/parameter_index.md
+++ b/docs/parameter_index.md
@@ -26,24 +26,22 @@ still holds two `filled_nhm_*.csv` files from the retired `filled_` prefix conve
 - *provenance* marks an emitted column that is not a PRMS parameter — a diagnostic, an
   intermediate, or a raw statistic.
 
-**Four columns are renames** (⚠️): `mean`→`hru_elev`, `mean`→`hru_slope`, `soils`→`soil_type`
-and `retention`→`rad_trncf`. Feed any of them to PRMS under its emitted name and PRMS will
-not recognise it.
+**Three columns are renames** (⚠️): `mean`→`hru_elev`, `soils`→`soil_type` and
+`retention`→`rad_trncf`. Feed any of them to PRMS under its emitted name and PRMS will not
+recognise it. All three are safe once you know them; the per-process tables below mark every
+one with ⚠️.
 
-Two of them are *actively dangerous* rather than merely misnamed — they produce wrong
-numbers. Each is explained in [Known gaps](#known-gaps):
+**One column is actively dangerous** rather than merely misnamed — it produces wrong numbers:
 
 | Emitted | Reality |
 | --- | --- |
-| `nhm_slope_params.csv:mean` | degrees, not PRMS rise/run — **~57× if copied verbatim** |
 | `nhm_aspect_params.csv:mean` | **DEFECTIVE** — arithmetic mean of a circular variable ([#201](https://github.com/rmcd-mscb/gfv2-params/issues/201)) |
 
-A third danger — `op_flow_thres` living outside `merged/`, so a `merged/nhm_*_params.csv`
-glob silently dropped a PRMSRunoff parameter — **is now fixed**; see
-[Known gaps](#op_flow_thres-was-not-in-merged-fixed).
-
-The other two renames (`soils`→`soil_type`, `retention`→`rad_trncf`) are safe once you know
-them; the per-process tables below mark every one with ⚠️.
+Two further dangers this index originally flagged are **now fixed**:
+`hru_slope` is emitted directly in rise/run rather than left as degrees under the name `mean`
+(see [Known gaps](#hru_slope-was-degrees-on-disk-fixed)), and `op_flow_thres` is copied into
+`merged/` rather than living only in `depstor_rasters/` (see
+[Known gaps](#op_flow_thres-was-not-in-merged-fixed)).
 
 ---
 
@@ -123,7 +121,7 @@ a partial-pixel **count**, not a `[0, 1]` fraction. The PRMS parameter is the on
 
 | PRMS parameter | Emitted file | Column | Config entry | Builder |
 | --- | --- | --- | --- | --- |
-| `hru_slope` ⚠️ | `nhm_slope_params.csv` | `tan(radians(mean))` — `mean` is **degrees** | `zonal_params.yml:56` | `zonal_runners/zonal.py` |
+| `hru_slope` | `nhm_slope_params.csv` | `hru_slope` — decimal fraction rise/run. `mean` in the same file is *provenance*, in **degrees** | `zonal_params.yml` (`slope`, `derived_columns:`) | `zonal_runners/zonal.py` + `zonal_runners/merge.py` |
 | `hru_aspect` | `nhm_aspect_params.csv` | **DEFECTIVE** — see [#201](https://github.com/rmcd-mscb/gfv2-params/issues/201) | `zonal_params.yml:64` | `zonal_runners/zonal.py` |
 
 ### Not consumed by any pywatershed process — 1 parameter
@@ -146,7 +144,7 @@ files — and by the `cov_type` reset rule at
 | Entry | Merged file | PRMS parameters | Provenance columns |
 | --- | --- | --- | --- |
 | `elevation` `:43` | `nhm_elevation_params.csv` | `hru_elev` ⚠️ (from `mean`) | `count`, `std`, `min`, `25%`, `50%`, `75%`, `max`, `sum` |
-| `slope` `:56` | `nhm_slope_params.csv` | `hru_slope` ⚠️ (from `tan(radians(mean))`) | same 8 stats, plus `mean` itself |
+| `slope` `:56` | `nhm_slope_params.csv` | `hru_slope` (emitted, via `derived_columns:`) | same 8 stats, plus `mean` itself (degrees) |
 | `aspect` `:64` | `nhm_aspect_params.csv` | **none — DEFECTIVE** | all 9 columns |
 | `soils` `:74` | `nhm_soils_params.csv` | `soil_type` ⚠️ (from `soils`) | — |
 | `soil_moist_max` `:81` | `nhm_soil_moist_max_params.csv` | `soil_moist_max` | — |
@@ -196,7 +194,7 @@ the rest. A NaN there is a result, not a gap, which is why they are excluded fro
 
 | Builder module | PRMS parameters produced |
 | --- | --- |
-| `zonal_runners/zonal.py` | `hru_elev` ⚠️, `hru_slope` ⚠️, `hru_aspect` (DEFECTIVE) |
+| `zonal_runners/zonal.py` | `hru_elev` ⚠️, `hru_slope` (via `merge.py`'s `derived_columns:`), `hru_aspect` (DEFECTIVE) |
 | `zonal_runners/soils.py` | `soil_type` ⚠️, `soil_moist_max` |
 | `zonal_runners/lulc_prederived.py` | `cov_type`, `covden_sum`, `covden_win`, `srain_intcp`, `wrain_intcp`, `snow_intcp`, `rad_trncf` ⚠️ |
 | `zonal_runners/lulc.py` | `cov_type`, `covden_sum`, `covden_win`, `srain_intcp`, `wrain_intcp`, `snow_intcp` (+ unverified `retention`) |
@@ -215,25 +213,41 @@ part of `depstor_builders/`), driven by `scripts/derive_depstor_params.py --mode
 
 ## Known gaps
 
-### `hru_slope` is degrees on disk; PRMS wants rise/run
+### `hru_slope` was degrees on disk — fixed
 
 `slope.vrt` is built as `rd.TerrainAttribute(dem, attrib="slope_degrees")`
-(`shared_rasters/compute_slope_aspect.py:72`), so `nhm_slope_params.csv:mean` is **degrees**.
-PRMS `hru_slope` is a decimal fraction rise/run ([TM6B9:536](NHM_description_Regan_2018_TM6B9.md)).
+(`shared_rasters/compute_slope_aspect.py:72`), so `nhm_slope_params.csv:mean` is **degrees**,
+while PRMS `hru_slope` is a decimal fraction rise/run
+([TM6B9:536](NHM_description_Regan_2018_TM6B9.md)).
 
 For small angles the discrepancy is 180/π ≈ **57×**. gfv2 HRU 1: `mean = 4.4252` →
 `hru_slope = 0.0774`. Copied verbatim, that declares a 77° cliff instead of a 4.4° hillslope.
 
-**The pipeline is not wrong** — `zonal_runners/ssflux.py:63` applies
+**The pipeline was never wrong internally** — `zonal_runners/ssflux.py:63` applies
 `raster_ops.deg_to_fraction` before deriving `ssr2gw_rate`/`slowcoef_lin`, so the flux
-parameters are correct. But nothing currently *emits* `hru_slope`. Apply
-`tan(radians(mean))` yourself until the pipeline emits it directly.
+parameters have always been correct. What was missing is that nothing *emitted* `hru_slope`.
 
-Known approximation once it does: `tan(mean θ) ≠ mean(tan θ)`, and `tan` is convex, so the
-conversion systematically underestimates. Estimated (second-order Taylor from the
-on-disk `mean`/`std` — `mean(tan θ)` is not recoverable from summary statistics) over all
-361,471 gfv2 HRUs: median
-**0.2%**, p90 2.4%, p99 5.6%.
+`nhm_slope_params.csv` now carries an `hru_slope` column, declared as
+`derived_columns: {hru_slope: {from: mean, transform: deg_to_fraction}}` on the `slope` entry
+and applied by `zonal_runners/merge.py` at merge time. `mean` is kept alongside it as
+declared provenance, so the derivation stays checkable. Because it is applied in `run_merge`,
+**no zonal re-run is needed** — but an existing fabric does need one re-merge:
+
+```bash
+python scripts/derive_zonal_params.py --config configs/zonal/zonal_params.yml \
+  --base_config configs/base_config.yml --fabric <fabric> --mode merge --param slope
+```
+
+`hru_slope` is declared in `fill_columns`, so a slope CSV merged before this change will make
+the next fill sweep **raise** until it is re-merged. That failure is loud and one command to
+fix; the alternative — a silent NaN `hru_slope` for exactly the HRUs that were missing — is
+not. (Run on gfv2 2026-08-05; oregon and tjc still need it.)
+
+Known approximation: `tan(mean θ) ≠ mean(tan θ)`, and `tan` is convex, so the conversion
+systematically underestimates. Estimated (second-order Taylor from the on-disk `mean`/`std` —
+`mean(tan θ)` is not recoverable from summary statistics) over all 361,471 gfv2 HRUs: median
+**0.2%**, p90 2.4%, p99 5.6%. Too small to justify building a CONUS fractional-slope VRT;
+none exists, and `ssflux` has carried the same approximation since it was written.
 
 ### `hru_aspect` is DEFECTIVE — do not use `nhm_aspect_params.csv:mean`
 

--- a/docs/parameter_index.md
+++ b/docs/parameter_index.md
@@ -8,14 +8,18 @@ Process membership is from `pywatershed.<Process>.get_parameters()` (pywatershed
 `reference` pixi env), not inference. Column lists are observed on-disk headers from
 `gfv2/params/merged/`.
 
-The 16 `nhm_*_params.csv` files below are the complete set. Note `gfv2/params/merged/` also
-still holds two `filled_nhm_*.csv` files from the retired `filled_` prefix convention
-(PR #189) — they are superseded, not parameters, and are not listed here.
+**19 config entries** are declared, of which **17** are built for gfv2 — `lulc_nlcd` and
+`lulc_foresce` have never been built on any fabric (see
+[Not built on any fabric](#not-built-on-any-fabric)). That is the complete set. Note
+`gfv2/params/merged/` also still holds two `filled_nhm_*.csv` files from the retired
+`filled_` prefix convention (PR #189) — they are superseded, not parameters, and are not
+listed here.
 
-> **Hand-maintained as of 2026-08-04.** Generated from `configs/` once
-> `scripts/build_parameter_index.py` lands — see
-> `docs/superpowers/specs/2026-08-04-prms-parameter-index-design.md` in the repo
-> (the `superpowers/` tree is excluded from this site).
+> **The three tables below are GENERATED** from the `prms:` blocks in `configs/` by
+> `scripts/build_parameter_index.py` — do not hand-edit them; edit the config and re-run.
+> Everything else on this page (this preamble, the notes under each view, Known gaps) is
+> hand-maintained and the generator never touches it. Run
+> `python scripts/build_parameter_index.py --check` to detect staleness.
 
 ## Reading this index
 
@@ -47,167 +51,191 @@ Two further dangers this index originally flagged are **now fixed**:
 
 ## By PRMS process
 
-### PRMSRunoff (`srunoff_smidx`) — 11 parameters
+<!-- BEGIN GENERATED: by-process -->
+### PRMSRunoff — 11 parameters
 
 | PRMS parameter | Emitted file | Column | Config entry | Builder |
 | --- | --- | --- | --- | --- |
-| `soil_moist_max` | `nhm_soil_moist_max_params.csv` | `soil_moist_max` | `zonal_params.yml:81` | `zonal_runners/soils.py` |
-| `dprst_seep_rate_open` | `nhm_ssflux_params.csv` | `dprst_seep_rate_open` | `zonal_params.yml:208` | `zonal_runners/ssflux.py` |
-| `dprst_flow_coef` | `nhm_ssflux_params.csv` | `dprst_flow_coef` | `zonal_params.yml:208` | `zonal_runners/ssflux.py` |
-| `sro_to_dprst_perv` | `nhm_sro_to_dprst_perv_params.csv` | `sro_to_dprst_perv` | `depstor_params.yml:134` | `depstor_builders/same_hru_drains.py` + `perv.py` → `depstor_ratios.py` |
-| `sro_to_dprst_imperv` | `nhm_sro_to_dprst_imperv_params.csv` | `sro_to_dprst_imperv` | `depstor_params.yml:141` | `depstor_builders/same_hru_drains.py` + `imperv.py` → `depstor_ratios.py` |
-| `carea_max` | `nhm_carea_max_params.csv` | `carea_max` | `depstor_params.yml:148` | `depstor_builders/carea_map.py` |
-| `smidx_coef` | `nhm_smidx_coef_params.csv` | `smidx_coef` | `depstor_params.yml:155` | `depstor_builders/carea_map.py` |
-| `hru_percent_imperv` | `nhm_hru_percent_imperv_params.csv` | `hru_percent_imperv` | `depstor_params.yml:164` | `depstor_builders/imperv.py` + `landmask.py` |
-| `dprst_frac` | `nhm_dprst_frac_params.csv` | `dprst_frac` | `depstor_params.yml:177` | `depstor_builders/dprst.py` + `landmask.py` |
-| `dprst_depth_avg` | `nhm_dprst_depth_avg_params.csv` | `dprst_depth_avg` | `depstor_params.yml:107` (`means:`) | `depstor_builders/dprst_depth.py` + `dprst_depth/aggregate.py` |
-| `op_flow_thres` | `nhm_op_flow_thres_params.csv` | `op_flow_thres` | `depstor_params.yml` (`constants:`) | `depstor_builders/dprst_depth.py:361` |
-
-`dprst_frac` also appears in `merged/_intermediates/` under the same filename — that copy is
-a partial-pixel **count**, not a `[0, 1]` fraction. The PRMS parameter is the one in
-`merged/`.
+| `carea_max` | `nhm_carea_max_params.csv` | `carea_max` | `depstor_params.yml:172` | `depstor_builders/carea_map.py` |
+| `dprst_depth_avg` | `nhm_dprst_depth_avg_params.csv` | `dprst_depth_avg` | `depstor_params.yml:107` | `depstor_builders/dprst_depth.py + dprst_depth/aggregate.py` |
+| `dprst_flow_coef` | `nhm_ssflux_params.csv` | `dprst_flow_coef` | `zonal_params.yml:451` | `zonal_runners/ssflux.py` |
+| `dprst_frac` | `nhm_dprst_frac_params.csv` | `dprst_frac` | `depstor_params.yml:224` | `depstor_builders/dprst.py + landmask.py` |
+| `dprst_seep_rate_open` | `nhm_ssflux_params.csv` | `dprst_seep_rate_open` | `zonal_params.yml:451` | `zonal_runners/ssflux.py` |
+| `hru_percent_imperv` | `nhm_hru_percent_imperv_params.csv` | `hru_percent_imperv` | `depstor_params.yml:202` | `depstor_builders/imperv.py + landmask.py` |
+| `op_flow_thres` | `nhm_op_flow_thres_params.csv` | `op_flow_thres` | `depstor_params.yml:252` | `depstor_builders/dprst_depth.py` |
+| `smidx_coef` | `nhm_smidx_coef_params.csv` | `smidx_coef` | `depstor_params.yml:186` | `depstor_builders/carea_map.py` |
+| `soil_moist_max` | `nhm_soil_moist_max_params.csv` | `soil_moist_max` | `zonal_params.yml:187` | `zonal_runners/soils.py` |
+| `sro_to_dprst_imperv` | `nhm_sro_to_dprst_imperv_params.csv` | `sro_to_dprst_imperv` | `depstor_params.yml:158` | `depstor_builders/same_hru_drains.py + imperv.py` |
+| `sro_to_dprst_perv` | `nhm_sro_to_dprst_perv_params.csv` | `sro_to_dprst_perv` | `depstor_params.yml:144` | `depstor_builders/same_hru_drains.py + perv.py` |
 
 ### PRMSSoilzone — 9 parameters
 
 | PRMS parameter | Emitted file | Column | Config entry | Builder |
 | --- | --- | --- | --- | --- |
-| `soil_type` ⚠️ | `nhm_soils_params.csv` | `soils` — identity, **1=sand, 2=loam, 3=clay**; the source metadata is wrong, see [Known gaps](#soils-soil_type-is-an-identity-mapping-and-the-source-metadata-says-otherwise) | `zonal_params.yml:74` | `zonal_runners/soils.py:78` |
-| `soil_moist_max` | `nhm_soil_moist_max_params.csv` | `soil_moist_max` | `zonal_params.yml:81` | `zonal_runners/soils.py` |
-| `cov_type` | `nhm_lulc_nhm_v11_params.csv` | `cov_type` | `zonal_params.yml:96` | `zonal_runners/lulc_prederived.py` |
-| `soil2gw_max` | `nhm_ssflux_params.csv` | `soil2gw_max` | `zonal_params.yml:208` | `zonal_runners/ssflux.py` |
-| `ssr2gw_rate` | `nhm_ssflux_params.csv` | `ssr2gw_rate` | `zonal_params.yml:208` | `zonal_runners/ssflux.py` |
-| `fastcoef_lin` | `nhm_ssflux_params.csv` | `fastcoef_lin` | `zonal_params.yml:208` | `zonal_runners/ssflux.py` |
-| `slowcoef_lin` | `nhm_ssflux_params.csv` | `slowcoef_lin` | `zonal_params.yml:208` | `zonal_runners/ssflux.py` |
-| `hru_percent_imperv` | `nhm_hru_percent_imperv_params.csv` | `hru_percent_imperv` | `depstor_params.yml:164` | `depstor_builders/imperv.py` + `landmask.py` |
-| `dprst_frac` | `nhm_dprst_frac_params.csv` | `dprst_frac` | `depstor_params.yml:177` | `depstor_builders/dprst.py` + `landmask.py` |
+| `cov_type` | `nhm_lulc_nhm_v11_params.csv` · `nhm_lulc_nalcms_params.csv` · `nhm_lulc_nlcd_params.csv` · `nhm_lulc_foresce_params.csv` | `cov_type` | `zonal_params.yml:209` · `zonal_params.yml:277` · `zonal_params.yml:331` · `zonal_params.yml:389` | `zonal_runners/lulc_prederived.py` · `zonal_runners/lulc.py` · `zonal_runners/lulc.py` · `zonal_runners/lulc.py` |
+| `dprst_frac` | `nhm_dprst_frac_params.csv` | `dprst_frac` | `depstor_params.yml:224` | `depstor_builders/dprst.py + landmask.py` |
+| `fastcoef_lin` | `nhm_ssflux_params.csv` | `fastcoef_lin` | `zonal_params.yml:451` | `zonal_runners/ssflux.py` |
+| `hru_percent_imperv` | `nhm_hru_percent_imperv_params.csv` | `hru_percent_imperv` | `depstor_params.yml:202` | `depstor_builders/imperv.py + landmask.py` |
+| `slowcoef_lin` | `nhm_ssflux_params.csv` | `slowcoef_lin` | `zonal_params.yml:451` | `zonal_runners/ssflux.py` |
+| `soil2gw_max` | `nhm_ssflux_params.csv` | `soil2gw_max` | `zonal_params.yml:451` | `zonal_runners/ssflux.py` |
+| `soil_moist_max` | `nhm_soil_moist_max_params.csv` | `soil_moist_max` | `zonal_params.yml:187` | `zonal_runners/soils.py` |
+| `soil_type` ⚠️ | `nhm_soils_params.csv` | `soils` | `zonal_params.yml:169` | `zonal_runners/soils.py` |
+| `ssr2gw_rate` | `nhm_ssflux_params.csv` | `ssr2gw_rate` | `zonal_params.yml:451` | `zonal_runners/ssflux.py` |
 
 ### PRMSSnow — 7 parameters
 
 | PRMS parameter | Emitted file | Column | Config entry | Builder |
 | --- | --- | --- | --- | --- |
-| `cov_type` | `nhm_lulc_nhm_v11_params.csv` | `cov_type` | `zonal_params.yml:96` | `zonal_runners/lulc_prederived.py` |
-| `covden_sum` | `nhm_lulc_nhm_v11_params.csv` | `covden_sum` | `zonal_params.yml:96` | `zonal_runners/lulc_prederived.py` |
-| `covden_win` | `nhm_lulc_nhm_v11_params.csv` | `covden_win` | `zonal_params.yml:96` | `zonal_runners/lulc_prederived.py` |
-| `rad_trncf` ⚠️ | `nhm_lulc_nhm_v11_params.csv` | `retention` (gfv2, oregon) \| `rad_trncf` (tjc) | `zonal_params.yml:96` | `zonal_runners/lulc_prederived.py` |
+| `cov_type` | `nhm_lulc_nhm_v11_params.csv` · `nhm_lulc_nalcms_params.csv` · `nhm_lulc_nlcd_params.csv` · `nhm_lulc_foresce_params.csv` | `cov_type` | `zonal_params.yml:209` · `zonal_params.yml:277` · `zonal_params.yml:331` · `zonal_params.yml:389` | `zonal_runners/lulc_prederived.py` · `zonal_runners/lulc.py` · `zonal_runners/lulc.py` · `zonal_runners/lulc.py` |
+| `covden_sum` | `nhm_lulc_nhm_v11_params.csv` · `nhm_lulc_nalcms_params.csv` · `nhm_lulc_nlcd_params.csv` · `nhm_lulc_foresce_params.csv` | `covden_sum` | `zonal_params.yml:209` · `zonal_params.yml:277` · `zonal_params.yml:331` · `zonal_params.yml:389` | `zonal_runners/lulc_prederived.py` · `zonal_runners/lulc.py` · `zonal_runners/lulc.py` · `zonal_runners/lulc.py` |
+| `covden_win` | `nhm_lulc_nhm_v11_params.csv` · `nhm_lulc_nalcms_params.csv` · `nhm_lulc_nlcd_params.csv` · `nhm_lulc_foresce_params.csv` | `covden_win` | `zonal_params.yml:209` · `zonal_params.yml:277` · `zonal_params.yml:331` · `zonal_params.yml:389` | `zonal_runners/lulc_prederived.py` · `zonal_runners/lulc.py` · `zonal_runners/lulc.py` · `zonal_runners/lulc.py` |
 | `hru_deplcrv` | `nhm_snarea_curve_params.csv` | `hru_deplcrv` | `snarea_library.yml` | `snarea/library.py` |
-| `snarea_thresh` | `nhm_snarea_curve_params.csv` | `snarea_thresh` | `snarea_library.yml` | `snarea/library.py` |
+| `rad_trncf` ⚠️ | `nhm_lulc_nhm_v11_params.csv` | `retention` \| `rad_trncf` | `zonal_params.yml:209` | `zonal_runners/lulc_prederived.py` |
 | `snarea_curve` | `nhm_snarea_curve_params.csv` | `snarea_curve_0` … `snarea_curve_10` | `snarea_library.yml` | `snarea/library.py` |
+| `snarea_thresh` | `nhm_snarea_curve_params.csv` | `snarea_thresh` | `snarea_library.yml` | `snarea/library.py` |
 
 ### PRMSCanopy — 6 parameters
 
 | PRMS parameter | Emitted file | Column | Config entry | Builder |
 | --- | --- | --- | --- | --- |
-| `cov_type` | `nhm_lulc_nhm_v11_params.csv` | `cov_type` | `zonal_params.yml:96` | `zonal_runners/lulc_prederived.py` |
-| `covden_sum` | `nhm_lulc_nhm_v11_params.csv` | `covden_sum` | `zonal_params.yml:96` | `zonal_runners/lulc_prederived.py` |
-| `covden_win` | `nhm_lulc_nhm_v11_params.csv` | `covden_win` | `zonal_params.yml:96` | `zonal_runners/lulc_prederived.py` |
-| `srain_intcp` | `nhm_lulc_nhm_v11_params.csv` | `srain_intcp` | `zonal_params.yml:96` | `zonal_runners/lulc_prederived.py` |
-| `wrain_intcp` | `nhm_lulc_nhm_v11_params.csv` | `wrain_intcp` | `zonal_params.yml:96` | `zonal_runners/lulc_prederived.py` |
-| `snow_intcp` | `nhm_lulc_nhm_v11_params.csv` | `snow_intcp` | `zonal_params.yml:96` | `zonal_runners/lulc_prederived.py` |
-
-### PRMSGroundwater — 1 parameter
-
-| PRMS parameter | Emitted file | Column | Config entry | Builder |
-| --- | --- | --- | --- | --- |
-| `gwflow_coef` | `nhm_ssflux_params.csv` | `gwflow_coef` | `zonal_params.yml:208` | `zonal_runners/ssflux.py` |
+| `cov_type` | `nhm_lulc_nhm_v11_params.csv` · `nhm_lulc_nalcms_params.csv` · `nhm_lulc_nlcd_params.csv` · `nhm_lulc_foresce_params.csv` | `cov_type` | `zonal_params.yml:209` · `zonal_params.yml:277` · `zonal_params.yml:331` · `zonal_params.yml:389` | `zonal_runners/lulc_prederived.py` · `zonal_runners/lulc.py` · `zonal_runners/lulc.py` · `zonal_runners/lulc.py` |
+| `covden_sum` | `nhm_lulc_nhm_v11_params.csv` · `nhm_lulc_nalcms_params.csv` · `nhm_lulc_nlcd_params.csv` · `nhm_lulc_foresce_params.csv` | `covden_sum` | `zonal_params.yml:209` · `zonal_params.yml:277` · `zonal_params.yml:331` · `zonal_params.yml:389` | `zonal_runners/lulc_prederived.py` · `zonal_runners/lulc.py` · `zonal_runners/lulc.py` · `zonal_runners/lulc.py` |
+| `covden_win` | `nhm_lulc_nhm_v11_params.csv` · `nhm_lulc_nalcms_params.csv` · `nhm_lulc_nlcd_params.csv` · `nhm_lulc_foresce_params.csv` | `covden_win` | `zonal_params.yml:209` · `zonal_params.yml:277` · `zonal_params.yml:331` · `zonal_params.yml:389` | `zonal_runners/lulc_prederived.py` · `zonal_runners/lulc.py` · `zonal_runners/lulc.py` · `zonal_runners/lulc.py` |
+| `snow_intcp` | `nhm_lulc_nhm_v11_params.csv` · `nhm_lulc_nalcms_params.csv` · `nhm_lulc_nlcd_params.csv` · `nhm_lulc_foresce_params.csv` | `snow_intcp` | `zonal_params.yml:209` · `zonal_params.yml:277` · `zonal_params.yml:331` · `zonal_params.yml:389` | `zonal_runners/lulc_prederived.py` · `zonal_runners/lulc.py` · `zonal_runners/lulc.py` · `zonal_runners/lulc.py` |
+| `srain_intcp` | `nhm_lulc_nhm_v11_params.csv` · `nhm_lulc_nalcms_params.csv` · `nhm_lulc_nlcd_params.csv` · `nhm_lulc_foresce_params.csv` | `srain_intcp` | `zonal_params.yml:209` · `zonal_params.yml:277` · `zonal_params.yml:331` · `zonal_params.yml:389` | `zonal_runners/lulc_prederived.py` · `zonal_runners/lulc.py` · `zonal_runners/lulc.py` · `zonal_runners/lulc.py` |
+| `wrain_intcp` | `nhm_lulc_nhm_v11_params.csv` · `nhm_lulc_nalcms_params.csv` · `nhm_lulc_nlcd_params.csv` · `nhm_lulc_foresce_params.csv` | `wrain_intcp` | `zonal_params.yml:209` · `zonal_params.yml:277` · `zonal_params.yml:331` · `zonal_params.yml:389` | `zonal_runners/lulc_prederived.py` · `zonal_runners/lulc.py` · `zonal_runners/lulc.py` · `zonal_runners/lulc.py` |
 
 ### PRMSEt — 2 parameters
 
 | PRMS parameter | Emitted file | Column | Config entry | Builder |
 | --- | --- | --- | --- | --- |
-| `hru_percent_imperv` | `nhm_hru_percent_imperv_params.csv` | `hru_percent_imperv` | `depstor_params.yml:164` | `depstor_builders/imperv.py` + `landmask.py` |
-| `dprst_frac` | `nhm_dprst_frac_params.csv` | `dprst_frac` | `depstor_params.yml:177` | `depstor_builders/dprst.py` + `landmask.py` |
+| `dprst_frac` | `nhm_dprst_frac_params.csv` | `dprst_frac` | `depstor_params.yml:224` | `depstor_builders/dprst.py + landmask.py` |
+| `hru_percent_imperv` | `nhm_hru_percent_imperv_params.csv` | `hru_percent_imperv` | `depstor_params.yml:202` | `depstor_builders/imperv.py + landmask.py` |
 
-### PRMSSolarGeometry / PRMSAtmosphere — 2 parameters
+### PRMSAtmosphere — 1 parameter (+1 defective)
 
 | PRMS parameter | Emitted file | Column | Config entry | Builder |
 | --- | --- | --- | --- | --- |
-| `hru_slope` | `nhm_slope_params.csv` | `hru_slope` — decimal fraction rise/run. `mean` in the same file is *provenance*, in **degrees** | `zonal_params.yml` (`slope`, `derived_columns:`) | `zonal_runners/zonal.py` + `zonal_runners/merge.py` |
-| `hru_aspect` | `nhm_aspect_params.csv` | **DEFECTIVE** — see [#201](https://github.com/rmcd-mscb/gfv2-params/issues/201) | `zonal_params.yml:64` | `zonal_runners/zonal.py` |
+| `hru_slope` | `nhm_slope_params.csv` | `hru_slope` | `zonal_params.yml:81` | `zonal_runners/zonal.py + zonal_runners/merge.py (derived_columns)` |
+| `hru_aspect` | `nhm_aspect_params.csv` | **DEFECTIVE** — `mean` is not this parameter ([#201](https://github.com/rmcd-mscb/gfv2-params/issues/201)) | `zonal_params.yml:133` | `zonal_runners/zonal.py` |
+
+### PRMSGroundwater — 1 parameter
+
+| PRMS parameter | Emitted file | Column | Config entry | Builder |
+| --- | --- | --- | --- | --- |
+| `gwflow_coef` | `nhm_ssflux_params.csv` | `gwflow_coef` | `zonal_params.yml:451` | `zonal_runners/ssflux.py` |
+
+### PRMSSolarGeometry — 1 parameter (+1 defective)
+
+| PRMS parameter | Emitted file | Column | Config entry | Builder |
+| --- | --- | --- | --- | --- |
+| `hru_slope` | `nhm_slope_params.csv` | `hru_slope` | `zonal_params.yml:81` | `zonal_runners/zonal.py + zonal_runners/merge.py (derived_columns)` |
+| `hru_aspect` | `nhm_aspect_params.csv` | **DEFECTIVE** — `mean` is not this parameter ([#201](https://github.com/rmcd-mscb/gfv2-params/issues/201)) | `zonal_params.yml:133` | `zonal_runners/zonal.py` |
 
 ### Not consumed by any pywatershed process — 1 parameter
 
 | PRMS parameter | Emitted file | Column | Config entry | Builder |
 | --- | --- | --- | --- | --- |
-| `hru_elev` ⚠️ | `nhm_elevation_params.csv` | `mean` (metres) | `zonal_params.yml:43` | `zonal_runners/zonal.py` |
+| `hru_elev` ⚠️ | `nhm_elevation_params.csv` | `mean` | `zonal_params.yml:43` | `zonal_runners/zonal.py` |
+<!-- END GENERATED: by-process -->
 
-`hru_elev` appears in no pywatershed `Process.get_parameters()` list. It is used by PRMS's
-temperature/precipitation distribution modules — which pywatershed handles by reading CBH
-files — and by the `cov_type` reset rule at
-[TM6B9:707](NHM_description_Regan_2018_TM6B9.md) (HRUs above 11,500 ft).
+**Notes on the tables above**
+
+- **Cells separated by `·` are alternative sources for the same parameter**, and the file,
+  config-entry and builder cells are **row-aligned**: the *n*-th file comes from the *n*-th
+  config entry via the *n*-th builder.
+- **The four LULC entries are alternatives, not four separate parameter sets.** That is the
+  only place `·` appears today. `lulc_nhm_v11`, `lulc_nalcms`, `lulc_nlcd` and
+  `lulc_foresce` each emit the same `cov_type` / `covden_*` / `*_intcp` set. Pick **one**
+  source per model run; `nhm_v11` and `nalcms` are both on disk for gfv2, and only `nhm_v11`
+  also derives `rad_trncf`. `lulc_nlcd` and `lulc_foresce` have never been built (see
+  [Not built on any fabric](#not-built-on-any-fabric)).
+- `dprst_frac` also appears in `merged/_intermediates/` under the same filename — that copy
+  is a partial-pixel **count**, not a `[0, 1]` fraction. The PRMS parameter is the one in
+  `merged/`.
+- `hru_elev` appears in no pywatershed `Process.get_parameters()` list. It is used by PRMS's
+  temperature/precipitation distribution modules — which pywatershed handles by reading CBH
+  files — and by the `cov_type` reset rule at
+  [TM6B9:707](NHM_description_Regan_2018_TM6B9.md) (HRUs above 11,500 ft). That is why its
+  `processes:` is empty rather than naming a module pywatershed does not have.
+- `snarea_curve` is one PRMS parameter of extent `ndeplval`, emitted as the 11 columns
+  `snarea_curve_0` … `snarea_curve_10`.
+- `soils` → `soil_type` is an **identity** mapping (1=sand, 2=loam, 3=clay) under a different
+  name; the source metadata says otherwise and is wrong — see
+  [Known gaps](#soils-soil_type-is-an-identity-mapping-and-the-source-metadata-says-otherwise).
 
 ---
 
 ## By config entry
 
-### `configs/zonal/zonal_params.yml`
-
-| Entry | Merged file | PRMS parameters | Provenance columns |
+<!-- BEGIN GENERATED: by-entry -->
+| Config entry | Merged file | PRMS parameters | Provenance columns |
 | --- | --- | --- | --- |
-| `elevation` `:43` | `nhm_elevation_params.csv` | `hru_elev` ⚠️ (from `mean`) | `count`, `std`, `min`, `25%`, `50%`, `75%`, `max`, `sum` |
-| `slope` `:56` | `nhm_slope_params.csv` | `hru_slope` (emitted, via `derived_columns:`) | same 8 stats, plus `mean` itself (degrees) |
-| `aspect` `:64` | `nhm_aspect_params.csv` | **none — DEFECTIVE** | all 9 columns |
-| `soils` `:74` | `nhm_soils_params.csv` | `soil_type` ⚠️ (from `soils`) | — |
-| `soil_moist_max` `:81` | `nhm_soil_moist_max_params.csv` | `soil_moist_max` | — |
-| `lulc_nhm_v11` `:96` | `nhm_lulc_nhm_v11_params.csv` | `cov_type`, `covden_sum`, `covden_win`, `srain_intcp`, `wrain_intcp`, `snow_intcp`, `rad_trncf` ⚠️ | — |
-| `lulc_nalcms` `:133` | `nhm_lulc_nalcms_params.csv` | `cov_type`, `covden_sum`, `covden_win`, `srain_intcp`, `wrain_intcp`, `snow_intcp` | `retention` — **unverified**, not `rad_trncf` |
-| `lulc_nlcd` `:154` | *never built* — `input/lulc_veg/nlcd/` absent | as `lulc_nalcms` | `retention` |
-| `lulc_foresce` `:179` | *never built* — `input/lulc_veg/foresce/` absent | as `lulc_nalcms` | `retention` |
-| `ssflux` `:208` | `nhm_ssflux_params.csv` | `soil2gw_max`, `ssr2gw_rate`, `fastcoef_lin`, `slowcoef_lin`, `gwflow_coef`, `dprst_seep_rate_open`, `dprst_flow_coef` | `k_perm_wtd`, `mean_slope_fraction`, `hru_area` |
+| `dprst_depth_avg` | `nhm_dprst_depth_avg_params.csv` | `dprst_depth_avg` | `dprst_depth_provenance` |
+| `sro_to_dprst_perv` | `nhm_sro_to_dprst_perv_params.csv` | `sro_to_dprst_perv` | — |
+| `sro_to_dprst_imperv` | `nhm_sro_to_dprst_imperv_params.csv` | `sro_to_dprst_imperv` | — |
+| `carea_max` | `nhm_carea_max_params.csv` | `carea_max` | — |
+| `smidx_coef` | `nhm_smidx_coef_params.csv` | `smidx_coef` | — |
+| `hru_percent_imperv` | `nhm_hru_percent_imperv_params.csv` | `hru_percent_imperv` | — |
+| `dprst_frac` | `nhm_dprst_frac_params.csv` | `dprst_frac` | — |
+| `op_flow_thres` | `nhm_op_flow_thres_params.csv` | `op_flow_thres` | — |
+| `snarea_curve` | `nhm_snarea_curve_params.csv` | `hru_deplcrv`, `snarea_curve`, `snarea_thresh` | `cv_assign`, `cv_empirical`, `cv_source`, `cv_subgrid`, `n_peak_years`, `n_seasons`, `peak_swe_mm`, `sca_class`, `sdc_status`, `similarity` |
+| `elevation` | `nhm_elevation_params.csv` | `hru_elev` | `25%`, `50%`, `75%`, `count`, `max`, `min`, `std`, `sum` |
+| `slope` | `nhm_slope_params.csv` | `hru_slope` | `25%`, `50%`, `75%`, `count`, `max`, `mean`, `min`, `std`, `sum` |
+| `aspect` | `nhm_aspect_params.csv` | `hru_aspect` — **DEFECTIVE** (emitted as `mean`) | `25%`, `50%`, `75%`, `count`, `max`, `min`, `std`, `sum` |
+| `soils` | `nhm_soils_params.csv` | `soil_type` | — |
+| `soil_moist_max` | `nhm_soil_moist_max_params.csv` | `soil_moist_max` | — |
+| `lulc_nhm_v11` | `nhm_lulc_nhm_v11_params.csv` | `cov_type`, `covden_sum`, `covden_win`, `rad_trncf`, `snow_intcp`, `srain_intcp`, `wrain_intcp` | — |
+| `lulc_nalcms` | `nhm_lulc_nalcms_params.csv` | `cov_type`, `covden_sum`, `covden_win`, `snow_intcp`, `srain_intcp`, `wrain_intcp` | `retention` |
+| `lulc_nlcd` | `nhm_lulc_nlcd_params.csv` | `cov_type`, `covden_sum`, `covden_win`, `snow_intcp`, `srain_intcp`, `wrain_intcp` | `retention` |
+| `lulc_foresce` | `nhm_lulc_foresce_params.csv` | `cov_type`, `covden_sum`, `covden_win`, `snow_intcp`, `srain_intcp`, `wrain_intcp` | `retention` |
+| `ssflux` | `nhm_ssflux_params.csv` | `dprst_flow_coef`, `dprst_seep_rate_open`, `fastcoef_lin`, `gwflow_coef`, `slowcoef_lin`, `soil2gw_max`, `ssr2gw_rate` | `hru_area`, `k_perm_wtd`, `mean_slope_fraction` |
+<!-- END GENERATED: by-entry -->
 
-### `configs/depstor/depstor_params.yml`
+**Notes on the table above**
 
-| Entry | Merged file | PRMS parameter | Provenance |
-| --- | --- | --- | --- |
-| `dprst_depth_avg` `:107` (`means:`) | `nhm_dprst_depth_avg_params.csv` | `dprst_depth_avg` | `dprst_depth_provenance` |
-| `sro_to_dprst_perv` `:134` (`ratios:`) | `nhm_sro_to_dprst_perv_params.csv` | `sro_to_dprst_perv` | — |
-| `sro_to_dprst_imperv` `:141` | `nhm_sro_to_dprst_imperv_params.csv` | `sro_to_dprst_imperv` | — |
-| `carea_max` `:148` | `nhm_carea_max_params.csv` | `carea_max` | — |
-| `smidx_coef` `:155` | `nhm_smidx_coef_params.csv` | `smidx_coef` | — |
-| `hru_percent_imperv` `:164` | `nhm_hru_percent_imperv_params.csv` | `hru_percent_imperv` | — |
-| `dprst_frac` `:177` | `nhm_dprst_frac_params.csv` | `dprst_frac` | — |
-
-The 10 `fractions:` entries are **intermediates**, not parameters. They write
-partial-pixel-weighted count CSVs to `merged/_intermediates/` and feed the ratios above.
-
-`constants:` holds params a depstor **builder** writes directly, with no zonal pass —
-their source lives in `{fabric}/depstor_rasters/`, and
-`scripts/derive_depstor_params.py --mode copy_constants` copies each into `merged/` under
-its canonical name.
-
-| Entry | Merged file | PRMS parameter | Source |
-| --- | --- | --- | --- |
-| `op_flow_thres` (`constants:`) | `nhm_op_flow_thres_params.csv` | `op_flow_thres` | `depstor_rasters/op_flow_thres_params.csv` (`depstor_rasters.yml:77`) |
-
-### `configs/snarea/snarea_library.yml`
-
-| Merged file | PRMS parameters | Provenance |
-| --- | --- | --- |
-| `nhm_snarea_curve_params.csv` | `hru_deplcrv`, `snarea_thresh`, `snarea_curve` (11 columns) | `cv_assign`, `cv_subgrid`, `cv_empirical`, `cv_source`, `sdc_status`, `sca_class`, `similarity`, `n_seasons`, `n_peak_years`, `peak_swe_mm` |
-
-The `cv_*` columns are **derivable for only ~42% of HRUs by design** — `cv_subgrid` rescues
-the rest. A NaN there is a result, not a gap, which is why they are excluded from
-`fill_columns`.
+- The 10 `fractions:` entries in `depstor_params.yml` are **intermediates**, not parameters.
+  They write partial-pixel-weighted count CSVs to `merged/_intermediates/` and feed the
+  `ratios:` above. `iter_declared_params` excludes them, so they never appear here.
+- `constants:` holds params a depstor **builder** writes directly, with no zonal pass — their
+  source lives in `{fabric}/depstor_rasters/`, and
+  `scripts/derive_depstor_params.py --mode copy_constants` copies each into `merged/`.
+- `snarea_curve`'s entry is the whole of `configs/snarea/snarea_library.yml`, not a list
+  element — it comes from the separate 3-stage SNODAS pipeline, so its `prms:` block is a
+  top-level key.
+- snarea's `cv_*` provenance columns are **derivable for only ~42% of HRUs by design** —
+  `cv_subgrid` rescues the rest. A NaN there is a result, not a gap, which is why they are
+  excluded from `fill_columns`.
+- `slope`'s `hru_slope` is not a raw zonal statistic: it is declared via `derived_columns:`
+  and computed at merge time from `mean`. See [Architecture](ARCHITECTURE.md).
 
 ---
 
 ## By builder
 
+<!-- BEGIN GENERATED: by-builder -->
 | Builder module | PRMS parameters produced |
 | --- | --- |
-| `zonal_runners/zonal.py` | `hru_elev` ⚠️, `hru_slope` (via `merge.py`'s `derived_columns:`), `hru_aspect` (DEFECTIVE) |
-| `zonal_runners/soils.py` | `soil_type` ⚠️, `soil_moist_max` |
-| `zonal_runners/lulc_prederived.py` | `cov_type`, `covden_sum`, `covden_win`, `srain_intcp`, `wrain_intcp`, `snow_intcp`, `rad_trncf` ⚠️ |
-| `zonal_runners/lulc.py` | `cov_type`, `covden_sum`, `covden_win`, `srain_intcp`, `wrain_intcp`, `snow_intcp` (+ unverified `retention`) |
-| `zonal_runners/ssflux.py` | `soil2gw_max`, `ssr2gw_rate`, `fastcoef_lin`, `slowcoef_lin`, `gwflow_coef`, `dprst_seep_rate_open`, `dprst_flow_coef` |
 | `depstor_builders/carea_map.py` | `carea_max`, `smidx_coef` |
-| `depstor_builders/imperv.py` + `landmask.py` | `hru_percent_imperv` |
-| `depstor_builders/dprst.py` + `landmask.py` | `dprst_frac` |
-| `depstor_builders/same_hru_drains.py` (+ `perv.py` / `imperv.py`) | `sro_to_dprst_perv`, `sro_to_dprst_imperv` |
-| `depstor_builders/dprst_depth.py` + `dprst_depth/aggregate.py` | `dprst_depth_avg`, `op_flow_thres` |
-| `snarea/library.py` (← `snarea/build.py` ← `aggregate/`) | `hru_deplcrv`, `snarea_thresh`, `snarea_curve` |
+| `depstor_builders/dprst.py + landmask.py` | `dprst_frac` |
+| `depstor_builders/dprst_depth.py` | `op_flow_thres` |
+| `depstor_builders/dprst_depth.py + dprst_depth/aggregate.py` | `dprst_depth_avg` |
+| `depstor_builders/imperv.py + landmask.py` | `hru_percent_imperv` |
+| `depstor_builders/same_hru_drains.py + imperv.py` | `sro_to_dprst_imperv` |
+| `depstor_builders/same_hru_drains.py + perv.py` | `sro_to_dprst_perv` |
+| `snarea/library.py` | `hru_deplcrv`, `snarea_curve`, `snarea_thresh` |
+| `zonal_runners/lulc.py` | `cov_type`, `covden_sum`, `covden_win`, `snow_intcp`, `srain_intcp`, `wrain_intcp` |
+| `zonal_runners/lulc_prederived.py` | `cov_type`, `covden_sum`, `covden_win`, `rad_trncf`, `snow_intcp`, `srain_intcp`, `wrain_intcp` |
+| `zonal_runners/soils.py` | `soil_moist_max`, `soil_type` |
+| `zonal_runners/ssflux.py` | `dprst_flow_coef`, `dprst_seep_rate_open`, `fastcoef_lin`, `gwflow_coef`, `slowcoef_lin`, `soil2gw_max`, `ssr2gw_rate` |
+| `zonal_runners/zonal.py` | `hru_elev`, `hru_aspect` **(DEFECTIVE)** |
+| `zonal_runners/zonal.py + zonal_runners/merge.py (derived_columns)` | `hru_slope` |
+<!-- END GENERATED: by-builder -->
 
-The depstor ratios are finalised by `gfv2_params/depstor_ratios.py` (a top-level module, not
-part of `depstor_builders/`), driven by `scripts/derive_depstor_params.py --mode ratios`.
+The `builder` string comes from each entry's `prms.builder` key, so it cannot drift from the
+configs the way a lookup table in the generator would. The depstor ratios are finalised by
+`gfv2_params/depstor_ratios.py` (a top-level module, not part of `depstor_builders/`), driven
+by `scripts/derive_depstor_params.py --mode ratios`.
 
 ---
 

--- a/docs/parameter_index.md
+++ b/docs/parameter_index.md
@@ -26,18 +26,21 @@ still holds two `filled_nhm_*.csv` files from the retired `filled_` prefix conve
 - *provenance* marks an emitted column that is not a PRMS parameter — a diagnostic, an
   intermediate, or a raw statistic.
 
-**Five columns are renames** (⚠️): `mean`→`hru_elev`, `mean`→`hru_slope`, `soils`→`soil_type`,
-`retention`→`rad_trncf`, and `op_flow_thres` (right name, wrong directory). Feed any of them
-to PRMS under its emitted name and PRMS will not recognise it.
+**Four columns are renames** (⚠️): `mean`→`hru_elev`, `mean`→`hru_slope`, `soils`→`soil_type`
+and `retention`→`rad_trncf`. Feed any of them to PRMS under its emitted name and PRMS will
+not recognise it.
 
-Three of those are *actively dangerous* rather than merely misnamed — they produce wrong
-numbers or silent omission. Each is explained in [Known gaps](#known-gaps):
+Two of them are *actively dangerous* rather than merely misnamed — they produce wrong
+numbers. Each is explained in [Known gaps](#known-gaps):
 
 | Emitted | Reality |
 | --- | --- |
 | `nhm_slope_params.csv:mean` | degrees, not PRMS rise/run — **~57× if copied verbatim** |
 | `nhm_aspect_params.csv:mean` | **DEFECTIVE** — arithmetic mean of a circular variable ([#201](https://github.com/rmcd-mscb/gfv2-params/issues/201)) |
-| `op_flow_thres_params.csv` | a PRMSRunoff parameter that is **not in `merged/`** |
+
+A third danger — `op_flow_thres` living outside `merged/`, so a `merged/nhm_*_params.csv`
+glob silently dropped a PRMSRunoff parameter — **is now fixed**; see
+[Known gaps](#op_flow_thres-was-not-in-merged-fixed).
 
 The other two renames (`soils`→`soil_type`, `retention`→`rad_trncf`) are safe once you know
 them; the per-process tables below mark every one with ⚠️.
@@ -60,7 +63,7 @@ them; the per-process tables below mark every one with ⚠️.
 | `hru_percent_imperv` | `nhm_hru_percent_imperv_params.csv` | `hru_percent_imperv` | `depstor_params.yml:164` | `depstor_builders/imperv.py` + `landmask.py` |
 | `dprst_frac` | `nhm_dprst_frac_params.csv` | `dprst_frac` | `depstor_params.yml:177` | `depstor_builders/dprst.py` + `landmask.py` |
 | `dprst_depth_avg` | `nhm_dprst_depth_avg_params.csv` | `dprst_depth_avg` | `depstor_params.yml:107` (`means:`) | `depstor_builders/dprst_depth.py` + `dprst_depth/aggregate.py` |
-| `op_flow_thres` ⚠️ | **`op_flow_thres_params.csv`** — in `depstor_rasters/`, **not** `merged/` | `op_flow_thres` | `depstor_rasters.yml:77` | `depstor_builders/dprst_depth.py:361` |
+| `op_flow_thres` | `nhm_op_flow_thres_params.csv` | `op_flow_thres` | `depstor_params.yml` (`constants:`) | `depstor_builders/dprst_depth.py:361` |
 
 `dprst_frac` also appears in `merged/_intermediates/` under the same filename — that copy is
 a partial-pixel **count**, not a `[0, 1]` fraction. The PRMS parameter is the one in
@@ -168,11 +171,14 @@ files — and by the `cov_type` reset rule at
 The 10 `fractions:` entries are **intermediates**, not parameters. They write
 partial-pixel-weighted count CSVs to `merged/_intermediates/` and feed the ratios above.
 
-### `configs/depstor/depstor_rasters.yml`
+`constants:` holds params a depstor **builder** writes directly, with no zonal pass —
+their source lives in `{fabric}/depstor_rasters/`, and
+`scripts/derive_depstor_params.py --mode copy_constants` copies each into `merged/` under
+its canonical name.
 
-| Entry | Output | PRMS parameter |
-| --- | --- | --- |
-| `dprst_depth` `:70`, output name `:77` | `depstor_rasters/op_flow_thres_params.csv` | `op_flow_thres` — **not in `merged/`** |
+| Entry | Merged file | PRMS parameter | Source |
+| --- | --- | --- | --- |
+| `op_flow_thres` (`constants:`) | `nhm_op_flow_thres_params.csv` | `op_flow_thres` | `depstor_rasters/op_flow_thres_params.csv` (`depstor_rasters.yml:77`) |
 
 ### `configs/snarea/snarea_library.yml`
 
@@ -249,13 +255,22 @@ is on disk** — a circular mean is not recoverable from an arithmetic one.
 
 Tracked as [#201](https://github.com/rmcd-mscb/gfv2-params/issues/201).
 
-### `op_flow_thres` is not in `merged/`
+### `op_flow_thres` was not in `merged/` — fixed
 
 A PRMSRunoff parameter written by a depstor builder to
-`{fabric}/depstor_rasters/op_flow_thres_params.csv`. Because it never reaches `merged/`, the
-gap-fill sweep never sees it and the "undeclared merged file" guard cannot flag it. If you
-assemble a parameter file by globbing `merged/nhm_*_params.csv`, **you will silently drop
-it**. It is a constant 1.0 for every HRU.
+`{fabric}/depstor_rasters/op_flow_thres_params.csv`. Because it never reached `merged/`, the
+gap-fill sweep never saw it and the "undeclared merged file" guard could not flag it — anyone
+assembling a parameter file by globbing `merged/nhm_*_params.csv` silently dropped it.
+
+It is now declared as a `constants:` entry in `depstor_params.yml` and copied into
+`merged/nhm_op_flow_thres_params.csv` by
+`scripts/derive_depstor_params.py --mode copy_constants` (step 4 of
+`slurm_batch/RUNME.md`). It is a constant 1.0 for every HRU.
+
+`constants:`, not `means:`, deliberately: `run_mean_zonal` reads
+`spec["source_raster"]` unconditionally and `_find_mean` advertises every `means[].name`
+as a runnable `--mean` target, so a raster-less `means` entry is a `KeyError` waiting for
+the first operator who types `--mean op_flow_thres`.
 
 ### `retention` means two different things
 

--- a/scripts/build_parameter_index.py
+++ b/scripts/build_parameter_index.py
@@ -1,0 +1,369 @@
+"""Render the three machine-derivable views of `docs/parameter_index.md` from `configs/`.
+
+Reads `gfv2_params.params_index` -- pure YAML, no data root, no geo imports -- and
+rewrites three MARKER-DELIMITED regions in `docs/parameter_index.md`:
+
+    <!-- BEGIN GENERATED: by-process -->  ...  <!-- END GENERATED: by-process -->
+    <!-- BEGIN GENERATED: by-entry -->    ...  <!-- END GENERATED: by-entry -->
+    <!-- BEGIN GENERATED: by-builder --> ...  <!-- END GENERATED: by-builder -->
+
+Everything outside those markers -- the preamble, "Reading this index", the notes
+under each view, "Known gaps", "See also" -- is HAND-MAINTAINED and never touched.
+That split is deliberate: the tables are a mechanical projection of the `prms:`
+blocks and go stale the moment a config changes, but the prose (the TEXT_PRMS.tif
+metadata investigation, the aspect measurement, the 57x worked example) is
+hydrologist-reviewed judgement a generator cannot reproduce and must not clobber.
+
+Config-entry line numbers are COMPUTED, not carried: adding a `prms:` block shifts
+every entry below it, so any literal `zonal_params.yml:81` in the doc would be
+wrong the moment this metadata landed.
+
+Usage:
+    python scripts/build_parameter_index.py            # rewrite in place
+    python scripts/build_parameter_index.py --check    # exit 1 if it would change
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+from gfv2_params.params_index import (
+    DEPSTOR_PARAMS_CONFIG,
+    SNAREA_LIBRARY_CONFIG,
+    ZONAL_PARAMS_CONFIG,
+    DeclaredParam,
+    load_declared_params,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+INDEX_PATH = _REPO_ROOT / "docs" / "parameter_index.md"
+
+# Which top-level list of each config `iter_declared_params` draws entries from.
+# `fractions:` is excluded there, and must be excluded here too: `dprst_frac` is a
+# name in BOTH `fractions:` (a count CSV in merged/_intermediates/) and `ratios:`
+# (the PRMS parameter), and a naive scan for `- name: dprst_frac` finds the wrong
+# one -- it appears first.
+_ENTRY_SECTIONS = {
+    ZONAL_PARAMS_CONFIG: ("params",),
+    DEPSTOR_PARAMS_CONFIG: ("means", "ratios", "constants"),
+}
+
+
+def _entry_locations() -> dict[str, str]:
+    """Map entry name -> "<config-basename>:<line>", scanning the raw YAML text.
+
+    A text scan rather than a YAML parse because PyYAML discards line numbers, and
+    the whole point of the cite is to be clickable at a specific line.
+    """
+    locations: dict[str, str] = {}
+    for config, sections in _ENTRY_SECTIONS.items():
+        current: str | None = None
+        for lineno, line in enumerate(config.read_text().splitlines(), start=1):
+            top = re.match(r"^([a-z_]+):\s*$", line)
+            if top:
+                current = top.group(1)
+                continue
+            if current not in sections:
+                continue
+            entry = re.match(r"^\s*-\s+name:\s*(\S+)", line)
+            if entry:
+                locations[entry.group(1)] = f"{config.name}:{lineno}"
+    # snarea_curve has no `- name:` line: the whole document is the entry.
+    locations["snarea_curve"] = SNAREA_LIBRARY_CONFIG.name
+    return locations
+
+
+def _natural_key(col: str):
+    """Sort snarea_curve_10 after snarea_curve_9, not after snarea_curve_1."""
+    m = re.match(r"^(.*?)(\d+)$", col)
+    return (m.group(1), int(m.group(2))) if m else (col, -1)
+
+
+def _render_columns(cols: list[str]) -> str:
+    """One table cell for the emitted column(s) behind a single PRMS parameter.
+
+    Two cases collapse many columns into one row: an ALIAS group (lulc_nhm_v11's
+    `retention` | `rad_trncf`, the same quantity under two names across fabric
+    vintages) and a DIMENSIONED parameter (snarea_curve_0..10, one PRMS
+    `snarea_curve` of extent ndeplval).
+    """
+    if len(cols) > 3:
+        ordered = sorted(cols, key=_natural_key)
+        return f"`{ordered[0]}` … `{ordered[-1]}`"
+    return r" \| ".join(f"`{c}`" for c in cols)
+
+
+def _process_rows(declared: list[DeclaredParam], locations: dict[str, str]):
+    """(process -> rows) plus the no-process bucket, from prms.columns + prms.defects.
+
+    A `defects` entry produces a DEFECTIVE row under every process it names, and is
+    NEVER merged with a real one -- that is the whole reason `defects` is a separate
+    bucket from `columns`.
+
+    Rows are keyed per (parameter, emitting FILE) and then COLLAPSED across files
+    that emit the same parameter from the same column name -- the four LULC sources
+    are alternatives, not four separate parameters, and left uncollapsed they turn
+    PRMSCanopy's six parameters into twenty-four rows. `_collapse` keeps the file,
+    entry and builder lists in the same order so a reader can pair them positionally.
+    """
+    by_process: dict[str, dict[tuple, dict]] = defaultdict(dict)
+    unconsumed: dict[tuple, dict] = {}
+
+    def _add(bucket, d, col, spec, defective):
+        prms_name = spec["prms"]
+        key = (prms_name, d.merged_file, d.name, defective)
+        row = bucket.setdefault(
+            key,
+            {
+                "prms": prms_name,
+                # Parallel-array invariant: sources[i] is one (file, entry,
+                # builder) triple, so the three rendered cells line up row-wise
+                # even after `_collapse` merges alternative sources.
+                "sources": [
+                    (
+                        d.merged_file,
+                        locations.get(d.name, d.name),
+                        d.prms.get("builder", "—"),
+                    )
+                ],
+                "cols": [],
+                "defective": defective,
+                "issue": spec.get("issue"),
+            },
+        )
+        row["cols"].append(col)
+
+    for d in declared:
+        for col, spec in (d.prms.get("columns") or {}).items():
+            processes = spec.get("processes") or []
+            if not processes:
+                _add(unconsumed, d, col, spec, False)
+            for process in processes:
+                _add(by_process[process], d, col, spec, False)
+        for col, spec in (d.prms.get("defects") or {}).items():
+            for process in spec.get("processes") or []:
+                _add(by_process[process], d, col, spec, True)
+
+    return (
+        {p: _collapse(rows) for p, rows in by_process.items()},
+        _collapse(unconsumed),
+    )
+
+
+def _collapse(rows: dict[tuple, dict]) -> dict[tuple, dict]:
+    """Merge rows that emit the same parameter from the same column name(s)."""
+    merged: dict[tuple, dict] = {}
+    for _, row in sorted(rows.items()):
+        key = (row["prms"], tuple(sorted(row["cols"])), row["defective"])
+        if key in merged:
+            for source in row["sources"]:
+                if source not in merged[key]["sources"]:
+                    merged[key]["sources"].append(source)
+        else:
+            merged[key] = row
+    # Config order, not alphabetical: the four LULC alternatives then read in the
+    # order they appear in zonal_params.yml, which is how an operator meets them.
+    for row in merged.values():
+        row["sources"].sort(key=lambda s: _entry_sort_key(s[1]))
+    return merged
+
+
+def _entry_sort_key(entry: str):
+    """Sort a `<config>:<line>` cite by file then NUMERIC line, not string line."""
+    config, _, line = entry.partition(":")
+    return (config, int(line) if line.isdigit() else 0)
+
+
+def _row_markdown(row: dict) -> str:
+    warn = "" if row["defective"] else _rename_marker(row)
+    if row["defective"]:
+        issue = row.get("issue")
+        link = (
+            f" ([#{issue}](https://github.com/rmcd-mscb/gfv2-params/issues/{issue}))"
+            if issue
+            else ""
+        )
+        column = f"**DEFECTIVE** — {_render_columns(row['cols'])} is not this parameter{link}"
+    else:
+        column = _render_columns(row["cols"])
+    files, entries, builders = (list(x) for x in zip(*row["sources"]))
+    return (
+        f"| `{row['prms']}`{warn} | {_cell(files)} | {column} "
+        f"| {_cell(entries)} | {_cell(builders)} |"
+    )
+
+
+def _cell(values: list[str]) -> str:
+    """One markdown cell. Repeats are kept so the three cells stay row-aligned."""
+    return " · ".join(f"`{v}`" for v in values)
+
+
+def _rename_marker(row: dict) -> str:
+    """⚠️ iff the emitted column name is not the PRMS parameter name.
+
+    A DIMENSIONED parameter is not a rename: `snarea_curve` of extent ndeplval is
+    emitted as `snarea_curve_0..10`, and flagging that ⚠️ would tell a reader to
+    translate a name that needs no translation. Only a genuinely different name --
+    `soils` for `soil_type`, `mean` for `hru_elev` -- earns the marker.
+
+    An ALIAS group does earn it, even though one alternative matches: lulc_nhm_v11
+    declares both `retention` and `rad_trncf`, and which one is on disk depends on
+    the fabric's vintage. A reader looking at gfv2 or oregon sees `retention` and
+    does need to translate, so the test is "is EVERY declared column the PRMS
+    name?", not "is ANY of them?".
+    """
+    if set(row["cols"]) == {row["prms"]}:
+        return ""
+    if all(re.fullmatch(rf"{re.escape(row['prms'])}_\d+", c) for c in row["cols"]):
+        return ""
+    return " ⚠️"
+
+
+_TABLE_HEAD = (
+    "| PRMS parameter | Emitted file | Column | Config entry | Builder |\n"
+    "| --- | --- | --- | --- | --- |"
+)
+
+
+def render_by_process(declared, locations) -> str:
+    by_process, unconsumed = _process_rows(declared, locations)
+    out: list[str] = []
+
+    def _section(title: str, rows: dict, count_note: str) -> None:
+        out.append(f"### {title} — {count_note}")
+        out.append("")
+        out.append(_TABLE_HEAD)
+        for _, row in sorted(rows.items(), key=lambda kv: (kv[1]["defective"], kv[0])):
+            out.append(_row_markdown(row))
+        out.append("")
+
+    # Most-consumed process first; a scientist asking "which parameters feed PRMS
+    # runoff?" should not have to scroll past PRMSGroundwater's single row.
+    def _n_params(rows):
+        return len({r["prms"] for r in rows.values() if not r["defective"]})
+
+    for process, rows in sorted(
+        by_process.items(), key=lambda kv: (-_n_params(kv[1]), kv[0])
+    ):
+        n = _n_params(rows)
+        n_defective = len({r["prms"] for r in rows.values() if r["defective"]})
+        note = f"{n} parameter{'s' if n != 1 else ''}"
+        if n_defective:
+            note += f" (+{n_defective} defective)"
+        _section(process, rows, note)
+
+    if unconsumed:
+        n = len({r["prms"] for r in unconsumed.values()})
+        _section(
+            "Not consumed by any pywatershed process",
+            unconsumed,
+            f"{n} parameter{'s' if n != 1 else ''}",
+        )
+
+    return "\n".join(out).rstrip()
+
+
+def render_by_entry(declared, locations) -> str:
+    """One row per config entry: what it emits, and what is provenance."""
+    out = [
+        "| Config entry | Merged file | PRMS parameters | Provenance columns |",
+        "| --- | --- | --- | --- |",
+    ]
+    # _entry_sort_key, not the raw string: "zonal_params.yml:43" sorts AFTER
+    # "zonal_params.yml:389" under a string comparison, which scrambled the table
+    # into 133, 169, 187, 209, 277, 331, 389, 43, 451, 81.
+    for d in sorted(declared, key=lambda d: (_entry_sort_key(locations.get(d.name, "")), d.name)):
+        columns = d.prms.get("columns") or {}
+        defects = d.prms.get("defects") or {}
+        cells = [f"`{p}`" for p in sorted({spec["prms"] for spec in columns.values()})]
+        cells += [
+            f"`{spec['prms']}` — **DEFECTIVE** (emitted as `{col}`)"
+            for col, spec in sorted(defects.items())
+        ]
+        rendered = ", ".join(cells) if cells else "—"
+        prov = sorted(d.prms.get("provenance") or {})
+        out.append(
+            f"| `{d.name}` | `{d.merged_file}` | {rendered} | "
+            f"{', '.join(f'`{c}`' for c in prov) if prov else '—'} |"
+        )
+    return "\n".join(out)
+
+
+def render_by_builder(declared) -> str:
+    """One row per `prms.builder` string, with the PRMS parameters it produces."""
+    good: dict[str, set[str]] = defaultdict(set)
+    broken: dict[str, set[str]] = defaultdict(set)
+    for d in declared:
+        builder = d.prms.get("builder", "—")
+        for spec in (d.prms.get("columns") or {}).values():
+            good[builder].add(spec["prms"])
+        for spec in (d.prms.get("defects") or {}).values():
+            broken[builder].add(spec["prms"])
+    out = [
+        "| Builder module | PRMS parameters produced |",
+        "| --- | --- |",
+    ]
+    for builder in sorted(set(good) | set(broken)):
+        # "(DEFECTIVE)" stays OUTSIDE the backticks -- inside, it reads as part of
+        # the parameter name, which is the one thing this column must not imply.
+        cells = [f"`{p}`" for p in sorted(good[builder])]
+        cells += [f"`{p}` **(DEFECTIVE)**" for p in sorted(broken[builder])]
+        out.append(f"| `{builder}` | {', '.join(cells)} |")
+    return "\n".join(out)
+
+
+def _replace_region(text: str, name: str, body: str) -> str:
+    begin, end = f"<!-- BEGIN GENERATED: {name} -->", f"<!-- END GENERATED: {name} -->"
+    pattern = re.compile(rf"{re.escape(begin)}.*?{re.escape(end)}", re.S)
+    if not pattern.search(text):
+        raise SystemExit(
+            f"{INDEX_PATH} has no '{name}' generated region. Expected a\n"
+            f"  {begin}\n  ...\n  {end}\n"
+            f"pair -- the generator only rewrites marked regions so it cannot clobber "
+            f"the hand-maintained prose around them."
+        )
+    # `\g<0>`-free literal replacement: body may contain backslashes (`\|` escapes
+    # a pipe inside a markdown table cell) and re.sub would treat them as group refs.
+    return pattern.sub(lambda _m: f"{begin}\n{body}\n{end}", text)
+
+
+def build(check: bool = False) -> int:
+    declared = load_declared_params()
+    locations = _entry_locations()
+
+    text = INDEX_PATH.read_text()
+    new = _replace_region(text, "by-process", render_by_process(declared, locations))
+    new = _replace_region(new, "by-entry", render_by_entry(declared, locations))
+    new = _replace_region(new, "by-builder", render_by_builder(declared))
+
+    if new == text:
+        print(f"{INDEX_PATH.relative_to(_REPO_ROOT)} is up to date.")
+        return 0
+    if check:
+        print(
+            f"{INDEX_PATH.relative_to(_REPO_ROOT)} is STALE -- re-run "
+            f"`python scripts/build_parameter_index.py`.",
+            file=sys.stderr,
+        )
+        return 1
+    INDEX_PATH.write_text(new)
+    print(f"Wrote {INDEX_PATH.relative_to(_REPO_ROOT)} ({len(declared)} declared entries).")
+    return 0
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="exit 1 if the index is stale instead of rewriting it",
+    )
+    raise SystemExit(build(check=parser.parse_args().check))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/build_parameter_index.py
+++ b/scripts/build_parameter_index.py
@@ -57,7 +57,8 @@ def _entry_locations() -> dict[str, str]:
     """Map entry name -> "<config-basename>:<line>", scanning the raw YAML text.
 
     A text scan rather than a YAML parse because PyYAML discards line numbers, and
-    the whole point of the cite is to be clickable at a specific line.
+    the whole point of the cite is to land a reader on a specific line (the cite
+    renders as inline code, so it is copy-pasteable rather than clickable).
     """
     locations: dict[str, str] = {}
     for config, sections in _ENTRY_SECTIONS.items():
@@ -86,10 +87,12 @@ def _natural_key(col: str):
 def _render_columns(cols: list[str]) -> str:
     """One table cell for the emitted column(s) behind a single PRMS parameter.
 
-    Two cases collapse many columns into one row: an ALIAS group (lulc_nhm_v11's
+    Row COLLAPSING happens in `_add`/`_collapse`; this only renders whatever
+    columns arrive. Two shapes reach it: a short ALIAS group (lulc_nhm_v11's
     `retention` | `rad_trncf`, the same quantity under two names across fabric
-    vintages) and a DIMENSIONED parameter (snarea_curve_0..10, one PRMS
-    `snarea_curve` of extent ndeplval).
+    vintages), joined with a pipe in declaration order; and a DIMENSIONED
+    parameter (snarea_curve_0..10, one PRMS `snarea_curve` of extent ndeplval),
+    abbreviated `first … last` once there are more than three.
     """
     if len(cols) > 3:
         ordered = sorted(cols, key=_natural_key)
@@ -145,7 +148,14 @@ def _process_rows(declared: list[DeclaredParam], locations: dict[str, str]):
             for process in processes:
                 _add(by_process[process], d, col, spec, False)
         for col, spec in (d.prms.get("defects") or {}).items():
-            for process in spec.get("processes") or []:
+            processes = spec.get("processes") or []
+            if not processes:
+                # Same fallback the columns loop has. Without it a defect whose
+                # consuming process is not yet known vanishes from the by-process
+                # view entirely -- the exact silent omission the defects bucket
+                # exists to prevent.
+                _add(unconsumed, d, col, spec, True)
+            for process in processes:
                 _add(by_process[process], d, col, spec, True)
 
     return (
@@ -331,6 +341,20 @@ def _replace_region(text: str, name: str, body: str) -> str:
     return pattern.sub(lambda _m: f"{begin}\n{body}\n{end}", text)
 
 
+def _display_path(path: Path) -> str:
+    """Repo-relative when possible, absolute otherwise.
+
+    `relative_to` RAISES on a path outside the repo, which made every log line in
+    `build` a crash whenever INDEX_PATH pointed elsewhere -- i.e. whenever a test
+    redirected it to a tmp_path. A progress message must never be the thing that
+    fails.
+    """
+    try:
+        return str(path.relative_to(_REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
 def build(check: bool = False) -> int:
     declared = load_declared_params()
     locations = _entry_locations()
@@ -341,17 +365,17 @@ def build(check: bool = False) -> int:
     new = _replace_region(new, "by-builder", render_by_builder(declared))
 
     if new == text:
-        print(f"{INDEX_PATH.relative_to(_REPO_ROOT)} is up to date.")
+        print(f"{_display_path(INDEX_PATH)} is up to date.")
         return 0
     if check:
         print(
-            f"{INDEX_PATH.relative_to(_REPO_ROOT)} is STALE -- re-run "
+            f"{_display_path(INDEX_PATH)} is STALE -- re-run "
             f"`python scripts/build_parameter_index.py`.",
             file=sys.stderr,
         )
         return 1
     INDEX_PATH.write_text(new)
-    print(f"Wrote {INDEX_PATH.relative_to(_REPO_ROOT)} ({len(declared)} declared entries).")
+    print(f"Wrote {_display_path(INDEX_PATH)} ({len(declared)} declared entries).")
     return 0
 
 

--- a/scripts/derive_depstor_params.py
+++ b/scripts/derive_depstor_params.py
@@ -1,6 +1,6 @@
 """Drive every depstor aggregation step from configs/depstor/depstor_params.yml.
 
-Five modes:
+Six modes:
   --mode zonal --fraction <name> --batch_id <N>
         Array task: run gdptools exactextract for one fraction over one HRU
         batch (same pattern as scripts/derive_zonal_params.py --mode zonal,
@@ -18,6 +18,11 @@ Five modes:
   --mode mean_finalize --mean <name>
         Concat the mean_zonal batch CSVs and finalize units/floor/provenance
         via gfv2_params.dprst_depth.aggregate.finalize_depth_params().
+  --mode copy_constants
+        Copy every `constants:` source (a per-HRU CSV a depstor BUILDER wrote
+        directly, with no zonal pass) into merged/ under its canonical name,
+        so "everything a consumer needs is in merged/" holds. Takes no
+        --fraction/--mean.
 
 The slurm wrapper slurm_batch/submit_depstor_params.sh chains the
 zonal/merge/ratios modes into a single afterok DAG; mean_zonal/mean_finalize
@@ -431,6 +436,47 @@ def run_merge(args, logger) -> None:
     logger.info("Merged %d rows -> %s", len(merged), out_path)
 
 
+def run_copy_constants(args, logger) -> None:
+    """Copy each `constants:` source into merged/ under its canonical name.
+
+    A straight copy, not a computation: the builder already wrote one row per HRU
+    (depstor_builders/dprst_depth.py builds the id column from ctx.hru_gpkg), so
+    there is nothing to aggregate and the fill declaration is a no-op.
+
+    The point is the LOCATION, not the values. op_flow_thres is a PRMSRunoff
+    parameter that a builder writes to depstor_rasters/, which made it invisible
+    to both iter_declared_params and warn_undeclared_merged_files -- anyone
+    assembling a parameter file by globbing merged/nhm_*_params.csv dropped it
+    silently.
+
+    Raises on a missing source rather than skipping: a constant that is not there
+    means the depstor raster build has not run, and a silent skip would leave the
+    same hole this mode exists to close.
+    """
+    config = _load_resolved_config(args)
+    constants = config.get("constants", []) or []
+    if not constants:
+        logger.warning("No `constants:` entries in %s -- nothing to copy.", args.config)
+        return
+
+    _, merged_dir = _merge_paths(config)
+    merged_dir.mkdir(parents=True, exist_ok=True)
+
+    logger.info("=== copy_constants (%d) ===", len(constants))
+    for entry in constants:
+        src = Path(entry["source"])
+        if not src.exists():
+            raise FileNotFoundError(
+                f"constants entry '{entry['name']}' source not found: {src}. "
+                f"Run the depstor raster build first -- this file is written by a "
+                f"builder, not by a zonal pass."
+            )
+        dst = merged_dir / entry["merged_file"]
+        df = pd.read_csv(src)
+        df.to_csv(dst, index=False)
+        logger.info("copy_constants: %s -> %s (%d rows)", src, dst, len(df))
+
+
 def run_ratios(args, logger) -> None:
     config = _load_resolved_config(args)
     defaults = config["defaults"]
@@ -510,7 +556,7 @@ def main():
     parser.add_argument("--fabric", default=None, help="Fabric name (overrides FABRIC env / default_fabric)")
     parser.add_argument(
         "--mode", required=True,
-        choices=["zonal", "merge", "ratios", "mean_zonal", "mean_finalize"],
+        choices=["zonal", "merge", "ratios", "mean_zonal", "mean_finalize", "copy_constants"],
     )
     parser.add_argument("--fraction", default=None, help="Fraction name (required for zonal/merge)")
     parser.add_argument("--mean", default=None, help="Mean-aggregation name (required for mean_zonal/mean_finalize)")
@@ -533,6 +579,8 @@ def main():
         run_mean_zonal(args, logger)
     elif args.mode == "mean_finalize":
         run_mean_finalize(args, logger)
+    elif args.mode == "copy_constants":
+        run_copy_constants(args, logger)
     else:
         run_ratios(args, logger)
 

--- a/scripts/derive_depstor_params.py
+++ b/scripts/derive_depstor_params.py
@@ -452,27 +452,77 @@ def run_copy_constants(args, logger) -> None:
     Raises on a missing source rather than skipping: a constant that is not there
     means the depstor raster build has not run, and a silent skip would leave the
     same hole this mode exists to close.
+
+    Validates before writing, because this function BLESSES bytes as a canonical
+    merged/ parameter file and every other writer into that directory validates
+    (`zonal_runners/merge.py` checks the id column, raises on duplicate ids, and
+    runs a gap census; `run_ratios` and `finalize_depth_params` likewise). A
+    truncated source -- the depstor build interrupted mid-flush, or a file left
+    over from a smaller earlier fabric -- would otherwise be copied, logged with a
+    row count nobody compares to anything, and become canonical. The fill sweep
+    then KNN-fills the missing HRUs; for a genuinely constant column the
+    interpolated value is right by luck, so the truncation is undetectable
+    forever, and the first `constants:` entry that is not constant ships
+    interpolated values under a canonical name.
     """
     config = _load_resolved_config(args)
     constants = config.get("constants", []) or []
     if not constants:
-        logger.warning("No `constants:` entries in %s -- nothing to copy.", args.config)
-        return
+        # Raise, not warn. An empty endorheic table is a legitimate DATA state
+        # (CLAUDE.md), but an empty `constants:` list is a CONFIG state in a
+        # single fabric-independent file, and there is no fabric for which
+        # "the operator asked to copy constants and there are none" is correct.
+        # --config is required with no default, so the realistic cause is a
+        # wrong config path -- which would otherwise exit 0 having copied
+        # nothing. Same lesson as 6b7547a (fail loud when a STEP_ORDER step has
+        # no config block).
+        raise ValueError(
+            f"No `constants:` entries in {args.config}. --mode copy_constants has "
+            f"nothing to do, which is never a correct outcome -- check that "
+            f"--config points at configs/depstor/depstor_params.yml. Top-level "
+            f"sections found: {sorted(k for k in config if not k.startswith('_'))}"
+        )
+
+    id_feature = config["defaults"]["id_feature"]
+    expected_max = config.get("expected_max_hru_id")
 
     _, merged_dir = _merge_paths(config)
     merged_dir.mkdir(parents=True, exist_ok=True)
 
     logger.info("=== copy_constants (%d) ===", len(constants))
     for entry in constants:
+        name = entry["name"]
         src = Path(entry["source"])
         if not src.exists():
             raise FileNotFoundError(
-                f"constants entry '{entry['name']}' source not found: {src}. "
+                f"constants entry '{name}' source not found: {src}. "
                 f"Run the depstor raster build first -- this file is written by a "
                 f"builder, not by a zonal pass."
             )
-        dst = merged_dir / entry["merged_file"]
         df = pd.read_csv(src)
+
+        if id_feature not in df.columns:
+            raise ValueError(
+                f"constants entry '{name}': {src} has no '{id_feature}' column "
+                f"(columns: {sorted(df.columns)}). The active fabric's id_feature "
+                f"must be present, or every downstream join silently misses."
+            )
+        dupes = df[df[id_feature].duplicated(keep=False)][id_feature].unique()
+        if len(dupes):
+            raise ValueError(
+                f"constants entry '{name}': {src} has {len(dupes)} duplicate "
+                f"{id_feature} values (first 10: {sorted(dupes)[:10]})."
+            )
+        if expected_max is not None and len(df) != int(expected_max):
+            raise ValueError(
+                f"constants entry '{name}': {src} has {len(df)} rows but this fabric "
+                f"has {expected_max} HRUs. Refusing to copy a partial file into "
+                f"merged/ -- the fill sweep would KNN-fill the gap, and for a "
+                f"constant column the interpolated value looks correct, so the "
+                f"truncation would never be noticed. Re-run the depstor build."
+            )
+
+        dst = merged_dir / entry["merged_file"]
         df.to_csv(dst, index=False)
         logger.info("copy_constants: %s -> %s (%d rows)", src, dst, len(df))
 

--- a/scripts/merge_and_fill_params.py
+++ b/scripts/merge_and_fill_params.py
@@ -13,17 +13,25 @@ import fnmatch
 import math
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import NamedTuple
 
 import geopandas as gpd
 import numpy as np
 import pandas as pd
-import yaml
 from sklearn.neighbors import NearestNeighbors
 from tqdm import tqdm
 
 from gfv2_params.config import load_base_config, require_config_key
 from gfv2_params.log import configure_logging
+
+# The declaration this sweep is driven by lives in the package, not here, so the
+# index generator and the two guards can import it without importing this script's
+# geo stack. Re-exported by this import: tests/test_merge_and_fill_params.py
+# reaches them as `maf.DeclaredParam` / `maf.iter_declared_params`.
+from gfv2_params.params_index import (  # noqa: F401  (DeclaredParam re-exported)
+    DeclaredParam,
+    iter_declared_params,
+    load_declared_params,
+)
 
 
 def find_missing_ids(param_file, expected_max, id_feature, logger):
@@ -338,121 +346,6 @@ def write_filled_in_place(complete_df, param_file, original_df, dtypes, logger=N
     return param_file
 
 
-# Repo-relative config paths consumed by `iter_declared_params`. Only the
-# static `name`/`merged_file`/`output_file`/`fill_columns` fields are read
-# here (none are {data_root}/{fabric}-templated), so a bare yaml.safe_load is
-# enough -- no need for gfv2_params.config.load_config's fabric-profile
-# resolution, which keeps this read safe with no data root (the CI contract:
-# tests may parse these files but must not touch a real data root).
-_REPO_ROOT = Path(__file__).resolve().parent.parent
-ZONAL_PARAMS_CONFIG = _REPO_ROOT / "configs" / "zonal" / "zonal_params.yml"
-DEPSTOR_PARAMS_CONFIG = _REPO_ROOT / "configs" / "depstor" / "depstor_params.yml"
-SNAREA_LIBRARY_CONFIG = _REPO_ROOT / "configs" / "snarea" / "snarea_library.yml"
-
-
-def _load_yaml_doc(path: Path) -> dict:
-    """Bare `yaml.safe_load` of a config file, no placeholder resolution."""
-    doc = yaml.safe_load(path.read_text())
-    return doc or {}
-
-
-class DeclaredParam(NamedTuple):
-    """One config entry's fill contract: what file, and what may be written into it.
-
-    A NamedTuple rather than a bare tuple because this record has now been widened
-    twice (`fill_columns`, then `fabric_columns`) and each widening has to reach FOUR
-    consumption sites. The `fabric_columns` widening missed one of them --
-    `warn_undeclared_merged_files`, whose `for _, merged_file, _ in ...` then raised
-    `ValueError: too many values to unpack` in all-params mode, the DEFAULT and the
-    only mode `slurm_batch/merge_and_fill_params.batch` runs. It aborted `main()`
-    outside `run_fill_sweep`'s per-param guard, so nothing was filled at all, while
-    the test suite stayed green because its fixtures hand-built the OLD 3-tuple shape
-    -- test and implementation wrong in the same direction, agreeing with each other.
-
-    Attribute access cannot drift that way: a fifth field is invisible to every
-    consumer that does not ask for it.
-    """
-
-    name: str
-    merged_file: str
-    fill_columns: list[str]
-    fabric_columns: dict
-
-
-def iter_declared_params(
-    zonal_cfg: dict, depstor_cfg: dict, snarea_cfg: dict | None = None
-) -> list[DeclaredParam]:
-    """Every param with a canonical `merged/` output, and what it declares fillable.
-
-    Returns `DeclaredParam(name, merged_file, fill_columns, fabric_columns)` records.
-    `fill_columns` is KNN-interpolated; `fabric_columns` is copied verbatim from the
-    fabric GDF (see `apply_fabric_columns`). Both default to empty for the params that
-    declare neither -- today every param but `ssflux` has an empty `fabric_columns`.
-
-    `zonal_cfg["params"]` and `depstor_cfg["means"]` name their canonical file
-    `merged_file`; `depstor_cfg["ratios"]` names it `output_file` instead (see
-    `derive_depstor_params.py`'s `run_mean_finalize` / `run_ratios`).
-    `depstor_cfg["fractions"]` is DELIBERATELY EXCLUDED: every fraction entry
-    also happens to carry a `merged_file` key, but that key names the
-    per-fraction COUNT csv written to `merged/_intermediates/` (`run_merge`),
-    never a `merged/` output -- fractions are intermediates, not
-    consumer-facing params, and are never filled.
-
-    `snarea_cfg` is optional and does NOT share either config's
-    list-of-entries shape. `snarea_curve` is not a `zonal_params.yml` entry at
-    all -- it comes from the separate 3-stage SNODAS pipeline
-    (`configs/snarea/snarea_library.yml`, Stage 3), a flat single-param config
-    whose `params_file` names the real `nhm_snarea_curve_params.csv`. A
-    synthetic `snarea_curve` entry could not live in `zonal_params.yml`
-    instead. `slurm_batch/submit_zonal_params.sh` does not read the YAML -- it
-    carries a hardcoded `PARAMS` bash array mirroring that `params:`
-    list -- and `tests/test_submit_wrapper_param_lists.py` requires the two to
-    match. So a phantom entry would have to be added to the array too, and the
-    wrapper would then submit a SLURM array job for an entry with no
-    `source_raster`/`script:`. Hence the separate optional argument rather than
-    a fourth zonal-shaped list.
-    """
-    def _record(name: str, merged_file: str, entry: dict) -> DeclaredParam:
-        return DeclaredParam(
-            name=name,
-            merged_file=merged_file,
-            fill_columns=list(entry.get("fill_columns") or []),
-            fabric_columns=dict(entry.get("fabric_columns") or {}),
-        )
-
-    declared: list[DeclaredParam] = []
-
-    for entry in zonal_cfg.get("params", []) or []:
-        merged_file = entry.get("merged_file")
-        if merged_file:
-            declared.append(_record(entry["name"], merged_file, entry))
-
-    for entry in depstor_cfg.get("means", []) or []:
-        merged_file = entry.get("merged_file")
-        if merged_file:
-            declared.append(_record(entry["name"], merged_file, entry))
-
-    for entry in depstor_cfg.get("ratios", []) or []:
-        merged_file = entry.get("output_file")
-        if merged_file:
-            declared.append(_record(entry["name"], merged_file, entry))
-
-    if snarea_cfg:
-        merged_file = snarea_cfg.get("params_file")
-        if merged_file:
-            declared.append(_record("snarea_curve", merged_file, snarea_cfg))
-
-    return declared
-
-
-def _load_declared_params() -> list[DeclaredParam]:
-    """`iter_declared_params` over the real in-repo configs."""
-    zonal_cfg = _load_yaml_doc(ZONAL_PARAMS_CONFIG)
-    depstor_cfg = _load_yaml_doc(DEPSTOR_PARAMS_CONFIG)
-    snarea_cfg = _load_yaml_doc(SNAREA_LIBRARY_CONFIG)
-    return iter_declared_params(zonal_cfg, depstor_cfg, snarea_cfg)
-
-
 def check_param_file_in_fabric(param_file: Path, merged_dir: Path) -> None:
     """Refuse a `--param_file` that does not live under the active fabric's
     own `merged/` directory.
@@ -745,7 +638,7 @@ def main():
         ) from exc
     logger.info("Loaded %d features", len(merged_gdf))
 
-    declared_params = _load_declared_params()
+    declared_params = load_declared_params()
 
     if args.param_file is not None:
         # Single-param mode: fill exactly the file named on the CLI, routed

--- a/slurm_batch/HPC_REFERENCE.md
+++ b/slurm_batch/HPC_REFERENCE.md
@@ -1337,7 +1337,7 @@ sacct -j <JOBID> -o JobID,State,Elapsed,MaxRSS
 | `slurm_batch/run_dprst_depth_batch.batch` | `submit_dprst_depth.sh` | `configs/depstor/depstor_rasters.yml` | `scripts/run_dprst_depth_batch.py --batch_id $SLURM_ARRAY_TASK_ID` |
 | `slurm_batch/mean_zonal_dprst_depth.batch` | `submit_dprst_depth.sh` | `configs/depstor/depstor_params.yml` | `scripts/derive_depstor_params.py --mode mean_zonal --mean dprst_depth_avg` |
 | `slurm_batch/mean_finalize_dprst_depth.batch` | `submit_dprst_depth.sh` | `configs/depstor/depstor_params.yml` | `scripts/derive_depstor_params.py --mode mean_finalize --mean dprst_depth_avg` |
-| *(no batch file — run directly)* | — | `configs/depstor/depstor_params.yml` | `scripts/derive_depstor_params.py --mode copy_constants` — copies every `constants:` source into `merged/`. Seconds, no array; needs `submit_dprst_depth.sh` to have written `op_flow_thres_params.csv` first |
+| `slurm_batch/copy_depstor_constants.batch` | `submit_depstor_params.sh` | `configs/depstor/depstor_params.yml` | `scripts/derive_depstor_params.py --mode copy_constants` — copies every `constants:` source into `merged/`, chained `afterok` on the ratios job. Seconds, no array; needs `submit_dprst_depth.sh` to have written `op_flow_thres_params.csv` first, and fails loudly if not |
 
 ### Stage 3 / fabric-prep batches
 

--- a/slurm_batch/HPC_REFERENCE.md
+++ b/slurm_batch/HPC_REFERENCE.md
@@ -1337,6 +1337,7 @@ sacct -j <JOBID> -o JobID,State,Elapsed,MaxRSS
 | `slurm_batch/run_dprst_depth_batch.batch` | `submit_dprst_depth.sh` | `configs/depstor/depstor_rasters.yml` | `scripts/run_dprst_depth_batch.py --batch_id $SLURM_ARRAY_TASK_ID` |
 | `slurm_batch/mean_zonal_dprst_depth.batch` | `submit_dprst_depth.sh` | `configs/depstor/depstor_params.yml` | `scripts/derive_depstor_params.py --mode mean_zonal --mean dprst_depth_avg` |
 | `slurm_batch/mean_finalize_dprst_depth.batch` | `submit_dprst_depth.sh` | `configs/depstor/depstor_params.yml` | `scripts/derive_depstor_params.py --mode mean_finalize --mean dprst_depth_avg` |
+| *(no batch file — run directly)* | — | `configs/depstor/depstor_params.yml` | `scripts/derive_depstor_params.py --mode copy_constants` — copies every `constants:` source into `merged/`. Seconds, no array; needs `submit_dprst_depth.sh` to have written `op_flow_thres_params.csv` first |
 
 ### Stage 3 / fabric-prep batches
 

--- a/slurm_batch/RUNME.md
+++ b/slurm_batch/RUNME.md
@@ -323,12 +323,23 @@ holds the full stack (through `carea_map_t8/t156_binary.tif`).
 BATCHES=$(pixi run data-root)/gfv2/batches
 slurm_batch/submit_zonal_params.sh   "$BATCHES" gfv2 configs/base_config.yml
 slurm_batch/submit_depstor_params.sh "$BATCHES" gfv2 configs/base_config.yml
+#     Copy the builder-written constants into merged/ (fast, no array job):
+pixi run --as-is python scripts/derive_depstor_params.py \
+  --config configs/depstor/depstor_params.yml \
+  --base_config configs/base_config.yml --fabric gfv2 --mode copy_constants
 ```
 
 **What it does:** `submit_zonal_params.sh` chains every zonal parameter (array
 + merge per param, `slope`→`ssflux` dependency and weights prereq handled
 automatically); `submit_depstor_params.sh` chains all 10 depstor fractions +
-the 6 PRMS ratios job.
+the 6 PRMS ratios job. `--mode copy_constants` then copies every
+`constants:` entry (today just `op_flow_thres`) from `{fabric}/depstor_rasters/`
+into `{fabric}/params/merged/` under its canonical `nhm_*_params.csv` name.
+That copy is what makes "everything a PRMS consumer needs is in `merged/`"
+true: `op_flow_thres` is a PRMSRunoff parameter a builder writes directly, so
+before it existed anyone globbing `merged/nhm_*_params.csv` silently dropped it.
+It needs step 3c (`submit_dprst_depth.sh`) to have run, and takes seconds — no
+SLURM job needed, but run it from a compute node if you prefer.
 
 **Wait for:** all submitted jobs `COMPLETED` — monitor with `squeue -u "$USER"`.
 

--- a/slurm_batch/RUNME.md
+++ b/slurm_batch/RUNME.md
@@ -323,23 +323,23 @@ holds the full stack (through `carea_map_t8/t156_binary.tif`).
 BATCHES=$(pixi run data-root)/gfv2/batches
 slurm_batch/submit_zonal_params.sh   "$BATCHES" gfv2 configs/base_config.yml
 slurm_batch/submit_depstor_params.sh "$BATCHES" gfv2 configs/base_config.yml
-#     Copy the builder-written constants into merged/ (fast, no array job):
-pixi run --as-is python scripts/derive_depstor_params.py \
-  --config configs/depstor/depstor_params.yml \
-  --base_config configs/base_config.yml --fabric gfv2 --mode copy_constants
 ```
 
 **What it does:** `submit_zonal_params.sh` chains every zonal parameter (array
 + merge per param, `slope`→`ssflux` dependency and weights prereq handled
 automatically); `submit_depstor_params.sh` chains all 10 depstor fractions +
-the 6 PRMS ratios job. `--mode copy_constants` then copies every
-`constants:` entry (today just `op_flow_thres`) from `{fabric}/depstor_rasters/`
-into `{fabric}/params/merged/` under its canonical `nhm_*_params.csv` name.
-That copy is what makes "everything a PRMS consumer needs is in `merged/`"
-true: `op_flow_thres` is a PRMSRunoff parameter a builder writes directly, so
-before it existed anyone globbing `merged/nhm_*_params.csv` silently dropped it.
-It needs step 3c (`submit_dprst_depth.sh`) to have run, and takes seconds — no
-SLURM job needed, but run it from a compute node if you prefer.
+the 6 PRMS ratios job, and finally chains a `copy_constants` job (`afterok` on
+ratios) that copies every `constants:` entry — today just `op_flow_thres` — from
+`{fabric}/depstor_rasters/` into `{fabric}/params/merged/` under its canonical
+`nhm_*_params.csv` name.
+
+That last job is what makes "everything a PRMS consumer needs is in `merged/`"
+**true** rather than aspirational: `op_flow_thres` is a PRMSRunoff parameter a
+builder writes directly, so without it anyone globbing `merged/nhm_*_params.csv`
+silently drops a parameter — and nothing downstream complains
+(`merge_and_fill_params.py` warns and still exits 0). It is chained rather than
+manual for exactly that reason. It needs step 3c (`submit_dprst_depth.sh`) to
+have COMPLETED, and fails loudly naming the missing file if not.
 
 **Wait for:** all submitted jobs `COMPLETED` — monitor with `squeue -u "$USER"`.
 

--- a/slurm_batch/copy_depstor_constants.batch
+++ b/slurm_batch/copy_depstor_constants.batch
@@ -1,0 +1,42 @@
+#!/bin/bash
+#SBATCH -p cpu
+#SBATCH -A impd
+#SBATCH --job-name=depstor_constants
+#SBATCH --output=logs/job_%j.out
+#SBATCH --error=logs/job_%j.err
+#SBATCH --time=00:10:00
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=2
+#SBATCH --mem=8G
+#
+# Copy every `constants:` entry in configs/depstor/depstor_params.yml from
+# {fabric}/depstor_rasters/ into {fabric}/params/merged/ under its canonical
+# nhm_*_params.csv name. Today that is just op_flow_thres.
+#
+# This job is what makes "everything a PRMS consumer needs is in merged/" TRUE
+# rather than aspirational. op_flow_thres is a PRMSRunoff parameter a depstor
+# builder writes directly, so before it was chained here the invariant rested on
+# an operator remembering a manual command: skip it and merge_and_fill_params
+# logs one WARNING among many and still exits 0, the on-disk guard SKIPS, and a
+# modeler globbing merged/nhm_*_params.csv silently drops the parameter. Chained,
+# not manual, for exactly the reason CLAUDE.md gives: a guard that lives only in
+# the producing builder never executes on the path operators actually use.
+#
+# Prereq: slurm_batch/submit_dprst_depth.sh must have COMPLETED — it writes
+# depstor_rasters/op_flow_thres_params.csv. If it has not, this job fails loudly
+# with a FileNotFoundError naming the missing source, which is the intent.
+#
+# Submitted with an afterok dependency on the ratios job by
+# slurm_batch/submit_depstor_params.sh. Standalone:
+#   sbatch --export=ALL,BASE_CONFIG=configs/base_config.yml,FABRIC=gfv2 \
+#       slurm_batch/copy_depstor_constants.batch
+
+cd "$SLURM_SUBMIT_DIR"
+BASE_CONFIG=${BASE_CONFIG:-configs/base_config.yml}
+FABRIC=${FABRIC:-gfv2}
+
+pixi run --as-is python scripts/derive_depstor_params.py \
+    --config configs/depstor/depstor_params.yml \
+    --base_config "$BASE_CONFIG" \
+    --fabric "$FABRIC" \
+    --mode copy_constants

--- a/slurm_batch/submit_depstor_params.sh
+++ b/slurm_batch/submit_depstor_params.sh
@@ -11,6 +11,14 @@
 # carea_max, smidx_coef, hru_percent_imperv, dprst_frac) into
 # {fabric}/params/merged/.
 #
+# Finally a copy_constants job (afterok on ratios) copies every `constants:`
+# entry -- today just op_flow_thres -- from {fabric}/depstor_rasters/ into
+# {fabric}/params/merged/. It is CHAINED rather than manual because it is what
+# makes "everything a PRMS consumer needs is in merged/" true: skipped, a
+# PRMSRunoff parameter goes missing and every downstream signal still reads
+# green (merge_and_fill_params warns and exits 0, the on-disk guard skips).
+# It needs submit_dprst_depth.sh to have COMPLETED first, and fails loudly if not.
+#
 # The 10 fractions are the canonical list from configs/depstor/depstor_params.yml; if
 # you add or remove fractions there, update FRACTIONS below.
 #
@@ -98,4 +106,10 @@ RATIOS_JOB_ID=$(sbatch --dependency=afterok:"$DEPENDS" \
                      slurm_batch/derive_depstor_ratios.batch | awk '{print $NF}')
 echo "  ratios afterok:$DEPENDS -> $RATIOS_JOB_ID"
 
-echo "Done. Final ratios job ID: $RATIOS_JOB_ID"
+echo "Submitting copy_constants job (afterok:$RATIOS_JOB_ID)"
+CONSTANTS_JOB_ID=$(sbatch --dependency=afterok:"$RATIOS_JOB_ID" \
+                     --export=ALL,BASE_CONFIG="$BASE_CONFIG",FABRIC="$FABRIC" \
+                     slurm_batch/copy_depstor_constants.batch | awk '{print $NF}')
+echo "  constants afterok:$RATIOS_JOB_ID -> $CONSTANTS_JOB_ID"
+
+echo "Done. Final copy_constants job ID: $CONSTANTS_JOB_ID"

--- a/src/gfv2_params/params_index.py
+++ b/src/gfv2_params/params_index.py
@@ -1,0 +1,170 @@
+"""Every parameter with a canonical ``merged/`` output, and what it declares.
+
+Moved here from ``scripts/merge_and_fill_params.py`` so the declaration is
+importable by the index generator (``scripts/build_parameter_index.py``) and by
+the two guards, not only by the fill sweep.
+
+Pure YAML: only the static ``name`` / ``merged_file`` / ``output_file`` /
+``fill_columns`` / ``fabric_columns`` / ``prms`` fields are read, none of which
+are ``{data_root}``/``{fabric}``-templated. That keeps this import safe with no
+data root -- the CI contract recorded at ``scripts/merge_and_fill_params.py``'s
+config-path block: tests may parse these files but must not touch a real data
+root.
+
+Import-safe by construction: ``src/gfv2_params/__init__.py`` holds only
+``__version__``, so ``import gfv2_params.params_index`` pulls in no geo
+libraries.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import NamedTuple
+
+import yaml
+
+# Repo-relative config paths consumed by `load_declared_params`. A bare
+# yaml.safe_load is enough -- no need for gfv2_params.config.load_config's
+# fabric-profile resolution, which is what keeps this read data-root-free.
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+ZONAL_PARAMS_CONFIG = _REPO_ROOT / "configs" / "zonal" / "zonal_params.yml"
+DEPSTOR_PARAMS_CONFIG = _REPO_ROOT / "configs" / "depstor" / "depstor_params.yml"
+SNAREA_LIBRARY_CONFIG = _REPO_ROOT / "configs" / "snarea" / "snarea_library.yml"
+
+
+class DeclaredParam(NamedTuple):
+    """One config entry's contract: what file, what may be filled, what PRMS calls it.
+
+    A NamedTuple rather than a bare tuple because this record has now been widened
+    THREE times (`fill_columns`, then `fabric_columns`, then `prms`) and each
+    widening has to reach several consumption sites. The `fabric_columns` widening
+    missed one of them -- `warn_undeclared_merged_files`, whose
+    `for _, merged_file, _ in ...` then raised `ValueError: too many values to
+    unpack` in all-params mode, the DEFAULT and the only mode
+    `slurm_batch/merge_and_fill_params.batch` runs. It aborted `main()` outside
+    `run_fill_sweep`'s per-param guard, so nothing was filled at all, while the test
+    suite stayed green because its fixtures hand-built the OLD 3-tuple shape -- test
+    and implementation wrong in the same direction, agreeing with each other.
+
+    Attribute access cannot drift that way: a fifth field is invisible to every
+    consumer that does not ask for it. `prms` carries a default so positional
+    construction in existing tests keeps working; tuple-EQUALITY assertions do NOT
+    survive a widening and must be rewritten to attribute access.
+
+    `prms` shape (see configs/*/: every declared entry carries one)::
+
+        prms:
+          builder: zonal_runners/ssflux.py    # module path, for the by-builder view
+          columns:                            # emitted column -> PRMS parameter
+            gwflow_coef: {prms: gwflow_coef, processes: [PRMSGroundwater]}
+          defects: {}                         # emitted column that does NOT represent
+                                              # its PRMS parameter (see below)
+          provenance:                         # emitted column that is not a PRMS param
+            k_perm_wtd: litho-weighted permeability, flux-normalisation input
+
+    `processes` is PER-COLUMN, not per-entry: `ssflux` alone spans PRMSSoilzone,
+    PRMSGroundwater and PRMSRunoff across different columns, so an entry-level key
+    would report 5 non-runoff parameters as feeding runoff.
+
+    `defects` is deliberately separate from `columns`: `params_for_process` never
+    reads it, so a column that does not currently represent its PRMS parameter can
+    never be returned as feeding a process, while the index generator can still
+    render it as a DEFECTIVE row rather than silently omitting the warning.
+    """
+
+    name: str
+    merged_file: str
+    fill_columns: list
+    fabric_columns: dict
+    prms: dict = {}
+
+
+def _load_yaml_doc(path: Path) -> dict:
+    """Bare `yaml.safe_load` of a config file, no placeholder resolution."""
+    doc = yaml.safe_load(path.read_text())
+    return doc or {}
+
+
+def iter_declared_params(
+    zonal_cfg: dict, depstor_cfg: dict, snarea_cfg: dict | None = None
+) -> list[DeclaredParam]:
+    """Every param with a canonical `merged/` output, and what it declares fillable.
+
+    Returns `DeclaredParam(name, merged_file, fill_columns, fabric_columns, prms)`
+    records. `fill_columns` is KNN-interpolated; `fabric_columns` is copied verbatim
+    from the fabric GDF (see `apply_fabric_columns`). Both default to empty for the
+    params that declare neither -- today every param but `ssflux` has an empty
+    `fabric_columns`.
+
+    `zonal_cfg["params"]`, `depstor_cfg["means"]` and `depstor_cfg["constants"]` name
+    their canonical file `merged_file`; `depstor_cfg["ratios"]` names it `output_file`
+    instead (see `derive_depstor_params.py`'s `run_mean_finalize` / `run_ratios`).
+    `depstor_cfg["fractions"]` is DELIBERATELY EXCLUDED: every fraction entry also
+    happens to carry a `merged_file` key, but that key names the per-fraction COUNT
+    csv written to `merged/_intermediates/` (`run_merge`), never a `merged/` output --
+    fractions are intermediates, not consumer-facing params, and are never filled.
+
+    `constants` are per-HRU params a depstor BUILDER writes directly with no zonal
+    pass; `--mode copy_constants` copies them into `merged/` so the "everything a
+    consumer needs is in merged/" invariant holds.
+
+    `snarea_cfg` is optional and does NOT share either config's list-of-entries shape
+    -- the whole document IS the entry, so a `prms:` block there is a top-level key.
+    `snarea_curve` is not a `zonal_params.yml` entry at all: it comes from the
+    separate 3-stage SNODAS pipeline (`configs/snarea/snarea_library.yml`, Stage 3),
+    a flat single-param config whose `params_file` names the real
+    `nhm_snarea_curve_params.csv`. A synthetic `snarea_curve` entry could not live in
+    `zonal_params.yml` instead: `slurm_batch/submit_zonal_params.sh` does not read the
+    YAML -- it carries a hardcoded `PARAMS` bash array mirroring that `params:` list --
+    and `tests/test_submit_wrapper_param_lists.py` requires the two to match. So a
+    phantom entry would have to be added to the array too, and the wrapper would then
+    submit a SLURM array job for an entry with no `source_raster`/`script:`. Hence the
+    separate optional argument rather than a fourth zonal-shaped list.
+    """
+
+    def _record(name: str, merged_file: str, entry: dict) -> DeclaredParam:
+        return DeclaredParam(
+            name=name,
+            merged_file=merged_file,
+            fill_columns=list(entry.get("fill_columns") or []),
+            fabric_columns=dict(entry.get("fabric_columns") or {}),
+            prms=dict(entry.get("prms") or {}),
+        )
+
+    declared: list[DeclaredParam] = []
+
+    for entry in zonal_cfg.get("params", []) or []:
+        merged_file = entry.get("merged_file")
+        if merged_file:
+            declared.append(_record(entry["name"], merged_file, entry))
+
+    for entry in depstor_cfg.get("means", []) or []:
+        merged_file = entry.get("merged_file")
+        if merged_file:
+            declared.append(_record(entry["name"], merged_file, entry))
+
+    for entry in depstor_cfg.get("ratios", []) or []:
+        merged_file = entry.get("output_file")
+        if merged_file:
+            declared.append(_record(entry["name"], merged_file, entry))
+
+    for entry in depstor_cfg.get("constants", []) or []:
+        merged_file = entry.get("merged_file")
+        if merged_file:
+            declared.append(_record(entry["name"], merged_file, entry))
+
+    if snarea_cfg:
+        merged_file = snarea_cfg.get("params_file")
+        if merged_file:
+            declared.append(_record("snarea_curve", merged_file, snarea_cfg))
+
+    return declared
+
+
+def load_declared_params() -> list[DeclaredParam]:
+    """`iter_declared_params` over the real in-repo configs."""
+    return iter_declared_params(
+        _load_yaml_doc(ZONAL_PARAMS_CONFIG),
+        _load_yaml_doc(DEPSTOR_PARAMS_CONFIG),
+        _load_yaml_doc(SNAREA_LIBRARY_CONFIG),
+    )

--- a/src/gfv2_params/params_index.py
+++ b/src/gfv2_params/params_index.py
@@ -5,11 +5,14 @@ importable by the index generator (``scripts/build_parameter_index.py``) and by
 the two guards, not only by the fill sweep.
 
 Pure YAML: only the static ``name`` / ``merged_file`` / ``output_file`` /
-``fill_columns`` / ``fabric_columns`` / ``prms`` fields are read, none of which
-are ``{data_root}``/``{fabric}``-templated. That keeps this import safe with no
-data root -- the CI contract recorded at ``scripts/merge_and_fill_params.py``'s
-config-path block: tests may parse these files but must not touch a real data
-root.
+``params_file`` / ``fill_columns`` / ``fabric_columns`` / ``prms`` fields are
+read, none of which are ``{data_root}``/``{fabric}``-templated. A bare
+``yaml.safe_load`` is therefore enough -- no need for
+``gfv2_params.config.load_config``'s fabric-profile resolution.
+
+**CI contract:** tests may parse these config files but must not touch a real
+data root. This module is where that contract now lives; it moved here with
+``iter_declared_params``.
 
 Import-safe by construction: ``src/gfv2_params/__init__.py`` holds only
 ``__version__``, so ``import gfv2_params.params_index`` pulls in no geo
@@ -19,7 +22,8 @@ libraries.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import NamedTuple
+from types import MappingProxyType
+from typing import Mapping, NamedTuple
 
 import yaml
 
@@ -76,7 +80,15 @@ class DeclaredParam(NamedTuple):
     merged_file: str
     fill_columns: list
     fabric_columns: dict
-    prms: dict = {}
+    # MappingProxyType, not `{}`: a NamedTuple default is a single object shared
+    # by every instance built without it, so one `d.prms[k] = v` on a defaulted
+    # record would poison the class default process-wide. docs/python-patterns.md
+    # Pattern 5 names this exact gotcha and prescribes `field(default_factory=dict)`
+    # -- unavailable on a NamedTuple, so a read-only empty mapping is the
+    # equivalent. `== {}` and `bool(...)` both still behave, so the positional
+    # constructions in the tests are unaffected. A `None` sentinel was rejected:
+    # it would force None-handling into all nine `d.prms.get(...)` call sites.
+    prms: Mapping = MappingProxyType({})
 
 
 def _load_yaml_doc(path: Path) -> dict:

--- a/src/gfv2_params/params_index.py
+++ b/src/gfv2_params/params_index.py
@@ -168,3 +168,27 @@ def load_declared_params() -> list[DeclaredParam]:
         _load_yaml_doc(DEPSTOR_PARAMS_CONFIG),
         _load_yaml_doc(SNAREA_LIBRARY_CONFIG),
     )
+
+
+def params_for_process(
+    process: str, declared: list[DeclaredParam] | None = None
+) -> list[tuple[str, DeclaredParam]]:
+    """Every (emitted_column, DeclaredParam) whose column feeds `process`.
+
+    Column-grained, not entry-grained: `ssflux` alone spans PRMSSoilzone,
+    PRMSGroundwater and PRMSRunoff across different columns, so returning whole
+    entries would report 5 non-runoff parameters as feeding runoff.
+
+    Reads `prms.columns` ONLY -- never `prms.defects`. A defective column is one
+    that is supposed to be the PRMS parameter and currently is not (aspect's `mean`
+    is an arithmetic mean of a circular variable), so returning it here would hand a
+    caller a broken column under a correct-looking name. The index generator reads
+    `defects` separately and renders it as a DEFECTIVE row, which is the opposite of
+    silently including it.
+    """
+    out: list[tuple[str, DeclaredParam]] = []
+    for d in declared if declared is not None else load_declared_params():
+        for col, spec in (d.prms.get("columns") or {}).items():
+            if process in (spec.get("processes") or []):
+                out.append((col, d))
+    return out

--- a/src/gfv2_params/zonal_runners/merge.py
+++ b/src/gfv2_params/zonal_runners/merge.py
@@ -44,7 +44,9 @@ def apply_derived_columns(df, derived_columns: dict | None):
                 f"derived column '{out_col}' reads '{src}', which is not in the merged "
                 f"frame (columns: {sorted(df.columns)})."
             )
-        df[out_col] = df[src].astype(float).apply(_TRANSFORMS[tname])
+        # The transform vectorises (deg_to_fraction is np.tan(np.deg2rad(x))),
+        # so hand it the Series rather than calling it 361k times per param.
+        df[out_col] = _TRANSFORMS[tname](df[src].astype(float))
     return df
 
 

--- a/src/gfv2_params/zonal_runners/merge.py
+++ b/src/gfv2_params/zonal_runners/merge.py
@@ -11,6 +11,42 @@ from pathlib import Path
 
 import pandas as pd
 
+from gfv2_params import raster_ops
+
+# Transforms a `derived_columns:` entry may name. Deliberately a whitelist rather
+# than getattr(raster_ops, name): a typo must raise, not silently resolve to some
+# other module-level function that happens to share the name.
+_TRANSFORMS = {
+    "deg_to_fraction": raster_ops.deg_to_fraction,
+}
+
+
+def apply_derived_columns(df, derived_columns: dict | None):
+    """Add each declared derived column to a merged frame.
+
+    Applied AFTER concat so it runs once per param rather than once per batch, and
+    at merge time rather than zonal time -- which is why adding one needs no zonal
+    re-run, only `--mode merge`.
+
+    The source column is KEPT: it is declared provenance, not a temporary. For
+    `slope` that matters, since `mean` (degrees) is what `hru_slope` is derived
+    from and what a reader needs to check the derivation.
+    """
+    for out_col, spec in (derived_columns or {}).items():
+        src, tname = spec["from"], spec["transform"]
+        if tname not in _TRANSFORMS:
+            raise ValueError(
+                f"`{tname}` is not a known transform for derived column '{out_col}'. "
+                f"Known: {sorted(_TRANSFORMS)}."
+            )
+        if src not in df.columns:
+            raise ValueError(
+                f"derived column '{out_col}' reads '{src}', which is not in the merged "
+                f"frame (columns: {sorted(df.columns)})."
+            )
+        df[out_col] = df[src].astype(float).apply(_TRANSFORMS[tname])
+    return df
+
 
 def run_merge(config: dict, logger) -> None:
     """Concat per-batch CSVs for one param into the merged output CSV.
@@ -69,6 +105,11 @@ def run_merge(config: dict, logger) -> None:
                 "If this is expected, run merge_and_fill_params.py to fill gaps via KNN.",
                 len(gaps), id_feature, expected_max, len(existing_ids), gaps[:10],
             )
+
+    derived = config.get("derived_columns")
+    if derived:
+        merged_df = apply_derived_columns(merged_df, derived)
+        logger.info("Applied derived columns: %s", sorted(derived))
 
     output_path = final_output_dir / merged_file
     merged_df.to_csv(output_path, index=False)

--- a/tests/test_build_parameter_index.py
+++ b/tests/test_build_parameter_index.py
@@ -1,0 +1,209 @@
+"""Unit coverage for scripts/build_parameter_index.py's pure logic.
+
+`test_generated_index_is_up_to_date` in tests/test_params_index.py proves only that
+the committed doc is a FIXED POINT of today's generator against today's configs. A
+bug in `_collapse`, `_rename_marker` or `_entry_locations` is baked into the
+committed doc, so generator and golden file agree with each other and the golden
+test passes forever -- the same "test and implementation wrong in the same
+direction" failure the DeclaredParam docstring exists to warn about.
+
+These test the logic directly instead. Pure text + YAML, CI-safe.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from gfv2_params.params_index import DeclaredParam
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_spec = importlib.util.spec_from_file_location(
+    "build_parameter_index", _REPO_ROOT / "scripts" / "build_parameter_index.py"
+)
+bpi = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(bpi)
+
+
+def _declared(name="p", merged="f.csv", fill=None, prms=None):
+    return DeclaredParam(name, merged, fill or [], {}, prms or {})
+
+
+# --- staleness detection: the failing direction the golden test never exercises ---
+
+
+def test_check_reports_stale_when_a_generated_region_drifts(tmp_path, monkeypatch):
+    """A generator that always returned 0 would pass CI without this.
+
+    test_generated_index_is_up_to_date only ever sees the passing direction.
+    """
+    doc = tmp_path / "parameter_index.md"
+    doc.write_text(_REPO_ROOT.joinpath("docs/parameter_index.md").read_text())
+    monkeypatch.setattr(bpi, "INDEX_PATH", doc)
+
+    assert bpi.build(check=True) == 0  # baseline: the copy is in sync
+
+    doc.write_text(doc.read_text().replace("`carea_max`", "`carea_maxx`", 1))
+    assert bpi.build(check=True) == 1
+
+
+def test_build_is_idempotent(tmp_path, monkeypatch):
+    """A non-fixed-point generator makes the CI staleness test flap unreproducibly."""
+    doc = tmp_path / "parameter_index.md"
+    doc.write_text(_REPO_ROOT.joinpath("docs/parameter_index.md").read_text())
+    monkeypatch.setattr(bpi, "INDEX_PATH", doc)
+
+    assert bpi.build() == 0
+    first = doc.read_text()
+    assert bpi.build() == 0
+    assert doc.read_text() == first
+
+
+def test_missing_marker_raises_rather_than_guessing(tmp_path, monkeypatch):
+    doc = tmp_path / "parameter_index.md"
+    doc.write_text("# no markers here\n")
+    monkeypatch.setattr(bpi, "INDEX_PATH", doc)
+    with pytest.raises(SystemExit, match="by-process"):
+        bpi.build()
+
+
+# --- the line-number scanner, and the documented dprst_frac collision ---
+
+
+def test_entry_locations_resolves_dprst_frac_to_the_ratios_entry():
+    """`- name: dprst_frac` appears in BOTH `fractions:` and `ratios:`.
+
+    The fractions one comes first, and it names a count CSV in
+    merged/_intermediates/, not the PRMS parameter. This is why `fractions:` is
+    excluded from _ENTRY_SECTIONS; adding it back would silently re-point the cite.
+    """
+    locations = bpi._entry_locations()
+    cite = locations["dprst_frac"]
+    lineno = int(cite.split(":")[1])
+    line = bpi.DEPSTOR_PARAMS_CONFIG.read_text().splitlines()[lineno - 1]
+    assert line.strip().startswith("- name: dprst_frac")
+
+    # ...and it is the ratios entry, i.e. the one carrying output_file.
+    tail = "\n".join(bpi.DEPSTOR_PARAMS_CONFIG.read_text().splitlines()[lineno:lineno + 6])
+    assert "output_file:" in tail, f"cite points at a non-ratios dprst_frac: {cite}"
+
+
+def test_entry_locations_covers_every_declared_entry():
+    """A miss degrades the cite to a bare param name and sorts the row to the top."""
+    from gfv2_params.params_index import load_declared_params
+
+    missing = {d.name for d in load_declared_params()} - set(bpi._entry_locations())
+    assert not missing, f"no computed cite for {sorted(missing)}"
+
+
+def test_entry_sort_key_orders_line_numbers_numerically():
+    """Regression: a string compare sorted `:43` after `:389`."""
+    cites = ["z.yml:43", "z.yml:389", "z.yml:81", "z.yml:133"]
+    assert sorted(cites, key=bpi._entry_sort_key) == [
+        "z.yml:43", "z.yml:81", "z.yml:133", "z.yml:389",
+    ]
+
+
+def test_natural_key_orders_snarea_curve_10_after_9():
+    cols = ["snarea_curve_0", "snarea_curve_10", "snarea_curve_9"]
+    assert sorted(cols, key=bpi._natural_key)[-1] == "snarea_curve_10"
+
+
+# --- the ⚠️ rename marker's four documented rules ---
+
+
+@pytest.mark.parametrize(
+    ("prms", "cols", "expect_marker"),
+    [
+        ("soil_type", ["soils"], True),          # genuine rename
+        ("hru_elev", ["mean"], True),            # genuine rename
+        ("carea_max", ["carea_max"], False),     # identical
+        ("snarea_curve", [f"snarea_curve_{i}" for i in range(11)], False),  # dimensioned
+        ("rad_trncf", ["retention", "rad_trncf"], True),  # alias: one member differs
+    ],
+)
+def test_rename_marker_rules(prms, cols, expect_marker):
+    """The alias rule is a subtle inversion worth pinning.
+
+    The test is "is EVERY declared column the PRMS name?", not "is ANY of them?" --
+    on gfv2 and oregon the on-disk column is `retention`, so a reader there DOES
+    need to translate. Reads wrong at a glance and would be "simplified" away.
+    """
+    row = {"prms": prms, "cols": cols, "defective": False}
+    assert bool(bpi._rename_marker(row)) is expect_marker
+
+
+# --- row collapsing across alternative sources ---
+
+
+def test_collapse_merges_alternative_sources_keeping_cells_row_aligned():
+    """The four LULC sources are alternatives, not four parameter sets.
+
+    Uncollapsed they turned PRMSCanopy's 6 parameters into 24 rows. The parallel
+    `sources` array is what keeps the file / entry / builder cells aligned, so a
+    reader can pair them positionally -- a collapse bug would mis-attribute a
+    builder to a file in published docs.
+    """
+    locations = {"a": "zonal_params.yml:100", "b": "zonal_params.yml:200"}
+    declared = [
+        _declared("a", "nhm_a.csv", prms={
+            "builder": "lulc_prederived.py",
+            "columns": {"cov_type": {"prms": "cov_type", "processes": ["PRMSCanopy"]}},
+        }),
+        _declared("b", "nhm_b.csv", prms={
+            "builder": "lulc.py",
+            "columns": {"cov_type": {"prms": "cov_type", "processes": ["PRMSCanopy"]}},
+        }),
+    ]
+    by_process, _ = bpi._process_rows(declared, locations)
+    rows = by_process["PRMSCanopy"]
+    assert len(rows) == 1, "alternative sources for one parameter must collapse"
+
+    (row,) = rows.values()
+    assert row["sources"] == [
+        ("nhm_a.csv", "zonal_params.yml:100", "lulc_prederived.py"),
+        ("nhm_b.csv", "zonal_params.yml:200", "lulc.py"),
+    ], "sources must stay in config order and keep file/entry/builder together"
+
+
+def test_defects_never_collapse_into_a_real_row():
+    """Merging a defect with a working column would erase the DEFECTIVE warning."""
+    declared = [
+        _declared("aspect", "nhm_aspect.csv", prms={
+            "builder": "zonal.py",
+            "columns": {"mean": {"prms": "hru_aspect", "processes": ["PRMSAtmosphere"]}},
+            "defects": {"mean": {"prms": "hru_aspect", "processes": ["PRMSAtmosphere"]}},
+        }),
+    ]
+    by_process, _ = bpi._process_rows(declared, {"aspect": "z.yml:1"})
+    verdicts = {r["defective"] for r in by_process["PRMSAtmosphere"].values()}
+    assert verdicts == {True, False}, "a defect must stay a distinct row"
+
+
+def test_defect_with_no_processes_still_appears():
+    """Regression: the defects loop had no empty-processes fallback.
+
+    A defect whose consuming process is not yet known vanished from the by-process
+    view entirely -- the exact silent omission the defects bucket exists to prevent.
+    """
+    declared = [
+        _declared("x", "nhm_x.csv", prms={
+            "builder": "b.py",
+            "defects": {"mean": {"prms": "hru_thing", "processes": []}},
+        }),
+    ]
+    _, unconsumed = bpi._process_rows(declared, {"x": "z.yml:1"})
+    assert [r["defective"] for r in unconsumed.values()] == [True]
+
+
+def test_defective_row_renders_the_issue_link():
+    row = {
+        "prms": "hru_aspect", "cols": ["mean"], "defective": True, "issue": 201,
+        "sources": [("nhm_aspect.csv", "z.yml:1", "zonal.py")],
+    }
+    md = bpi._row_markdown(row)
+    assert "**DEFECTIVE**" in md
+    assert "issues/201" in md
+    assert "⚠️" not in md, "DEFECTIVE supersedes the rename marker"

--- a/tests/test_copy_constants.py
+++ b/tests/test_copy_constants.py
@@ -1,0 +1,153 @@
+"""`--mode copy_constants` — the depstor mode that puts builder-written params in merged/.
+
+This mode BLESSES bytes as a canonical `merged/nhm_*_params.csv`, so every guard it
+carries is load-bearing. It had no tests when it shipped; these were added after a
+review pointed out that a truncated or wrong-fabric source would be copied, logged
+with a row count nobody compares to anything, and become canonical -- and that for a
+genuinely constant column the fill sweep's KNN interpolation would then produce the
+right value by luck, making the truncation undetectable forever.
+
+`_load_resolved_config` is monkeypatched rather than exercised: it needs a real
+base_config + data root, and the contract at scripts/merge_and_fill_params.py's
+config-path block says tests must not touch one. Pure pandas + tmp_path, CI-safe.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_spec = importlib.util.spec_from_file_location(
+    "derive_depstor_params", _REPO_ROOT / "scripts" / "derive_depstor_params.py"
+)
+ddp = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(ddp)
+
+_LOGGER = logging.getLogger("test_copy_constants")
+
+
+def _config(tmp_path: Path, *, rows=3, expected_max=3, id_feature="nat_hru_id",
+            constants=None, source_rows=None):
+    """A resolved-config dict shaped like _load_resolved_config's output."""
+    src = tmp_path / "depstor_rasters" / "op_flow_thres_params.csv"
+    src.parent.mkdir(parents=True, exist_ok=True)
+    frame = source_rows if source_rows is not None else pd.DataFrame(
+        {id_feature: range(1, rows + 1), "op_flow_thres": [1.0] * rows}
+    )
+    frame.to_csv(src, index=False)
+
+    if constants is None:
+        constants = [{
+            "name": "op_flow_thres",
+            "source": str(src),
+            "merged_file": "nhm_op_flow_thres_params.csv",
+            "fill_columns": ["op_flow_thres"],
+        }]
+    config = {
+        "defaults": {
+            "output_dir": str(tmp_path / "params"),
+            "merged_subdir": "merged",
+            "merged_intermediates_subdir": "merged/_intermediates",
+            "id_feature": id_feature,
+        },
+        "constants": constants,
+    }
+    if expected_max is not None:
+        config["expected_max_hru_id"] = expected_max
+    return config, src
+
+
+def _run(monkeypatch, config):
+    monkeypatch.setattr(ddp, "_load_resolved_config", lambda args: config)
+    args = SimpleNamespace(config="configs/depstor/depstor_params.yml")
+    ddp.run_copy_constants(args, _LOGGER)
+    return Path(config["defaults"]["output_dir"]) / "merged"
+
+
+def test_copies_into_merged_under_the_canonical_name(tmp_path, monkeypatch):
+    """The LOCATION is the point of this mode, so assert the destination exactly.
+
+    Catches a merged_file/source key swap, and a write into _intermediates/ --
+    _merge_paths returns (intermediates, ratios) in that order, so binding the
+    wrong element of the tuple is a live mistake this pins.
+    """
+    config, src = _config(tmp_path)
+    merged = _run(monkeypatch, config)
+
+    dst = merged / "nhm_op_flow_thres_params.csv"
+    assert dst.exists()
+    assert not (merged / "_intermediates" / "nhm_op_flow_thres_params.csv").exists()
+    pd.testing.assert_frame_equal(pd.read_csv(dst), pd.read_csv(src))
+
+
+def test_creates_merged_dir_when_absent(tmp_path, monkeypatch):
+    config, _ = _config(tmp_path)
+    assert not (tmp_path / "params" / "merged").exists()
+    assert _run(monkeypatch, config).is_dir()
+
+
+def test_missing_source_raises_rather_than_skipping(tmp_path, monkeypatch):
+    """Fail loud: a missing source means the builder never ran.
+
+    A skip here would leave exactly the hole this mode exists to close -- the
+    parameter absent from merged/ while every downstream signal reads green.
+    """
+    config, src = _config(tmp_path)
+    src.unlink()
+    with pytest.raises(FileNotFoundError, match="op_flow_thres"):
+        _run(monkeypatch, config)
+
+
+def test_empty_constants_list_raises(tmp_path, monkeypatch):
+    """An empty `constants:` is a CONFIG state, not a data state.
+
+    Unlike an empty endorheic table (a legitimate result for a domain with no
+    closed basin), there is no fabric for which "asked to copy constants, found
+    none" is correct. The realistic cause is a wrong --config, which must not
+    exit 0 having copied nothing.
+    """
+    config, _ = _config(tmp_path, constants=[])
+    with pytest.raises(ValueError, match="nothing to do"):
+        _run(monkeypatch, config)
+
+
+def test_source_missing_the_fabrics_id_column_raises(tmp_path, monkeypatch):
+    config, _ = _config(
+        tmp_path,
+        source_rows=pd.DataFrame({"hru_id": [1, 2, 3], "op_flow_thres": [1.0] * 3}),
+    )
+    with pytest.raises(ValueError, match="no 'nat_hru_id' column"):
+        _run(monkeypatch, config)
+
+
+def test_duplicate_ids_raise(tmp_path, monkeypatch):
+    config, _ = _config(
+        tmp_path,
+        source_rows=pd.DataFrame({"nat_hru_id": [1, 2, 2], "op_flow_thres": [1.0] * 3}),
+    )
+    with pytest.raises(ValueError, match="duplicate"):
+        _run(monkeypatch, config)
+
+
+def test_truncated_source_raises(tmp_path, monkeypatch):
+    """The failure mode that motivated validation.
+
+    A short file copied silently becomes canonical; the fill sweep then KNN-fills
+    the gap, and because op_flow_thres is a constant 1.0 the interpolated value is
+    indistinguishable from the truth. The truncation would never be noticed.
+    """
+    config, _ = _config(tmp_path, rows=2, expected_max=3)
+    with pytest.raises(ValueError, match="2 rows but this fabric has 3"):
+        _run(monkeypatch, config)
+
+
+def test_row_count_unchecked_when_the_profile_declares_no_expected_max(tmp_path, monkeypatch):
+    """expected_max_hru_id is optional per fabric; absent, the check is skipped."""
+    config, _ = _config(tmp_path, rows=2, expected_max=None)
+    assert (_run(monkeypatch, config) / "nhm_op_flow_thres_params.csv").exists()

--- a/tests/test_merge_and_fill_params.py
+++ b/tests/test_merge_and_fill_params.py
@@ -628,15 +628,26 @@ def test_iter_declared_params_excludes_fractions_includes_means_and_ratios():
     assert names == {"elevation", "dprst_depth_avg", "dprst_frac"}
     assert "perv_frac" not in names  # fraction excluded despite its merged_file key
 
+    # Attribute access, NOT tuple equality: DeclaredParam is a NamedTuple, so a
+    # 4-tuple comparison silently encodes today's field count and breaks on every
+    # widening (`prms` was the third). Naming the fields makes a new defaulted
+    # field invisible here, which is the whole point of the NamedTuple.
     by_name = {d[0]: d for d in declared}
-    assert by_name["dprst_frac"] == ("dprst_frac", "nhm_dprst_frac_params.csv", ["dprst_frac"], {})
-    assert by_name["elevation"] == ("elevation", "nhm_elevation_params.csv", ["mean"], {})
+    d = by_name["dprst_frac"]
+    assert (d.name, d.merged_file, d.fill_columns, d.fabric_columns) == (
+        "dprst_frac", "nhm_dprst_frac_params.csv", ["dprst_frac"], {})
+    d = by_name["elevation"]
+    assert (d.name, d.merged_file, d.fill_columns, d.fabric_columns) == (
+        "elevation", "nhm_elevation_params.csv", ["mean"], {})
 
 
 def test_iter_declared_params_includes_snarea_when_given():
     snarea_cfg = {"params_file": "nhm_snarea_curve_params.csv", "fill_columns": ["hru_deplcrv"]}
     declared = maf.iter_declared_params({}, {}, snarea_cfg)
-    assert declared == [("snarea_curve", "nhm_snarea_curve_params.csv", ["hru_deplcrv"], {})]
+    assert len(declared) == 1
+    d = declared[0]
+    assert (d.name, d.merged_file, d.fill_columns, d.fabric_columns) == (
+        "snarea_curve", "nhm_snarea_curve_params.csv", ["hru_deplcrv"], {})
 
 
 def test_iter_declared_params_snarea_optional():
@@ -782,7 +793,7 @@ class TestWarnUndeclaredMergedFiles:
         (tmp_path / "nhm_mystery_params.csv").write_text("hru_id,v\n1,1\n")
 
         undeclared = maf.warn_undeclared_merged_files(
-            tmp_path, maf._load_declared_params(), logging.getLogger("test_warn_undeclared_real"),
+            tmp_path, maf.load_declared_params(), logging.getLogger("test_warn_undeclared_real"),
         )
 
         assert undeclared == ["nhm_mystery_params.csv"]

--- a/tests/test_merge_params.py
+++ b/tests/test_merge_params.py
@@ -12,6 +12,7 @@ import pandas as pd
 import pytest
 
 from gfv2_params.zonal_runners import run_merge as process_files
+from gfv2_params.zonal_runners.merge import apply_derived_columns
 
 
 def _make_config(tmp_path, fabric="gfv2", source_type="elevation", expected_max=None):
@@ -97,3 +98,72 @@ class TestProcessFiles:
 
         with pytest.raises(ValueError, match="nat_hru_id"):
             process_files(config, logger)
+
+
+# ---------------------------------------------------------------------------
+# derived_columns: PRMS-quantity columns computed at merge time (D0a).
+#
+# Lives here rather than in tests/test_params_index.py because importing
+# gfv2_params.zonal_runners pulls the geo stack (raster_ops -> rasterio/GDAL),
+# and that module is deliberately geo-import-free.
+# ---------------------------------------------------------------------------
+
+
+def test_apply_derived_columns_converts_slope_degrees_to_rise_run():
+    """gfv2 HRU 1 is the worked example: mean = 4.4252 deg -> hru_slope = 0.0774.
+
+    Copied verbatim without this conversion, `mean` declares a 77-degree cliff
+    instead of a 4.4-degree hillslope.
+    """
+    import math
+
+    df = pd.DataFrame({"nat_hru_id": [1, 2], "mean": [4.4252, 45.0]})
+    out = apply_derived_columns(
+        df, {"hru_slope": {"from": "mean", "transform": "deg_to_fraction"}}
+    )
+    assert math.isclose(out["hru_slope"][0], 0.077398, rel_tol=1e-4)
+    assert math.isclose(out["hru_slope"][1], 1.0, rel_tol=1e-9)  # tan(45 deg) == 1
+    assert "mean" in out.columns  # the raw stat is kept as declared provenance
+
+
+def test_apply_derived_columns_rejects_an_unknown_transform():
+    """A whitelist, not getattr(raster_ops, name): a typo must raise."""
+    df = pd.DataFrame({"mean": [1.0]})
+    with pytest.raises(ValueError, match="not a known transform"):
+        apply_derived_columns(df, {"x": {"from": "mean", "transform": "nope"}})
+
+
+def test_apply_derived_columns_rejects_a_missing_source_column():
+    df = pd.DataFrame({"mean": [1.0]})
+    with pytest.raises(ValueError, match="not in the merged"):
+        apply_derived_columns(
+            df, {"x": {"from": "absent", "transform": "deg_to_fraction"}}
+        )
+
+
+def test_apply_derived_columns_is_a_noop_when_undeclared():
+    df = pd.DataFrame({"mean": [1.0]})
+    assert list(apply_derived_columns(df, None).columns) == ["mean"]
+    assert list(apply_derived_columns(df, {}).columns) == ["mean"]
+
+
+def test_run_merge_emits_the_declared_derived_column(tmp_path):
+    """End to end through run_merge: config -> merged CSV with hru_slope."""
+    config = _make_config(tmp_path, source_type="slope")
+    config["derived_columns"] = {
+        "hru_slope": {"from": "mean", "transform": "deg_to_fraction"}
+    }
+    batch_dir = Path(config["output_dir"]) / "slope"
+    pd.DataFrame({"nat_hru_id": [1, 2], "mean": [4.4252, 45.0]}).to_csv(
+        batch_dir / "base_nhm_slope_gfv2_batch_0_param.csv", index=False
+    )
+
+    import logging
+
+    process_files(config, logging.getLogger("test_derived"))
+
+    out = pd.read_csv(
+        Path(config["output_dir"]) / "merged" / "nhm_slope_params.csv"
+    )
+    assert "hru_slope" in out.columns
+    assert abs(out.loc[out["nat_hru_id"] == 1, "hru_slope"].iloc[0] - 0.077398) < 1e-5

--- a/tests/test_merge_params.py
+++ b/tests/test_merge_params.py
@@ -6,6 +6,7 @@ is the source of truth; the CLI shell in scripts/merge_params.py now
 delegates to it. These tests target the library function directly.
 """
 
+import math
 from pathlib import Path
 
 import pandas as pd
@@ -119,8 +120,6 @@ def test_apply_derived_columns_converts_slope_degrees_to_rise_run():
     enough to pass a 1e-3 tolerance and fail a 1e-4 one, which is exactly what it
     did. The value here is the computed one.
     """
-    import math
-
     df = pd.DataFrame({"nat_hru_id": [1, 2], "mean": [4.4252, 45.0]})
     out = apply_derived_columns(
         df, {"hru_slope": {"from": "mean", "transform": "deg_to_fraction"}}
@@ -170,4 +169,9 @@ def test_run_merge_emits_the_declared_derived_column(tmp_path):
         Path(config["output_dir"]) / "merged" / "nhm_slope_params.csv"
     )
     assert "hru_slope" in out.columns
-    assert abs(out.loc[out["nat_hru_id"] == 1, "hru_slope"].iloc[0] - 0.077398) < 1e-5
+    # Same computed value as the unit test above -- NOT the plan's 0.077398, which
+    # sat here passing on 2.5% of a 1e-5 budget while a docstring 55 lines up
+    # declared it wrong.
+    assert math.isclose(
+        out.loc[out["nat_hru_id"] == 1, "hru_slope"].iloc[0], 0.07738825, rel_tol=1e-6
+    )

--- a/tests/test_merge_params.py
+++ b/tests/test_merge_params.py
@@ -114,6 +114,10 @@ def test_apply_derived_columns_converts_slope_degrees_to_rise_run():
 
     Copied verbatim without this conversion, `mean` declares a 77-degree cliff
     instead of a 4.4-degree hillslope.
+
+    tan(radians(4.4252)) is 0.07738825, not the 0.077398 the plan quoted -- close
+    enough to pass a 1e-3 tolerance and fail a 1e-4 one, which is exactly what it
+    did. The value here is the computed one.
     """
     import math
 
@@ -121,7 +125,7 @@ def test_apply_derived_columns_converts_slope_degrees_to_rise_run():
     out = apply_derived_columns(
         df, {"hru_slope": {"from": "mean", "transform": "deg_to_fraction"}}
     )
-    assert math.isclose(out["hru_slope"][0], 0.077398, rel_tol=1e-4)
+    assert math.isclose(out["hru_slope"][0], 0.07738825, rel_tol=1e-6)
     assert math.isclose(out["hru_slope"][1], 1.0, rel_tol=1e-9)  # tan(45 deg) == 1
     assert "mean" in out.columns  # the raw stat is kept as declared provenance
 

--- a/tests/test_params_index.py
+++ b/tests/test_params_index.py
@@ -9,6 +9,8 @@ new column reaching disk with no PRMS decision recorded.
 
 from __future__ import annotations
 
+import pytest
+
 from gfv2_params import params_index as pi
 
 
@@ -88,3 +90,90 @@ def test_iter_declared_params_carries_prms_block():
     }
     declared = pi.iter_declared_params(zonal, {})
     assert declared[0].prms["columns"]["hru_slope"]["prms"] == "hru_slope"
+
+
+# ---------------------------------------------------------------------------
+# Guard 1: prms.columns | prms.defects | prms.provenance is the DECLARED
+# COMPLETE column list for every entry.
+# ---------------------------------------------------------------------------
+
+
+def _flatten(fill_columns):
+    """fill_columns entries may be a list of alias alternatives, not only a string.
+
+    zonal_params.yml's lulc_nhm_v11 carries [retention, rad_trncf] because
+    lulc_prederived.py renamed the same computed quantity; fabrics built before the
+    rename carry `retention`, after carry `rad_trncf`. EVERY alternative must be
+    declared, so a fabric of either vintage is covered. Without this flatten the
+    guard raises `TypeError: unhashable type: 'list'` rather than failing usefully.
+    """
+    out = []
+    for item in fill_columns:
+        if isinstance(item, (list, tuple)):
+            out.extend(item)
+        else:
+            out.append(item)
+    return out
+
+
+def _declared_columns(declared):
+    """Every emitted column the entry has recorded a PRMS decision for.
+
+    Three buckets, because there are three distinct decisions: `columns` is "this
+    IS the PRMS parameter", `defects` is "this is SUPPOSED to be the PRMS parameter
+    and currently is not", `provenance` is "this is not a PRMS parameter at all".
+    """
+    return (
+        set(declared.prms.get("columns") or {})
+        | set(declared.prms.get("defects") or {})
+        | set(declared.prms.get("provenance") or {})
+    )
+
+
+@pytest.mark.parametrize("declared", pi.load_declared_params(), ids=lambda d: d.name)
+def test_guard1_prms_declares_every_fillable_column(declared):
+    """Guard 1 only proves the declaration is SELF-CONSISTENT.
+
+    It runs declaration -> declaration and cannot see disk, so it is a tautology on
+    most entries and vacuous on the three whose on-disk payload exceeds their
+    fill_columns (ssflux declares 7 of 10 columns, snarea 13 of 23, dprst_depth_avg
+    1 of 2). Guard 2 (tests/test_params_index_ondisk.py) is the one that catches a
+    new column reaching disk with no PRMS decision recorded.
+    """
+    assert declared.prms, (
+        f"{declared.name} has no `prms:` block. It is mandatory, not optional -- "
+        f"without it this guard passes vacuously."
+    )
+    required = set(_flatten(declared.fill_columns)) | set(declared.fabric_columns or {})
+    missing = required - _declared_columns(declared)
+    assert not missing, (
+        f"{declared.name}: {sorted(missing)} are declared fillable but appear in none "
+        f"of prms.columns / prms.defects / prms.provenance. Every emitted column "
+        f"needs a PRMS decision."
+    )
+
+
+@pytest.mark.parametrize("declared", pi.load_declared_params(), ids=lambda d: d.name)
+def test_guard1_prms_declares_a_builder(declared):
+    """`builder:` drives the index's by-builder view.
+
+    Kept in the config rather than a lookup table in the generator, which would
+    drift the moment a builder moves.
+    """
+    assert declared.prms.get("builder"), f"{declared.name} declares no prms.builder"
+
+
+@pytest.mark.parametrize("declared", pi.load_declared_params(), ids=lambda d: d.name)
+def test_guard1_no_column_is_declared_twice(declared):
+    """columns / defects / provenance are mutually exclusive verdicts.
+
+    A column in two buckets means two contradictory answers to "is this the PRMS
+    parameter?", and `_declared_columns`'s union would hide it from Guard 1.
+    """
+    buckets = [
+        set(declared.prms.get(k) or {}) for k in ("columns", "defects", "provenance")
+    ]
+    overlaps = (
+        (buckets[0] & buckets[1]) | (buckets[0] & buckets[2]) | (buckets[1] & buckets[2])
+    )
+    assert not overlaps, f"{declared.name}: {sorted(overlaps)} declared in two buckets"

--- a/tests/test_params_index.py
+++ b/tests/test_params_index.py
@@ -209,3 +209,61 @@ def test_op_flow_thres_is_not_a_means_entry():
     assert "op_flow_thres" in {e["name"] for e in depstor.get("constants") or []}
     for entry in depstor.get("constants") or []:
         assert "source_raster" not in entry, f"{entry['name']} is not a zonal target"
+
+
+# ---------------------------------------------------------------------------
+# params_for_process + the index generator.
+# ---------------------------------------------------------------------------
+
+
+def test_params_for_process_is_column_grained_not_entry_grained():
+    """ssflux spans three processes; asking for PRMSRunoff must return only its
+    two runoff columns, not the whole 10-column file."""
+    hits = pi.params_for_process("PRMSRunoff")
+    ssflux_cols = {col for col, d in hits if d.name == "ssflux"}
+    assert ssflux_cols == {"dprst_seep_rate_open", "dprst_flow_coef"}
+    assert "gwflow_coef" not in ssflux_cols  # PRMSGroundwater
+    assert "soil2gw_max" not in ssflux_cols  # PRMSSoilzone
+
+
+def test_prms_runoff_has_the_expected_parameter_count():
+    hits = pi.params_for_process("PRMSRunoff")
+    assert len({col for col, _ in hits}) == 11
+
+
+def test_params_for_process_never_returns_a_defective_column():
+    """aspect's `mean` names PRMSSolarGeometry/PRMSAtmosphere in prms.defects.
+
+    Returning it here would hand a caller a broken column under a correct-looking
+    parameter name -- the exact failure the defects/columns split exists to prevent.
+    """
+    for process in ("PRMSSolarGeometry", "PRMSAtmosphere"):
+        hits = pi.params_for_process(process)
+        assert all(d.name != "aspect" for _, d in hits), process
+        assert {col for col, _ in hits} == {"hru_slope"}
+
+
+def test_generated_index_is_up_to_date():
+    """docs/parameter_index.md's generated regions must match the configs.
+
+    Pure text + YAML, so it runs on CI. This is what stops the index drifting from
+    the `prms:` blocks the moment someone edits a config -- the whole failure mode
+    that made a hand-maintained index untrustworthy.
+    """
+    import importlib.util
+    from pathlib import Path
+
+    import pytest
+
+    spec = importlib.util.spec_from_file_location(
+        "build_parameter_index",
+        Path(__file__).resolve().parent.parent / "scripts" / "build_parameter_index.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    if module.build(check=True) != 0:
+        pytest.fail(
+            "docs/parameter_index.md is stale -- run "
+            "`python scripts/build_parameter_index.py` and commit the result."
+        )

--- a/tests/test_params_index.py
+++ b/tests/test_params_index.py
@@ -177,3 +177,35 @@ def test_guard1_no_column_is_declared_twice(declared):
         (buckets[0] & buckets[1]) | (buckets[0] & buckets[2]) | (buckets[1] & buckets[2])
     )
     assert not overlaps, f"{declared.name}: {sorted(overlaps)} declared in two buckets"
+
+
+def test_op_flow_thres_is_declared_with_a_merged_file():
+    """D1: op_flow_thres is a PRMSRunoff param that was written outside merged/.
+
+    A depstor BUILDER wrote it straight to depstor_rasters/, so it was invisible to
+    iter_declared_params AND to warn_undeclared_merged_files (which globs merged_dir).
+    Anyone assembling a parameter file by globbing merged/nhm_*_params.csv dropped it
+    silently, and the fill sweep never saw it either.
+    """
+    declared = {d.name: d for d in pi.load_declared_params()}
+    assert "op_flow_thres" in declared
+    assert declared["op_flow_thres"].merged_file == "nhm_op_flow_thres_params.csv"
+    assert declared["op_flow_thres"].prms["columns"]["op_flow_thres"]["processes"] == [
+        "PRMSRunoff"
+    ]
+
+
+def test_op_flow_thres_is_not_a_means_entry():
+    """`constants:`, deliberately, not `means:`.
+
+    run_mean_zonal does Path(spec["source_raster"]) unconditionally and _find_mean
+    advertises every means[].name as a runnable --mean target, so a raster-less
+    means entry is a KeyError waiting for the first operator who types
+    `--mean op_flow_thres`. op_flow_thres is a constant 1.0 built from the fabric's
+    id list, with no raster at all.
+    """
+    depstor = pi._load_yaml_doc(pi.DEPSTOR_PARAMS_CONFIG)
+    assert "op_flow_thres" not in {e["name"] for e in depstor.get("means") or []}
+    assert "op_flow_thres" in {e["name"] for e in depstor.get("constants") or []}
+    for entry in depstor.get("constants") or []:
+        assert "source_raster" not in entry, f"{entry['name']} is not a zonal target"

--- a/tests/test_params_index.py
+++ b/tests/test_params_index.py
@@ -134,11 +134,14 @@ def _declared_columns(declared):
 def test_guard1_prms_declares_every_fillable_column(declared):
     """Guard 1 only proves the declaration is SELF-CONSISTENT.
 
-    It runs declaration -> declaration and cannot see disk, so it is a tautology on
-    most entries and vacuous on the three whose on-disk payload exceeds their
-    fill_columns (ssflux declares 7 of 10 columns, snarea 13 of 23, dprst_depth_avg
-    1 of 2). Guard 2 (tests/test_params_index_ondisk.py) is the one that catches a
-    new column reaching disk with no PRMS decision recorded.
+    It runs declaration -> declaration and cannot see disk. On 16 of 19 entries
+    fill_columns and the declared columns are the same set, so it is a literal
+    tautology; on the other three the fill_columns cover only part of the on-disk
+    header (ssflux 7 of 10, snarea 13 of 23, dprst_depth_avg 1 of 2), leaving the
+    remainder unchecked HERE -- note `prms:` itself declares all of them, it is
+    `fill_columns` that is the smaller set. Guard 2
+    (tests/test_params_index_ondisk.py) is the one that catches a new column
+    reaching disk with no PRMS decision recorded.
     """
     assert declared.prms, (
         f"{declared.name} has no `prms:` block. It is mandatory, not optional -- "

--- a/tests/test_params_index.py
+++ b/tests/test_params_index.py
@@ -1,0 +1,90 @@
+"""Unit coverage for gfv2_params.params_index.
+
+Pure YAML parsing -- no geo imports, no data root. Safe on CI's ubuntu-latest.
+
+The DISK-facing half of this contract lives in tests/test_params_index_ondisk.py,
+which is data-root-gated and therefore SKIPS here. Nothing in this file can catch a
+new column reaching disk with no PRMS decision recorded.
+"""
+
+from __future__ import annotations
+
+from gfv2_params import params_index as pi
+
+
+def test_declared_param_has_prms_field_defaulting_to_empty():
+    d = pi.DeclaredParam("elevation", "nhm_elevation_params.csv", ["mean"], {})
+    assert d.prms == {}
+    assert d.name == "elevation"
+
+
+def test_iter_declared_params_unions_four_config_families():
+    zonal = {
+        "params": [
+            {
+                "name": "elevation",
+                "merged_file": "nhm_elevation_params.csv",
+                "fill_columns": ["mean"],
+            }
+        ]
+    }
+    depstor = {
+        "fractions": [{"name": "perv_frac", "merged_file": "nhm_perv_frac_params.csv"}],
+        "means": [
+            {
+                "name": "dprst_depth_avg",
+                "merged_file": "nhm_dprst_depth_avg_params.csv",
+                "fill_columns": ["dprst_depth_avg"],
+            }
+        ],
+        "ratios": [
+            {
+                "name": "dprst_frac",
+                "output_file": "nhm_dprst_frac_params.csv",
+                "fill_columns": ["dprst_frac"],
+            }
+        ],
+    }
+    declared = pi.iter_declared_params(zonal, depstor)
+    names = {d.name for d in declared}
+    assert names == {"elevation", "dprst_depth_avg", "dprst_frac"}
+    # fractions are intermediates -- excluded despite carrying a merged_file key
+    assert "perv_frac" not in names
+
+
+def test_iter_declared_params_includes_constants():
+    """`constants:` are builder-written per-HRU params copied into merged/."""
+    depstor = {
+        "constants": [
+            {
+                "name": "op_flow_thres",
+                "merged_file": "nhm_op_flow_thres_params.csv",
+                "fill_columns": ["op_flow_thres"],
+            }
+        ]
+    }
+    declared = pi.iter_declared_params({}, depstor)
+    assert [d.name for d in declared] == ["op_flow_thres"]
+    assert declared[0].merged_file == "nhm_op_flow_thres_params.csv"
+
+
+def test_iter_declared_params_carries_prms_block():
+    zonal = {
+        "params": [
+            {
+                "name": "slope",
+                "merged_file": "nhm_slope_params.csv",
+                "fill_columns": ["mean"],
+                "prms": {
+                    "columns": {
+                        "hru_slope": {
+                            "prms": "hru_slope",
+                            "processes": ["PRMSSolarGeometry"],
+                        }
+                    }
+                },
+            }
+        ]
+    }
+    declared = pi.iter_declared_params(zonal, {})
+    assert declared[0].prms["columns"]["hru_slope"]["prms"] == "hru_slope"

--- a/tests/test_params_index.py
+++ b/tests/test_params_index.py
@@ -267,3 +267,87 @@ def test_generated_index_is_up_to_date():
             "docs/parameter_index.md is stale -- run "
             "`python scripts/build_parameter_index.py` and commit the result."
         )
+
+
+# The 8 processes any declared column may name. pywatershed 2.0.4's Process
+# classes plus the two PRMS-only consumers TM6B9 documents. Hardcoded rather than
+# imported: pywatershed lives in the `reference` pixi env, not `dev`, so importing
+# it would make this test env-dependent -- and the point is to catch a TYPO, which
+# a frozen list does as well as a live import.
+_KNOWN_PROCESSES = {
+    "PRMSRunoff",
+    "PRMSSoilzone",
+    "PRMSSnow",
+    "PRMSCanopy",
+    "PRMSGroundwater",
+    "PRMSEt",
+    "PRMSSolarGeometry",
+    "PRMSAtmosphere",
+}
+
+
+@pytest.mark.parametrize("declared", pi.load_declared_params(), ids=lambda d: d.name)
+def test_guard1_column_specs_are_well_formed(declared):
+    """Every columns/defects spec needs a `prms` name and a `processes` list.
+
+    Guard 1 otherwise looks only at the spec KEYS, so a spec like
+    `{processes: [PRMSRunoff]}` with the `prms:` key omitted passes Guard 1, passes
+    Guard 2, makes params_for_process silently return nothing useful, and then dies
+    inside scripts/build_parameter_index.py as a bare `KeyError: 'prms'` -- an error
+    pointing at a documentation generator rather than at the typo'd YAML.
+    """
+    for bucket in ("columns", "defects"):
+        for col, spec in (declared.prms.get(bucket) or {}).items():
+            where = f"{declared.name}.prms.{bucket}.{col}"
+            assert isinstance(spec, dict), f"{where} must be a mapping, got {spec!r}"
+            assert isinstance(spec.get("prms"), str) and spec["prms"], (
+                f"{where} has no `prms:` name. Without it the index generator "
+                f"raises a bare KeyError far from the config that caused it."
+            )
+            assert isinstance(spec.get("processes"), list), (
+                f"{where} has no `processes:` list. Use [] for a parameter no "
+                f"pywatershed Process consumes (hru_elev), not a missing key."
+            )
+
+
+@pytest.mark.parametrize("declared", pi.load_declared_params(), ids=lambda d: d.name)
+def test_guard1_process_names_are_known(declared):
+    """A misspelt process name fails NOTHING without this.
+
+    `PRMSSoilzon` silently drops that column from params_for_process("PRMSSoilzone")
+    and invents a phantom `### PRMSSoilzon` section in the generated index -- and
+    because the index is regenerated from the same typo, the staleness check still
+    passes. The doc would confidently document a process that does not exist.
+    """
+    for bucket in ("columns", "defects"):
+        for col, spec in (declared.prms.get(bucket) or {}).items():
+            unknown = set(spec.get("processes") or []) - _KNOWN_PROCESSES
+            assert not unknown, (
+                f"{declared.name}.prms.{bucket}.{col} names unknown process(es) "
+                f"{sorted(unknown)}. Known: {sorted(_KNOWN_PROCESSES)}. If this is a "
+                f"genuinely new pywatershed Process, add it to _KNOWN_PROCESSES."
+            )
+
+
+def test_every_config_entry_reaches_the_declaration():
+    """An entry with a typo'd `merged_file:` vanishes silently from the declaration.
+
+    iter_declared_params skips any entry whose merged_file/output_file is falsy, and
+    a skipped entry generates no parametrize case -- so the "prms: is mandatory" rule
+    and both guards simply never run on it, and it never reaches the index. The
+    backstop is a KeyError inside a SLURM-chained merge job, where it has to be
+    noticed in sacct; this catches it in CI instead.
+    """
+    declared = {d.name for d in pi.load_declared_params()}
+    for config, sections in (
+        (pi.ZONAL_PARAMS_CONFIG, ("params",)),
+        (pi.DEPSTOR_PARAMS_CONFIG, ("means", "ratios", "constants")),
+    ):
+        doc = pi._load_yaml_doc(config)
+        for section in sections:
+            for entry in doc.get(section) or []:
+                assert entry["name"] in declared, (
+                    f"{config.name}'s `{section}:` entry '{entry['name']}' never "
+                    f"reached load_declared_params() -- check its "
+                    f"merged_file:/output_file: key for a typo."
+                )

--- a/tests/test_params_index_ondisk.py
+++ b/tests/test_params_index_ondisk.py
@@ -10,10 +10,19 @@ of defect it was written for. This is the guard that catches a new column reachi
 disk with no PRMS decision recorded -- which is exactly how the hru_slope and
 hru_aspect defects arose.
 
-Direction matters: this asserts DISK is a subset of DECLARED, not equality. Alias
-columns (lulc_nhm_v11's retention | rad_trncf) mean only one alternative is present
-on any given fabric, so declared-but-absent is expected and fine. Absent-but-
-undeclared is the failure.
+BOTH directions are checked, by two separate tests:
+
+* disk -> declared: a column reached disk with no PRMS decision recorded.
+* declared -> disk: `prms.columns` claims a PRMS parameter the file does not
+  actually carry. The generated index renders every `prms.columns` entry as a fact
+  about what is on disk, so without this the doc can advertise a parameter nobody
+  emits. This is not hypothetical -- `hru_slope` is this PR's headline deliverable
+  and, checked only one way, nothing anywhere verified it reached disk.
+
+Alias groups are the reason the second direction is not simple equality: only one
+alternative of lulc_nhm_v11's `retention` | `rad_trncf` exists on any given fabric,
+so alias members are exempted. They are derived from the list-valued entries of
+`fill_columns`, not hardcoded.
 
 Pure pandas + yaml: no rasterio/GDAL/pyogrio, so it is head-node safe -- but per
 CLAUDE.md, run it under srun on a compute node anyway, not on the login node.
@@ -31,13 +40,21 @@ from gfv2_params.params_index import load_declared_params
 
 _DECLARED = load_declared_params()
 
-# Columns that identify an HRU rather than parameterise it. Mirrors
-# scripts/merge_and_fill_params.py's ID_COLUMNS, duplicated rather than imported
-# because that module pulls in geopandas/sklearn and this test must not. The
-# active fabric's own id_feature is added on top: the four stages do not all agree
-# on the id column name (gfv2's id_feature is nat_hru_id, but the depstor mean and
-# snarea stages write hru_id), and an id column is never a PRMS parameter.
-_ID_COLUMNS = {"hru_id", "nat_hru_id", "model_hru_idx", "vpu"}
+def _alias_members(declared) -> set[str]:
+    """Column names that are alternatives of one another, not independent columns.
+
+    A list-valued `fill_columns` entry IS the alias declaration -- lulc_nhm_v11's
+    `[retention, rad_trncf]` marks the same computed quantity under two names across
+    fabric vintages. Exactly one member is on disk for a given fabric, so the
+    declared -> disk direction must exempt them. Derived, not hardcoded, so a new
+    alias group needs no edit here.
+    """
+    return {
+        alt
+        for item in declared.fill_columns
+        if isinstance(item, (list, tuple))
+        for alt in item
+    }
 
 
 def _merged_dir_and_id() -> tuple[Path, str]:
@@ -64,13 +81,59 @@ def test_guard2_declared_columns_cover_disk(declared):
         | set(declared.prms.get("provenance") or {})
     )
 
-    undeclared = header - declared_cols - _ID_COLUMNS - {id_feature}
+    undeclared = header - declared_cols - {id_feature}
     assert not undeclared, (
         f"{declared.name}: {sorted(undeclared)} exist in {path.name} but are declared "
         f"in none of prms.columns / prms.defects / prms.provenance. A new column "
         f"reached disk with no PRMS decision recorded -- that is exactly how the "
         f"hru_slope and hru_aspect defects arose."
     )
+
+
+@pytest.mark.parametrize("declared", _DECLARED, ids=lambda d: d.name)
+def test_guard2_declared_columns_are_present_on_disk(declared):
+    """The converse direction: prms.columns must not claim a column nobody emits.
+
+    scripts/build_parameter_index.py renders every prms.columns entry into
+    docs/parameter_index.md as a statement about what is in merged/, so a declared
+    column absent from disk means the published index advertises a PRMS parameter
+    that does not exist.
+
+    `hru_slope` is exactly why this matters. It is emitted by a `derived_columns:`
+    block applied at merge time, so if the operator never re-ran the merge, or a
+    future edit dropped the block, the config would still claim the column, the doc
+    would still advertise it, and the disk -> declared direction would still pass.
+    Nothing would notice. (There IS a loud path today via resolve_fill_plan, but
+    only because hru_slope was also added to fill_columns -- a derived column that
+    is not declared fillable would have no backstop at all.)
+    """
+    merged_dir, _ = _merged_dir_and_id()
+    if not merged_dir.exists():
+        pytest.skip(f"no data root on this host: {merged_dir}")
+
+    path = merged_dir / declared.merged_file
+    if not path.exists():
+        pytest.skip(f"not built for this fabric: {path}")
+
+    header = set(pd.read_csv(path, nrows=0).columns)
+    required = set(declared.prms.get("columns") or {}) - _alias_members(declared)
+    missing = required - header
+    assert not missing, (
+        f"{declared.name}: {sorted(missing)} are declared in prms.columns as PRMS "
+        f"parameters but are NOT in {path.name}. Either the file needs rebuilding "
+        f"(for a derived_columns output, re-run --mode merge for this param), or "
+        f"the declaration is wrong. docs/parameter_index.md is currently "
+        f"advertising a parameter that is not on disk."
+    )
+
+    # An alias group must contribute at least one member, or the parameter really
+    # is absent and the exemption above would hide it.
+    aliases = _alias_members(declared) & set(declared.prms.get("columns") or {})
+    if aliases:
+        assert aliases & header, (
+            f"{declared.name}: none of the alias alternatives {sorted(aliases)} is "
+            f"present in {path.name}. Exactly one is expected per fabric vintage."
+        )
 
 
 def test_guard2_is_gated_not_silently_empty():

--- a/tests/test_params_index_ondisk.py
+++ b/tests/test_params_index_ondisk.py
@@ -1,0 +1,83 @@
+"""Guard 2: the declared column list must cover the on-disk header.
+
+DATA-ROOT-GATED. CI (ubuntu-latest) has no data root, so every case SKIPS there and
+CI reports green while proving nothing -- record this test's result by SLURM job id,
+never infer it from a CI badge. See the companion spec's Testing section.
+
+Guard 1 (tests/test_params_index.py) runs declaration -> declaration and is a
+tautology on most entries; it cannot see disk, and therefore cannot catch the class
+of defect it was written for. This is the guard that catches a new column reaching
+disk with no PRMS decision recorded -- which is exactly how the hru_slope and
+hru_aspect defects arose.
+
+Direction matters: this asserts DISK is a subset of DECLARED, not equality. Alias
+columns (lulc_nhm_v11's retention | rad_trncf) mean only one alternative is present
+on any given fabric, so declared-but-absent is expected and fine. Absent-but-
+undeclared is the failure.
+
+Pure pandas + yaml: no rasterio/GDAL/pyogrio, so it is head-node safe -- but per
+CLAUDE.md, run it under srun on a compute node anyway, not on the login node.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from gfv2_params.config import load_base_config, require_config_key
+from gfv2_params.params_index import load_declared_params
+
+_DECLARED = load_declared_params()
+
+# Columns that identify an HRU rather than parameterise it. Mirrors
+# scripts/merge_and_fill_params.py's ID_COLUMNS, duplicated rather than imported
+# because that module pulls in geopandas/sklearn and this test must not. The
+# active fabric's own id_feature is added on top: the four stages do not all agree
+# on the id column name (gfv2's id_feature is nat_hru_id, but the depstor mean and
+# snarea stages write hru_id), and an id column is never a PRMS parameter.
+_ID_COLUMNS = {"hru_id", "nat_hru_id", "model_hru_idx", "vpu"}
+
+
+def _merged_dir_and_id() -> tuple[Path, str]:
+    base = load_base_config(None, fabric=None)
+    merged_dir = Path(base["data_root"]) / base["fabric"] / "params" / "merged"
+    id_feature = require_config_key(base, "id_feature", "test_params_index_ondisk")
+    return merged_dir, str(id_feature)
+
+
+@pytest.mark.parametrize("declared", _DECLARED, ids=lambda d: d.name)
+def test_guard2_declared_columns_cover_disk(declared):
+    merged_dir, id_feature = _merged_dir_and_id()
+    if not merged_dir.exists():
+        pytest.skip(f"no data root on this host: {merged_dir}")
+
+    path = merged_dir / declared.merged_file
+    if not path.exists():
+        pytest.skip(f"not built for this fabric: {path}")
+
+    header = set(pd.read_csv(path, nrows=0).columns)
+    declared_cols = (
+        set(declared.prms.get("columns") or {})
+        | set(declared.prms.get("defects") or {})
+        | set(declared.prms.get("provenance") or {})
+    )
+
+    undeclared = header - declared_cols - _ID_COLUMNS - {id_feature}
+    assert not undeclared, (
+        f"{declared.name}: {sorted(undeclared)} exist in {path.name} but are declared "
+        f"in none of prms.columns / prms.defects / prms.provenance. A new column "
+        f"reached disk with no PRMS decision recorded -- that is exactly how the "
+        f"hru_slope and hru_aspect defects arose."
+    )
+
+
+def test_guard2_is_gated_not_silently_empty():
+    """Fail loudly if the parametrize list is empty.
+
+    Every case above is allowed to skip, so an empty _DECLARED would make this whole
+    module report green while asserting nothing -- the same vacuous-pass failure mode
+    the `prms:`-is-mandatory rule exists to prevent one level up.
+    """
+    assert _DECLARED, "load_declared_params() returned nothing -- configs unreadable?"


### PR DESCRIPTION
Executes Tasks 3-8 of `docs/superpowers/plans/2026-08-04-prms-parameter-index.md`, continuing PR #202 (Tasks 1-2). Seven atomic commits.

The index is no longer hand-maintained: the `prms:` metadata now lives in `configs/`, two guards keep it honest, and `scripts/build_parameter_index.py` renders the three tables from it.

## What landed

| Task | Commit | What |
| --- | --- | --- |
| 3 | `cd6d5c1` | `src/gfv2_params/params_index.py` — `iter_declared_params` moved out of `merge_and_fill_params.py`, `DeclaredParam` widened with a defaulted `prms` field |
| 4 | `3213fbf` | `prms:` blocks on all 18 declared entries + Guard 1 |
| 5 | `ace4cfb` | Guard 2 — on-disk header check, data-root-gated |
| 6 | `b29382e` | `constants:` list + `--mode copy_constants`; `op_flow_thres` now reaches `merged/` |
| 7 | `2325215` | `derived_columns:` + `hru_slope` emitted in rise/run |
| 8 | `74de536` | `scripts/build_parameter_index.py` — the index is generated |
| — | `0bc990f` | test fix: `tan(radians(4.4252))` is `0.07738825`, not the plan's `0.077398` |
| — | `838dea4` | closes the last inferred mapping: `mean` → `hru_elev` is verified, and it is **metres** |

## Verification

`pytest` cannot run on the HPC head node, so everything was run under `srun` on a compute node and CI is the gate here.

| Check | Result |
| --- | --- |
| Full suite, final state | **946 passed, 2 skipped** (compute node) |
| **Guard 2 against real gfv2** — *skips on CI, so record it by job id* | **18 passed, 2 skipped**, SLURM job **2395597** |
| `--mode copy_constants` on gfv2 | 361,471 rows → `merged/nhm_op_flow_thres_params.csv`, job **2395578** |
| `--mode merge --param slope` on gfv2 | `hru_slope` column added, job **2395596** |
| `hru_elev` units check | job **2395621** |
| `pre-commit` on all 17 changed files | clean — see "Pre-existing lint" below |
| `docs-build` | exits 0, no new warnings |

`docs/parameter_index.md` picked up two content changes as a direct result of the fixes: the `hru_slope`-is-degrees and `op_flow_thres`-not-in-`merged/` gaps are now rewritten as fixed.

## Scope expansion beyond the plan

Six deviations, each because following the plan literally would have been wrong:

1. **A third `prms:` bucket, `defects:`.** The plan puts every column in `columns:` or `provenance:`. `aspect`'s `mean` fits neither — declaring it `{prms: hru_aspect}` asserts the broken column IS the parameter, and burying it in `provenance` drops the DEFECTIVE warning the spec calls "the whole point of having an index". `defects:` carries `prms`/`processes`/`reason`/`recovery`/`issue`, and `params_for_process` provably never reads it.
2. **The generator writes only marker-delimited regions.** The plan's "write to `docs/parameter_index.md`" would have clobbered the hydrologist-reviewed prose — the `TEXT_PRMS.tif` metadata investigation, the aspect measurement, the 57× worked example. Tables generated, prose hand-maintained, and the script raises rather than guessing if a marker is missing.
3. **Config-entry line numbers are computed, not carried.** Adding the `prms:` blocks shifted every entry, so all 19 literal cites in the hand-written index were already stale.
4. **`elevation`'s `hru_elev` gets `processes: []`, not `[temp_distribution]`.** pywatershed has no such Process; inventing one puts a phantom heading in the generated index.
5. **`hru_slope` is declared in `fill_columns`.** Otherwise an HRU missing from the merged CSV gets `mean` KNN-filled but lands NaN in the PRMS parameter. Consequence, documented in three places: **a re-merge is now a prerequisite of the next fill sweep on any fabric whose slope CSV predates this** — gfv2 is done, **oregon and tjc are not**.
6. **`run_copy_constants` uses `_merge_paths(config)`.** The plan's `config["output_dir"]` KeyErrors — in `depstor_params.yml` those keys live under `defaults:`.

## Findings from diffing generated vs. hand-written

The plan says any row that changes meaning is a real finding. Six were, all fixed in the generator rather than by relaxing the target:

- `snarea_curve` was marked ⚠️ as a rename — it is a **dimensioned** parameter (`snarea_curve_0..10`), and the marker told readers to translate a name needing no translation.
- `rad_trncf` was **not** marked ⚠️, because `rad_trncf` is one of its two alias columns — but on gfv2 and oregon the on-disk column is `retention`, so it IS a rename there.
- The four LULC sources are alternatives, not four parameter sets; uncollapsed they turned PRMSCanopy's 6 parameters into **24 rows**.
- The by-entry table sorted `zonal_params.yml:43` after `:389` — a string compare on line numbers.
- The by-entry `aspect` row concatenated an empty-list em dash onto the defect text.
- The by-builder table put `(DEFECTIVE)` inside the backticks, where it reads as part of the parameter name.

Two differences are **deliberate and not reconciled**: PRMSSolarGeometry and PRMSAtmosphere get separate sections rather than one combined heading, and all four LULC alternatives appear rather than only `nhm_v11` — which of the four is delivered is an open question in the spec, so the generator must not silently pick one. A note explains both.

## Open item closed

`mean` → `hru_elev` was the last unverified mapping. It is **documented, not inferred**: TM6B9:534 defines `hru_elev` as "Mean elevation for each HRU", dimension `nhru`, units **meters**, and TM6B9:601 states it was derived from the HRU outline and a DEM.

Checked against the data too, since the `TEXT_PRMS.tif` metadata turned out to be wrong: `elevation.vrt` is float32, CRS linear units metre, scale 1.0/offset 0.0; the 361,471 gfv2 HRU means run min −84.6, median 427.8, p99 2,940.3, max 3,851.2. As feet the maximum HRU mean would be 1,174 m and CONUS's high country would be absent. The 327 negative-mean HRUs are Death Valley and the Salton Sea.

Two unit traps recorded: TM6B9:707's `cov_type` reset rule is stated in **feet** ("exceeds 11,500 feet") for a parameter carried in metres (= 3,505 m), and TM6B9 used the NHDPlus v1.0 DEM while this pipeline uses `elevation.vrt` — same quantity, different source.

## Hard constraints held

`configs/zonal/zonal_params.yml`'s `params:` is still a flat list and every `name:` is unchanged, so `submit_zonal_params.sh` and `submit_depstor_params.sh` are untouched and `tests/test_submit_wrapper_param_lists.py` still passes. `constants:` is a new list, which the plan's own table confirms has no wrapper impact.

## Pre-existing lint, not from this PR

`pre-commit run --all-files` cannot pass on `main` today, and this PR does not change that either way:

- `scripts/derive_depstor_params.py` — 4 `E402`s from the startup-heartbeat block that predates it
- `configs/zonal/zonal_params.yml` — 14 yamllint `braces` errors in `ssflux`'s `flux_params:` block

Both verified against `main` with `git stash`. Worth a separate cleanup commit; deliberately not folded in here.

Note this is also why the `prms:` blocks use **block mappings** rather than the flow mappings the plan sketched: yamllint wants no spaces inside braces and prettier inserts them, so `{ prms: x, processes: [y] }` makes the two hooks fight indefinitely.

## Follow-ups

- **oregon and tjc need `--mode merge --param slope`** before their next fill sweep, or `resolve_fill_plan` raises on the newly declared `hru_slope`.
- `hru_aspect` remains DEFECTIVE — #201, scoped out by the spec.
- `retention` on `lulc_nalcms`/`nlcd`/`foresce` is still unverified and stays in `provenance`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
