### PR TITLE
chore(lint): make pre-commit run --all-files actually pass

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,8 +43,15 @@ repos:
         # below. Its `pip:` block uses 4-space nesting yamllint wants at 6; fixing
         # that would mean editing a file the repo has stopped maintaining.
         exclude: ^environment\.yml$
-  - repo: https://github.com/koalaman/shellcheck-precommit
-    rev: v0.10.0
+  # shellcheck-py, NOT koalaman/shellcheck-precommit. The koalaman hook runs
+  # shellcheck inside docker, and docker is not installed on the HPC where this
+  # repo is developed -- so it did not fail, it ERRORED
+  # (`CalledProcessError: docker system info`), and since CI runs pytest only,
+  # shell scripts were effectively linted by nothing on any machine anyone used.
+  # shellcheck-py ships a pip-installed binary and runs here. Same shellcheck,
+  # same rules; it just works without a container runtime.
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.10.0.1
     hooks:
       - id: shellcheck
         files: \.(sh|slurm|sbatch)$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,6 +68,13 @@ repos:
     hooks:
       - id: prettier
         files: \.(yml|yaml)$
+        # environment.yml again -- prettier wants to reindent its `pip:` block from
+        # 4 spaces to 6. That is the same spot yamllint flags, and letting prettier
+        # rewrite it would reformat the deprecated conda fallback the repo has
+        # stopped maintaining. It is now excluded from all four hooks that would
+        # touch it (yamllint, end-of-file-fixer, trailing-whitespace, prettier),
+        # which is the consistent treatment for a file kept only for reference.
+        exclude: ^environment\.yml$
   # nbstripout strips outputs from .ipynb on commit. Notebooks are kept
   # output-free in git; figures get rendered to docs/figures/<fabric>/ via
   # scripts/render_figures.py (see notebooks/<fabric>/README.md).

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,23 @@
+# Python trees excluded from BOTH linters below. These are reference artifacts,
+# not maintained source, and linting them produces failures nobody may act on:
+#
+#   docs/0b_TB_depr_stor.py  -- the original ArcPy depression-storage script. It is
+#     the authoritative record of the legacy behaviour that depstor_builders/
+#     reproduces, and CLAUDE.md cites it by line number (e.g. `:214` for the
+#     Con(rSro == hru) same-HRU rule, `:220-312` for the clamp-to-one convention).
+#     Reformatting it would break those cites and make it a less faithful copy;
+#     its 17 ruff findings (bare excepts, ArcPy globals ruff cannot see) are
+#     properties of the original, not defects to fix. The FILE STAYS -- this only
+#     stops linting it.
+#   notebooks/_archive/  -- exploratory notebooks kept deliberately. CLAUDE.md and
+#     the parameter-index spec both depend on this tree surviving: it holds the
+#     only written record of the known aspect-circularity simplification, which is
+#     why issue #201 can be framed as a measured limitation rather than an oversight.
+#
+# Scope this list tightly. Everything else -- src/, scripts/, tests/, and the live
+# notebooks/ scripts -- IS linted, and adding to this list is how that erodes.
+exclude: ^(docs/0b_TB_depr_stor\.py|notebooks/_archive/)
+
 repos:
   # isort for sorting Python imports
   - repo: https://github.com/pycqa/isort
@@ -18,6 +38,11 @@ repos:
     hooks:
       - id: yamllint
         files: \.(yml|yaml)$
+        # environment.yml is the DEPRECATED conda fallback (CLAUDE.md: "do not add
+        # to it"), already excluded from end-of-file-fixer and trailing-whitespace
+        # below. Its `pip:` block uses 4-space nesting yamllint wants at 6; fixing
+        # that would mean editing a file the repo has stopped maintaining.
+        exclude: ^environment\.yml$
   - repo: https://github.com/koalaman/shellcheck-precommit
     rev: v0.10.0
     hooks:

--- a/configs/shared_rasters/merge_rpu_by_vpu_twi.yml
+++ b/configs/shared_rasters/merge_rpu_by_vpu_twi.yml
@@ -7,7 +7,6 @@
 #
 # VPU 08 includes RPU 03g — same cross-VPU case as the NHD merge.
 
-
 "01":
   TWI:
     rpus:

--- a/configs/zonal/zonal_params.yml
+++ b/configs/zonal/zonal_params.yml
@@ -524,11 +524,28 @@ params:
     # Lithology permeability + PRMS flux normalisation (lifted verbatim
     # from configs/zonal/ssflux_param.yml).
     k_perm_min: -16.48
+    # Block mappings, not `{ name: x, min: y }` flow style: yamllint's braces rule
+    # wants no spaces inside braces and prettier inserts them, so flow style makes
+    # the two hooks fight forever. Values are unchanged.
     flux_params:
-      - { name: soil2gw_max, min: 0.1, max: 0.3 }
-      - { name: ssr2gw_rate, min: 0.3, max: 0.7 }
-      - { name: fastcoef_lin, min: 0.01, max: 0.6 }
-      - { name: slowcoef_lin, min: 0.005, max: 0.3 }
-      - { name: gwflow_coef, min: 0.005, max: 0.3 }
-      - { name: dprst_seep_rate_open, min: 0.005, max: 0.2 }
-      - { name: dprst_flow_coef, min: 0.005, max: 0.5 }
+      - name: soil2gw_max
+        min: 0.1
+        max: 0.3
+      - name: ssr2gw_rate
+        min: 0.3
+        max: 0.7
+      - name: fastcoef_lin
+        min: 0.01
+        max: 0.6
+      - name: slowcoef_lin
+        min: 0.005
+        max: 0.3
+      - name: gwflow_coef
+        min: 0.005
+        max: 0.3
+      - name: dprst_seep_rate_open
+        min: 0.005
+        max: 0.2
+      - name: dprst_flow_coef
+        min: 0.005
+        max: 0.5

--- a/docs/Runoff_sensitivity_snow_depletion_Sexstone_2020.md
+++ b/docs/Runoff_sensitivity_snow_depletion_Sexstone_2020.md
@@ -2501,5 +2501,3 @@ depletion curve representation within a continental scale
 
 hydrologic model. Hydrological Processes. 2020;34:
 2365–2380. https://doi.org/10.1002/hyp.13735
-
-

--- a/notebooks/inspect_fabric.py
+++ b/notebooks/inspect_fabric.py
@@ -31,13 +31,12 @@ def _():
     from pathlib import Path
 
     import geopandas as gpd
+    import marimo as mo
     import matplotlib.pyplot as plt
     import numpy as np
     import pandas as pd
     from pyogrio import list_layers, read_info
     from pyproj import CRS
-
-    import marimo as mo
 
     from gfv2_params.config import load_base_config
 

--- a/notebooks/merge_vpu_targets.py
+++ b/notebooks/merge_vpu_targets.py
@@ -21,9 +21,9 @@ def _():
     from pathlib import Path
 
     import geopandas as gpd
+    import marimo as mo
     import pandas as pd
     import shapely
-    import marimo as mo
 
     from gfv2_params.config import VPUS_DETAILED, load_base_config
 

--- a/scripts/derive_depstor_params.py
+++ b/scripts/derive_depstor_params.py
@@ -47,11 +47,16 @@ print(
 )
 _t_imports = time.time()
 
-import pandas as pd
+# noqa: E402 on each -- these imports are DELIBERATELY below the heartbeat print.
+# Hoisting them to the top would defeat the whole point: the print has to reach the
+# SLURM log BEFORE the geo stack is touched, so a hang in rasterio/GDAL/PROJ/pyogrio
+# init under shared-FS metadata contention is localisable to the import chain rather
+# than looking like a silent task that never started.
+import pandas as pd  # noqa: E402
 
-from gfv2_params.config import load_config, require_config_key
-from gfv2_params.depstor_ratios import compute_ratio
-from gfv2_params.log import configure_logging
+from gfv2_params.config import load_config, require_config_key  # noqa: E402
+from gfv2_params.depstor_ratios import compute_ratio  # noqa: E402
+from gfv2_params.log import configure_logging  # noqa: E402
 
 print(f"[startup] base imports complete in {time.time() - _t_imports:.1f}s", flush=True)
 

--- a/slurm_batch/submit_zonal_params.sh
+++ b/slurm_batch/submit_zonal_params.sh
@@ -148,6 +148,10 @@ for PARAM in "${PARAMS[@]}"; do
     fi
 
     # Step C: array zonal job.
+    # shellcheck disable=SC2086  # $DEP_ARG is deliberately unquoted: it is either
+    # empty or a whole `--dependency=...` argument, and quoting it would pass an
+    # EMPTY string as an argument to sbatch whenever this param has no upstream
+    # dependency. The word-splitting is the mechanism, not an oversight.
     ARRAY_JOB_ID=$(sbatch --array="$ARRAY_SPEC" \
                          $DEP_ARG \
                          --export=ALL,BASE_CONFIG="$BASE_CONFIG",FABRIC="$FABRIC",PARAM="$PARAM" \

--- a/src/gfv2_params/download/nhm_v11_lulc.py
+++ b/src/gfv2_params/download/nhm_v11_lulc.py
@@ -18,9 +18,9 @@ to run the pipeline with these inputs.
 Extracts to: {data_root}/input/lulc_veg/nhm_v11/
 """
 
+import subprocess
 from pathlib import Path
 from zipfile import ZipFile
-import subprocess
 
 import requests
 import urllib3

--- a/tests/test_batching.py
+++ b/tests/test_batching.py
@@ -1,9 +1,5 @@
-import tempfile
-from pathlib import Path
-
 import geopandas as gpd
 import numpy as np
-import pytest
 import yaml
 from shapely.geometry import box
 

--- a/tests/test_build_depstor_perv.py
+++ b/tests/test_build_depstor_perv.py
@@ -6,7 +6,6 @@ import pytest
 
 from gfv2_params.depstor_builders.perv import compute_perv_binary
 
-
 # (imperv, dprst, land_valid, expected_perv)
 # Convention: imperv/dprst are 1 = present, 255 = absent/nodata.
 # land_valid is the HRU-fabric land mask (True = on land).

--- a/tests/test_compute_carea_map_binary.py
+++ b/tests/test_compute_carea_map_binary.py
@@ -5,7 +5,6 @@ import pytest
 
 from gfv2_params.depstor import compute_carea_map_binary
 
-
 # (perv_val, onstream_val, twi_val, threshold, twi_nodata, land_val, expected_out)
 # Convention: perv/onstream are uint8 binary (1 = present, 255 = nodata).
 # twi is float32. land_val is the boolean template-DEM land mask.

--- a/tests/test_copernicus_dem.py
+++ b/tests/test_copernicus_dem.py
@@ -1,5 +1,3 @@
-import pytest
-
 from gfv2_params.download.copernicus_dem import tile_label, tiles_for_bbox
 
 

--- a/tests/test_intersect_binaries.py
+++ b/tests/test_intersect_binaries.py
@@ -5,7 +5,6 @@ import pytest
 
 from gfv2_params.depstor import intersect_binaries
 
-
 # (a_val, b_val, expected_out)
 TRUTH_TABLE = [
     (1, 1, 1),       # both present → intersect

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,5 +1,4 @@
 import logging
-import os
 
 import pytest
 


### PR DESCRIPTION
## Why

`pre-commit run --all-files` has **never passed on `main`**, which makes CLAUDE.md's "run it before pushing" instruction unfollowable — and trains people to read a red result as normal. That is how the two pre-existing failure classes in #203's review went unnoticed long enough to need re-verifying against `main` before they could be attributed.

Four causes, addressed in three reviewable commits.

## `dbc3480` — exclusions, deliberate `E402`, and the braces fight

**Excluded two reference trees** from linting. Neither file is removed; they are just no longer linted:

- **`docs/0b_TB_depr_stor.py`** — the original ArcPy depression-storage script, and the authoritative record of the legacy behaviour `depstor_builders/` reproduces. CLAUDE.md cites it **by line number** (`:214` for the `Con(rSro == hru)` same-HRU rule, `:220-312` for clamp-to-one), so reformatting would break those cites and make it a less faithful copy. Its 17 findings (bare excepts, ArcPy globals ruff can't resolve) are properties of the original, not defects to fix.
- **`notebooks/_archive/`** — CLAUDE.md and the parameter-index spec both depend on this tree surviving: it holds the only written record of the known aspect-circularity simplification, which is why [#201](https://github.com/rmcd-mscb/gfv2-params/issues/201) reads as a *measured limitation* rather than an oversight.
- **`environment.yml`** from yamllint — the deprecated conda fallback ("do not add to it"), already excluded from two other hooks.

**Annotated the 4 `E402`s rather than reordering.** Those imports sit below the startup heartbeat print deliberately: the print must reach the SLURM log *before* the geo stack is touched, so a hang in rasterio/GDAL/PROJ/pyogrio init under shared-FS contention is localisable to the import chain instead of looking like a task that never started. Hoisting them defeats the purpose, so the `noqa` carries that reason.

**Converted `ssflux`'s `flux_params` to block mappings** — 14 of the errors were this one block. yamllint wants no spaces inside braces, prettier inserts them, so flow style made the two hooks fight indefinitely. Values verified identical by parsing before and after.

## `709a72c` — shellcheck actually runs now

The `koalaman/shellcheck-precommit` hook runs shellcheck **inside docker**, and docker isn't installed on the HPC. It didn't *fail*, it **errored** (`CalledProcessError: docker system info`), which reads as environment noise rather than an unlinted file. Combined with CI running pytest only, every `.sh`/`.batch` in `slurm_batch/` was linted by **nothing on any machine anyone uses**.

Swapped to `shellcheck-py`, which ships a pip-installed binary. Same shellcheck, same rules, no container runtime.

It found exactly one issue repo-wide — and it's one where **applying the suggested fix would introduce a bug**. `SC2086` on `$DEP_ARG` in `submit_zonal_params.sh`: that variable is either empty or an entire `--dependency=afterok:NNN` argument, so quoting it would pass an *empty string* to `sbatch` for every param with no upstream dependency. The word-splitting is the mechanism. Disabled with that reason inline.

## `fb0681c`, `c968788`, `1c7bd18` — the mechanical remainder

Auto-fixes, reviewed rather than accepted blind — `ruff --fix` deleting an "unused" import is usually right and occasionally breaks a fixture.

- **Reordering** (isort): `marimo` into the third-party block ×2, `subprocess` hoisted.
- **Removal** (F401), each verified to have zero remaining references: `tempfile`/`Path`/`pytest` from `test_batching.py`, `pytest` from `test_copernicus_dem.py`, `os` from `test_log.py`.
- Blank-line normalisation, and a missing trailing newline on an imported reference paper.
- Two hand fixes the tools left behind: removing the first import left `test_batching.py` and `test_copernicus_dem.py` each starting with a blank line, which the fixers don't clean up.
- A stray double blank line in `merge_rpu_by_vpu_twi.yml`.
- **`environment.yml` excluded from prettier as well.** Prettier wanted to reindent its `pip:` block from 4 spaces to 6 — the same lines yamllint flags. Excluding it from the linter but not the formatter would have left the file being rewritten anyway. It is now excluded from all four hooks that touch it; two of those exclusions predate this branch.

## Verification

| Check | Result |
| --- | --- |
| Full suite | **1026 passed, 4 skipped** — identical to before the import removals, so nothing depended on them for a side effect |
| `pre-commit run --all-files` | **exit code 0** — all 8 hooks pass, and the working tree is clean afterward, so it is idempotent |
| `bash -n` on the changed script | clean |

Before the exclusions, these same hooks wanted to rewrite **6 files** in the two protected trees. After, they touch none.

## Note

The `flux_params` conversion is the only change to a file with runtime meaning; its parse is byte-identical in value. Everything else is comments, config, imports and whitespace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
