### PR TITLE
fix: run_fill_sweep consumes DeclaredParam records, not a positional shadow tuple

### DIFF
--- a/scripts/merge_and_fill_params.py
+++ b/scripts/merge_and_fill_params.py
@@ -497,8 +497,16 @@ def apply_fabric_columns(complete_df, missing_ids, merged_gdf, fabric_columns, i
 
 
 def run_fill_sweep(targets, merged_gdf, expected_max, id_feature, k_neighbors, logger) -> list[str]:
-    """Fill every `(name, param_file, fill_columns, fabric_col_spec)` in `targets`,
-    isolating per-param failures.
+    """Fill every `(DeclaredParam, param_file)` in `targets`, isolating per-param failures.
+
+    `targets` carries the DeclaredParam record ITSELF, not a positional re-derivation
+    of its fields. That is the whole point: this function used to take an anonymous
+    `(name, param_file, fill_columns, fabric_col_spec)` 4-tuple built at the call
+    site, which reproduced -- one layer down -- exactly the shape whose widening
+    broke `warn_undeclared_merged_files` (see `DeclaredParam`'s docstring). A sixth
+    field is now invisible here, as it is to every other consumer that reads by name.
+    `param_file` stays a companion value because it is COMPUTED (merged_dir /
+    merged_file), not declared.
 
     One param's config drift (e.g. a column rename that resolve_fill_plan can't
     resolve) must not starve every OTHER declared param of its fill -- a
@@ -508,11 +516,15 @@ def run_fill_sweep(targets, merged_gdf, expected_max, id_feature, k_neighbors, l
     decides the process exit code from the returned failure list.
     """
     failed_params: list[str] = []
-    for name, param_file, declared_columns, fabric_col_spec in targets:
+    for declared, param_file in targets:
+        name = declared.name
         logger.info("=== %s (%s) ===", name, param_file.name)
         try:
             param_df, missing_ids = find_missing_ids(param_file, expected_max, id_feature, logger)
-            plan = resolve_fill_plan(param_df, declared_columns, missing_ids, id_feature, name, fabric_col_spec)
+            plan = resolve_fill_plan(
+                param_df, declared.fill_columns, missing_ids, id_feature, name,
+                declared.fabric_columns,
+            )
 
             for col, n in plan.undeclared_with_nan.items():
                 logger.warning(
@@ -659,7 +671,7 @@ def main():
                 "configs/depstor/depstor_params.yml, or configs/snarea/snarea_library.yml "
                 "-- add a `fill_columns` entry for it before filling."
             )
-        targets = [(match.name, param_file, match.fill_columns, match.fabric_columns)]
+        targets = [(match, param_file)]
     else:
         # All-params mode (default): every declared param whose merged file has
         # already been produced for this fabric. A param not yet produced
@@ -672,7 +684,7 @@ def main():
             if not pf.exists():
                 logger.warning("Skipping %s: %s not found (not yet produced for this fabric)", d.name, pf)
                 continue
-            targets.append((d.name, pf, d.fill_columns, d.fabric_columns))
+            targets.append((d, pf))
         if not targets:
             logger.warning("No declared params' merged files were found under %s", merged_dir)
             return 0

--- a/tests/test_merge_and_fill_params.py
+++ b/tests/test_merge_and_fill_params.py
@@ -22,6 +22,18 @@ fill_missing_values_knn = _mod.fill_missing_values_knn
 maf = _mod
 
 
+def _declared(name, merged_file, fill_columns, fabric_columns=None):
+    """Build a real DeclaredParam for a run_fill_sweep target.
+
+    A helper rather than an inline literal so the fixtures go through the SAME
+    constructor production does. Hand-built tuples are what let the last
+    DeclaredParam widening break four consumption sites while the suite stayed
+    green -- test and implementation wrong in the same direction, agreeing with
+    each other. See issue #204.
+    """
+    return maf.DeclaredParam(name, merged_file, fill_columns, fabric_columns or {})
+
+
 class TestFindMissingIds:
     def test_finds_missing_ids(self, tmp_path):
         import logging
@@ -683,8 +695,9 @@ class TestRunFillSweep:
         pd.DataFrame({"hru_id": [1, 2], "v": [1.0, 2.0]}).to_csv(bad, index=False)
 
         targets = [
-            ("good_param", good, ["v"], {}),
-            ("bad_param", bad, ["typo_column"], {}),  # not present -> resolve_fill_plan raises
+            (_declared("good_param", "nhm_good_params.csv", ["v"]), good),
+            # typo_column is not present -> resolve_fill_plan raises
+            (_declared("bad_param", "nhm_bad_params.csv", ["typo_column"]), bad),
         ]
 
         failed = maf.run_fill_sweep(
@@ -697,6 +710,41 @@ class TestRunFillSweep:
         result = pd.read_csv(good)
         assert result["hru_id"].tolist() == [1, 2, 3]
 
+    def test_consumes_the_real_producers_records(self, tmp_path):
+        """Feed `load_declared_params()`'s ACTUAL records in, not hand-built ones.
+
+        The counterpart to TestWarnUndeclaredMergedFiles's version of this test, and
+        the reason issue #204 was filed: run_fill_sweep used to take an anonymous
+        `(name, param_file, fill_columns, fabric_columns)` 4-tuple re-derived at the
+        call site, so it carried -- one layer down -- the exact shape whose widening
+        broke warn_undeclared_merged_files while the suite stayed green. Every
+        run_fill_sweep test hand-built that tuple, which is precisely the fixture
+        pattern that cannot catch a producer/consumer contract change.
+
+        This one takes a REAL DeclaredParam off the real configs and drives a fill
+        with it. If a future field widening breaks the unpacking, this fails.
+        """
+        import logging
+
+        declared = next(
+            d for d in maf.load_declared_params() if d.name == "soil_moist_max"
+        )
+        pf = tmp_path / declared.merged_file
+        pd.DataFrame({"hru_id": [1, 2], "soil_moist_max": [10.0, 20.0]}).to_csv(
+            pf, index=False
+        )
+
+        failed = maf.run_fill_sweep(
+            [(declared, pf)], self._merged_gdf(), expected_max=3,
+            id_feature="hru_id", k_neighbors=1,
+            logger=logging.getLogger("test_fill_sweep_real"),
+        )
+
+        assert failed == []
+        result = pd.read_csv(pf)
+        assert result["hru_id"].tolist() == [1, 2, 3]
+        assert result["soil_moist_max"].notna().all()
+
     def test_no_failures_returns_empty_list(self, tmp_path):
         import logging
         logger = logging.getLogger("test")
@@ -705,7 +753,8 @@ class TestRunFillSweep:
         pd.DataFrame({"hru_id": [1, 2], "v": [10.0, 20.0]}).to_csv(good, index=False)
 
         failed = maf.run_fill_sweep(
-            [("good_param", good, ["v"], {})], self._merged_gdf(), expected_max=3,
+            [(_declared("good_param", "nhm_good_params.csv", ["v"]), good)],
+            self._merged_gdf(), expected_max=3,
             id_feature="hru_id", k_neighbors=1, logger=logger,
         )
         assert failed == []
@@ -940,7 +989,8 @@ class TestFabricColumnsThroughRunFillSweep:
         pd.DataFrame({"hru_id": [1, 2], "hru_area": [111.0, 222.0], "v": [10.0, 20.0]}).to_csv(pf, index=False)
 
         failed = maf.run_fill_sweep(
-            [("ssflux", pf, ["v"], {"hru_area": {"source": "geometry", "scale": 1.0}})],
+            [(_declared("ssflux", "nhm_ssflux_params.csv", ["v"],
+                        {"hru_area": {"source": "geometry", "scale": 1.0}}), pf)],
             self._gdf(), expected_max=3, id_feature="hru_id", k_neighbors=1,
             logger=logging.getLogger("test"),
         )
@@ -965,7 +1015,8 @@ class TestFabricColumnsThroughRunFillSweep:
         pd.DataFrame({"hru_id": [1, 2], "hru_area": [111.0, 222.0]}).to_csv(pf, index=False)
 
         failed = maf.run_fill_sweep(
-            [("areaonly", pf, [], {"hru_area": {"source": "geometry", "scale": 1.0}})],
+            [(_declared("areaonly", "nhm_areaonly_params.csv", [],
+                        {"hru_area": {"source": "geometry", "scale": 1.0}}), pf)],
             self._gdf(), expected_max=3, id_feature="hru_id", k_neighbors=1,
             logger=logging.getLogger("test"),
         )
@@ -982,7 +1033,8 @@ class TestFabricColumnsThroughRunFillSweep:
         pd.DataFrame({"hru_id": [1, 2], "hru_area": [111.0, 222.0], "v": [10.0, 20.0]}).to_csv(pf, index=False)
 
         failed = maf.run_fill_sweep(
-            [("ssflux", pf, ["v"], {"hru_area": {"source": "typo_col", "scale": 1.0}})],
+            [(_declared("ssflux", "nhm_ssflux_params.csv", ["v"],
+                        {"hru_area": {"source": "typo_col", "scale": 1.0}}), pf)],
             self._gdf(), expected_max=3, id_feature="hru_id", k_neighbors=1,
             logger=logging.getLogger("test"),
         )


### PR DESCRIPTION
Closes #204.

## The problem

`DeclaredParam` was made a `NamedTuple` specifically so a widening cannot silently break consumers. Its docstring records why:

> the `fabric_columns` widening missed one of them — `warn_undeclared_merged_files` … raised `ValueError: too many values to unpack` in all-params mode, the DEFAULT and the only mode `slurm_batch/merge_and_fill_params.batch` runs … while the test suite stayed green because its fixtures hand-built the OLD 3-tuple shape.

That protection stopped one layer short. `main()` immediately **re-derived an anonymous positional 4-tuple** from each record:

```python
targets.append((d.name, pf, d.fill_columns, d.fabric_columns))   # :675
...
for name, param_file, declared_columns, fabric_col_spec in targets:   # :511
```

So `targets` was a second, unnamed shadow of the record — carrying exactly the shape that caused the original bug, in the code path that consumes it. And all five `run_fill_sweep` tests hand-built that tuple, which is precisely the fixture pattern that *cannot* catch a producer/consumer contract change.

## The fix

`run_fill_sweep` now takes `(DeclaredParam, param_file)` pairs and reads `declared.fill_columns` / `declared.fabric_columns` by name. `param_file` stays a companion value because it is **computed** (`merged_dir / merged_file`), not declared.

Fixtures now go through a `_declared()` helper that calls the **same constructor production does**, so they cannot encode a stale shape.

Adds `test_consumes_the_real_producers_records` — takes a real `DeclaredParam` off the real configs and drives an actual fill with it. This is the counterpart to `TestWarnUndeclaredMergedFiles::test_consumes_the_real_producers_output`, which is what closed this class for that consumer. A fixture can never catch a contract change; consuming the producer can.

## Verified the trap is closed, not moved

I simulated a **sixth** field on the record and re-ran the real consumers:

| Check | Result |
| --- | --- |
| 6-field record through `warn_undeclared_merged_files` | works |
| `run_fill_sweep` reads by attribute | yes (`declared.fill_columns`, `declared.fabric_columns`) |
| `run_fill_sweep` indexes positionally | no |
| Remaining positional unpackings | only `for declared, param_file in targets` — which destructures the 2-tuple **wrapper**, not the record |

## Testing

Suite **1026 → 1027 passed**, 4 skipped. The +1 is the new producer-consuming test. No documentation references the signature, so nothing else needed updating.

## Scope

Deliberately narrow. This does not touch `FillPlan`, `resolve_fill_plan`'s signature, or any behaviour — only how the record travels from `main()` into the sweep. No parameter values change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
