### PR TITLE
Snakemake I1-I5 investigation: all five answered, two spec assumptions corrected

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,6 +185,9 @@ cython_debug/
 # repo specific
 output/
 logs/
+# Snakemake's run state + per-job logs, created by anything under workflow/.
+# Regenerated on every invocation; never a source artifact.
+.snakemake/
 
 # Fabric results-viewer figures: the PNGs under docs/figures/<fabric>/ are
 # committed (regenerate with `scripts/render_figures.py`); only the executed

--- a/docs/superpowers/specs/2026-08-04-snakemake-migration-design.md
+++ b/docs/superpowers/specs/2026-08-04-snakemake-migration-design.md
@@ -147,6 +147,71 @@ See below. One of them — I1 — cannot be answered by the method the previous 
 Each item is a question with a method. Migration dates get set **after** all five are
 answered, when tranche cost is knowable rather than guessed.
 
+> ### ✅ RUN 2026-08-05 — all five answered
+>
+> Probes and full findings: [`workflow/probe/`](../../../workflow/probe/). Snakemake
+> **9.25.1** in the `workflow` pixi env. Verdict per item below; two of the five
+> corrected assumptions in this spec, and one finding falls outside all five.
+>
+> | | Result |
+> | --- | --- |
+> | **I1** | **Answered — yes.** `--group-components=N` collapses submissions exactly at the divisor (16 instances → 4 job ids at N=4). Production 650 → **41** at N=16, so the spec's "~640 → 40" is achievable. |
+> | **I2** | **Partially answered.** The feared mechanism is RULED OUT — grouped members start serialised (+0.0/+3.2/+6.3/+9.1s), not simultaneously. Warm-cache import cost is a wash (0.190s grouped vs 0.177s ungrouped). Cold-cache-under-grouping remains **open** and is not manufacturable without root. |
+> | **I3** | **Answered, and this spec's premise was WRONG.** See correction below. |
+> | **I4** | **Answered.** Snakemake's default builds **0 of 2** good targets when one is unbuildable; bash builds 8 of 10 today. `--keep-going` recovers them and still exits 1. Recommend `--keep-going` as standard; `enabled: false` only as a documented second mechanism, never alone — it exits 0 and makes a broken entry invisible. |
+> | **I5** | **Answered.** `slurm_batch/data_root_tests.batch`, plus the convention that a data-root-gated result is recorded by SLURM job id. The pattern already had a precedent: Guard 2 (`tests/test_params_index_ondisk.py`, PR #203) is the same shape. |
+>
+> #### Correction to I3 — the stated mechanism and its test are both wrong
+>
+> This spec says "every `.batch` run bumps mtimes and makes downstream Snakemake
+> targets stale". **Measured false.** Snakemake 9 decides staleness from input
+> CONTENT, not mtime, despite `mtime` being in the default `--rerun-triggers` set:
+>
+> | change to a shared input | rerun? |
+> | --- | --- |
+> | `touch` (mtime only) | **no** — with *or* without `ancient()` |
+> | content change, no `ancient()` | yes |
+> | content change, with `ancient()` | **no**, output preserved |
+>
+> Consequently the proposed verification — "`--dry-run` after a deliberate `touch`
+> of a shared VRT, zero rules should trigger" — **passes even with no containment
+> at all** and cannot distinguish a contained workflow from an uncontained one. Do
+> not use it. `ancient()` is still the right rule, verified against the case that
+> actually matters (content change), but the check should be a STATIC test
+> asserting every `shared/`/`input/` path in the Snakefile is wrapped — checkable
+> in CI, no data root, cannot pass vacuously.
+>
+> The hazard itself is confirmed live: `carussel` owns `gfv2_car/` and
+> `gfv2_car_conus/` on the same `{data_root}`, consuming the same `shared/` and
+> `input/` trees.
+>
+> #### Finding outside the five — a nested `pixi run` inherits its parent's env
+>
+> This one falsifies a claimed property of PR #142. Snakemake must be launched from
+> the `workflow` env, which exports `PIXI_ENVIRONMENT_NAME=workflow`; every rule's
+> shell command inherits it, so a bare nested `pixi run --as-is` resolves to
+> **`.pixi/envs/workflow`**, not `default`.
+>
+> `workflow/spike/Snakefile` claims its rules "shell out via `pixi run --as-is` so
+> all geo work runs in the frozen default env (race-safe; CLAUDE.md constraint)".
+> That was never true as written — the spike's rules ran in the *workflow* env. It
+> only appeared to work because the spike declared
+> `workflow = { features = ["workflow"] }`, which *includes* the default feature and
+> therefore the whole geo stack. Give the controller env `no-default-feature = true`
+> — correct, so a scheduler does not carry GDAL — and every rule dies with
+> `ModuleNotFoundError: No module named 'geopandas'`, which is exactly what happened
+> on the first real submission here.
+>
+> **Every rule must pin `pixi run --as-is -e default`**, and a test should assert no
+> rule carries a bare `pixi run --as-is` without an explicit `-e`.
+>
+> #### What this does NOT settle
+>
+> The two blockers that gate a schedule are untouched by these five: the validation
+> baselines still do not exist (`gfv2_dev` has no `params/`), and the baseline cost
+> (~45.5 h wall / ~340 CPU-h per depstor cascade, two passes per A/B round) is still
+> unbudgeted. `retries:` semantics against a real OOM also remain unmeasured.
+
 ### I1 — Does `group:` collapse submissions into one SLURM job?
 
 **Why it matters.** Today one param = one array job of 64 tasks throttled `%4`; ten params =

--- a/pixi.lock
+++ b/pixi.lock
@@ -3,6 +3,7 @@ environments:
   all:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
+    - url: https://conda.anaconda.org/bioconda/
     indexes:
     - https://pypi.org/simple
     options:
@@ -466,6 +467,7 @@ environments:
   default:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
+    - url: https://conda.anaconda.org/bioconda/
     indexes:
     - https://pypi.org/simple
     options:
@@ -807,6 +809,7 @@ environments:
   dev:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
+    - url: https://conda.anaconda.org/bioconda/
     indexes:
     - https://pypi.org/simple
     options:
@@ -1165,6 +1168,7 @@ environments:
   docs:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
+    - url: https://conda.anaconda.org/bioconda/
     indexes:
     - https://pypi.org/simple
     options:
@@ -1531,6 +1535,7 @@ environments:
   marp:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
+    - url: https://conda.anaconda.org/bioconda/
     options:
       pypi-prerelease-mode: if-necessary-or-explicit
     packages:
@@ -1575,6 +1580,7 @@ environments:
   notebooks:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
+    - url: https://conda.anaconda.org/bioconda/
     indexes:
     - https://pypi.org/simple
     options:
@@ -2002,6 +2008,7 @@ environments:
   reference:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
+    - url: https://conda.anaconda.org/bioconda/
     options:
       pypi-prerelease-mode: if-necessary-or-explicit
     packages:
@@ -2406,6 +2413,138 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.2-h25fd6f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-ng-2.3.3-hceb46e0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+  workflow:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    - url: https://conda.anaconda.org/bioconda/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/amply-0.1.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.5-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argparse-dataclass-2.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/backports.zstd-1.6.0-py314h680f03e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.2.0-py314h3de4e8d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.7.22-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/coin-or-cbc-2.10.13-h4d16d09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/coin-or-cgl-0.60.10-hc46dffc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/coin-or-clp-1.17.11-hc03379b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/coin-or-osi-0.108.12-hf4fecb4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/coin-or-utils-2.11.13-hc93afbd_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/coloredlogs-15.0.1-pyhd8ed1ab_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/conda-inject-1.3.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/configargparse-1.7.5-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/connection_pool-0.0.3-pyhd3deb0d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/docutils-0.22.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dpath-2.2.0-pyha770c72_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/eido-0.2.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.12-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.58-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/greenlet-3.5.4-py314h42812f9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.4.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/humanfriendly-10.0-pyh707e725_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h54a6638_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.18-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/immutables-0.21-py314h5bd0f2a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.26.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2025.9.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-8_h4a7cf45_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-8_h0358290_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.1.0-ha9f2e26_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-16.1.0-h69a702a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-16.1.0-h79bb938_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.1.0-he0feb66_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-8_h47877c9_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapacke-3.11.0-8_h6ae95b6_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.33-pthreads_h94d23a6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.4-hf4e2dac_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.1.0-h934c35e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/logmuse-0.3.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.3-py314h67df5f8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.5.1-py314h2b28147_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.3-h35e630c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.3.3-py314ha0b5721_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pephubclient-0.6.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/peppy-0.40.8-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.11.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.2.2-py314h0f05182_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pulp-2.8.0-py314h312e2f4_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.46.4-py314h2e6c369_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.6-habeac84_101_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.22.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2026.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2026.3.post1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py314h67df5f8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.37.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.34.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-2026.6.3-py314h1bee95f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/slack-sdk-3.43.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/slack_sdk-3.43.0-pyh9dfb50f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/smart_open-7.7.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.3-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-9.25.1-hdfd78af_0.conda
+      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-executor-plugin-slurm-2.7.1-pyhdfd78af_0.conda
+      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-executor-plugin-slurm-jobstep-0.4.0-pyhdfd78af_0.conda
+      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-common-1.23.0-pyhdfd78af_1.conda
+      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-executor-plugins-9.4.0-pyh84498cf_0.conda
+      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-logger-plugins-2.1.0-pyhdfd78af_0.conda
+      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-report-plugins-1.3.0-pyhd4c3c12_0.conda
+      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-scheduler-plugins-2.0.2-pyhd4c3c12_0.conda
+      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-storage-plugins-4.4.1-pyh84498cf_0.conda
+      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-minimal-9.25.1-pyhdfd78af_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlalchemy-2.0.51-py314h0f05182_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sqlmodel-0.0.37-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.10.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tenacity-9.1.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/throttler-1.2.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd70dff1_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhcf101f3_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.16.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.27.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.16.0-h69aa097_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhcf101f3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.16.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ubiquerg-0.9.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.17.3-py314h5bd0f2a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/yte-1.9.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
   build_number: 20
@@ -2560,6 +2699,26 @@ packages:
   license_family: LGPL
   size: 592377
   timestamp: 1781521980743
+- conda: https://conda.anaconda.org/conda-forge/noarch/amply-0.1.7-pyhd8ed1ab_0.conda
+  sha256: a21c69c91d735faaf7b74dc2b3d013b14016951b66354461fc1d796caab9b1c4
+  md5: 69a01a9927733014f3955861e2969a7b
+  depends:
+  - docutils >=0.3
+  - pyparsing
+  - python >=3.10
+  license: EPL-2.0
+  size: 26885
+  timestamp: 1782349642228
+- conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.5-pyhcf101f3_0.conda
+  sha256: a0a320c709fded9b5178108dedebf81a1f5a5d9c7720e3af50c1ab058dadd296
+  md5: d68ec17cb915cab4642357417ec0a104
+  depends:
+  - python >=3.10
+  - python
+  license: MIT
+  license_family: MIT
+  size: 16785
+  timestamp: 1785335690199
 - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
   sha256: e0ea1ba78fbb64f17062601edda82097fcf815012cf52bb704150a2668110d48
   md5: 2934f256a8acfe48f6ebb4fce6cde29c
@@ -2572,6 +2731,16 @@ packages:
   - pkg:pypi/annotated-types?source=hash-mapping
   size: 18074
   timestamp: 1733247158254
+- conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.8.0-pyhd8ed1ab_0.conda
+  sha256: b8fcb994134d3918d1c64a9d62f4168ff85d5bfb89e698102fe4ed679fe0df24
+  md5: 108c928d2a8551832dbc762b535e90bb
+  depends:
+  - python >=3.10
+  - typing-extensions >=4.0.0
+  license: MIT
+  license_family: MIT
+  size: 19461
+  timestamp: 1784935220549
 - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.13.0-pyhcf101f3_0.conda
   sha256: f09aed24661cd45ba54a43772504f05c0698248734f9ae8cd289d314ac89707e
   md5: af2df4b9108808da3dc76710fe50eae2
@@ -2634,6 +2803,15 @@ packages:
   license_family: MIT
   size: 35370
   timestamp: 1762509501470
+- conda: https://conda.anaconda.org/conda-forge/noarch/argparse-dataclass-2.0.0-pyhd8ed1ab_1.conda
+  sha256: fd512bde81be7f942e1efb54c6a7305c16375347ccacf9375ada70cdc0f4f0d3
+  md5: 3c0e753fd317fa10d34020a2bc8add8e
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 12806
+  timestamp: 1764079623900
 - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.4.0-pyhcf101f3_0.conda
   sha256: 792da8131b1b53ff667bd6fc617ea9087b570305ccb9913deb36b8e12b3b5141
   md5: 85c4f19f377424eafc4ed7911b291642
@@ -3024,6 +3202,15 @@ packages:
   license: BSD-3-Clause AND MIT AND EPL-2.0
   size: 192901
   timestamp: 1781450813638
+- conda: https://conda.anaconda.org/conda-forge/noarch/backports.zstd-1.6.0-py314h680f03e_0.conda
+  noarch: generic
+  sha256: 709cac7434d1c5a8828105036212a2a36022a07d807e89e2e99cac939c2d2526
+  md5: 40d89d8546ad6e139e73ec8f6d56068b
+  depends:
+  - python >=3.14
+  license: BSD-3-Clause AND MIT AND EPL-2.0
+  size: 7526
+  timestamp: 1781450817767
 - conda: https://conda.anaconda.org/conda-forge/noarch/backrefs-7.0-pyhcf101f3_0.conda
   sha256: 4e32871acb663d8d64342c486d960b3e64e24b7c715247a1e6a6f46d1b428802
   md5: 970a19304a794630a882b9dcd9e1beb4
@@ -3293,6 +3480,21 @@ packages:
   - pkg:pypi/brotli?source=compressed-mapping
   size: 368300
   timestamp: 1764017300621
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.2.0-py314h3de4e8d_1.conda
+  sha256: 3ad3500bff54a781c29f16ce1b288b36606e2189d0b0ef2f67036554f47f12b0
+  md5: 8910d2c46f7e7b519129f486e0fe927a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - python >=3.14,<3.15.0a0
+  - python_abi 3.14.* *_cp314
+  constrains:
+  - libbrotlicommon 1.2.0 hb03c661_1
+  license: MIT
+  license_family: MIT
+  size: 367376
+  timestamp: 1764017265553
 - conda: https://conda.anaconda.org/conda-forge/linux-64/brotlicffi-1.2.0.1-py312h1289d80_0.conda
   sha256: d4dc2e7b594465cdb9e44147cc6ddc679bd15c41ebf53ed2cb92a092cf4208a7
   md5: 8b51a1eeaf16853d993d08487793ca38
@@ -3309,6 +3511,16 @@ packages:
   - pkg:pypi/brotlicffi?source=hash-mapping
   size: 381426
   timestamp: 1772795916477
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_10.conda
+  sha256: 1a0d382c515ebf55f8ee1f38c8b81bc95af5c2acc42ad53b66bc5df932032f96
+  md5: e675fabcf81499adc7edf58124fb1e01
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 257808
+  timestamp: 1785906269155
 - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
   sha256: 0b75d45f0bba3e95dc693336fa51f40ea28c980131fec438afb7ce6118ed05f6
   md5: d2ffd7602c02f2b316fd921d39876885
@@ -3363,6 +3575,14 @@ packages:
   license: ISC
   size: 128866
   timestamp: 1781708962055
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+  sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
+  md5: 0f51e2391ade309db462a55611263e9c
+  depends:
+  - __unix
+  license: ISC
+  size: 131780
+  timestamp: 1784754889428
 - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_2.conda
   noarch: python
   sha256: 0d00dd61cb91b1bd1536600c64c9db4f94f3c699fec42864d0a2f4bc2ad8c3e8
@@ -3506,6 +3726,14 @@ packages:
   license: ISC
   size: 133877
   timestamp: 1781719949728
+- conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.7.22-pyhd8ed1ab_0.conda
+  sha256: fb167de4388e64e52aa3907ed099afab944c1fa6e5f74b281a312dae1bcf7f3b
+  md5: 37e13edbe3b48f1095a9d085ef9cd83b
+  depends:
+  - python >=3.10
+  license: ISC
+  size: 137015
+  timestamp: 1784717699092
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.0.0-py310he7384ee_1.conda
   sha256: bf76ead6d59b70f3e901476a73880ac92011be63b151972d135eec55bbbe6091
   md5: 803e2d778b8dcccdc014127ec5001681
@@ -3609,6 +3837,15 @@ packages:
   license: MIT
   size: 61278
   timestamp: 1783374645872
+- conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.9-pyhd8ed1ab_0.conda
+  sha256: 8d8813ef655b4e75e4fb897abd83ad548882efad7b4e836b021b797f42780799
+  md5: d154b40b109e503430979e8a8d099eaf
+  depends:
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  size: 61418
+  timestamp: 1783505332569
 - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.8-pyh707e725_0.conda
   sha256: c920d23cd1fcf565031c679adb62d848af60d6fbb0edc2d50ba475cea4f0d8ab
   md5: f22f4d4970e09d68a10b922cbb0408d3
@@ -3668,6 +3905,119 @@ packages:
   - pkg:pypi/cloudpickle?source=hash-mapping
   size: 27353
   timestamp: 1765303462831
+- conda: https://conda.anaconda.org/conda-forge/linux-64/coin-or-cbc-2.10.13-h4d16d09_1.conda
+  sha256: 200da7fefacb1a196dd7b4b6f45106cebe017042b1491e2b27c7cc833beed8ea
+  md5: 5f68e67b2b9463501260e731e2999dec
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - coin-or-cgl >=0.60,<0.61.0a0
+  - coin-or-clp >=1.17,<1.18.0a0
+  - coin-or-osi >=0.108,<0.109.0a0
+  - coin-or-utils >=2.11,<2.12.0a0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc >=14
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  - liblapack >=3.9.0,<4.0a0
+  - liblapacke >=3.9.0,<4.0a0
+  - libstdcxx >=14
+  - libzlib >=1.3.2,<2.0a0
+  constrains:
+  - coincbc * *_metapackage
+  license: EPL-2.0
+  license_family: OTHER
+  size: 910148
+  timestamp: 1778586394891
+- conda: https://conda.anaconda.org/conda-forge/linux-64/coin-or-cgl-0.60.10-hc46dffc_1.conda
+  sha256: 032ab70fed60c1a23656c883e51573e8f257f6450cab7ebdf1429e6264495336
+  md5: 0990c6102633709868d18151e850072a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - coin-or-clp >=1.17,<1.18.0a0
+  - coin-or-osi >=0.108,<0.109.0a0
+  - coin-or-utils >=2.11,<2.12.0a0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc >=14
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  - liblapack >=3.9.0,<4.0a0
+  - liblapacke >=3.9.0,<4.0a0
+  - libstdcxx >=14
+  - libzlib >=1.3.2,<2.0a0
+  constrains:
+  - coincbc * *_metapackage
+  license: EPL-2.0
+  license_family: OTHER
+  size: 533910
+  timestamp: 1778571381173
+- conda: https://conda.anaconda.org/conda-forge/linux-64/coin-or-clp-1.17.11-hc03379b_1.conda
+  sha256: e7d0bfe4e2b9bd358e538c459427f0b8a6b7e4458becea63befb536bb42959ee
+  md5: e79a3a170436d665098f0a40f7cd655b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - coin-or-osi >=0.108,<0.109.0a0
+  - coin-or-utils >=2.11,<2.12.0a0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc >=14
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  - liblapack >=3.9.0,<4.0a0
+  - liblapacke >=3.9.0,<4.0a0
+  - libstdcxx >=14
+  - libzlib >=1.3.2,<2.0a0
+  constrains:
+  - coincbc * *_metapackage
+  license: EPL-2.0
+  license_family: OTHER
+  size: 1153761
+  timestamp: 1778519879680
+- conda: https://conda.anaconda.org/conda-forge/linux-64/coin-or-osi-0.108.12-hf4fecb4_1.conda
+  sha256: d81c8ddbfbc3a071413249bd70bebddb9fa036591be63e1df896ff59ab0e6eca
+  md5: 02578ed9fe1a1923d66effeb932e71ce
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - coin-or-utils >=2.11,<2.12.0a0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc >=14
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  - liblapack >=3.9.0,<4.0a0
+  - liblapacke >=3.9.0,<4.0a0
+  - libstdcxx >=14
+  - libzlib >=1.3.2,<2.0a0
+  constrains:
+  - coincbc * *_metapackage
+  license: EPL-2.0
+  license_family: OTHER
+  size: 378434
+  timestamp: 1778511053515
+- conda: https://conda.anaconda.org/conda-forge/linux-64/coin-or-utils-2.11.13-hc93afbd_1.conda
+  sha256: f1fae7f3783f5dcbe91527d4b168e98b7107f9d90bf548cb1facd0b64ffccd92
+  md5: 4020946ef1fad683935a408ab7127582
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - libblas >=3.9.0,<4.0a0
+  - libgcc >=14
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx >=14
+  - libzlib >=1.3.2,<2.0a0
+  constrains:
+  - coincbc * *_metapackage
+  license: EPL-2.0
+  license_family: OTHER
+  size: 664399
+  timestamp: 1778500281099
 - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
   sha256: ab29d57dc70786c1269633ba3dff20288b81664d3ff8d21af995742e2bb03287
   md5: 962b9857ee8e7018c22f2776ffa0b2d7
@@ -3689,6 +4039,16 @@ packages:
   - pkg:pypi/colorcet?source=hash-mapping
   size: 174387
   timestamp: 1777396861701
+- conda: https://conda.anaconda.org/conda-forge/noarch/coloredlogs-15.0.1-pyhd8ed1ab_4.conda
+  sha256: 8021c76eeadbdd5784b881b165242db9449783e12ce26d6234060026fd6a8680
+  md5: b866ff7007b934d564961066c8195983
+  depends:
+  - humanfriendly >=9.1
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 43758
+  timestamp: 1733928076798
 - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
   sha256: 576a44729314ad9e4e5ebe055fbf48beb8116b60e58f9070278985b2b634f212
   md5: 2da13f2b299d8e1995bafbbe9689a2f7
@@ -3701,6 +4061,36 @@ packages:
   - pkg:pypi/comm?source=hash-mapping
   size: 14690
   timestamp: 1753453984907
+- conda: https://conda.anaconda.org/conda-forge/noarch/conda-inject-1.3.2-pyhd8ed1ab_0.conda
+  sha256: c1b355af599e548c4b69129f4d723ddcdb9f6defb939985731499cee2e26a578
+  md5: e52c2a160d6bd0649c9fafdf0c813357
+  depends:
+  - python >=3.9.0,<4.0.0
+  - pyyaml >=6.0.0,<7.0.0
+  license: MIT
+  license_family: MIT
+  size: 10327
+  timestamp: 1717043667069
+- conda: https://conda.anaconda.org/conda-forge/noarch/configargparse-1.7.5-pyhcf101f3_0.conda
+  sha256: 7f8ea42a8411b433ec7244dfd30637d90564256c13a114dbe42455fe032ae89c
+  md5: 12389a21e7f69704b0ae77f44355e30b
+  depends:
+  - python >=3.10
+  - toml
+  - python
+  license: MIT
+  license_family: MIT
+  size: 45817
+  timestamp: 1773233306055
+- conda: https://conda.anaconda.org/conda-forge/noarch/connection_pool-0.0.3-pyhd3deb0d_0.tar.bz2
+  sha256: 799a515e9e73e447f46f60fb3f9162f437ae1a2a00defddde84282e9e225cb36
+  md5: e270fff08907db8691c02a0eda8d38ae
+  depends:
+  - python
+  license: MIT
+  license_family: MIT
+  size: 8331
+  timestamp: 1608581999360
 - conda: https://conda.anaconda.org/conda-forge/noarch/contextily-1.7.0-pyhd8ed1ab_0.conda
   sha256: ded63e2434aad12d73aec04a74812bfb7e6159d69adbd70b33e31d910309b0b3
   md5: e7d5beefd8351cf01a2f4bfcb8b6dbdb
@@ -4123,6 +4513,28 @@ packages:
   - pkg:pypi/donfig?source=hash-mapping
   size: 22491
   timestamp: 1734368817583
+- conda: https://conda.anaconda.org/conda-forge/noarch/dpath-2.2.0-pyha770c72_1.conda
+  sha256: 74e5def37983c19165beebbbfae4e5494b7cb030e97351114de31dcdbc91b951
+  md5: 7b2af124684a994217e62c641bca2e48
+  depends:
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  size: 21853
+  timestamp: 1762165431693
+- conda: https://conda.anaconda.org/conda-forge/noarch/eido-0.2.6-pyhd8ed1ab_0.conda
+  sha256: d81e5b6903e0e47c8bc1f4a57bc8ba857f73490e829cc46b1e152d7c0b877a29
+  md5: e2253e1bb76e005d0264797163e8330a
+  depends:
+  - jsonschema >=3.0.1
+  - logmuse >=0.2.5
+  - peppy >=0.40.6
+  - python >=3.8
+  - ubiquerg >=0.6.2
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 21410
+  timestamp: 1784827822320
 - conda: https://conda.anaconda.org/conda-forge/noarch/epiweeks4cf-2.3.0-pyhd8ed1ab_1.conda
   sha256: ca0421072bca09ac73bcbe19ab6ee57a762c75e9a9f989bfc735e7e543b96b1d
   md5: 219bb828bdb0c60de8a4e8f86e4ba637
@@ -4750,7 +5162,7 @@ packages:
 - pypi: ./
   name: gfv2-params
   version: 0.1.0
-  sha256: 5a938f478ad3c8dc1e6d6583698ebe6ce1a56d4913b8b98ce2cbdb8d6074cfa9
+  sha256: 780fbb8f583f8334fa8045b5ed03c2cdd51ee4515c2ad66dbcaa94834cc7d81d
   requires_dist:
   - gdptools>=0.3.13
   - pandas
@@ -4822,6 +5234,27 @@ packages:
   license: GPL-2.0-or-later and LGPL-2.1-or-later
   size: 11613263
   timestamp: 1763469108409
+- conda: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.12-pyhd8ed1ab_0.conda
+  sha256: dbbec21a369872c8ebe23cb9a3b9d63638479ee30face165aa0fccc96e93eec3
+  md5: 7c14f3706e099f8fcd47af2d494616cc
+  depends:
+  - python >=3.9
+  - smmap >=3.0.1,<6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 53136
+  timestamp: 1735887290843
+- conda: https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.58-pyhd8ed1ab_0.conda
+  sha256: 43398f3d71b4848c812138a038c5a31259de8411576142aec02ae32059933ccf
+  md5: bc8f693d50dd19da32818460fd3f532f
+  depends:
+  - gitdb >=4.0.1,<5
+  - python >=3.10
+  - typing_extensions >=3.10.0.2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 167633
+  timestamp: 1785926562206
 - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.86.2-hf516916_0.conda
   sha256: 5517dae367d069de42c16d48f4b7e269acdedc11d43a5d4ec8d077d43ae00f45
   md5: 14ad79cb7501b6a408485b04834a734c
@@ -4904,6 +5337,19 @@ packages:
   license_family: Other
   size: 2417740
   timestamp: 1765099199559
+- conda: https://conda.anaconda.org/conda-forge/linux-64/greenlet-3.5.4-py314h42812f9_0.conda
+  sha256: 9e3c3711e4e84368a5cd07326a42d13b8f25a8d81a4436e58cbf18115f9960f5
+  md5: feec8f5a0aa58e94c8eeb53ad73ed805
+  depends:
+  - python
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - python_abi 3.14.* *_cp314
+  license: MIT
+  license_family: MIT
+  size: 277466
+  timestamp: 1784885441255
 - conda: https://conda.anaconda.org/conda-forge/noarch/griffe-2.0.2-pyhcf101f3_0.conda
   sha256: 14cc12f55b19ddf164fb5df96dd156eaa6a8ab60b8ded337deda43fdcf70c369
   md5: 48dc0933013b4d09bd14373bbca33a44
@@ -5019,6 +5465,18 @@ packages:
   - pkg:pypi/h2?source=hash-mapping
   size: 95967
   timestamp: 1756364871835
+- conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.4.1-pyhcf101f3_0.conda
+  sha256: 307dd6ec90140c3cf4171071b0e5e870abec314f4565c1edd5bc433e942cdcc0
+  md5: e652ac7756069c456d0da2a922cd7df5
+  depends:
+  - python >=3.10
+  - hyperframe >=6.1,<7
+  - hpack >=4.2,<5
+  - python
+  license: MIT
+  license_family: MIT
+  size: 100789
+  timestamp: 1785796355216
 - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-12.2.0-h15599e2_0.conda
   sha256: 6bd8b22beb7d40562b2889dc68232c589ff0d11a5ad3addd41a8570d11f039d9
   md5: b8690f53007e9b5ee2c2178dd4ac778c
@@ -5188,6 +5646,16 @@ packages:
   license_family: BSD
   size: 63082
   timestamp: 1733663449209
+- conda: https://conda.anaconda.org/conda-forge/noarch/humanfriendly-10.0-pyh707e725_8.conda
+  sha256: fa2071da7fab758c669e78227e6094f6b3608228740808a6de5d6bce83d9e52d
+  md5: 7fe569c10905402ed47024fc481bb371
+  depends:
+  - __unix
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  size: 73563
+  timestamp: 1733928021866
 - conda: https://conda.anaconda.org/conda-forge/noarch/hvplot-0.12.2-pyhd8ed1ab_0.conda
   sha256: 2b1b67462c87b1252733b8d45d88a68de513ba9852d210c77f64f0d20a558603
   md5: a3ebf00cb037e464061fcf68a5a75d83
@@ -5241,6 +5709,17 @@ packages:
   purls: []
   size: 12723451
   timestamp: 1773822285671
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h54a6638_2.conda
+  sha256: d7c260b7e1cf22ce04d6ba8a86eabf4e6c50bc96a5c27fe2ecb32298af3e88eb
+  md5: 4ef4b977bb216a3001a3334696a80850
+  depends:
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  license: MIT
+  license_family: MIT
+  size: 14455340
+  timestamp: 1784916378180
 - conda: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.19-pyhd8ed1ab_0.conda
   sha256: 381cedccf0866babfc135d65ee40b778bd20e927d2a5ec810f750c5860a7c5b8
   md5: 84a3233b709a289a4ddd7a2fd27dd988
@@ -5284,6 +5763,18 @@ packages:
   license_family: MIT
   size: 15729
   timestamp: 1773752188889
+- conda: https://conda.anaconda.org/conda-forge/linux-64/immutables-0.21-py314h5bd0f2a_2.conda
+  sha256: 1c9163fd77943c55fe727f5399545141df54f696422bf101089a32526aea3234
+  md5: d4d65cfb5c2569d5dbd344039471a534
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python >=3.14.0rc2,<3.15.0a0
+  - python_abi 3.14.* *_cp314
+  license: Apache-2.0
+  license_family: APACHE
+  size: 55407
+  timestamp: 1757685419776
 - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
   sha256: 82ab2a0d91ca1e7e63ab6a4939356667ef683905dea631bc2121aa534d347b16
   md5: 080594bf4493e6bae2607e65390c520a
@@ -6048,6 +6539,18 @@ packages:
   purls: []
   size: 728002
   timestamp: 1774197446916
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
+  sha256: 27d83f1188cd19bcb7754a078b3fa7f4cfb8527f8eb2fde54dd01fc529d1adec
+  md5: 449500f2c089da11c40f5c21312e3e07
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - zstd >=1.5.7,<1.6.0a0
+  constrains:
+  - binutils_impl_linux-64 2.46.1
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 745303
+  timestamp: 1784214507189
 - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.1.0-hdb68285_0.conda
   sha256: f84cb54782f7e9cea95e810ea8fef186e0652d0fa73d3009914fa2c1262594e1
   md5: a752488c68f2e7c456bcbd8f16eec275
@@ -6593,6 +7096,19 @@ packages:
   license_family: GPL
   size: 1041084
   timestamp: 1778269013026
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.1.0-ha9f2e26_1.conda
+  sha256: d5cb8475131c31680f8fd30512c418f373064e272e452063276a8fb14c9fa42f
+  md5: 5a7d954665c707c93311657cd779c705
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex >=4.5
+  constrains:
+  - libgomp 16.1.0 he0feb66_1
+  - libgcc-ng ==16.1.0=*_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1057877
+  timestamp: 1785375436766
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_18.conda
   sha256: e318a711400f536c81123e753d4c797a821021fb38970cebfb3f454126016893
   md5: d5e96b1ed75ca01906b3d2469b4ce493
@@ -6952,6 +7468,17 @@ packages:
   license_family: GPL
   size: 27655
   timestamp: 1778269042954
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-16.1.0-h69a702a_1.conda
+  sha256: 9e82d410a50bd4e5e47cbbb026454c3eb543954baca4db23929575b571bf56a3
+  md5: 2fbed65cc90cf0724e1ec4de13696737
+  depends:
+  - libgfortran5 16.1.0 h79bb938_1
+  constrains:
+  - libgfortran-ng ==16.1.0=*_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 28134
+  timestamp: 1785375470055
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_18.conda
   sha256: 539b57cf50ec85509a94ba9949b7e30717839e4d694bc94f30d41c9d34de2d12
   md5: 646855f357199a12f02a87382d429b75
@@ -6977,6 +7504,18 @@ packages:
   license_family: GPL
   size: 2483673
   timestamp: 1778269025089
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-16.1.0-h79bb938_1.conda
+  sha256: 05078ab464d506dff971860cb1a553b35bc27c0b5ce8ec29b8bfaca5f2359652
+  md5: dd51ed33e8c70995f8e33cc9dc537297
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=16.1.0
+  constrains:
+  - libgfortran 16.1.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 2538696
+  timestamp: 1785375448623
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_2.conda
   sha256: dc2752241fa3d9e40ce552c1942d0a4b5eeb93740c9723873f6fcf8d39ef8d2d
   md5: 928b8be80851f5d8ffb016f9c81dae7a
@@ -7107,6 +7646,15 @@ packages:
   license_family: GPL
   size: 603817
   timestamp: 1778268942614
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.1.0-he0feb66_1.conda
+  sha256: 62cb599ad0539d99386515326d9d5e8f51f75a60c69c2131b21df76edf35bd89
+  md5: 88f2d91cb1533194c323534253094d23
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 640415
+  timestamp: 1785375373755
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-3.3.0-h25dbb67_1.conda
   sha256: 17ea802cef3942b0a850b8e33b03fc575f79734f3c829cdd6a4e56e2dae60791
   md5: b2baa4ce6a9d9472aaa602b88f8d40ac
@@ -7260,6 +7808,20 @@ packages:
   license_family: BSD
   size: 18790
   timestamp: 1779859115086
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapacke-3.11.0-8_h6ae95b6_openblas.conda
+  build_number: 8
+  sha256: 0b982865888a73fe7c2e7d8e8ee3738ac378b83012a7da1a12264a473cb2382b
+  md5: da17457f689df5c0f246d2f0b3798fd2
+  depends:
+  - libblas 3.11.0 8_h4a7cf45_openblas
+  - libcblas 3.11.0 8_h0358290_openblas
+  - liblapack 3.11.0 8_h47877c9_openblas
+  constrains:
+  - blas 2.308   openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18824
+  timestamp: 1779859122364
 - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
   sha256: ec30e52a3c1bf7d0425380a189d209a52baa03f22fb66dd3eb587acaa765bd6d
   md5: b88d90cad08e6bc8ad540cb310a761fb
@@ -7272,6 +7834,16 @@ packages:
   purls: []
   size: 113478
   timestamp: 1775825492909
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
+  sha256: fe171ed5cf5959993d43ff72de7596e8ac2853e9021dec0344e583734f1e0843
+  md5: 2c21e66f50753a083cbe6b80f38268fa
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 92400
+  timestamp: 1769482286018
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libnetcdf-4.10.0-nompi_h3c9b436_104.conda
   sha256: 6a1dbee34abe246c32abb89bd35855c25551de09562a719da97c4e5975f5f035
   md5: 6d38346d49e4638ec98649121d295d54
@@ -7623,6 +8195,17 @@ packages:
   license: blessing
   size: 962119
   timestamp: 1782519076616
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.4-hf4e2dac_0.conda
+  sha256: 72023efc207fe681e26b65fc9d668062cf0b4f0eacf3431e6eb099b95c1f2efd
+  md5: df088a279cd5e6fd2790b4c196434da1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - icu >=78.3,<79.0a0
+  - libgcc >=14
+  - libzlib >=1.3.2,<2.0a0
+  license: blessing
+  size: 964200
+  timestamp: 1785016112246
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
   sha256: fa39bfd69228a13e553bd24601332b7cfeb30ca11a3ca50bb028108fe90a7661
   md5: eecce068c7e4eddeb169591baac20ac4
@@ -7661,6 +8244,18 @@ packages:
   license_family: GPL
   size: 5852044
   timestamp: 1778269036376
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.1.0-h934c35e_1.conda
+  sha256: 79721dd08aeb0ab9e773f1f9ef41cf4e6c17477e3d72319147619045bce05a09
+  md5: aed6cf89adc1e9b846e4367ac538e434
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc 16.1.0 ha9f2e26_1
+  constrains:
+  - libstdcxx-ng ==16.1.0=*_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 6631744
+  timestamp: 1785375462643
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_18.conda
   sha256: 3c902ffd673cb3c6ddde624cdb80f870b6c835f8bf28384b0016e7d444dd0145
   md5: 6235adb93d064ecdf3d44faee6f468de
@@ -7972,6 +8567,17 @@ packages:
   purls: []
   size: 63629
   timestamp: 1774072609062
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
+  sha256: eb8a0db0aa570124f7d2a93d7c7f596e3390df5e047818d873baad32985fc736
+  md5: 0de0122d9570a8ab637c6b73db268389
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  constrains:
+  - zlib 1.3.2 *_3
+  license: Zlib
+  license_family: Other
+  size: 63713
+  timestamp: 1785362952714
 - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.1.0-pyhcf101f3_0.conda
   sha256: 991a82fbb64aba6d10719a017ce354e28df02ea5df1d9c7b0221da573c168d27
   md5: 1005e1f39083adad2384772e8e384e43
@@ -8027,6 +8633,16 @@ packages:
   - pkg:pypi/locket?source=hash-mapping
   size: 8250
   timestamp: 1650660473123
+- conda: https://conda.anaconda.org/conda-forge/noarch/logmuse-0.3.0-pyhcf101f3_0.conda
+  sha256: 36167f5a11ad1a69d24ac062f866f6abe6618eff9750d5b6efecd64b76aec759
+  md5: 789b0a3d1b8e7d69733894ac32eb8b69
+  depends:
+  - python >=3.10
+  - python
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 16027
+  timestamp: 1773520433396
 - conda: https://conda.anaconda.org/conda-forge/linux-64/loro-1.10.3-py312h121d7ae_1.conda
   sha256: cfcd019bbbf26bb905abe091547cad0e7d7ad02c852e9a12a8e0f78f372d998a
   md5: fe1f239d51177d5644b47e3cf2dcbcf9
@@ -8196,6 +8812,20 @@ packages:
   - pkg:pypi/markupsafe?source=compressed-mapping
   size: 26057
   timestamp: 1772445297924
+- conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.3-py314h67df5f8_1.conda
+  sha256: c279be85b59a62d5c52f5dd9a4cd43ebd08933809a8416c22c3131595607d4cf
+  md5: 9a17c4307d23318476d7fbf0fedc0cde
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python >=3.14,<3.15.0a0
+  - python_abi 3.14.* *_cp314
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27424
+  timestamp: 1772445227915
 - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.10.9-py310hfde16b3_0.conda
   sha256: 3f5901d067947d6f4bce4f994b891fa26865f31bc976275359f81f1ffbf9294f
   md5: 182cef60d49535a1d8c3db692dbf053d
@@ -9080,6 +9710,24 @@ packages:
   - pkg:pypi/numpy?source=hash-mapping
   size: 8757569
   timestamp: 1773839284329
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.5.1-py314h2b28147_0.conda
+  sha256: fb665b7e30f9472c58098983f614598cfcf34e7a26b6c419648803095c390aa7
+  md5: 59044905d27ba41bfb280ed4692c15e2
+  depends:
+  - python
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - python_abi 3.14.* *_cp314
+  - libcblas >=3.9.0,<4.0a0
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 9089255
+  timestamp: 1783206203765
 - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
   sha256: 3900f9f2dbbf4129cf3ad6acf4e4b6f7101390b53843591c53b00f034343bc4d
   md5: 11b3379b191f63139e29c0d19dee24cd
@@ -9133,6 +9781,17 @@ packages:
   license_family: Apache
   size: 3159683
   timestamp: 1781069855778
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.3-h35e630c_1.conda
+  sha256: 012096056b97abf1f68c46b7146bd2cbd68c1be762340b4f5dad4fbbe99177bc
+  md5: c5955c27917ff2234def47f075e71e02
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - ca-certificates
+  - libgcc >=14
+  license: Apache-2.0
+  license_family: Apache
+  size: 3182423
+  timestamp: 1785913583650
 - conda: https://conda.anaconda.org/conda-forge/linux-64/orc-2.3.0-h21090e2_0.conda
   sha256: a60c2578c8422e0c67206d269767feb4d3e627511558b6866e5daf2231d5214d
   md5: 8027fce94fdfdf2e54f9d18cbae496df
@@ -9163,6 +9822,16 @@ packages:
   license_family: APACHE
   size: 30139
   timestamp: 1734587755455
+- conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
+  sha256: 289861ed0c13a15d7bbb408796af4de72c2fe67e2bcb0de98f4c3fce259d7991
+  md5: 58335b26c38bf4a20f399384c33cbcf9
+  depends:
+  - python >=3.8
+  - python
+  license: Apache-2.0
+  license_family: APACHE
+  size: 62477
+  timestamp: 1745345660407
 - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
   sha256: 3906abfb6511a3bb309e39b9b1b7bc38f50a723971de2395489fd1f379255890
   md5: 4c06a92e74452cfa53623a81592e8934
@@ -9236,6 +9905,56 @@ packages:
   license_family: BSD
   size: 12391209
   timestamp: 1764615007370
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.3.3-py314ha0b5721_2.conda
+  sha256: 0a86a582b906d9cfd4d2c59180898fe9d714b55eea7ced71630a1fedae206c62
+  md5: fe3a5c8be07a7b82058bdeb39d33d93b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - numpy >=1.22.4
+  - numpy >=1.23,<3
+  - python >=3.14,<3.15.0a0
+  - python-dateutil >=2.8.2
+  - python-tzdata >=2022.7
+  - python_abi 3.14.* *_cp314
+  - pytz >=2020.1
+  constrains:
+  - pyarrow >=10.0.1
+  - numba >=0.56.4
+  - odfpy >=1.4.1
+  - xlsxwriter >=3.0.5
+  - tabulate >=0.9.0
+  - html5lib >=1.1
+  - lxml >=4.9.2
+  - blosc >=1.21.3
+  - s3fs >=2022.11.0
+  - fsspec >=2022.11.0
+  - psycopg2 >=2.9.6
+  - pandas-gbq >=0.19.0
+  - openpyxl >=3.1.0
+  - qtpy >=2.3.0
+  - python-calamine >=0.1.7
+  - sqlalchemy >=2.0.0
+  - pyqt5 >=5.15.9
+  - bottleneck >=1.3.6
+  - zstandard >=0.19.0
+  - numexpr >=2.8.4
+  - tzdata >=2022.7
+  - scipy >=1.10.0
+  - gcsfs >=2022.11.0
+  - pyxlsb >=1.0.10
+  - matplotlib >=3.6.3
+  - pytables >=3.8.0
+  - beautifulsoup4 >=4.11.2
+  - pyreadstat >=1.2.0
+  - fastparquet >=2022.12.0
+  - xlrd >=2.0.1
+  - xarray >=2022.12.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15178918
+  timestamp: 1764615084415
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-3.0.2-py312h8ecdadd_0.conda
   sha256: 4aad0f99a06e799acdd46af0df8f7c8273164cabce8b5c94a44b012b7d1a30a6
   md5: 42050f82a0c0f6fa23eda3d93b251c18
@@ -9507,6 +10226,37 @@ packages:
   purls: []
   size: 1222481
   timestamp: 1763655398280
+- conda: https://conda.anaconda.org/conda-forge/noarch/pephubclient-0.6.0-pyhd8ed1ab_0.conda
+  sha256: cdf0a400cb25ea638aaedc794003bad52e46a717edcda7b64b7a207028b177c1
+  md5: 597251588fcfcb101c55d15dfb50df14
+  depends:
+  - coloredlogs >=15.0.1
+  - pandas >=2.0.0
+  - peppy >=0.40.5
+  - pydantic >=2.5.0
+  - python >=3.10
+  - requests >=2.28.2
+  - toml >=0.10.2
+  - typer >=0.7.0
+  - ubiquerg >=0.6.3
+  license: BSD-2-Clause
+  size: 27789
+  timestamp: 1785943335031
+- conda: https://conda.anaconda.org/conda-forge/noarch/peppy-0.40.8-pyhd8ed1ab_0.conda
+  sha256: e05978b7e71202052e0a06ac31a59ff5456e5af87877436a508b7cdf21f96004
+  md5: af8214b9b5fd6d49175958be2a4f5321
+  depends:
+  - logmuse >=0.2
+  - pandas >=0.24.2
+  - pephubclient >=0.4.2
+  - python >=3.10
+  - pyyaml >=5
+  - rich
+  - ubiquerg >=0.5.2
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 30161
+  timestamp: 1760990724770
 - conda: https://conda.anaconda.org/conda-forge/linux-64/perl-5.32.1-7_hd590300_perl5.conda
   build_number: 7
   sha256: 9ec32b6936b0e37bcb0ed34f22ec3116e75b3c0964f9f50ecea5f58734ed6ce9
@@ -9631,6 +10381,16 @@ packages:
   license_family: MIT
   size: 26308
   timestamp: 1779972894916
+- conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.11.0-pyhcf101f3_0.conda
+  sha256: a4b8c7d3b3703d10f93187986d59aec09b22033978945845899beb7f849a7be6
+  md5: 1fadaa6dd1d03d062075f84157ac2cc7
+  depends:
+  - python >=3.10
+  - python
+  license: MIT
+  license_family: MIT
+  size: 26632
+  timestamp: 1784661349391
 - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
   sha256: 8f29915c172f1f7f4f7c9391cd5dac3ebf5d13745c8b7c8006032615246345a5
   md5: 89c0b6d1793601a2a3a3f7d2d3d8b937
@@ -9901,6 +10661,18 @@ packages:
   - pkg:pypi/psutil?source=compressed-mapping
   size: 225545
   timestamp: 1769678155334
+- conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.2.2-py314h0f05182_0.conda
+  sha256: f15574ed6c8c8ed8c15a0c5a00102b1efe8b867c0bd286b498cd98d95bd69ae5
+  md5: 4f225a966cfee267a79c5cb6382bd121
+  depends:
+  - python
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.14.* *_cp314
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 231303
+  timestamp: 1769678156552
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
   sha256: 9c88f8c64590e9567c6c80823f0328e58d3b1efb0e1c539c0315ceca764e0973
   md5: b3c17d95b5a10c6e64a21fa17573e70e
@@ -9922,6 +10694,18 @@ packages:
   - pkg:pypi/ptyprocess?source=hash-mapping
   size: 19457
   timestamp: 1733302371990
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pulp-2.8.0-py314h312e2f4_3.conda
+  sha256: 32354767a80f6650ad043356a975e7562c7286f7b2cdbb2acfe15bd057508e2f
+  md5: 057e330e50d141ee706f1d4c46594979
+  depends:
+  - amply >=0.1.2
+  - coin-or-cbc
+  - python >=3.14.0rc2,<3.15.0a0
+  - python_abi 3.14.* *_cp314
+  license: MIT
+  license_family: MIT
+  size: 230470
+  timestamp: 1757853295064
 - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_1.conda
   sha256: 71bd24600d14bb171a6321d523486f6a06f855e75e547fa0cb2a0953b02047f0
   md5: 3bfdfb8dbcdc4af1ae3f9a8eb3948f04
@@ -10091,6 +10875,21 @@ packages:
   - pkg:pypi/pydantic-core?source=hash-mapping
   size: 1895409
   timestamp: 1778084226169
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.46.4-py314h2e6c369_0.conda
+  sha256: 802e216c39f1359aed60823b6e11d8ccd812b0ae1c81ae5ac1c81f99446409ab
+  md5: 0c96993dbeadf3a277cf757b9f1c9412
+  depends:
+  - python
+  - typing-extensions >=4.6.0,!=4.7.0
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.14.* *_cp314
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  size: 1895020
+  timestamp: 1778084229247
 - conda: https://conda.anaconda.org/conda-forge/noarch/pydata-sphinx-theme-0.15.4-pyhd8ed1ab_0.conda
   sha256: 5ec877142ded763061e114e787a4e201c2fb3f0b1db2f04ace610a1187bb34ae
   md5: c7c50dd5192caa58a05e6a4248a27acb
@@ -10425,6 +11224,33 @@ packages:
   purls: []
   size: 31608571
   timestamp: 1772730708989
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.6-habeac84_101_cp314.conda
+  build_number: 101
+  sha256: ee8f2006e1724b1f2e9e0ccc5a7cfdcab973460faa2f63ac1f6e44fdad4c0344
+  md5: 78975a41cf3c525da654f17e35bfca9e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.36.1
+  - libexpat >=2.8.1,<3.0a0
+  - libffi >=3.5.2,<3.6.0a0
+  - libgcc >=14
+  - liblzma >=5.8.3,<6.0a0
+  - libmpdec >=4.0.0,<5.0a0
+  - libsqlite >=3.53.3,<4.0a0
+  - libuuid >=2.42.2,<3.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - ncurses >=6.6,<7.0a0
+  - openssl >=3.5.7,<4.0a0
+  - python_abi 3.14.* *_cp314
+  - readline >=8.3,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - zstd >=1.5.7,<1.6.0a0
+  license: Python-2.0
+  size: 36869055
+  timestamp: 1784910110714
+  python_site_packages_path: lib/python3.14/site-packages
 - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
   sha256: d6a17ece93bbd5139e02d2bd7dbfa80bee1a4261dced63f65f679121686bf664
   md5: 5b8d21249ff20967101ffa321cab24e8
@@ -10485,6 +11311,16 @@ packages:
   - pkg:pypi/fastjsonschema?source=hash-mapping
   size: 244628
   timestamp: 1755304154927
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.22.1-pyhcf101f3_0.conda
+  sha256: 2243b305387413fa716827dce44011ea121be002e7ec24404ba00651db0279cd
+  md5: d066c36f0c7658ef422c60d598ea8495
+  depends:
+  - python >=3.10
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 252180
+  timestamp: 1785242896823
 - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.10.20-hd8ed1ab_1.conda
   sha256: 84bab2600eb7a94016f33cb580a1a1bbb9fbc2d11460a337d5d014e8151d0bdf
   md5: 33296afcbf60357874f99aec38ead969
@@ -10523,6 +11359,15 @@ packages:
   license_family: APACHE
   size: 146639
   timestamp: 1777068997932
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2026.3-pyhd8ed1ab_0.conda
+  sha256: 3f05db78cf8be33cf6dbc469664b8e3a01f3980d61d6d6bef48669b171896d8a
+  md5: eefc8d916bd2e708d76d40398ef9a1ee
+  depends:
+  - python >=3.10
+  license: Apache-2.0
+  license_family: APACHE
+  size: 146862
+  timestamp: 1783704822814
 - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.10-8_cp310.conda
   build_number: 8
   sha256: 7ad76fa396e4bde336872350124c0819032a9e8a0a40590744ff9527b54351c1
@@ -10544,6 +11389,16 @@ packages:
   purls: []
   size: 6958
   timestamp: 1752805918820
+- conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+  build_number: 8
+  sha256: ad6d2e9ac39751cc0529dd1566a26751a0bf2542adb0c232533d32e176e21db5
+  md5: 0539938c55b6b1a59b560e843ad864a4
+  constrains:
+  - python 3.14.* *_cp314
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6989
+  timestamp: 1752805904792
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pytokens-0.4.1-py310h139afa4_2.conda
   sha256: 6e74e99787870ee4158165dacd312347342a8cdf67814086365c4fe95512151b
   md5: 1874447dc9421e6fa984853d5df7ec2a
@@ -10566,6 +11421,16 @@ packages:
   license_family: MIT
   size: 201747
   timestamp: 1777892201250
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2026.3.post1-pyhcf101f3_0.conda
+  sha256: ad774abda71c759baef515983bfedbba34d56d6227974c23715c04612f812a90
+  md5: eb2fb9070c0232e96ae5515d8b28e4f9
+  depends:
+  - python >=3.10
+  - python
+  license: MIT
+  license_family: MIT
+  size: 201126
+  timestamp: 1785077087428
 - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.6-pyhd8ed1ab_0.conda
   sha256: 4095768d06ffbe31aa98f1d4a982c1f483de088749f30e990673fcae94f1d8d1
   md5: e0f2c3ecb4dc40d031bbe88869a2a7a1
@@ -10662,6 +11527,19 @@ packages:
   - pkg:pypi/pyyaml?source=hash-mapping
   size: 198293
   timestamp: 1770223620706
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py314h67df5f8_1.conda
+  sha256: b318fb070c7a1f89980ef124b80a0b5ccf3928143708a85e0053cde0169c699d
+  md5: 2035f68f96be30dc60a5dfd7452c7941
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python >=3.14,<3.15.0a0
+  - python_abi 3.14.* *_cp314
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 202391
+  timestamp: 1770223462836
 - conda: https://conda.anaconda.org/conda-forge/noarch/pyyaml-env-tag-1.1-pyhd8ed1ab_0.conda
   sha256: 69ab63bd45587406ae911811fc4d4c1bf972d643fa57a009de7c01ac978c4edd
   md5: e8e53c4150a1bba3b160eacf9d53a51b
@@ -10913,6 +11791,19 @@ packages:
   license_family: MIT
   size: 22913
   timestamp: 1752876729969
+- conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
+  sha256: 3d6ba2c0fcdac3196ba2f0615b4104e532525ffa1335b50a2878be5ff488814a
+  md5: 0242025a3c804966bf71aa04eee82f66
+  depends:
+  - markdown-it-py >=2.2.0
+  - pygments >=2.13.0,<3.0.0
+  - python >=3.10
+  - typing_extensions >=4.0.0,<5.0.0
+  - python
+  license: MIT
+  license_family: MIT
+  size: 208577
+  timestamp: 1775991661559
 - conda: https://conda.anaconda.org/conda-forge/linux-64/richdem-2.3.0-py312h5fc20e3_16.conda
   sha256: 4e44c0821faefc58dc09510137f50117f9343428fd8c7aa8180e46421a3eb62a
   md5: 0efcba16e7f7763ed812203d6da49aa3
@@ -10979,6 +11870,20 @@ packages:
   - pkg:pypi/rpds-py?source=hash-mapping
   size: 383750
   timestamp: 1764543174231
+- conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-2026.6.3-py314h1bee95f_0.conda
+  sha256: 064e56d6c233cbcfac5b0183c0dd10b732668ff27aa1ea3580459acceae95473
+  md5: add3cbcc5eb677f6c1720e01cd82aac5
+  depends:
+  - python
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.14.* *_cp314
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  size: 300129
+  timestamp: 1782831350283
 - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.15.12-h994f30f_0.conda
   noarch: python
   sha256: 98c771464ed93a2733bae460c39cfa9640feb20972d2e651b44e85db296942eb
@@ -11171,6 +12076,15 @@ packages:
   - pkg:pypi/shapely?source=hash-mapping
   size: 631649
   timestamp: 1762523699384
+- conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
+  sha256: 1d6534df8e7924d9087bd388fbac5bd868c5bf8971c36885f9f016da0657d22b
+  md5: 83ea3a2ddb7a75c1b09cea582aa4f106
+  depends:
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  size: 15018
+  timestamp: 1762858315311
 - conda: https://conda.anaconda.org/conda-forge/linux-64/simplejson-4.1.1-py312h4c3975b_0.conda
   sha256: 70a0ab8787576d55f23d114cc1d7569fd83f5b148c71a7f277180299e86ea8f1
   md5: bb3b931588a7dc83cc7b82836b0017df
@@ -11197,6 +12111,193 @@ packages:
   - pkg:pypi/six?source=hash-mapping
   size: 18455
   timestamp: 1753199211006
+- conda: https://conda.anaconda.org/conda-forge/noarch/slack-sdk-3.43.0-pyhcf101f3_0.conda
+  sha256: ced52f45472152e569feaa8193b83c0d171367ed502291295b151d6219a0482a
+  md5: 29622829da9d267ecd6d6124714f94ec
+  depends:
+  - python >=3.10
+  - python
+  license: MIT
+  license_family: MIT
+  size: 169309
+  timestamp: 1782870770202
+- conda: https://conda.anaconda.org/conda-forge/noarch/slack_sdk-3.43.0-pyh9dfb50f_0.conda
+  sha256: 26de3f318d1b594f2ffe9153a5928cd33f5664a98b57a25d27e56a0a34dce2c2
+  md5: d9115c7d679981cec034a4808b294d70
+  depends:
+  - python >=3.10
+  - slack-sdk ==3.43.0 pyhcf101f3_0
+  - python
+  license: MIT
+  license_family: MIT
+  size: 7393
+  timestamp: 1782870770202
+- conda: https://conda.anaconda.org/conda-forge/noarch/smart_open-7.7.1-pyhcf101f3_0.conda
+  sha256: d0abe2d97b67d42aca30fcd34b3db6cd5de57b4a9ffcf4e04091dd9f4a0cf1e6
+  md5: fd2e276dbbd1a2ae15ffdbdbabd908f1
+  depends:
+  - python >=3.10
+  - wrapt
+  - python
+  license: MIT
+  license_family: MIT
+  size: 57158
+  timestamp: 1782573421136
+- conda: https://conda.anaconda.org/conda-forge/noarch/smmap-5.0.3-pyhcf101f3_1.conda
+  sha256: bc86861086db65c9b56dd6a1605755f41a9875b94fc3b69e137f686700d91aa1
+  md5: b899f1195be56d8215ed1973a8f409c3
+  depends:
+  - python >=3.10
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27262
+  timestamp: 1781021238494
+- conda: https://conda.anaconda.org/bioconda/noarch/snakemake-9.25.1-hdfd78af_0.conda
+  sha256: 7087c0b145f1772145127d4f1fc422b5b03c42309d08d16b4e9fbb154a09030e
+  md5: 862c3d4de4f2bf98cee204bd25d4a113
+  depends:
+  - eido
+  - pandas <3
+  - peppy
+  - pygments
+  - slack_sdk
+  - snakemake-minimal 9.25.1.*
+  license: MIT
+  license_family: MIT
+  size: 11362
+  timestamp: 1785882299472
+- conda: https://conda.anaconda.org/bioconda/noarch/snakemake-executor-plugin-slurm-2.7.1-pyhdfd78af_0.conda
+  sha256: 68962051fc8f68c8fb3e6a57635c92226ff95841e4649e5acdd3fca770dff16f
+  md5: d11d20e557970783b9dbc68d36d3c37a
+  depends:
+  - numpy >=1.26.4,<3.0
+  - pandas >=2.2.3,<3.0
+  - python >=3.11.0,<4.0.0
+  - pyyaml
+  - snakemake-executor-plugin-slurm-jobstep >=0.4.0,<0.5.0
+  - snakemake-interface-common >=1.21.0,<2.0.0
+  - snakemake-interface-executor-plugins >=9.3.9,<10.0.0
+  - throttler >=1.2.2,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 47320
+  timestamp: 1780309106075
+- conda: https://conda.anaconda.org/bioconda/noarch/snakemake-executor-plugin-slurm-jobstep-0.4.0-pyhdfd78af_0.conda
+  sha256: 82ad84bf106e0fbab62f6c001311aff53faefe323254c8b2b3540f310bb48dfe
+  md5: 7d4f2bf739967798eb4d8c02d59cf36c
+  depends:
+  - python >=3.11.0,<4.0.0
+  - snakemake-interface-common >=1.13.0,<2.0.0
+  - snakemake-interface-executor-plugins >=9.0.0,<10.0.0
+  license: MIT
+  size: 14678
+  timestamp: 1765807808315
+- conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-common-1.23.0-pyhdfd78af_1.conda
+  sha256: 1e8393a8ef060c62ef963fa9e0b3cc8f69b1dec4bdb51599c0dfcdeb9b8c7d12
+  md5: a5ec344abd4b0cdda5a52e870e4d25a3
+  depends:
+  - argparse-dataclass >=2.0.0
+  - configargparse >=1.7
+  - packaging >=24.0
+  - python >=3.8
+  license: MIT
+  license_family: MIT
+  size: 22751
+  timestamp: 1780096495612
+- conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-executor-plugins-9.4.0-pyh84498cf_0.conda
+  sha256: 16c8e1ba64837b10460459e710e2578e8b0be5d1ed9501cfcf27b2ba316e5ad2
+  md5: 0d8bbf1699b16ac225031ae0c73729f8
+  depends:
+  - argparse-dataclass >=2.0.0,<3.0.0
+  - python >=3.11.0,<4.0.0
+  - snakemake-interface-common >=1.19.0
+  - throttler >=1.2.2,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 25394
+  timestamp: 1772990565157
+- conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-logger-plugins-2.1.0-pyhdfd78af_0.conda
+  sha256: 1fc3115ce77aee110a7cf7bc6ffb3a4ab82af3173109b0bad6ac9adb00296de7
+  md5: 78f0a9e3ec845ef8e35e319bc36dee9b
+  depends:
+  - python >=3.11.0,<4.0.0
+  - snakemake-interface-common >=1.17.4,<2.0.0
+  license: MIT
+  size: 21021
+  timestamp: 1779291141116
+- conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-report-plugins-1.3.0-pyhd4c3c12_0.conda
+  sha256: 7b7be41b59f2d904acb014ee182561610c930bef5f607742011ee23befe73831
+  md5: e6fd8cfb23b294da699e395dbc968d11
+  depends:
+  - python >=3.11.0,<4.0.0
+  - snakemake-interface-common >=1.16.0,<2.0.0
+  license: MIT
+  size: 14490
+  timestamp: 1761910544502
+- conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-scheduler-plugins-2.0.2-pyhd4c3c12_0.conda
+  sha256: d5234883768d5876707df6897151a100581293336a599195ead32894bea4fa2f
+  md5: 1500fccf5e46c7f91d14925449ff3632
+  depends:
+  - python >=3.11.0,<4.0.0
+  - snakemake-interface-common >=1.20.1,<2.0.0
+  license: MIT
+  size: 16446
+  timestamp: 1760984180933
+- conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-storage-plugins-4.4.1-pyh84498cf_0.conda
+  sha256: 695a2c5c2bc417df0e440943f7637953f9e8c6e887c59432947d7e14ae1ffdac
+  md5: 8e6d2ea30aec2f8eabd03cac524f1f33
+  depends:
+  - humanfriendly >=10.0,<11
+  - python >=3.11.0,<4.0.0
+  - snakemake-interface-common >=1.12.0,<2.0.0
+  - tenacity >=9.1.4,<10.0
+  - throttler >=1.2.2,<2.0.0
+  - wrapt >=1.15.0,<2.0.0
+  license: MIT
+  license_family: MIT
+  size: 22783
+  timestamp: 1773699846635
+- conda: https://conda.anaconda.org/bioconda/noarch/snakemake-minimal-9.25.1-pyhdfd78af_0.conda
+  sha256: 643957e2ec7dc2c7d77e4c5e9b89621d264b14d4b2cd83a23c0e645e5b004182
+  md5: d639ba3846ef46c86a57bed676115deb
+  depends:
+  - conda-inject >=1.3.1,<2.0
+  - configargparse
+  - connection_pool >=0.0.3
+  - docutils >=0.20,<0.23
+  - dpath >=2.1.6,<3.0.0
+  - gitpython
+  - humanfriendly
+  - immutables
+  - jinja2 >=3.0,<4.0
+  - jsonschema
+  - nbformat
+  - packaging >=24.0,<26
+  - platformdirs
+  - psutil
+  - pulp >=2.3.1,<3.4
+  - python >=3.11
+  - pyyaml
+  - referencing
+  - requests >=2.8.1,<3.0
+  - smart_open >=4.0,<8.0
+  - snakemake-interface-common >=1.20.1,<2.0
+  - snakemake-interface-executor-plugins >=9.3.2,<10.0
+  - snakemake-interface-logger-plugins >=1.1.0,<3.0.0
+  - snakemake-interface-report-plugins >=1.2.0,<2.0.0
+  - snakemake-interface-scheduler-plugins >=2.0.0,<3.0.0
+  - snakemake-interface-storage-plugins >=4.4.1,<5.0
+  - sqlmodel >=0.0.37,<0.0.38
+  - tabulate
+  - tenacity >=9.1.4,<10.0
+  - throttler
+  - wrapt
+  - yte >=1.5.5,<2.0
+  license: MIT
+  license_family: MIT
+  size: 889521
+  timestamp: 1785882296560
 - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.2-h03e3b7b_1.conda
   sha256: 48f3f6a76c34b2cfe80de9ce7f2283ecb55d5ed47367ba91e8bb8104e12b8f11
   md5: 98b6c9dc80eb87b2519b97bcf7e578dd
@@ -11431,6 +12532,20 @@ packages:
   license_family: BSD
   size: 30640
   timestamp: 1781260357443
+- conda: https://conda.anaconda.org/conda-forge/linux-64/sqlalchemy-2.0.51-py314h0f05182_0.conda
+  sha256: 3c46e9af535a376c7269b61563f84c601235b00d50fc97f87ffbf3b68a51fe17
+  md5: aeb7447f3ea37b2bb32167267dcf0bfe
+  depends:
+  - python
+  - greenlet !=0.4.17
+  - typing-extensions >=4.6.0
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python_abi 3.14.* *_cp314
+  license: MIT
+  license_family: MIT
+  size: 4034632
+  timestamp: 1781547880247
 - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.53.1-hbc0de68_0.conda
   sha256: d167fa92781bcdcd3b9aaa6bb1cd50c5b108f6190c170098a118b5cf5df2f881
   md5: 8e0b8654ead18e50af552e54b5a08a61
@@ -11458,6 +12573,18 @@ packages:
   license: blessing
   size: 206481
   timestamp: 1782519082269
+- conda: https://conda.anaconda.org/conda-forge/noarch/sqlmodel-0.0.37-pyhcf101f3_0.conda
+  sha256: 9cbf4805021fd817fde2654ccc1a1bd0352647614819a28381e81098efe4da20
+  md5: 00e6147bef9a85139099c9861c3b976b
+  depends:
+  - python >=3.10
+  - sqlalchemy >=2.0.14,<2.1.0
+  - pydantic >=2.11.0
+  - python
+  license: MIT
+  license_family: MIT
+  size: 30854
+  timestamp: 1771872849343
 - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
   sha256: 570da295d421661af487f1595045760526964f41471021056e993e73089e9c41
   md5: b1b505328da7a6b246787df4b5a49fbc
@@ -11506,6 +12633,16 @@ packages:
   - pkg:pypi/statsmodels?source=hash-mapping
   size: 11903737
   timestamp: 1764983555676
+- conda: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.10.0-pyhcf101f3_0.conda
+  sha256: 3f661e98a09f976775a494488beb3d35ebb00f535b169c6bd891f2e280d55783
+  md5: 3b887b7b3468b0f494b4fad40178b043
+  depends:
+  - python >=3.10
+  - python
+  license: MIT
+  license_family: MIT
+  size: 43964
+  timestamp: 1772732795746
 - conda: https://conda.anaconda.org/conda-forge/noarch/tblib-3.2.2-pyhcf101f3_0.conda
   sha256: 6b549360f687ee4d11bf85a6d6a276a30f9333df1857adb0fe785f0f8e9bcd60
   md5: f88bb644823094f436792f80fba3207e
@@ -11518,6 +12655,16 @@ packages:
   - pkg:pypi/tblib?source=hash-mapping
   size: 19397
   timestamp: 1762956379123
+- conda: https://conda.anaconda.org/conda-forge/noarch/tenacity-9.1.4-pyhcf101f3_0.conda
+  sha256: 32e75900d6a094ffe4290a8c9f1fa15744d9da8ff617aba4acaa0f057a065c34
+  md5: 043f0599dc8aa023369deacdb5ac24eb
+  depends:
+  - python >=3.10
+  - python
+  license: Apache-2.0
+  license_family: APACHE
+  size: 31404
+  timestamp: 1770510172846
 - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyhc90fa1f_1.conda
   sha256: 6b6727a13d1ca6a23de5e6686500d0669081a117736a87c8abf444d60c1e40eb
   md5: 17b43cee5cc84969529d5d0b0309b2cb
@@ -11553,6 +12700,15 @@ packages:
   - pkg:pypi/threadpoolctl?source=hash-mapping
   size: 23869
   timestamp: 1741878358548
+- conda: https://conda.anaconda.org/conda-forge/noarch/throttler-1.2.2-pyhd8ed1ab_0.conda
+  sha256: cdd2067b03db7ed7a958de74edc1a4f8c4ae6d0aa1a61b5b70b89de5013f0f78
+  md5: 6fc48bef3b400c82abaee323a9d4e290
+  depends:
+  - python >=3.6
+  license: MIT
+  license_family: MIT
+  size: 12341
+  timestamp: 1691135604942
 - conda: https://conda.anaconda.org/conda-forge/linux-64/tiledb-2.30.1-h8789cd1_7.conda
   sha256: b02de843833c2801092790dc23cd7be01d0d8121d90c55dabd2d148a78da37b2
   md5: 64486fa8704e58dfb50b689e408fc495
@@ -11613,6 +12769,19 @@ packages:
   purls: []
   size: 3301196
   timestamp: 1769460227866
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd70dff1_3.conda
+  build_number: 103
+  sha256: 43624eab22f5f29df7d6ffe914cf442f28fd559b55b290906255492826e636e8
+  md5: 48a1049e710857572fc2a832aa394d9f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libzlib >=1.3.2,<2.0a0
+  constrains:
+  - xorg-libx11 >=1.8.13,<2.0a0
+  license: TCL
+  size: 3550916
+  timestamp: 1784229071544
 - conda: https://conda.anaconda.org/conda-forge/noarch/tokenize-rt-6.2.0-pyhd8ed1ab_0.conda
   sha256: b8da0c728e1313e116a06084ea770c6ad752b9cd086d52b20fcd464bdce52e4b
   md5: 0a42378794e0425eb5defc9d63e60607
@@ -11622,6 +12791,16 @@ packages:
   license_family: MIT
   size: 12383
   timestamp: 1748092106333
+- conda: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhcf101f3_3.conda
+  sha256: fd30e43699cb22ab32ff3134d3acf12d6010b5bbaa63293c37076b50009b91f8
+  md5: d0fc809fa4c4d85e959ce4ab6e1de800
+  depends:
+  - python >=3.10
+  - python
+  license: MIT
+  license_family: MIT
+  size: 24017
+  timestamp: 1764486833072
 - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
   sha256: 91cafdb64268e43e0e10d30bd1bef5af392e69f00edd34dfaf909f69ab2da6bd
   md5: b5325cf06a000c5b14970462ff5e4d58
@@ -11729,6 +12908,29 @@ packages:
   license_family: BSD
   size: 115158
   timestamp: 1780507822178
+- conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.16.1-pyhcf101f3_0.conda
+  sha256: 03dba5917f944c6684ab44c81daacac1624cd148e4b2cae215dcec594a210c48
+  md5: a79bf97561232a31447b6246c2153ab5
+  depends:
+  - python >=3.10
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 116935
+  timestamp: 1785761789772
+- conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.27.1-pyhcf101f3_0.conda
+  sha256: cfa5c42642e238e5a4200ac3ff5f46b7997fae6c6f8d4c84909be58d5356f7ce
+  md5: 8df7a3ee62a94dca4ea22c3f4d38d9eb
+  depends:
+  - annotated-doc >=0.0.2
+  - colorama
+  - python >=3.10
+  - rich >=13.8.0
+  - shellingham >=1.3.0
+  - python
+  license: MIT AND BSD-3-Clause
+  size: 188113
+  timestamp: 1785796291853
 - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
   sha256: 7c2df5721c742c2a47b2c8f960e718c930031663ac1174da67c1ed5999f7938c
   md5: edd329d7d3a4ab45dcf905899a7a6115
@@ -11810,6 +13012,21 @@ packages:
   purls: []
   size: 119135
   timestamp: 1767016325805
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+  sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
+  md5: fcb489df604d100968b737f2cb6076c6
+  license: LicenseRef-Public-Domain
+  size: 118849
+  timestamp: 1784250406640
+- conda: https://conda.anaconda.org/conda-forge/noarch/ubiquerg-0.9.3-pyhd8ed1ab_0.conda
+  sha256: 33afef3f9b2e3b73254a9401cf7a101632ac74f704fdf7e744ca896720797caa
+  md5: 04429efde19509f6672b9f9434676ae9
+  depends:
+  - python >=3.10
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 23293
+  timestamp: 1775148942723
 - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-2.0.0-pyhcf101f3_0.conda
   sha256: 9e5a0e70e876fca50de075b1cc6641cdc009a16c18f4d52ab03edb777729a1bc
   md5: 4fdd327852ffefc83173a7c029690d0c
@@ -12089,6 +13306,18 @@ packages:
   license_family: BSD
   size: 889195
   timestamp: 1762040404362
+- conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.17.3-py314h5bd0f2a_1.conda
+  sha256: e2b6545651aed5e7dead39b7ba3bf8c2669f194c71e89621343bd0bb321a87f1
+  md5: 82da729c870ada2f675689a39b4f697f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python >=3.14.0rc2,<3.15.0a0
+  - python_abi 3.14.* *_cp314
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 64997
+  timestamp: 1756851739706
 - conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-2.1.2-py312h4c3975b_0.conda
   sha256: 5bf21e14a364018a36869a16d9f706fb662c6cb6da3066100ba6822a70f93d2d
   md5: 7f2ef073d94036f8b16b6ee7d3562a88
@@ -12495,6 +13724,18 @@ packages:
   - pkg:pypi/yarl?source=compressed-mapping
   size: 147028
   timestamp: 1772409590700
+- conda: https://conda.anaconda.org/conda-forge/noarch/yte-1.9.4-pyhd8ed1ab_0.conda
+  sha256: 1ad021f32290e72b70a84dfe0c9b278c61aaa1254f1e1c287d68c32ee4f1093f
+  md5: 89d5edf5d52d3bc1ed4d7d3feef508ba
+  depends:
+  - argparse-dataclass >=2.0.0,<3
+  - dpath >=2.1,<3.0
+  - python >=3.10
+  - pyyaml >=6.0,<7.0
+  license: MIT
+  license_family: MIT
+  size: 16215
+  timestamp: 1764250734338
 - conda: https://conda.anaconda.org/conda-forge/noarch/zarr-3.2.1-pyhc364b38_0.conda
   sha256: 88716d633ac7fdc896ce7aa00efdfc91df6363d51bebabfb60d34399c023a3d0
   md5: b787cd1f01e24b161261438a5589df51

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,10 @@ pythonpath = ["."]
 # Run `pixi install` to materialise envs under `.pixi/envs/`.
 # ---------------------------------------------------------------------------
 [tool.pixi.workspace]
-channels = ["conda-forge"]
+# bioconda supplies snakemake + its SLURM executor plugin (the `workflow`
+# feature below). conda-forge stays first so every runtime/geo package still
+# resolves from it.
+channels = ["conda-forge", "bioconda"]
 platforms = ["linux-64"]
 
 [tool.pixi.tasks]
@@ -176,6 +179,15 @@ ruff = "*"
 # generation still uses the richer `notebooks` env; dev only needs it to import.
 matplotlib-base = "*"
 
+[tool.pixi.feature.workflow.dependencies]
+# Snakemake, for the I1-I5 investigation in
+# docs/superpowers/specs/2026-08-04-snakemake-migration-design.md.
+# A FEATURE, not a [project.dependency]: this is orchestration tooling under
+# evaluation, not a runtime dep, and it must not be pulled into the frozen
+# default env that SLURM array tasks run in.
+snakemake = ">=8"
+snakemake-executor-plugin-slurm = "*"
+
 [tool.pixi.feature.docs.dependencies]
 mkdocs = "*"
 mkdocs-material = "*"
@@ -213,6 +225,12 @@ reference = { features = ["reference"], solve-group = "reference", no-default-fe
 # `pixi run -e marp marp-setup`); no-default-feature keeps the heavy geo stack
 # out so operators only pay ~250 MB when they render decks. Own solve-group.
 marp = { features = ["marp"], solve-group = "marp", no-default-feature = true }
+# The snakemake controller only. no-default-feature keeps the geo stack out --
+# every rule shells out to `pixi run --as-is` so the actual work still happens in
+# the frozen default env, which is the race-safety constraint CLAUDE.md sets for
+# concurrent array tasks. Own solve-group so a snakemake pin can never move the
+# production solve.
+workflow = { features = ["workflow"], solve-group = "workflow", no-default-feature = true }
 all = { features = ["notebooks", "dev", "docs"], solve-group = "default" }
 
 [tool.isort]

--- a/slurm_batch/data_root_tests.batch
+++ b/slurm_batch/data_root_tests.batch
@@ -1,0 +1,75 @@
+#!/bin/bash
+#SBATCH -p cpu
+#SBATCH -A impd
+#SBATCH --job-name=data_root_tests
+#SBATCH --output=logs/job_%j.out
+#SBATCH --error=logs/job_%j.err
+#SBATCH --time=00:30:00
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=2
+#SBATCH --mem=16G
+#
+# Run every DATA-ROOT-GATED test on a compute node, and print the job id that
+# their result must be recorded against.
+#
+# WHY THIS EXISTS (answers I5 of the Snakemake migration spec).
+#
+# A whole class of test in this repo asserts something about real on-disk
+# products, so it cannot run in CI: `.github/workflows/ci.yml` is
+# `runs-on: ubuntu-latest` with no data root, and these tests `pytest.skip` when
+# the data root is absent. CI therefore reports them GREEN while they assert
+# NOTHING. And CLAUDE.md forbids pytest on the HPC login node. So without a job
+# like this, such a test has nowhere to run at all -- which is exactly the
+# blocker the migration spec identified for its proposed parity gate.
+#
+# The convention, which the spec asks for and this job enforces:
+#
+#   A data-root-gated test's result is recorded BY SLURM JOB ID, in the relevant
+#   issue or PR. It is NEVER inferred from a green CI badge, because a green CI
+#   badge for these tests means "skipped".
+#
+# CURRENT MEMBERS
+#   tests/test_params_index_ondisk.py -- Guard 2 of the PRMS parameter index
+#       (PR #203). Asserts the declared column set matches the on-disk header in
+#       BOTH directions. 4 skip points, all data-root conditional.
+#
+# A Snakemake/.batch parity test joins this list when one exists (spec I5). It is
+# the same shape: it needs two real product trees to compare, so it can only run
+# where a data root does.
+#
+# USAGE
+#   sbatch slurm_batch/data_root_tests.batch                 # active fabric
+#   sbatch --export=ALL,FABRIC=oregon slurm_batch/data_root_tests.batch
+#
+# Then quote the job id. `sacct -j <id> --format=JobID,JobName,State,Elapsed`
+# is the receipt.
+
+cd "$SLURM_SUBMIT_DIR"
+FABRIC=${FABRIC:-}
+
+echo "=================================================================="
+echo " data-root-gated tests"
+echo " SLURM job id : ${SLURM_JOB_ID}   <-- RECORD THIS. A green CI badge"
+echo "                                      does not cover these tests."
+echo " host         : $(hostname)"
+echo " fabric       : ${FABRIC:-<active default from base_config.yml>}"
+echo "=================================================================="
+
+if [ -n "$FABRIC" ]; then
+    export FABRIC
+fi
+
+# -ra surfaces the skip REASONS. A run where everything skipped is a run that
+# proved nothing, and the reasons are how you tell that from a real pass.
+pixi run --as-is -e dev python -m pytest \
+    tests/test_params_index_ondisk.py \
+    -v -ra
+RC=$?
+
+echo "=================================================================="
+echo " exit code $RC for SLURM job ${SLURM_JOB_ID}"
+if [ $RC -ne 0 ]; then
+    echo " FAILED -- do not record this as a passing gate."
+fi
+echo "=================================================================="
+exit $RC

--- a/workflow/probe/README.md
+++ b/workflow/probe/README.md
@@ -1,0 +1,65 @@
+# Snakemake I1–I5 investigation probes
+
+Scratch Snakefiles for the five investigation questions in
+[`docs/superpowers/specs/2026-08-04-snakemake-migration-design.md`](../../docs/superpowers/specs/2026-08-04-snakemake-migration-design.md).
+
+These are **probes, not production workflow**. They exist to answer questions whose
+answers determine whether the migration is viable at all, and they should be deleted
+(or promoted deliberately) once the spec records the findings.
+
+Run everything through SLURM. Per `CLAUDE.md`, nothing heavy runs on the login node —
+and `--dry-run`, which is login-node safe, is specifically NOT sufficient for I1: a
+dry run never submits, so it cannot count submissions.
+
+| Probe | Question |
+| --- | --- |
+| `i1_i2_group.smk` | Does `group:` collapse per-rule-instance submissions, and does it re-create the import storm? |
+| `i3_containment.smk` | Do `ancient()` shared inputs stop a shared-VRT `touch` from triggering rebuilds? |
+| `i4_partial_failure.smk` | How does the DAG behave when one param is unbuildable? |
+
+---
+
+## Finding that applies to ALL rules, not one probe
+
+**A nested `pixi run --as-is` inherits the parent's environment selection.**
+
+Snakemake lives in the `workflow` env, so it must be launched as
+`pixi run -e workflow snakemake ...`. That exports `PIXI_ENVIRONMENT_NAME=workflow`,
+and every rule's shell command inherits it. Measured 2026-08-05:
+
+| invocation | resolves to |
+| --- | --- |
+| `pixi run --as-is python` from a clean shell | `.pixi/envs/default` |
+| `pixi run --as-is python` from inside `pixi run -e workflow` | `.pixi/envs/**workflow**` |
+| `pixi run --as-is -e default python` from either | `.pixi/envs/default` |
+
+So **every rule must pin `-e default` explicitly**. A bare `pixi run --as-is` in a
+rule does not do what it says.
+
+### This falsifies a claimed property of the PR #142 spike
+
+`workflow/spike/Snakefile` states:
+
+> Rules shell out to the existing orchestrator via `pixi run --as-is` so all geo
+> work runs in the frozen default env (race-safe; CLAUDE.md constraint).
+
+That was never true of the spike as written. Its rules resolved to the **workflow**
+env, not `default`. It appeared to work only because the spike declared
+`workflow = { features = ["workflow"] }` — which *includes* the default feature, so
+that env happened to contain the whole geo stack too.
+
+Two consequences:
+
+1. The spike's central race-safety claim was untested, because the mechanism it
+   documented was not the mechanism operating.
+2. The failure is **silent until it isn't**. Give the controller env
+   `no-default-feature = true` — the correct thing to do, so operators don't pay
+   ~2 GB of geo stack to run a scheduler — and every rule dies with
+   `ModuleNotFoundError: No module named 'geopandas'`. That is exactly what
+   happened here on the first real submission.
+
+**Recommendation for the migration:** the controller env must be
+`no-default-feature = true` (a scheduler has no business carrying GDAL), and every
+rule's shell prefix must read `pixi run --as-is -e default`. A test should assert
+that no rule in the production Snakefile contains a bare `pixi run --as-is` without
+an explicit `-e`.

--- a/workflow/probe/analyze_i1_i2.py
+++ b/workflow/probe/analyze_i1_i2.py
@@ -1,0 +1,59 @@
+"""Read the I1/I2 probe records and answer both questions numerically.
+
+I1 -- submission count: how many distinct SLURM job ids did N rule instances become?
+I2 -- import storm: were instances started together (storm risk) or serialised
+      (grouping bought nothing), and did geo-import wall-time degrade?
+
+Usage:
+    pixi run --as-is -e default python workflow/probe/analyze_i1_i2.py <arm_label>
+"""
+
+from __future__ import annotations
+
+import json
+import statistics
+import sys
+from pathlib import Path
+
+from gfv2_params.config import load_base_config
+
+
+def main() -> int:
+    label = sys.argv[1] if len(sys.argv) > 1 else "unlabelled"
+    base = load_base_config(None, fabric="tjc")
+    probe_dir = Path(base["data_root"]) / "tjc" / "_i1i2_probe"
+
+    records = []
+    for p in sorted(probe_dir.glob("import_*.json")):
+        records.append(json.loads(p.read_text()))
+    if not records:
+        print(f"[{label}] NO RECORDS in {probe_dir} -- the arm did not complete.")
+        return 1
+
+    job_ids = {r["slurm_job_id"] for r in records}
+    hosts = {r["host"] for r in records}
+    starts = sorted(r["t_start_epoch"] for r in records)
+    geo = [r["import_geo_s"] for r in records]
+    total = [r["import_total_s"] for r in records]
+
+    # Concurrency proxy: how many instances began within 2s of the earliest.
+    # A group that runs its members together shows a tight cluster here; one that
+    # serialises them shows a spread.
+    burst = sum(1 for s in starts if s - starts[0] <= 2.0)
+    span = starts[-1] - starts[0]
+
+    print(f"=== I1/I2 arm: {label} ===")
+    print(f"  instances completed   : {len(records)}")
+    print(f"  DISTINCT SLURM job ids: {len(job_ids)}   <-- I1: submissions")
+    print(f"  distinct hosts        : {len(hosts)}")
+    print(f"  start span            : {span:.1f}s")
+    print(f"  started within 2s     : {burst}/{len(records)}   <-- I2: concurrency")
+    print(f"  geo import   median   : {statistics.median(geo):.3f}s  "
+          f"max {max(geo):.3f}s")
+    print(f"  total import median   : {statistics.median(total):.3f}s  "
+          f"max {max(total):.3f}s")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/workflow/probe/i1_i2_group.smk
+++ b/workflow/probe/i1_i2_group.smk
@@ -1,0 +1,132 @@
+# I1 + I2 -- does `group:` collapse submissions, and does it re-create the import storm?
+#
+# WHY A SYNTHETIC PROBE RATHER THAN REAL PARAMS. The questions are about
+# SNAKEMAKE'S behaviour (how many sbatch submissions does N rule instances become,
+# and do grouped instances start together or serially), not about any fabric's
+# data. tjc has 1 batch and oregon has 2 -- far too few instances to see grouping
+# at all, and far too few to create a storm. So this probe generates N synthetic
+# instances that each do the ONE thing that matters for I2: import the real geo
+# stack and record how long that import took.
+#
+# I2's measurement comes from the same startup heartbeat the production scripts
+# print (scripts/derive_depstor_params.py:42-48), so the numbers are comparable
+# to a real run's.
+#
+# RUN IT (never on the login node -- these submit real SLURM jobs):
+#
+#   # A) ungrouped: how many submissions does N instances become?
+#   PROBE_N=16 pixi run -e workflow snakemake -s workflow/probe/i1_i2_group.smk \
+#       --profile workflow/probe/profile_nogroup
+#
+#   # B) grouped: same N, with --groups + --group-components
+#   PROBE_N=16 pixi run -e workflow snakemake -s workflow/probe/i1_i2_group.smk \
+#       --profile workflow/probe/profile_group
+#
+# then count actual submissions and read the import timings:
+#   sacct -X --starttime now-2hours --format=JobID,JobName%24,Elapsed,State
+#   cat $(pixi run data-root)/tjc/_i1i2_probe/*.json
+#
+# EXIT CRITERIA
+#   I1: (B)'s sacct job count is materially lower than (A)'s. If equal, `group:`
+#       does not collapse submissions and the 640-job projection stands.
+#   I2: grouped instances' import wall-times are NOT worse than ungrouped. If
+#       they degrade, or if concurrency within a group exceeds the %4 the arrays
+#       deliberately cap at, grouping re-creates the documented storm -- which
+#       does not slow the run, it hangs it (HPC_REFERENCE.md:40-47).
+
+import os
+from pathlib import Path
+
+configfile: "configs/base_config.yml"
+
+DATA_ROOT = config["data_root"]
+FABRIC = os.environ.get("PROBE_FABRIC", "tjc")
+N = int(os.environ.get("PROBE_N", "16"))
+OUT = f"{DATA_ROOT}/{FABRIC}/_i1i2_probe"
+
+INSTANCES = [f"{i:03d}" for i in range(N)]
+
+
+rule all:
+    input:
+        expand(f"{OUT}/import_{{i}}.json", i=INSTANCES),
+
+
+rule import_probe:
+    """Import the real geo stack and record how long it took.
+
+    Shells out via `pixi run --as-is` exactly as the production rules would, so
+    the import happens in the frozen default env -- the same env, and the same
+    shared-FS contention, that the %4 array cap exists to protect.
+    """
+    output:
+        f"{OUT}/import_{{i}}.json",
+    # NOTE: `group:` is NOT set here. It is applied per-arm from the profile via
+    # `--groups import_probe=importers`, which "overwrites any group definitions
+    # from the workflow" -- so one rule definition serves both arms and the two
+    # runs differ ONLY in the thing being tested. (A `**{...}` conditional inside
+    # a rule body is not valid Snakemake DSL; the rule block is not real Python.)
+    resources:
+        mem_mb=8000,
+        runtime=20,
+        cpus_per_task=2,
+    shell:
+        # `-e default` is LOAD-BEARING and must never be dropped. snakemake runs
+        # from the `workflow` env, which exports PIXI_ENVIRONMENT_NAME=workflow;
+        # a nested bare `pixi run --as-is` INHERITS that and resolves to the
+        # workflow env, not default. Measured: bare -> .pixi/envs/workflow,
+        # explicit -> .pixi/envs/default. Without -e default this probe dies with
+        # ModuleNotFoundError: No module named 'geopandas'.
+        "pixi run --as-is -e default python workflow/probe/import_timer.py {output} {wildcards.i}"
+
+
+# ============================ FINDINGS (2026-08-05) ============================
+#
+# Three runs of N=16 on tjc. Arm A was run twice -- the second time deliberately,
+# as a control, because arm B's numbers looked too good to be true.
+#
+#   run                              hosts  SLURM job ids  geo import median
+#   -------------------------------  -----  -------------  -----------------
+#   A  ungrouped        (first, cold)   4         16             13.592s
+#   B  --group-components=4 (warm)      2          4              0.190s
+#   A  ungrouped     (re-run, warm)     3         16              0.177s
+#   solo, one job alone on a node       1          1         1.27s / 1.61s
+#
+# ---- I1: ANSWERED, YES ----
+#
+# `group:` + `--group-components=N` collapses submissions exactly at the divisor:
+# 16 instances -> 4 SLURM job ids at N=4. This is structural and cache-independent
+# (arm A gave 16 job ids on BOTH runs, cold and warm).
+#
+# Extrapolated to the production shape (10 params x 64 batches + 10 merges = 650):
+#     --group-components=4  -> 163 submissions
+#     --group-components=8  ->  82
+#     --group-components=16 ->  41
+# So the spec's "~640 -> 40" projection is achievable, at N=16.
+#
+# ---- I2: PARTIALLY ANSWERED ----
+#
+# RULED OUT -- the specific mechanism the spec feared. Grouping does NOT start
+# its members simultaneously. Within every allocation the four instances began at
+# +0.0s / +3.2s / +6.3s / +9.1s -- serialised, one after another. So `group:`
+# cannot re-create the storm by firing N imports at once, because it does not
+# fire them at once.
+#
+# NO MEASURABLE IMPORT COST -- on a warm node. Grouped 0.190s vs ungrouped 0.177s
+# is a wash. Arm B's apparent 71x speedup over arm A's first run was PAGE CACHE,
+# not grouping: the arm A re-run, ungrouped, on warmed nodes, matched arm B
+# exactly. Do not cite that 71x as a benefit of grouping -- it is not one.
+#
+# STILL OPEN -- cold-cache behaviour under grouping. The only cold measurement
+# (13.592s median, 8-way concurrent, ungrouped, 4 hosts) has no grouped
+# counterpart, and one cannot be manufactured: clearing a compute node's page
+# cache needs root, and node assignment is not controllable from a batch script.
+# What the numbers DO establish is that import cost swings ~70x on cache state
+# alone -- far more than on any orchestration choice -- so the `%4` cap's real
+# protective value is about limiting CONCURRENT COLD imports specifically.
+#
+# CONSEQUENCE FOR THE MIGRATION. The residual risk the spec identifies is
+# unchanged and remains correct: snakemake's `jobs:` is a GLOBAL DAG-wide cap
+# with no per-rule form, whereas `%N` is per-array. A DAG mixing a 640-instance
+# zonal rule with cheap rules cannot throttle only the expensive one. Grouping
+# does not solve that; it reduces submission COUNT, not concurrency.

--- a/workflow/probe/i3_containment.smk
+++ b/workflow/probe/i3_containment.smk
@@ -1,0 +1,105 @@
+# I3 -- can two orchestrators share a data root?   ANSWERED 2026-08-05.
+#
+# ============================ FINDINGS ============================
+#
+# 1. THE SPEC'S STATED MECHANISM IS WRONG. It says "every `.batch` run bumps
+#    mtimes and makes downstream Snakemake targets stale". Measured on snakemake
+#    9.25.1, an mtime bump alone triggers NOTHING:
+#
+#       touch an input (content identical)  -> "Nothing to be done"
+#       change the input's CONTENT          -> "reason: Updated input files"
+#
+#    Snakemake 9 decides staleness from input CONTENT, not raw mtime, even though
+#    `mtime` is listed in the default --rerun-triggers set. So mtime churn from a
+#    concurrent .batch run is harmless; only a genuine content change is not.
+#
+# 2. THE SPEC'S PROPOSED VERIFICATION IS VACUOUS. It says: "Verify with a
+#    --dry-run after a deliberate `touch` of a shared VRT -- zero rules should
+#    trigger." Zero rules trigger after a touch WITH OR WITHOUT `ancient()`, so
+#    that test passes even with no containment whatsoever. It cannot distinguish
+#    a contained workflow from an uncontained one. Do not use it.
+#
+# 3. `ancient()` IS STILL THE RIGHT CONTAINMENT RULE -- verified against the case
+#    that actually matters. With a real content change to a shared input:
+#
+#       without ancient()  -> rule triggers, would rebuild under the other user
+#       with ancient()     -> "Nothing to be done", output preserved intact
+#
+#    So the rule stands, but for a narrower and more specific reason than the
+#    spec gives: it protects against another writer genuinely CHANGING a shared
+#    input, not against mtime noise.
+#
+# 4. THE HAZARD IS REAL AND CURRENT. Verified on disk: `carussel` owns
+#    gfv2_car/ and gfv2_car_conus/ under the same {data_root}, consuming the same
+#    shared/ and input/ trees that rmcd owns. The exposed non-fabric-keyed paths:
+#      weight_dir: {data_root}/shared/conus/weights   (zonal_params.yml:38)
+#      {data_root}/shared/conus/vrt/*.vrt             (6 VRTs, 7 config refs)
+#      {data_root}/input/**                           (13 distinct subtrees)
+#
+# ========================== RECOMMENDATION ==========================
+#
+# Keep the containment rule (ancient() on every shared/ + input/ path; every
+# rule's outputs scoped to fabric-keyed paths), but replace the verification.
+# A `touch` test proves nothing. Use instead a STATIC test over the production
+# Snakefile: assert that every input path resolving under {data_root}/shared or
+# {data_root}/input is wrapped in ancient(). That is checkable in CI, needs no
+# data root, and cannot pass vacuously -- unlike the runtime touch probe.
+#
+# ============================== METHOD ==============================
+#
+# The mechanism was established in an isolated lab directory, NOT against
+# production files -- proving `ancient()` requires CHANGING an input's content,
+# and no probe should be capable of that to a shared VRT another user depends on.
+# Reproduce:
+#
+#   mkdir -p /tmp/i3lab && cd /tmp/i3lab && echo original > shared_input.txt
+#   cat > Snakefile <<'EOF'
+#   rule all:
+#       input: "out.txt"
+#   rule make:
+#       input: ancient("shared_input.txt")   # drop ancient() for the control
+#       output: "out.txt"
+#       shell: "cat {input} > {output}"
+#   EOF
+#   pixi run -e workflow snakemake -d /tmp/i3lab -s /tmp/i3lab/Snakefile --cores 1
+#   echo modified > shared_input.txt
+#   pixi run -e workflow snakemake -d /tmp/i3lab -s /tmp/i3lab/Snakefile --dry-run
+#
+# The rule below is retained as a shape reference for a production Snakefile:
+# shared inputs wrapped, outputs confined to a fabric-keyed path. It is safe to
+# run (it writes only under {fabric}/_i3_probe/) but it no longer proves
+# anything on its own -- see finding 2.
+
+import os
+
+import yaml
+
+configfile: "configs/base_config.yml"
+
+DATA_ROOT = config["data_root"]
+FABRIC = os.environ.get("PROBE_FABRIC", "tjc")
+SCRATCH = f"{DATA_ROOT}/{FABRIC}/_i3_probe"
+
+SHARED_VRTS = [
+    f"{DATA_ROOT}/shared/conus/vrt/elevation.vrt",
+    f"{DATA_ROOT}/shared/conus/vrt/slope.vrt",
+]
+
+
+rule all:
+    input:
+        f"{SCRATCH}/contained.txt",
+
+
+rule consumes_shared_inputs:
+    input:
+        # ancient(): this workflow READS these and never owns them. Another user
+        # writes the same tree; without this, a content change on their side marks
+        # our targets stale and we would rebuild a shared artifact under them.
+        vrts=[ancient(v) for v in SHARED_VRTS],
+    output:
+        # Fabric-keyed. Never shared/, never input/.
+        f"{SCRATCH}/contained.txt",
+    shell:
+        "mkdir -p $(dirname {output}) && "
+        "echo 'i3 probe: consumed shared inputs without claiming ownership' > {output}"

--- a/workflow/probe/i4_partial_failure.smk
+++ b/workflow/probe/i4_partial_failure.smk
@@ -1,0 +1,112 @@
+# I4 -- how does the DAG behave when one target is unbuildable?
+#
+# WHY IT MATTERS. Two production entries point at input directories that do not
+# exist on disk: zonal_params.yml's `lulc_nlcd` ({data_root}/input/lulc_veg/nlcd/)
+# and `lulc_foresce` ({data_root}/input/lulc_veg/foresce/). The 2026-05-29 CONUS
+# run shows what bash does with that: zonal_param n=640, 512 COMPLETED, 128 FAILED
+# -- exactly 2 params x 64 batches -- and the other 8 params merged normally. The
+# wrapper loop tolerates a failing param because each param is its own submission.
+#
+# A `rule all` built from `{p["name"]: p for p in cfg["params"]}` does NOT: it
+# demands every target and aborts the whole DAG. The spike never hit this because
+# it used a purpose-built 3-param config that excluded both broken entries.
+#
+# More generally every real CONUS run shows 0.5-20% OOM/TIMEOUT, and the spike saw
+# zero failures, so `--keep-going` and `retries:` semantics are wholly untested.
+#
+# THE THREE CANDIDATE ANSWERS (the spec asks which):
+#   (a) an `enabled: false` key per config entry, filtered when building `rule all`
+#   (b) a profile-level explicit target list
+#   (c) `--keep-going` as standard operating procedure
+#
+# WHAT THIS PROBE MEASURES. Three synthetic targets, one of which always fails,
+# under each policy -- so the difference between them is observable rather than
+# argued:
+#
+#   PROBE_POLICY=none      pixi run -e workflow snakemake -s .../i4_partial_failure.smk --cores 1
+#   PROBE_POLICY=none      ... --cores 1 --keep-going          # (c)
+#   PROBE_POLICY=enabled   ... --cores 1                       # (a)
+#
+# EXIT CRITERION: for each policy, how many of the two GOOD targets exist
+# afterwards? Bash's behaviour today is 2 of 2. Any policy that yields fewer is a
+# regression in operator experience, not just a semantic difference.
+#
+# Runs locally (--cores 1); no SLURM needed, since the question is DAG semantics
+# rather than scheduling.
+
+import os
+
+configfile: "configs/base_config.yml"
+
+DATA_ROOT = config["data_root"]
+FABRIC = os.environ.get("PROBE_FABRIC", "tjc")
+OUT = f"{DATA_ROOT}/{FABRIC}/_i4_probe"
+POLICY = os.environ.get("PROBE_POLICY", "none")
+
+# Mirrors the real shape: a list of entries, one of which cannot be built because
+# its declared input does not exist. `enabled` is candidate (a).
+ENTRIES = [
+    {"name": "good_one", "enabled": True, "buildable": True},
+    {"name": "broken", "enabled": POLICY != "enabled", "buildable": False},
+    {"name": "good_two", "enabled": True, "buildable": True},
+]
+
+BUILDABLE = {e["name"]: e["buildable"] for e in ENTRIES}
+TARGETS = [e["name"] for e in ENTRIES if e["enabled"]]
+
+
+rule all:
+    input:
+        expand(f"{OUT}/{{name}}.txt", name=TARGETS),
+
+
+rule build:
+    output:
+        f"{OUT}/{{name}}.txt",
+    params:
+        # An unbuildable entry fails the way the real ones do: its input is simply
+        # not there, so the underlying command exits non-zero.
+        buildable=lambda w: BUILDABLE[w.name],
+    shell:
+        "mkdir -p $(dirname {output}) && "
+        "if [ '{params.buildable}' = 'True' ]; then echo built > {output}; "
+        "else echo 'input directory does not exist' >&2; exit 1; fi"
+
+
+# ============================ FINDINGS (2026-08-05) ============================
+#
+#   policy                                exit   GOOD targets built
+#   ------------------------------------  ----   ------------------
+#   baseline: all targets, no keep-going     1          0 of 2
+#   (c) --keep-going                         1          2 of 2
+#   (a) enabled:false filters rule all       0          2 of 2
+#
+# 1. THE DEFAULT IS A REGRESSION AGAINST BASH. Today the wrapper loop builds 8 of
+#    10 params when lulc_nlcd and lulc_foresce fail. Snakemake's default builds
+#    ZERO -- one unbuildable target aborts work that has nothing to do with it.
+#    Any migration that does not address this makes a CONUS run strictly worse,
+#    because every run has 0.5-20% OOM/TIMEOUT.
+#
+# 2. RECOMMENDATION: (c) `--keep-going` as standard, NOT (a) alone.
+#    Both recover the good targets, but they differ on the thing that matters:
+#      * (c) exits 1 -- the failure stays VISIBLE, matching the convention
+#        merge_and_fill_params.py already uses ("%d of %d param(s) FAILED ...",
+#        return 1). Build everything buildable, then report loudly.
+#      * (a) exits 0. An entry marked `enabled: false` is removed from the target
+#        set, so it never surfaces as a problem again. That is precisely how
+#        lulc_nlcd/lulc_foresce would stay quietly broken forever -- the silent
+#        skip this repo keeps having to fix (cf. CLAUDE.md on the endorheic floor,
+#        and copy_constants shipping unchained in PR #203).
+#
+# 3. (a) IS STILL USEFUL, BUT ONLY AS A SECOND MECHANISM, never the only one:
+#    `enabled: false` is the right way to express "this entry is KNOWN unbuildable
+#    and that is a deliberate, documented decision" -- as opposed to "this entry
+#    failed today". Pair it with --keep-going so unexpected failures still show.
+#    If it is used, an enabled:false entry must be reported at INFO on every run,
+#    or it becomes invisible.
+#
+# 4. STILL UNTESTED: `retries:`. The spike saw zero failures, so retry semantics
+#    against a real OOM (as opposed to a deterministic missing-input failure) are
+#    unmeasured. An OOM that succeeds on retry and one that never will are
+#    indistinguishable to the DAG, and a retry loop on a 268-CPU-h rule is
+#    expensive to get wrong.

--- a/workflow/probe/import_timer.py
+++ b/workflow/probe/import_timer.py
@@ -1,0 +1,72 @@
+"""Time the geo-library import chain and record who/where/when. I2's instrument.
+
+Mirrors the startup heartbeat in scripts/derive_depstor_params.py:42-48 -- the same
+imports, in the same order, in the same frozen default env -- so the wall-times are
+comparable to a real array task's.
+
+I2 asks whether packing rule instances into one SLURM allocation via `group:`
+re-creates the import storm the `%4` array cap exists to prevent
+(HPC_REFERENCE.md:40-47: "concurrent geo-library imports (rasterio / GDAL / PROJ /
+pyogrio) can deadlock under shared-FS metadata contention when many tasks start
+simultaneously"). The signal is import wall-time, plus the start timestamps: if
+instances in a group all start within a second of each other, the group is running
+them concurrently and the cap has been lost.
+
+Deliberately writes a machine-readable record rather than logging, so the two arms
+of the experiment can be diffed rather than eyeballed.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import sys
+import time
+from pathlib import Path
+
+
+def main() -> int:
+    out_path, instance = sys.argv[1], sys.argv[2]
+    # Create our own parent. Doing it in the shell prefix meant 16 concurrent
+    # `mkdir -p` calls against one directory on a shared FS, which is how arm A's
+    # first attempt failed. exist_ok makes this safe under any concurrency.
+    Path(out_path).parent.mkdir(parents=True, exist_ok=True)
+
+    t_start = time.time()
+    # The real chain, in the production order. Not a stand-in: the whole question
+    # is whether THESE imports contend.
+    import numpy  # noqa: F401
+    import pandas  # noqa: F401
+    t_after_light = time.time()
+
+    import geopandas  # noqa: F401
+    import pyogrio  # noqa: F401
+    import rasterio  # noqa: F401
+    from osgeo import gdal  # noqa: F401
+    t_end = time.time()
+
+    record = {
+        "instance": instance,
+        "host": socket.gethostname(),
+        "pid": os.getpid(),
+        "slurm_job_id": os.environ.get("SLURM_JOB_ID"),
+        "slurm_array_task_id": os.environ.get("SLURM_ARRAY_TASK_ID"),
+        # Absolute start, so concurrency within a group is visible: instances that
+        # begin within ~1s of each other were started together, not serialised.
+        "t_start_epoch": t_start,
+        "import_light_s": round(t_after_light - t_start, 3),
+        "import_geo_s": round(t_end - t_after_light, 3),
+        "import_total_s": round(t_end - t_start, 3),
+    }
+
+    with open(out_path, "w") as fh:
+        json.dump(record, fh, indent=2)
+    print(f"[import_timer] {instance} total={record['import_total_s']}s "
+          f"geo={record['import_geo_s']}s host={record['host']} "
+          f"job={record['slurm_job_id']}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/workflow/probe/profile_group/config.yaml
+++ b/workflow/probe/profile_group/config.yaml
@@ -1,0 +1,16 @@
+# I1/I2 arm B: grouping. --group-components sets how many instances of a group
+# are packed into ONE submission; 4 mirrors the %4 array cap the production
+# wrappers use, so arm B is the closest grouped analogue of today's behaviour.
+executor: slurm
+jobs: 8
+printshellcmds: True
+latency-wait: 60
+group-components:
+  - importers=4
+default-resources:
+  slurm_account: impd
+  slurm_partition: cpu
+  mem_mb: 8000
+  runtime: 20
+groups:
+  - import_probe=importers

--- a/workflow/probe/profile_nogroup/config.yaml
+++ b/workflow/probe/profile_nogroup/config.yaml
@@ -1,0 +1,10 @@
+# I1/I2 arm A: no grouping. Baseline submission count.
+executor: slurm
+jobs: 8
+printshellcmds: True
+latency-wait: 60
+default-resources:
+  slurm_account: impd
+  slurm_partition: cpu
+  mem_mb: 8000
+  runtime: 20


### PR DESCRIPTION
Runs the I1–I5 investigation phase from `docs/superpowers/specs/2026-08-04-snakemake-migration-design.md` — the five questions the spec says must be answered *before* migration dates mean anything. Refs #141.

All five are answered. **Two corrected assumptions in the spec, and one finding falls outside all five and falsifies a claimed property of the #142 spike.**

## Results

| | Verdict |
| --- | --- |
| **I1** | **Yes.** `--group-components=N` collapses submissions exactly at the divisor: 16 rule instances → **4** SLURM job ids at N=4. Structural — confirmed on both a cold and a warm run. Production (10 params × 64 batches + 10 merges = 650) → **41** at N=16, so the spec's "~640 → 40" is achievable. |
| **I2** | **Partial.** Feared mechanism ruled out; magnitude question still open. See below. |
| **I3** | **Answered — and the spec's premise and its test are both wrong.** |
| **I4** | **Answered.** Snakemake's default builds **0 of 2** good targets when one is unbuildable; bash builds 8 of 10 today. |
| **I5** | **Answered.** `slurm_batch/data_root_tests.batch` + the record-by-job-id convention. |

## I2 — I nearly reported a spectacular false result

Arm B (grouped) showed **0.190s** geo imports against arm A's first run at **13.592s**. A 71× win, and completely false.

Arm B landed on nodes arm A had already warmed. Re-running **arm A ungrouped on warm nodes gave 0.177s** — indistinguishable from grouped.

| run | hosts | job ids | geo import median |
| --- | --- | --- | --- |
| A ungrouped (first, cold) | 4 | 16 | 13.592s |
| B grouped (warm) | 2 | 4 | 0.190s |
| **A ungrouped (re-run, warm)** | 3 | 16 | **0.177s** |
| solo, alone on a node | 1 | 1 | 1.27s / 1.61s |

Import cost swings **~70× on page-cache state alone** — far more than on any orchestration choice. The trap is written into the findings so nobody re-derives the wrong number.

What *is* established: grouped members start **serialised** (+0.0 / +3.2 / +6.3 / +9.1s within each allocation), so `group:` cannot fire N simultaneous imports — the specific storm mechanism the spec feared. Cold-cache-under-grouping stays **open** and is not manufacturable: clearing a compute node's page cache needs root, and node assignment isn't controllable from a batch script.

## I3 — the spec's verification would have passed with no containment at all

The spec says *"every `.batch` run bumps mtimes and makes downstream Snakemake targets stale."* Measured false — snakemake 9 decides staleness from input **content**, despite `mtime` being in the default `--rerun-triggers` set:

| change to a shared input | rerun? |
| --- | --- |
| `touch` (mtime only) | **no** — with *or* without `ancient()` |
| content change, no `ancient()` | yes |
| content change, with `ancient()` | **no**, output preserved |

So the proposed check — *"`--dry-run` after a deliberate `touch` of a shared VRT, zero rules should trigger"* — **passes whether or not the workflow is contained**. It cannot distinguish the two cases. `ancient()` is still the right rule, now verified against the case that actually matters; the check should be a **static CI test** asserting every `shared/`/`input/` path is wrapped — no data root, cannot pass vacuously.

The hazard is confirmed live: `carussel` owns `gfv2_car/` and `gfv2_car_conus/` on the same `{data_root}`, consuming the same `shared/` and `input/` trees.

## I4 — the default is a regression against bash

| policy | exit | good targets built |
| --- | --- | --- |
| baseline (all targets demanded) | 1 | **0 of 2** |
| `--keep-going` | 1 | **2 of 2** |
| `enabled: false` | 0 | 2 of 2 |

Every CONUS run has 0.5–20% OOM/TIMEOUT, so this is not hypothetical. **Recommend `--keep-going` as standard** — it recovers the good targets *and* still exits 1, matching `merge_and_fill_params.py`'s existing "N of M FAILED, return 1" convention. `enabled: false` exits **0**, which is how `lulc_nlcd`/`lulc_foresce` would stay quietly broken forever; useful only as a documented second mechanism, never alone.

## Outside the five — a nested `pixi run` inherits its parent's env

The most consequential finding, and it falsifies a claimed property of PR #142.

Snakemake must run from the `workflow` env, which exports `PIXI_ENVIRONMENT_NAME=workflow`. Every rule's shell command inherits it:

| invocation | resolves to |
| --- | --- |
| `pixi run --as-is python` from a clean shell | `.pixi/envs/default` |
| `pixi run --as-is python` inside `pixi run -e workflow` | `.pixi/envs/`**`workflow`** |
| `pixi run --as-is -e default python` | `.pixi/envs/default` |

`workflow/spike/Snakefile` claims its rules *"shell out via `pixi run --as-is` so all geo work runs in the frozen default env (race-safe; CLAUDE.md constraint)"*. **Never true as written** — the spike's rules ran in the *workflow* env. It only appeared to work because the spike declared `workflow = { features = ["workflow"] }`, which *includes* the default feature and therefore the whole geo stack.

Give the controller env `no-default-feature = true` — correct, so a scheduler doesn't carry GDAL — and every rule dies with `ModuleNotFoundError: No module named 'geopandas'`. That is exactly what happened on the first real submission here.

**Every rule must pin `-e default`**, and a test should assert no rule carries a bare `pixi run --as-is`.

## What this does NOT settle

The two blockers that actually gate a schedule are untouched:

- **The validation baselines still do not exist.** `gfv2_dev` has no `params/` directory, so every "gfv2_dev re-run matches" gate still has no left-hand side.
- **Baseline cost is still unbudgeted**: ~45.5 h wall / ~340 CPU-h per depstor cascade, two passes per A/B round.
- `retries:` semantics against a real OOM remain unmeasured — the probes' failures were deterministic missing-input ones.

**Recommendation: still do not set dates.** I1 moved from unknown to favourable, but nothing here changes the cost side.

## Contents

- `pyproject.toml` / `pixi.lock` — isolated `workflow` env (snakemake 9.25.1 + SLURM executor, bioconda), own solve-group, `no-default-feature = true`
- `workflow/probe/` — the probes, each carrying its findings inline
- `slurm_batch/data_root_tests.batch` — I5's deliverable
- `.gitignore` — `.snakemake/`
- the spec — findings block at the head of the investigation phase

## Testing

Suite **1027 passed, 4 skipped** — unchanged, so the env addition perturbs nothing. Default env still resolves the geo stack; the workflow env correctly has none. All probe artifacts cleaned from the data root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
