### PR TITLE
fix(ssflux): intensive log-space aggregation + reduce-step normalisation (closes #175)

### DIFF
--- a/.amazonq/rules/workflow.md
+++ b/.amazonq/rules/workflow.md
@@ -85,6 +85,13 @@ Configuration (CFG-*), Code Quality (CODE-*), Hygiene (HYG-*), Architecture (ARC
     was read from the YAML) + `tests/test_submit_wrapper_param_lists.py`
   - PR #203 — `prms:` metadata on all 19 declared entries, two guards, generated
     index, `hru_slope` emitted in rise/run, `op_flow_thres` into `merged/`
+- #175 (ssflux normalisation) — the 7 `ssflux` PRMS params were spatially
+  degenerate (~90% pinned at range minimum) because permeability was aggregated
+  as an EXTENSIVE variable. Fixed on `fix/ssflux-normalisation-175`: intensive
+  log10 area-weighted-mean aggregation + a new fabric-wide reduce step for
+  normalisation (map/reduce split via `MERGE_REDUCERS`). See
+  `docs/superpowers/specs/2026-08-10-ssflux-normalisation-design.md` and
+  CLAUDE.md's `k_perm` gotcha for the architectural detail.
 
 ### Up next (priority order)
 - CFG-1 — remove commented opt-in keys from fabric profiles in base_config.yml
@@ -113,6 +120,11 @@ Configuration (CFG-*), Code Quality (CODE-*), Hygiene (HYG-*), Architecture (ARC
   `scripts/derive_depstor_params.py`'s startup-heartbeat import block and 14 yamllint
   `braces` errors in `configs/zonal/zonal_params.yml`'s `flux_params:` block. Check
   new findings against `main` (via `git stash`) before attributing them to your diff.
+- **Run the `--all-files` sweep under `srun`, not on the login node.** The
+  `prettier` hook needs 16-64 GB to lint 17 small YAML files (a broken-tool
+  artifact, not file size) and gets SIGKILLed on the login node / `oom_kill`'d
+  below 64G: `srun -p cpu -A impd --time=00:20:00 --ntasks=1 --cpus-per-task=4
+  --mem=64G pixi run -e dev pre-commit run --all-files`.
 - Do not run pytest on the HPC login node
 - `sbatch slurm_batch/ab_drains_to_dprst.batch [VPU] [FABRIC]` — the #147 FDR
   A/B (production vs fill vs breach) on one VPU; defaults VPU 16 / gfv2_dev.

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,16 @@
+# Reference PDFs in docs/ are managed by git-lfs. These are source documents
+# (USGS reports, journal articles) kept alongside their markdown companions so
+# the historical and current workflow stay documented together; they are large
+# and never diffed, which is exactly the LFS case.
+#
+# git-lfs is NOT assumed on PATH -- HPC nodes have no system git-lfs and no
+# sudo. It ships in the `dev` pixi feature. After cloning:
+#     pixi shell -e dev && git lfs install && git lfs pull
+# Without that you will see small pointer files instead of real PDFs.
+#
+# NOTE: PDFs committed before this file was added (DepStor_workflow.pdf,
+# "Snow Depletion Curves.pdf", hyp.13735.pdf, tm6b9.pdf) remain ordinary git
+# objects in history. Converting them would require `git lfs migrate` to rewrite
+# already-pushed history and force-push, which would break every existing clone
+# -- deliberately not done. New PDFs go to LFS from here on.
+*.pdf filter=lfs diff=lfs merge=lfs -text

--- a/.gitattributes
+++ b/.gitattributes
@@ -4,8 +4,11 @@
 # and never diffed, which is exactly the LFS case.
 #
 # git-lfs is NOT assumed on PATH -- HPC nodes have no system git-lfs and no
-# sudo. It ships in the `dev` pixi feature. After cloning:
-#     pixi shell -e dev && git lfs install && git lfs pull
+# sudo. Install it per user (git's LFS filters run OUTSIDE the pixi env, so a
+# global install beats `pixi shell -e dev`, though the `dev` feature has it too):
+#     pixi global install git-lfs   # -> ~/.pixi/bin, already on PATH
+#     git lfs install               # once per clone
+#     git lfs pull                  # fetch PDFs into an existing clone
 # Without that you will see small pointer files instead of real PDFs.
 #
 # NOTE: PDFs committed before this file was added (DepStor_workflow.pdf,

--- a/.gitignore
+++ b/.gitignore
@@ -203,3 +203,8 @@ docs/presentations/*.html
 docs/presentations/*.pdf
 docs/presentations/*.pptx
 .launch/
+
+# Subagent-driven-development scratch (ledger, briefs, review packages).
+# Per-plan workspaces under .superpowers/sdd/<plan>/ — never part of the record;
+# git history is. Safe to delete.
+.superpowers/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -302,6 +302,22 @@ These are hard-won; violating them silently corrupts outputs.
   any other fabric use `threshold_mode: percentile` in
   `configs/depstor/depstor_rasters.yml` with `twi_raster` pointing at
   `twi_hydrodem.vrt` and run the `twi_reference` shared-raster step first.
+- **`k_perm` is INTENSIVE — aggregate it as an area-weighted mean, never an
+  area-prorated sum.** `ssflux.py` originally used gdptools' *extensive* form
+  (`Σ Vᵢ·aᵢ/Aᵢ`, dividing by the SOURCE polygon area, the column gdptools labels
+  "for extensive variables"), which is correct for population or volume but not
+  for a property of the medium. Per-HRU weight sums spanned 3.6e13× instead of
+  1.0, inflating spread from a physical 5.6 to an artifactual 15.4 orders of
+  magnitude and pinning ~90% of HRUs at the range minimum (#175). Use
+  `normalized_area_weight` (gdptools' `wght`) and renormalise by its per-HRU sum
+  — that also corrects the 1,828 coverage-gap and 98 overlapping-source HRUs.
+  Related traps: `k_perm == 0` is a **no-data flag**, not a measurement, and must
+  be excluded rather than floored to `k_perm_min` (-16.48 is simultaneously the
+  genuine least-permeable lithology class, 26,441 polygons); `k_perm` has only
+  **8 distinct values**, so ~5% of HRUs sitting at the range minimum is real
+  geology, not a defect. Normalisation is a **reduce step** — never per batch;
+  and never fix the per-batch scope before fixing the log-space aggregation, or
+  degeneracy goes from ~90% to 97-100%.
 
 ## Working in this repo
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,21 @@ from a shell where `~/.pixi/bin` is on `PATH`.
 
 Lint/format runs via pre-commit: `pixi run -e dev pre-commit run --all-files`.
 
+**Run the `--all-files` sweep under `srun`, not on the login node** — the
+`prettier` hook (mirrors-prettier `v4.0.0-alpha.8` on node v24.1.0) needs
+between 16 GB and 64 GB to lint 17 small YAML files. On the login node it is
+SIGKILLed (`exit code -9`) and at `--mem=16G` SLURM reports `oom_kill`; at 64 GB
+it passes. The memory demand is a broken-tool artifact, not file size — the
+largest tracked YAML is 27 KB, and any single file passes in isolation.
+
+```bash
+srun -p cpu -A impd --time=00:20:00 --ntasks=1 --cpus-per-task=4 --mem=64G \
+  pixi run -e dev pre-commit run --all-files
+```
+
+Targeted runs (`--files a b c`) are fine on the login node — prettier is scoped
+to `\.(yml|yaml)$`, so it no-ops unless you touched YAML.
+
 Local docs preview: `pixi run -e docs docs-serve` (live-reload on
 `localhost:8000`); `pixi run -e docs docs-build` renders the static site
 to `./site/`. Configuration: [`mkdocs.yml`](mkdocs.yml).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,11 +45,23 @@ largest tracked YAML is 27 KB, and any single file passes in isolation.
 
 ```bash
 srun -p cpu -A impd --time=00:20:00 --ntasks=1 --cpus-per-task=4 --mem=64G \
-  pixi run -e dev pre-commit run --all-files
+  pixi run -e dev --as-is pre-commit run --all-files
 ```
 
 Targeted runs (`--files a b c`) are fine on the login node — prettier is scoped
 to `\.(yml|yaml)$`, so it no-ops unless you touched YAML.
+
+**Anything launched through `srun`/`sbatch` takes `--as-is`, tests included** —
+the same rule as the SLURM batches above, for the same reason: without it each
+task re-checks the lock and can mutate `.pixi/envs/.../conda-meta`, which
+concurrent jobs then race on. It is also markedly faster, since the lock check
+is skipped — a full `pytest tests/` run measured 56.6 s with `--as-is` versus
+174.2 s without.
+
+```bash
+srun -p cpu -A impd --time=00:30:00 --ntasks=1 --cpus-per-task=4 --mem=32G \
+  pixi run -e dev --as-is pytest tests/ -q
+```
 
 Local docs preview: `pixi run -e docs docs-serve` (live-reload on
 `localhost:8000`); `pixi run -e docs docs-build` renders the static site

--- a/README.md
+++ b/README.md
@@ -17,7 +17,23 @@ pixi run -e dev pytest tests/test_wbt.py -v           # example: run a small tes
 ```
 
 Install pixi once per user (see https://pixi.sh/latest/installation/) and ensure
-`~/.pixi/bin` is on your `PATH`. For the full HPC workflow (downloads → shared
+`~/.pixi/bin` is on your `PATH`.
+
+The reference PDFs under [`docs/`](docs/) are stored with
+[git-lfs](https://git-lfs.com). Install it once per user so plain `git` can
+resolve them — without it you get small pointer files instead of real PDFs:
+
+```bash
+pixi global install git-lfs   # lands in ~/.pixi/bin, already on your PATH
+git lfs install               # once per clone
+git lfs pull                  # fetch the PDFs for an existing clone
+```
+
+(`git-lfs` is also in the `dev` feature, so `pixi shell -e dev` works too — but
+the global install is preferable because git's LFS filters run outside the pixi
+environment.)
+
+For the full HPC workflow (downloads → shared
 rasters → fabric → zonal + depstor params), see
 [`slurm_batch/RUNME.md`](slurm_batch/RUNME.md) (runbook) and
 [`slurm_batch/HPC_REFERENCE.md`](slurm_batch/HPC_REFERENCE.md) (per-stage detail).

--- a/configs/zonal/zonal_params.yml
+++ b/configs/zonal/zonal_params.yml
@@ -471,13 +471,21 @@ params:
     #                             # above which the mismatch is WARNED about
     #                             # (not raised); lower it to surface a smaller
     #                             # coverage-gap cluster sooner.
-    #   hard_bad_fraction: 0.35  # tail fraction above which the mismatch is
+    #   band_lo: 0.5              # plausible per-HRU weight-sum band used by
+    #   band_hi: 2.0               # the magnitude raise below (default
+    #                             # [0.5, 2.0]). Real CONUS data measures
+    #                             # 0.111% of HRUs outside this band vs. 85.4%
+    #                             # under the #175 extensive-form bug.
+    #   magnitude_bad_fraction: 0.05  # fraction of HRUs outside [band_lo,
+    #                             # band_hi] above which the mismatch is
     #                             # RAISED even with a near-1.0 median (catches
     #                             # a partial extensive-form regression the
-    #                             # median alone can miss). Only raise this
-    #                             # after confirming a specific batch's larger
-    #                             # tail is a legitimate clustered gap -- never
-    #                             # to silence a real regression.
+    #                             # median alone can miss -- keyed on
+    #                             # magnitude, not a bare tail count). Only
+    #                             # raise this after confirming a specific
+    #                             # batch's larger tail is a legitimate
+    #                             # clustered gap -- never to silence a real
+    #                             # regression.
     source_shapefile: "{data_root}/input/soils_litho/Lithology_exp_Konly_Project.shp"
     merged_slope_file: "{data_root}/{fabric}/params/merged/nhm_slope_params.csv"
     merged_file: nhm_ssflux_params.csv

--- a/configs/zonal/zonal_params.yml
+++ b/configs/zonal/zonal_params.yml
@@ -461,13 +461,17 @@ params:
     source_shapefile: "{data_root}/input/soils_litho/Lithology_exp_Konly_Project.shp"
     merged_slope_file: "{data_root}/{fabric}/params/merged/nhm_slope_params.csv"
     merged_file: nhm_ssflux_params.csv
-    # Observed on-disk header (oregon + gfv2) is k_perm_log_wtd, fflux, vpu,
-    # mean_slope_fraction, hru_area, soil2gw_max, ssr2gw_rate, fastcoef_lin,
-    # slowcoef_lin, gwflow_coef, dprst_seep_rate_open, dprst_flow_coef. The
-    # first five are litho/slope/vpu INPUTS to the flux normalisation below,
-    # not PRMS parameters themselves -- only the 7 derived flux params are
-    # declared fillable. fflux and vpu are measured facts (prms.provenance),
-    # deliberately NOT interpolable and so NOT in fill_columns.
+    # Expected on-disk header (verified against run_ssflux_batch/run_ssflux_reduce;
+    # no fabric has been rebuilt against this yet, so this is the header the
+    # NEXT rebuild will produce, not an observed one) is <id_feature>,
+    # k_perm_log_wtd, fflux, mean_slope_fraction, hru_area, vpu, soil2gw_max,
+    # ssr2gw_rate, fastcoef_lin, slowcoef_lin, gwflow_coef,
+    # dprst_seep_rate_open, dprst_flow_coef. The five columns between
+    # <id_feature> and the 7 derived flux params are litho/slope/vpu INPUTS to
+    # the flux normalisation below, not PRMS parameters themselves -- only the
+    # 7 derived flux params are declared fillable. fflux and vpu are measured
+    # facts (prms.provenance), deliberately NOT interpolable and so NOT in
+    # fill_columns.
     fill_columns:
       - soil2gw_max
       - ssr2gw_rate
@@ -531,11 +535,13 @@ params:
           area-weighted mean of log10 permeability (geometric mean, gdptools
           INTENSIVE form) -- flux-normalisation input, replaces the pre-#175
           k_perm_wtd which used the EXTENSIVE form and was not an average at all
-        fflux:
-          fraction of HRU area underlain by valid (non-no-data) lithology; -1
-          where there is no overlap at all. Matches the reference
-          implementation's fflux attribute (Viger 2014, doi:10.5066/F7CN71XR).
-          A measured coverage fact, deliberately NOT in fill_columns
+        fflux: fraction of HRU area underlain by valid (non-no-data) lithology.
+          Normally 0.0-1.0; -1 where there is no overlap at all (98 HRUs with
+          overlapping source lithology polygons can push it above 1.0, up to
+          ~2.0 -- a real diagnostic of the source layer, deliberately left
+          unclipped rather than hidden). Matches the reference implementation's
+          fflux attribute (Viger 2014, doi:10.5066/F7CN71XR). A measured
+          coverage fact, deliberately NOT in fill_columns
         vpu: "per-HRU VPU, carried so the reducer can honour norm_scope: vpu"
         mean_slope_fraction: tan(radians(slope mean)), flux-normalisation input
         hru_area: fabric geometry.area in m2 -- NOT PRMS hru_area, which is acres

--- a/configs/zonal/zonal_params.yml
+++ b/configs/zonal/zonal_params.yml
@@ -458,6 +458,26 @@ params:
     # `vpu` reproduces TM 6-B9's per-GF-region wording; it needs the per-HRU
     # `vpu` attribute and introduces discontinuities at region boundaries.
     norm_scope: fabric
+    # Weight-coverage validation thresholds (validate_weight_coverage in
+    # zonal_runners/ssflux_math.py), all optional -- absent means the code's
+    # own default is used exactly as before this was exposed. Uncomment to
+    # override for one fabric's run without a code change:
+    #   median_tol: 0.1          # how far median(sum(wght)) may stray from 1.0
+    #                             # before raising; this is the primary signal
+    #                             # of the #175 extensive-form regression, so
+    #                             # only loosen it for a source layer with a
+    #                             # deliberately different expected coverage.
+    #   max_bad_fraction: 0.05   # tail fraction of HRUs outside 1.0 +/- tol
+    #                             # above which the mismatch is WARNED about
+    #                             # (not raised); lower it to surface a smaller
+    #                             # coverage-gap cluster sooner.
+    #   hard_bad_fraction: 0.35  # tail fraction above which the mismatch is
+    #                             # RAISED even with a near-1.0 median (catches
+    #                             # a partial extensive-form regression the
+    #                             # median alone can miss). Only raise this
+    #                             # after confirming a specific batch's larger
+    #                             # tail is a legitimate clustered gap -- never
+    #                             # to silence a real regression.
     source_shapefile: "{data_root}/input/soils_litho/Lithology_exp_Konly_Project.shp"
     merged_slope_file: "{data_root}/{fabric}/params/merged/nhm_slope_params.csv"
     merged_file: nhm_ssflux_params.csv

--- a/configs/zonal/zonal_params.yml
+++ b/configs/zonal/zonal_params.yml
@@ -528,6 +528,18 @@ params:
       hru_area:
         source: geometry
         scale: 1.0
+    # `vpu` is written verbatim per batch ("01".."09", but also "03N"/"03S"/
+    # "03W"/"10L"/"10U"), and pandas infers dtype PER FILE at merge time: a
+    # batch containing only numeric-looking labels reads `vpu` as int64
+    # (silently stripping the leading zero, "01" -> 1) while a batch with a
+    # mixed-alphanumeric label reads it as str. Measured on a real gfv2_dev
+    # rebuild: 12/20 ssflux batches went int64, 8/20 str, producing 28 distinct
+    # vpu labels in the merged product against the fabric's 21 -- 8 of them
+    # (1,2,4,5,6,7,8,9) not present in the fabric at all. `read_dtypes` pins
+    # the dtype at read time so every batch is parsed identically; see
+    # run_merge in zonal_runners/merge.py.
+    read_dtypes:
+      vpu: str
     # `processes:` is PER-COLUMN, and ssflux is why. This one entry spans
     # PRMSSoilzone, PRMSGroundwater and PRMSRunoff across different columns, so an
     # entry-level `processes: [PRMSRunoff]` would report 5 non-runoff parameters as

--- a/configs/zonal/zonal_params.yml
+++ b/configs/zonal/zonal_params.yml
@@ -451,14 +451,23 @@ params:
   - name: ssflux
     script: ssflux
     depends_on: build_weights
+    # Normalisation runs once over the whole merged frame, not per batch --
+    # min/max over an arbitrary SLURM chunk made identical HRUs disagree (#175).
+    reducer: ssflux
+    # `fabric` (one min/max over every HRU) is batch-invariant by construction.
+    # `vpu` reproduces TM 6-B9's per-GF-region wording; it needs the per-HRU
+    # `vpu` attribute and introduces discontinuities at region boundaries.
+    norm_scope: fabric
     source_shapefile: "{data_root}/input/soils_litho/Lithology_exp_Konly_Project.shp"
     merged_slope_file: "{data_root}/{fabric}/params/merged/nhm_slope_params.csv"
     merged_file: nhm_ssflux_params.csv
-    # Observed on-disk header (oregon + gfv2) is k_perm_wtd, mean_slope_fraction,
-    # hru_area, soil2gw_max, ssr2gw_rate, fastcoef_lin, slowcoef_lin, gwflow_coef,
-    # dprst_seep_rate_open, dprst_flow_coef. The first three are litho/slope
-    # INPUTS to the flux normalisation below, not PRMS parameters themselves --
-    # only the 7 derived flux params are declared fillable.
+    # Observed on-disk header (oregon + gfv2) is k_perm_log_wtd, fflux, vpu,
+    # mean_slope_fraction, hru_area, soil2gw_max, ssr2gw_rate, fastcoef_lin,
+    # slowcoef_lin, gwflow_coef, dprst_seep_rate_open, dprst_flow_coef. The
+    # first five are litho/slope/vpu INPUTS to the flux normalisation below,
+    # not PRMS parameters themselves -- only the 7 derived flux params are
+    # declared fillable. fflux and vpu are measured facts (prms.provenance),
+    # deliberately NOT interpolable and so NOT in fill_columns.
     fill_columns:
       - soil2gw_max
       - ssr2gw_rate
@@ -518,12 +527,20 @@ params:
           prms: dprst_flow_coef
           processes: [PRMSRunoff]
       provenance:
-        k_perm_wtd: litho-weighted permeability, flux-normalisation input
+        k_perm_log_wtd:
+          area-weighted mean of log10 permeability (geometric mean, gdptools
+          INTENSIVE form) -- flux-normalisation input, replaces the pre-#175
+          k_perm_wtd which used the EXTENSIVE form and was not an average at all
+        fflux:
+          fraction of HRU area underlain by valid (non-no-data) lithology; -1
+          where there is no overlap at all. Matches the reference
+          implementation's fflux attribute (Viger 2014, doi:10.5066/F7CN71XR).
+          A measured coverage fact, deliberately NOT in fill_columns
+        vpu: "per-HRU VPU, carried so the reducer can honour norm_scope: vpu"
         mean_slope_fraction: tan(radians(slope mean)), flux-normalisation input
         hru_area: fabric geometry.area in m2 -- NOT PRMS hru_area, which is acres
     # Lithology permeability + PRMS flux normalisation (lifted verbatim
     # from configs/zonal/ssflux_param.yml).
-    k_perm_min: -16.48
     # Block mappings, not `{ name: x, min: y }` flow style: yamllint's braces rule
     # wants no spaces inside braces and prettier inserts them, so flow style makes
     # the two hooks fight forever. Values are unchanged.
@@ -548,4 +565,7 @@ params:
         max: 0.2
       - name: dprst_flow_coef
         min: 0.005
-        max: 0.5
+        # 0.1, not 0.5: Driscoll 2020 Table 1 gives the NHM's calibrated range as
+        # 0.0001-0.1 (median 0.048), and pywatershed's default 0.05 sits on that
+        # median. The old 0.5 was 5x the calibrated maximum.
+        max: 0.1

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -301,6 +301,28 @@ filled), alongside the existing `merged/_intermediates/` per-fraction/derived
 CSVs. A one-time migration off an existing `filled_`-prefixed product is
 `scripts/migrate_filled_params.py` (dry-run by default, `--apply` required).
 
+#### `reducer` — whole-population statistics computed at merge time
+
+A zonal param entry may also declare a `reducer:` tag, naming a `(df, config,
+logger) -> df` callable dispatched from `MERGE_REDUCERS` in
+`zonal_runners/__init__.py`. Unlike `derived_columns` (a row-local transform),
+a reducer runs once over the **entire concatenated merged frame**, after the
+per-batch concat and before the CSV write, for parameters whose values need a
+statistic computed across the whole population — a min/max, a mean, a
+percentile — rather than something derivable from that row alone.
+
+`ssflux` is the first (and so far only) consumer: its `reducer: ssflux` entry
+resolves to `run_ssflux_reduce`, which min-max-normalises each `L_<param>`
+column from `run_ssflux_batch` onto that parameter's configured
+`flux_params` range and drops the `L_*` columns, replacing them with the
+final PRMS values. This must be a reduce step, not a per-batch one: taking
+min/max over an arbitrary SLURM batch chunk instead of the whole fabric made
+identical HRUs in different batches disagree (#175). The companion
+`norm_scope` key (`fabric`, the default — one min/max over every HRU, batch-
+invariant by construction; or `vpu` — one min/max per VPU, reproducing TM
+6-B9's per-GF-region wording) selects the population a reducer normalises
+over; `ssflux` is again the only consumer today.
+
 ### Common fabrics
 
 - **`gfv2`** — CONUS production fabric (~361k HRUs).

--- a/docs/GIS_Weasel_Viger_Leavesley_2007_TM6B4.md
+++ b/docs/GIS_Weasel_Viger_Leavesley_2007_TM6B4.md
@@ -1,0 +1,110 @@
+# The GIS Weasel User's Manual (Viger & Leavesley, 2007) — TM 6-B4
+
+Local copy: [`tm6b4.pdf`](tm6b4.pdf) (16.3 MB, 201 p.)
+
+**Citation.** Viger, R.J., and Leavesley, G.H., 2007, Section 4 — The GIS Weasel
+user's manual: U.S. Geological Survey Techniques and Methods, book 6, chap. B4,
+201 p., <https://doi.org/10.3133/tm6B4>.
+Landing page: <https://pubs.usgs.gov/tm/2007/06B04>
+
+This document is cited by TM 6-B9 and by the Geospatial Fabric attribute-table
+metadata as the source of per-parameter derivation methods. This page records
+**what it actually contains**, because that turns out to differ from what those
+citations promise.
+
+---
+
+## ⚠️ It does NOT document the Gleeson subsurface-flux parameters
+
+The FGDC record for *Geospatial Fabric Attribute Tables for PRMS Subsurface Flux
+Parameters based on Gleeson* ([doi:10.5066/F7CN71XR](https://doi.org/10.5066/F7CN71XR))
+states:
+
+> "The methodologies used to derive the individual attributes can be located in
+> the Appendix of the GIS Weasel Users Manual by the name of the attribute,
+> which is the same as the name of the corresponding PRMS parameter, in
+> (Viger and Leavesley, 2007)."
+
+**That pointer does not hold for the flux table.** Full-text search of TM 6-B4
+returns **zero** occurrences of:
+
+`soil2gw_max` · `ssr2gw_rate` · `slowcoef_lin` · `fastcoef_lin` ·
+`gwflow_coef` · `k_perm` · `Gleeson` · `conductivity`
+
+The reason is chronological and decisive: **Gleeson and others (2011) postdates
+this 2007 manual by four years.** A 2007 document cannot describe a derivation
+based on a 2011 dataset.
+
+**Consequence for [issue #175](https://github.com/rmcd-mscb/gfv2-params/issues/175):**
+the definitive statement of whether TM 6-B9's "*k_perm* cubed" means the log10
+value or the linear permeability **is not in this document, and is not in any
+reference TM 6-B9 cites.** Do not re-run this search. The best available
+evidence is:
+
+1. the FGDC attribute definitions in `GFAttsNhruPrms_subsurface-Gleeson.xml`
+   (which establish "feature **average** hydraulic conductivity" and cube
+   placement on `soil2gw_max` only), and
+2. the reference implementation's actual per-region output, downloadable as
+   `GeospatialFabricAttributes-PRMS_Gleeson_{01..21}.zip` from the same
+   ScienceBase item — the only remaining way to settle the question, and then
+   only distributionally.
+
+See [`superpowers/specs/2026-08-10-ssflux-normalisation-design.md`](superpowers/specs/2026-08-10-ssflux-normalisation-design.md).
+
+## What it does contain
+
+The manual documents the **GIS Weasel**, an ArcInfo Workstation (8.0.2+) / GRID
+application for preparing spatial information for lumped and distributed
+hydrologic models. Body chapters cover the GUI workflow — DEM filling, flow
+direction/accumulation, AOI delineation, drainage extraction, zone-map creation.
+Much of this is obsolete as software instruction; the value is historical, in
+recording how the Geospatial Fabric's geometric and topographic attributes were
+originally produced.
+
+**Appendix: Parameterization Methods** (p. 86 ff.) documents **37** methods, each
+as `param_<name>.aml` with a standard entry format:
+
+> DEFINITION · ORIGINAL PURPOSE · EXTRA DATA USED · SUBROUTINES CALLED ·
+> DESCRIPTION · REFERENCES
+
+The methods are generic zone-summary operations, not parameter-specific
+derivations:
+
+| group | methods |
+|---|---|
+| geometry | `param_area` `param_perimeter` `param_slope` `param_flowlength` `param_dist2headwater` |
+| statistics | `param_max` `param_min` `param_range` `param_sum` `param_majority` `param_generic` |
+| routing | `param_traveltime` `param_velocity` `param_nac` `param_nchan` `param_ntopchan` |
+| land cover | `param_imperv` |
+| feature counts | `param_nhru` `param_nssr` `param_nradpl` `param_nmru` `param_nshed` `param_nlink` `param_nreach` `param_ns` `param_nsc` `param_ngw` `param_ngwrow` `param_ngwcol` `param_nflowplane` `param_ndanode` `param_ndabranch` `param_ndajunction` `param_daf_pct_area` |
+| misc | `param_id` `param_method1` `param_method2` |
+
+Note the appendix explicitly declines to document the generic family
+individually:
+
+> "Despite the fact that all these routines have different names, the routines
+> are computationally identical. The variations are limited only to the choice
+> of summary statistic. ... Therefore, these routines will not be individually
+> documented."
+
+**There is no soils, land-cover-crosswalk, permeability, or subsurface-flux
+method here.** For those, TM 6-B9 and the per-dataset ScienceBase FGDC records
+are the authoritative sources.
+
+## Relevance to this repo
+
+Low-to-moderate, and mostly as provenance. `param_area`, `param_slope` and
+`param_imperv` are conceptual ancestors of our zonal steps, but our own
+derivations are documented far more specifically in
+[`ARCHITECTURE.md`](ARCHITECTURE.md), [`parameter_index.md`](parameter_index.md)
+and the `prms:` blocks in `configs/zonal/zonal_params.yml`. Keep this PDF as the
+canonical citation target, not as a working reference.
+
+## Reproducing the text extraction
+
+No poppler or Python PDF library is installed in the pixi envs. Ghostscript
+(`/usr/bin/gs`) is available and sufficient:
+
+```bash
+gs -q -dNOPAUSE -dBATCH -dSAFER -sDEVICE=txtwrite -o tm6b4.txt docs/tm6b4.pdf
+```

--- a/docs/parameter_index.md
+++ b/docs/parameter_index.md
@@ -190,7 +190,7 @@ Two further dangers this index originally flagged are **now fixed**:
 | `lulc_nalcms` | `nhm_lulc_nalcms_params.csv` | `cov_type`, `covden_sum`, `covden_win`, `snow_intcp`, `srain_intcp`, `wrain_intcp` | `retention` |
 | `lulc_nlcd` | `nhm_lulc_nlcd_params.csv` | `cov_type`, `covden_sum`, `covden_win`, `snow_intcp`, `srain_intcp`, `wrain_intcp` | `retention` |
 | `lulc_foresce` | `nhm_lulc_foresce_params.csv` | `cov_type`, `covden_sum`, `covden_win`, `snow_intcp`, `srain_intcp`, `wrain_intcp` | `retention` |
-| `ssflux` | `nhm_ssflux_params.csv` | `dprst_flow_coef`, `dprst_seep_rate_open`, `fastcoef_lin`, `gwflow_coef`, `slowcoef_lin`, `soil2gw_max`, `ssr2gw_rate` | `hru_area`, `k_perm_wtd`, `mean_slope_fraction` |
+| `ssflux` | `nhm_ssflux_params.csv` | `dprst_flow_coef`, `dprst_seep_rate_open`, `fastcoef_lin`, `gwflow_coef`, `slowcoef_lin`, `soil2gw_max`, `ssr2gw_rate` | `fflux`, `hru_area`, `k_perm_log_wtd`, `mean_slope_fraction`, `vpu` |
 <!-- END GENERATED: by-entry -->
 
 **Notes on the table above**

--- a/docs/superpowers/plans/2026-08-10-ssflux-normalisation.md
+++ b/docs/superpowers/plans/2026-08-10-ssflux-normalisation.md
@@ -1,0 +1,1122 @@
+# ssflux Normalisation Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the seven `ssflux` parameters, currently ~90% pinned at their range minimum, by aggregating permeability as an intensive variable in log10 space and moving normalisation out of the per-batch task into a reduce step.
+
+**Architecture:** Pure numerical helpers move to a new `ssflux_math.py` so the maths is testable without geo fixtures. `run_ssflux_batch` becomes a map phase emitting raw log-space `L_*` columns; a new `MERGE_REDUCERS` dispatch (mirroring the existing `BATCH_RUNNERS`) lets `run_merge` call an ssflux reducer that computes min/max over the whole fabric (or per VPU) and interpolates linearly.
+
+**Tech Stack:** Python 3.12, pandas, numpy, gdptools (weights only), pixi, pytest.
+
+**Spec:** [`../specs/2026-08-10-ssflux-normalisation-design.md`](../specs/2026-08-10-ssflux-normalisation-design.md)
+**Issue:** [#175](https://github.com/rmcd-mscb/gfv2-params/issues/175)
+
+## Global Constraints
+
+- **Do not run `pytest` on the HPC login node.** CI (`.github/workflows/ci.yml`) is the test gate. Quick `py_compile`/import checks on the head node are fine.
+- **`pre-commit run --all-files` must run under `srun` with `--mem=64G`** (the prettier hook OOMs). Targeted `--files a b c` runs are fine locally.
+- Every declared config entry needs a `prms:` block; every emitted column goes in exactly one of `columns:` / `defects:` / `provenance:`. `processes:` is **per column**.
+- After editing any `prms:` block run `python scripts/build_parameter_index.py`; CI fails if `docs/parameter_index.md` is stale.
+- Paths and fabric inputs come from the profile via `require_config_key`, never hardcoded.
+- **No exact `==` on computed floats.** The one deliberate exception is `k_perm == 0`, a *stored* no-data flag — comment why.
+- **Rebuild on `gfv2_dev` first**, never the canonical `gfv2` product.
+- Atomic commits; split combined fixes before pushing.
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `src/gfv2_params/zonal_runners/ssflux_math.py` | **new** — pure functions: intensive aggregation, log-additive derivation, linear interpolation. No I/O, no geo imports. |
+| `src/gfv2_params/zonal_runners/ssflux.py` | modify — map phase; emits `k_perm_log_wtd`, `fflux`, `vpu`, `L_*`. No normalisation. |
+| `src/gfv2_params/zonal_runners/merge.py` | modify — accept an optional `reducer` callable, call it after concat, before write. |
+| `src/gfv2_params/zonal_runners/__init__.py` | modify — add `MERGE_REDUCERS`, re-export `run_ssflux_reduce`. |
+| `scripts/derive_zonal_params.py` | modify — resolve `reducer:` tag → callable, pass to `run_merge`. |
+| `configs/zonal/zonal_params.yml` | modify — `reducer:`, `norm_scope:`, `dprst_flow_coef` cap, `prms:` block. |
+| `tests/test_ssflux_math.py` | **new** — unit tests for the pure functions. |
+| `tests/test_ssflux.py` | **new** — map/reduce behaviour, batch invariance, CSV round-trip. |
+
+---
+
+### Task 1: Pure numerical helpers (`ssflux_math.py`)
+
+Delivers tested pure functions with **no behaviour change** — nothing calls them yet.
+
+**Files:**
+- Create: `src/gfv2_params/zonal_runners/ssflux_math.py`
+- Test: `tests/test_ssflux_math.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `aggregate_k_perm_log(weights: pd.DataFrame, id_feature: str, *, weight_col: str = "normalized_area_weight", k_col: str = "k_perm") -> pd.DataFrame` — returns columns `[id_feature, "k_perm_log_wtd", "fflux"]`.
+  - `derive_log_params(k_perm_log_wtd: np.ndarray, slope_fraction: np.ndarray, hru_area: np.ndarray) -> dict[str, np.ndarray]` — keys are the seven parameter names.
+  - `interpolate_to_range(values: np.ndarray, lo: float, hi: float) -> np.ndarray`
+  - `validate_weight_coverage(weights: pd.DataFrame, id_feature: str, logger, *, weight_col: str = "normalized_area_weight", tol: float = 0.01, max_bad_fraction: float = 0.05) -> None`
+  - Constants `K_PERM_NODATA = 0.0`, `FFLUX_NO_OVERLAP = -1.0`, `SLOPE_FLOOR = 1e-4`, `SLOPE_CEIL = 1.0 - 1e-4`, `PARAM_NAMES` (tuple of 7).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_ssflux_math.py`:
+
+```python
+"""Unit tests for the pure ssflux maths (no geo fixtures, no data root)."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from gfv2_params.zonal_runners.ssflux_math import (
+    FFLUX_NO_OVERLAP,
+    PARAM_NAMES,
+    aggregate_k_perm_log,
+    derive_log_params,
+    interpolate_to_range,
+    validate_weight_coverage,
+)
+
+ID = "nat_hru_id"
+
+
+def _weights(rows):
+    return pd.DataFrame(rows, columns=[ID, "k_perm", "normalized_area_weight"])
+
+
+def test_intensive_aggregation_is_area_weighted_mean():
+    """(sum v*a)/(sum a) -- gdptools INTENSIVE form, not the extensive sum."""
+    w = _weights([(1, -10.0, 0.25), (1, -14.0, 0.75)])
+    out = aggregate_k_perm_log(w, ID)
+    assert out.loc[out[ID] == 1, "k_perm_log_wtd"].iloc[0] == pytest.approx(-13.0)
+
+
+def test_weights_are_renormalised_when_coverage_is_partial():
+    """A gap (weights summing to 0.5) must not halve the mean."""
+    w = _weights([(1, -10.0, 0.25), (1, -14.0, 0.25)])
+    out = aggregate_k_perm_log(w, ID)
+    assert out.loc[out[ID] == 1, "k_perm_log_wtd"].iloc[0] == pytest.approx(-12.0)
+    assert out.loc[out[ID] == 1, "fflux"].iloc[0] == pytest.approx(0.5)
+
+
+def test_nodata_k_perm_is_excluded_not_floored():
+    """k_perm == 0 is a no-data flag; it must not enter the mean."""
+    w = _weights([(1, -10.0, 0.5), (1, 0.0, 0.5)])
+    out = aggregate_k_perm_log(w, ID)
+    assert out.loc[out[ID] == 1, "k_perm_log_wtd"].iloc[0] == pytest.approx(-10.0)
+    assert out.loc[out[ID] == 1, "fflux"].iloc[0] == pytest.approx(0.5)
+
+
+def test_hru_with_no_valid_lithology_is_nan_with_sentinel_fflux():
+    w = _weights([(1, 0.0, 1.0)])
+    out = aggregate_k_perm_log(w, ID)
+    assert np.isnan(out.loc[out[ID] == 1, "k_perm_log_wtd"].iloc[0])
+    assert out.loc[out[ID] == 1, "fflux"].iloc[0] == FFLUX_NO_OVERLAP
+
+
+def test_aggregation_rejects_missing_weight_column():
+    w = _weights([(1, -10.0, 0.5)]).rename(columns={"normalized_area_weight": "wght"})
+    with pytest.raises(ValueError, match="normalized_area_weight"):
+        aggregate_k_perm_log(w, ID)
+
+
+def test_derive_log_params_matches_closed_forms():
+    k = np.array([-12.0])
+    slope = np.array([0.25])
+    area = np.array([100.0])
+    out = derive_log_params(k, slope, area)
+    assert out["soil2gw_max"][0] == pytest.approx(-36.0)              # 3*k
+    assert out["ssr2gw_rate"][0] == pytest.approx(-12.0 + np.log10(0.75))
+    expected_slow = -12.0 + np.log10(0.25) - np.log10(100.0)
+    assert out["slowcoef_lin"][0] == pytest.approx(expected_slow)
+    assert out["fastcoef_lin"][0] == pytest.approx(expected_slow + np.log10(2))
+    assert out["gwflow_coef"][0] == pytest.approx(expected_slow)
+    assert out["dprst_seep_rate_open"][0] == pytest.approx(out["ssr2gw_rate"][0])
+    assert out["dprst_flow_coef"][0] == pytest.approx(out["fastcoef_lin"][0])
+    assert set(out) == set(PARAM_NAMES)
+
+
+def test_slope_guards_produce_finite_output():
+    """slope == 0 and slope >= 1 must not yield -inf or NaN."""
+    k = np.array([-12.0, -12.0, -12.0])
+    slope = np.array([0.0, 1.0, 2.34])
+    area = np.array([100.0, 100.0, 100.0])
+    out = derive_log_params(k, slope, area)
+    for name in PARAM_NAMES:
+        assert np.all(np.isfinite(out[name])), name
+
+
+def test_nan_k_perm_propagates_as_nan_not_an_error():
+    out = derive_log_params(np.array([np.nan]), np.array([0.5]), np.array([100.0]))
+    assert np.isnan(out["soil2gw_max"][0])
+
+
+def test_derive_rejects_non_positive_area():
+    with pytest.raises(ValueError, match="hru_area"):
+        derive_log_params(np.array([-12.0]), np.array([0.5]), np.array([0.0]))
+
+
+def test_interpolate_maps_endpoints_and_is_affine_invariant():
+    v = np.array([-3.0, -2.0, -1.0])
+    out = interpolate_to_range(v, 0.1, 0.3)
+    assert out[0] == pytest.approx(0.1)
+    assert out[-1] == pytest.approx(0.3)
+    # the cube is a scale on the exponent -> absorbed by min-max normalisation
+    assert interpolate_to_range(3 * v, 0.1, 0.3) == pytest.approx(out, abs=1e-12)
+
+
+def test_interpolate_ignores_nan_but_preserves_position():
+    v = np.array([-3.0, np.nan, -1.0])
+    out = interpolate_to_range(v, 0.0, 1.0)
+    assert out[0] == pytest.approx(0.0)
+    assert np.isnan(out[1])
+    assert out[2] == pytest.approx(1.0)
+
+
+def test_interpolate_raises_on_degenerate_range():
+    with pytest.raises(ValueError, match="degenerate"):
+        interpolate_to_range(np.array([2.0, 2.0, 2.0]), 0.0, 1.0)
+
+
+def test_extensive_form_is_not_silently_accepted():
+    """A frame carrying ONLY the extensive columns must raise, not guess.
+
+    Guards the #175 root cause: dividing by the source-polygon area is gdptools'
+    EXTENSIVE form and must never be reachable again by accident.
+    """
+    w = pd.DataFrame(
+        {ID: [1, 1], "k_perm": [-10.0, -14.0],
+         "area_weight": [100.0, 300.0], "flux_id_area": [400.0, 1200.0]}
+    )
+    with pytest.raises(ValueError, match="extensive"):
+        aggregate_k_perm_log(w, ID)
+
+
+class _CapturingLogger:
+    def __init__(self): self.warnings = []
+    def info(self, *a, **k): pass
+    def debug(self, *a, **k): pass
+    def warning(self, msg, *a): self.warnings.append(msg % a if a else msg)
+
+
+def test_weight_coverage_passes_when_weights_sum_to_one():
+    w = _weights([(1, -10.0, 0.5), (1, -12.0, 0.5), (2, -11.0, 1.0)])
+    log = _CapturingLogger()
+    validate_weight_coverage(w, ID, log)
+    assert log.warnings == []
+
+
+def test_weight_coverage_warns_on_gaps_and_overlaps():
+    w = _weights([(1, -10.0, 0.4), (2, -11.0, 2.0), (3, -12.0, 1.0)])
+    log = _CapturingLogger()
+    validate_weight_coverage(w, ID, log, max_bad_fraction=0.9)
+    assert any("outside" in m for m in log.warnings)
+
+
+def test_weight_coverage_raises_when_too_many_are_bad():
+    """A wholesale deviation from 1.0 means the wrong weight column."""
+    w = _weights([(1, -10.0, 0.02), (2, -11.0, 0.03), (3, -12.0, 0.01)])
+    with pytest.raises(ValueError, match="normalized_area_weight"):
+        validate_weight_coverage(w, ID, _CapturingLogger())
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+pixi run -e dev pytest tests/test_ssflux_math.py -v
+```
+
+Expected: collection error — `ModuleNotFoundError: No module named 'gfv2_params.zonal_runners.ssflux_math'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/gfv2_params/zonal_runners/ssflux_math.py`:
+
+```python
+"""Pure numerical helpers for the ssflux derivation.
+
+Kept separate from ``ssflux.py`` so the maths is unit-testable without geo
+fixtures, a data root, or SLURM. See
+``docs/superpowers/specs/2026-08-10-ssflux-normalisation-design.md``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+# Gleeson k_perm is log10 permeability, so 0 would mean 1 m^2 -- physically
+# impossible. It is the dataset's no-data flag (9,409 of 202,108 CONUS
+# polygons). This is a STORED flag, not a computed value, so exact equality is
+# correct here; a tolerance would risk swallowing a genuine measurement. Note
+# -16.48 is NOT a sentinel -- it is the real least-permeable lithology class
+# (26,441 polygons), which is why no-data must be excluded rather than floored.
+K_PERM_NODATA = 0.0
+
+# fflux value for an HRU with no valid lithology overlap at all, matching the
+# reference implementation (Viger 2014, doi:10.5066/F7CN71XR).
+FFLUX_NO_OVERLAP = -1.0
+
+# mean_slope_fraction is tan(slope), so it is unbounded above; 317 CONUS HRUs
+# are exactly 0 and 3 exceed 1 (up to 66.85 deg), where log10(slope) and
+# log10(1 - slope) are undefined. Clamp rather than drop: these are real HRUs
+# that still need a parameter value.
+SLOPE_FLOOR = 1e-4
+SLOPE_CEIL = 1.0 - 1e-4
+
+# Below this width the input range carries no information and min-max
+# normalisation would divide by ~0.
+RANGE_ATOL = 1e-12
+
+PARAM_NAMES = (
+    "soil2gw_max",
+    "ssr2gw_rate",
+    "fastcoef_lin",
+    "slowcoef_lin",
+    "gwflow_coef",
+    "dprst_seep_rate_open",
+    "dprst_flow_coef",
+)
+
+
+def validate_weight_coverage(
+    weights: pd.DataFrame,
+    id_feature: str,
+    logger,
+    *,
+    weight_col: str = "normalized_area_weight",
+    tol: float = 0.01,
+    max_bad_fraction: float = 0.05,
+) -> None:
+    """Assert the weights behave like gdptools' intensive ``wght``.
+
+    ``wght`` sums to ~1.0 per target for a spatially continuous source layer.
+    Real CONUS data is close but not exact: 1,828 HRUs have coverage gaps and 98
+    have overlapping source polygons, so a handful outside ``[1-tol, 1+tol]`` is
+    expected and only warned about.
+
+    A *wholesale* deviation means the wrong column is being summed -- the
+    extensive construction that caused #175 gave per-HRU sums spanning 3.6e13x
+    with a median of 0.022. That raises. This is the guard that stops the
+    extensive/intensive confusion from silently returning.
+    """
+    if weight_col not in weights.columns:
+        raise ValueError(
+            f"Weight frame is missing '{weight_col}', gdptools' intensive weight. "
+            f"Columns: {sorted(weights.columns)}."
+        )
+    sums = weights.groupby(id_feature)[weight_col].sum()
+    bad = ~np.isclose(sums.to_numpy(), 1.0, rtol=0.0, atol=tol)
+    bad_fraction = float(bad.mean()) if len(sums) else 0.0
+    if bad_fraction > max_bad_fraction:
+        raise ValueError(
+            f"{bad_fraction:.1%} of HRUs have sum({weight_col}) outside "
+            f"1.0 +/- {tol} (median {float(sums.median()):.4f}, "
+            f"min {float(sums.min()):.4g}, max {float(sums.max()):.4g}). "
+            f"'{weight_col}' must be gdptools' `wght`, which sums to ~1 per "
+            "target. A median far from 1 means an EXTENSIVE construction such as "
+            "area_weight / <source>_area is being used -- that is issue #175."
+        )
+    if bad.any():
+        logger.warning(
+            "%d of %d HRUs have sum(%s) outside 1.0 +/- %s (min %.4g, max %.4g) -- "
+            "lithology coverage gaps and overlapping source polygons; the "
+            "aggregation renormalises by the per-HRU sum, so these are handled.",
+            int(bad.sum()), len(sums), weight_col, tol,
+            float(sums.min()), float(sums.max()),
+        )
+
+
+def aggregate_k_perm_log(
+    weights: pd.DataFrame,
+    id_feature: str,
+    *,
+    weight_col: str = "normalized_area_weight",
+    k_col: str = "k_perm",
+) -> pd.DataFrame:
+    """Area-weighted mean of log10 permeability -- gdptools' INTENSIVE form.
+
+    Permeability is intensive: it does not add up when regions combine, so the
+    aggregation is ``(sum v_i a_i) / (sum a_i)``, NOT the extensive
+    ``sum V_i (a_i / A_i)``. gdptools labels the source-polygon area column
+    "for extensive variables"; using it here was the root cause of #175.
+
+    ``weight_col`` is gdptools' ``wght`` (shipped as ``normalized_area_weight``),
+    the proportional area of the source polygon within the target.
+
+    Dividing by ``den`` is load-bearing beyond no-data exclusion: the lithology
+    layer is not perfectly continuous (1,828 CONUS HRUs have coverage gaps, 98
+    have overlapping source polygons).
+
+    Returns one row per HRU with ``k_perm_log_wtd`` (NaN where no valid
+    lithology) and ``fflux`` (valid-coverage fraction, ``FFLUX_NO_OVERLAP``
+    where none).
+    """
+    for col in (id_feature, k_col, weight_col):
+        if col not in weights.columns:
+            raise ValueError(
+                f"Weight frame is missing '{col}'. Columns: {sorted(weights.columns)}. "
+                f"'{weight_col}' is gdptools' intensive weight and is required -- do "
+                f"not substitute area_weight / <source>_area, which is the extensive form."
+            )
+
+    w = weights[[id_feature, k_col, weight_col]].copy()
+    w[k_col] = w[k_col].astype(float)
+    w[weight_col] = w[weight_col].astype(float)
+
+    # Exact comparison is deliberate: a stored no-data flag, not a computed value.
+    valid = w[k_col].notna() & (w[k_col] != K_PERM_NODATA)
+
+    all_ids = pd.Index(w[id_feature].unique(), name=id_feature).sort_values()
+    v = w[valid]
+    num = (v[k_col] * v[weight_col]).groupby(v[id_feature]).sum().reindex(all_ids)
+    den = v[weight_col].groupby(v[id_feature]).sum().reindex(all_ids)
+
+    den_arr = den.to_numpy()
+    covered = np.isfinite(den_arr) & (den_arr > 0.0)
+
+    k_log = np.full(len(all_ids), np.nan)
+    np.divide(num.to_numpy(), den_arr, out=k_log, where=covered)
+
+    fflux = np.where(covered, den_arr, FFLUX_NO_OVERLAP)
+
+    return pd.DataFrame(
+        {id_feature: all_ids.to_numpy(), "k_perm_log_wtd": k_log, "fflux": fflux}
+    )
+
+
+def derive_log_params(
+    k_perm_log_wtd: np.ndarray,
+    slope_fraction: np.ndarray,
+    hru_area: np.ndarray,
+) -> dict[str, np.ndarray]:
+    """TM 6-B9's structure, expressed additively in log10 space.
+
+    Because ``k_perm_log_wtd`` is already log10, a product becomes a sum and the
+    cube becomes a factor of 3 on the exponent::
+
+        L(soil2gw_max)  = 3*k
+        L(ssr2gw_rate)  =   k + log10(1 - slope)
+        L(slowcoef_lin) =   k + log10(slope) - log10(hru_area)
+
+    The cube is on ``soil2gw_max`` only, matching the reference implementation's
+    FGDC attribute definitions (Viger 2014) and today's code -- TM 6-B9 line 790
+    states a cube for the other two, but the 2014 source metadata does not. It
+    makes no difference to output anyway: for ``soil2gw_max`` the x3 is a pure
+    scale on the exponent and is fully absorbed by the later min-max
+    interpolation.
+
+    NaN in ``k_perm_log_wtd`` propagates to NaN, which is the signal for the
+    downstream KNN gap-fill.
+    """
+    k = np.asarray(k_perm_log_wtd, dtype=float)
+    slope = np.asarray(slope_fraction, dtype=float)
+    area = np.asarray(hru_area, dtype=float)
+
+    if np.any(~np.isfinite(area) | (area <= 0.0)):
+        bad = int(np.sum(~np.isfinite(area) | (area <= 0.0)))
+        raise ValueError(
+            f"hru_area must be finite and > 0 for log10; {bad} row(s) violate this. "
+            "A non-positive area means the fabric geometry is degenerate."
+        )
+
+    slope_c = np.clip(slope, SLOPE_FLOOR, SLOPE_CEIL)
+
+    out: dict[str, np.ndarray] = {}
+    out["soil2gw_max"] = 3.0 * k
+    out["ssr2gw_rate"] = k + np.log10(1.0 - slope_c)
+    out["slowcoef_lin"] = k + np.log10(slope_c) - np.log10(area)
+    out["fastcoef_lin"] = out["slowcoef_lin"] + np.log10(2.0)
+    out["gwflow_coef"] = out["slowcoef_lin"]
+    out["dprst_seep_rate_open"] = out["ssr2gw_rate"]
+    out["dprst_flow_coef"] = out["fastcoef_lin"]
+    return out
+
+
+def interpolate_to_range(values: np.ndarray, lo: float, hi: float) -> np.ndarray:
+    """Linearly scale ``values`` onto ``[lo, hi]`` -- TM 6-B9's interpolation.
+
+    NaN is preserved in place (it marks an HRU for the KNN gap-fill) and is
+    excluded from the min/max. ``min``/``max`` are exact and order-independent,
+    which is what makes the merged output invariant to batch partitioning.
+    """
+    v = np.asarray(values, dtype=float)
+    finite = np.isfinite(v)
+    if not finite.any():
+        raise ValueError("No finite values to interpolate; cannot derive a range.")
+
+    lo_in = float(np.min(v[finite]))
+    hi_in = float(np.max(v[finite]))
+    span = hi_in - lo_in
+    if span <= RANGE_ATOL:
+        raise ValueError(
+            f"Input range is degenerate (min={lo_in!r}, max={hi_in!r}, "
+            f"span={span!r} <= {RANGE_ATOL}). Refusing to emit a constant field; "
+            "this means every HRU shares one value, which is the #175 failure mode."
+        )
+
+    out = np.full(v.shape, np.nan)
+    np.divide(v - lo_in, span, out=out, where=finite)
+    return out * (hi - lo) + lo
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+pixi run -e dev pytest tests/test_ssflux_math.py -v
+```
+
+Expected: 16 passed.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+pixi run -e dev pre-commit run --files \
+  src/gfv2_params/zonal_runners/ssflux_math.py tests/test_ssflux_math.py
+git add src/gfv2_params/zonal_runners/ssflux_math.py tests/test_ssflux_math.py
+git commit -m "feat(ssflux): pure intensive-aggregation and log-space helpers (#175)"
+```
+
+---
+
+### Task 2: `MERGE_REDUCERS` dispatch
+
+Adds the reduce hook with **no ssflux behaviour change** — params without a `reducer:` key are untouched.
+
+**Files:**
+- Modify: `src/gfv2_params/zonal_runners/merge.py:53-118`
+- Modify: `src/gfv2_params/zonal_runners/__init__.py:74-105`
+- Modify: `scripts/derive_zonal_params.py:140-146`
+- Test: `tests/test_merge_reducers.py`
+
+**Interfaces:**
+- Consumes: nothing from Task 1.
+- Produces:
+  - `run_merge(config: dict, logger, *, reducer: Callable[[pd.DataFrame, dict, object], pd.DataFrame] | None = None) -> None`
+  - `MERGE_REDUCERS: dict[str, Callable]` in `zonal_runners/__init__.py` (empty at end of this task; Task 3 registers `"ssflux"`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_merge_reducers.py`:
+
+```python
+"""The optional reduce hook on run_merge."""
+
+import pandas as pd
+import pytest
+
+from gfv2_params.zonal_runners import MERGE_REDUCERS, run_merge
+
+
+class _Logger:
+    def info(self, *a, **k): pass
+    def debug(self, *a, **k): pass
+    def warning(self, *a, **k): pass
+
+
+def _write_batches(tmp_path, n_batches=2):
+    d = tmp_path / "ssflux"
+    d.mkdir(parents=True)
+    rows = [(1, 10.0), (2, 20.0), (3, 30.0), (4, 40.0)]
+    per = len(rows) // n_batches
+    for i in range(n_batches):
+        chunk = rows[i * per:(i + 1) * per]
+        pd.DataFrame(chunk, columns=["nat_hru_id", "L_x"]).to_csv(
+            d / f"base_nhm_ssflux_testfab_batch_{i:04d}_param.csv", index=False
+        )
+    return {
+        "source_type": "ssflux",
+        "id_feature": "nat_hru_id",
+        "merged_file": "out.csv",
+        "fabric": "testfab",
+        "output_dir": str(tmp_path),
+    }
+
+
+def test_merge_without_reducer_is_unchanged(tmp_path):
+    cfg = _write_batches(tmp_path)
+    run_merge(cfg, _Logger())
+    out = pd.read_csv(tmp_path / "merged" / "out.csv")
+    assert list(out.columns) == ["nat_hru_id", "L_x"]
+    assert out["L_x"].tolist() == [10.0, 20.0, 30.0, 40.0]
+
+
+def test_reducer_receives_full_frame_and_its_result_is_written(tmp_path):
+    cfg = _write_batches(tmp_path)
+    seen = {}
+
+    def reducer(df, config, logger):
+        seen["n"] = len(df)
+        return df.assign(scaled=df["L_x"] / df["L_x"].max()).drop(columns=["L_x"])
+
+    run_merge(cfg, _Logger(), reducer=reducer)
+    out = pd.read_csv(tmp_path / "merged" / "out.csv")
+    assert seen["n"] == 4, "reducer must see all batches, not one"
+    assert "L_x" not in out.columns
+    assert out["scaled"].max() == pytest.approx(1.0)
+
+
+def test_reducer_must_return_a_dataframe(tmp_path):
+    cfg = _write_batches(tmp_path)
+    with pytest.raises(TypeError, match="DataFrame"):
+        run_merge(cfg, _Logger(), reducer=lambda df, config, logger: None)
+
+
+def test_merge_reducers_is_a_dict():
+    assert isinstance(MERGE_REDUCERS, dict)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+pixi run -e dev pytest tests/test_merge_reducers.py -v
+```
+
+Expected: `ImportError: cannot import name 'MERGE_REDUCERS'`.
+
+- [ ] **Step 3: Add the `reducer` hook to `run_merge`**
+
+In `src/gfv2_params/zonal_runners/merge.py`, change the signature and add the call. Replace the `def run_merge(config: dict, logger) -> None:` line and its docstring opening with:
+
+```python
+def run_merge(config: dict, logger, *, reducer=None) -> None:
+    """Concat per-batch CSVs for one param into the merged output CSV.
+
+    Originally extracted from the now-retired scripts/merge_params.py:process_files()
+    (see PR #85). Validates no
+    duplicates, warns on gaps (if expected_max_hru_id is set in config).
+
+    ``reducer`` is an optional ``(df, config, logger) -> df`` callable applied
+    once to the CONCATENATED frame, before the file is written. It exists for
+    params whose final values need a statistic over the whole population and so
+    cannot be computed per batch -- ssflux's min/max interpolation. The
+    orchestrator resolves it from the config's ``reducer:`` tag via
+    MERGE_REDUCERS; params without that tag keep today's behaviour exactly.
+    """
+```
+
+Then insert the reducer call immediately **after** the `derived` block and **before** `output_path` (currently lines 111-116):
+
+```python
+    if reducer is not None:
+        merged_df = reducer(merged_df, config, logger)
+        if not isinstance(merged_df, pd.DataFrame):
+            raise TypeError(
+                f"reducer must return a pandas DataFrame, got "
+                f"{type(merged_df).__name__}. It is applied to the concatenated "
+                "frame and its return value is what gets written."
+            )
+        logger.info("Applied merge reducer: %s", config.get("reducer"))
+
+    output_path = final_output_dir / merged_file
+```
+
+- [ ] **Step 4: Add `MERGE_REDUCERS` to the package**
+
+In `src/gfv2_params/zonal_runners/__init__.py`, add `"MERGE_REDUCERS"` to `__all__` (keep it alphabetically first, beside `BATCH_RUNNERS`), then append after the `BATCH_RUNNERS` block:
+
+```python
+# Dispatch table: `reducer:` tag in configs/zonal/zonal_params.yml -> a
+# (df, config, logger) -> df callable applied once to the CONCATENATED merged
+# frame. Mirrors BATCH_RUNNERS above. Params with no `reducer:` tag are
+# unaffected. Used by scripts/derive_zonal_params.py.
+MERGE_REDUCERS = {}
+```
+
+- [ ] **Step 5: Wire the orchestrator**
+
+In `scripts/derive_zonal_params.py`, change the import on line 32 to include `MERGE_REDUCERS`:
+
+```python
+from gfv2_params.zonal_runners import BATCH_RUNNERS, MERGE_REDUCERS, run_build_weights, run_merge
+```
+
+Then replace the `run_merge(param_cfg, logger)` call in `run_merge_mode` (line 146) with:
+
+```python
+    reducer_tag = param_cfg.get("reducer")
+    reducer = None
+    if reducer_tag is not None:
+        if reducer_tag not in MERGE_REDUCERS:
+            raise ValueError(
+                f"Unknown reducer '{reducer_tag}' for param '{args.param}'. "
+                f"Available: {sorted(MERGE_REDUCERS)}"
+            )
+        reducer = MERGE_REDUCERS[reducer_tag]
+    run_merge(param_cfg, logger, reducer=reducer)
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+```bash
+pixi run -e dev pytest tests/test_merge_reducers.py tests/test_zonal_runners_package.py -v
+```
+
+Expected: all pass.
+
+- [ ] **Step 7: Lint and commit**
+
+```bash
+pixi run -e dev pre-commit run --files \
+  src/gfv2_params/zonal_runners/merge.py \
+  src/gfv2_params/zonal_runners/__init__.py \
+  scripts/derive_zonal_params.py tests/test_merge_reducers.py
+git add src/gfv2_params/zonal_runners/merge.py \
+        src/gfv2_params/zonal_runners/__init__.py \
+        scripts/derive_zonal_params.py tests/test_merge_reducers.py
+git commit -m "feat(zonal): add MERGE_REDUCERS reduce hook to run_merge (#175)"
+```
+
+---
+
+### Task 3: Cut ssflux over to map/reduce
+
+The behaviour change. Map and reduce land **together** — the map phase stops writing final parameters, so the reducer must exist in the same commit or the pipeline is broken.
+
+**Files:**
+- Modify: `src/gfv2_params/zonal_runners/ssflux.py:66-148`
+- Modify: `src/gfv2_params/zonal_runners/__init__.py` (register `"ssflux"`, re-export `run_ssflux_reduce`)
+- Test: `tests/test_ssflux.py`
+
+**Interfaces:**
+- Consumes: `aggregate_k_perm_log`, `derive_log_params`, `interpolate_to_range`, `PARAM_NAMES` from Task 1; the `reducer=` kwarg and `MERGE_REDUCERS` from Task 2.
+- Produces: `run_ssflux_reduce(df: pd.DataFrame, config: dict, logger) -> pd.DataFrame`; batch CSVs gain `k_perm_log_wtd`, `fflux`, `vpu`, `L_<param>` ×7 and lose `k_perm_wtd`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_ssflux.py`:
+
+```python
+"""Map/reduce behaviour for ssflux (no geo fixtures -- the reducer is pure)."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from gfv2_params.zonal_runners import MERGE_REDUCERS, run_ssflux_reduce
+from gfv2_params.zonal_runners.ssflux_math import PARAM_NAMES
+
+ID = "nat_hru_id"
+
+FLUX_PARAMS = [
+    {"name": "soil2gw_max", "min": 0.1, "max": 0.3},
+    {"name": "ssr2gw_rate", "min": 0.3, "max": 0.7},
+    {"name": "fastcoef_lin", "min": 0.01, "max": 0.6},
+    {"name": "slowcoef_lin", "min": 0.005, "max": 0.3},
+    {"name": "gwflow_coef", "min": 0.005, "max": 0.3},
+    {"name": "dprst_seep_rate_open", "min": 0.005, "max": 0.2},
+    {"name": "dprst_flow_coef", "min": 0.005, "max": 0.1},
+]
+
+
+class _Logger:
+    def info(self, *a, **k): pass
+    def debug(self, *a, **k): pass
+    def warning(self, *a, **k): pass
+
+
+def _frame(n=50, with_vpu=False):
+    rng = np.random.default_rng(0)
+    df = pd.DataFrame({ID: np.arange(1, n + 1)})
+    for p in PARAM_NAMES:
+        df[f"L_{p}"] = rng.normal(-12.0, 2.0, n)
+    if with_vpu:
+        df["vpu"] = np.where(df[ID] <= n // 2, "01", "02")
+    return df
+
+
+def _cfg(scope="fabric"):
+    return {"id_feature": ID, "flux_params": FLUX_PARAMS, "norm_scope": scope}
+
+
+def test_reduce_maps_into_configured_ranges_and_drops_L_columns():
+    out = run_ssflux_reduce(_frame(), _cfg(), _Logger())
+    for p in FLUX_PARAMS:
+        col = out[p["name"]]
+        assert col.min() == pytest.approx(p["min"])
+        assert col.max() == pytest.approx(p["max"])
+    assert not [c for c in out.columns if c.startswith("L_")]
+
+
+def test_reduce_is_registered():
+    assert MERGE_REDUCERS["ssflux"] is run_ssflux_reduce
+
+
+def test_batch_invariance_is_bit_exact():
+    """The issue's acceptance criterion: identical output across batch splits."""
+    df = _frame(40)
+    whole = run_ssflux_reduce(df.copy(), _cfg(), _Logger())
+    # same rows, different partition + arrival order
+    shuffled = pd.concat([df.iloc[20:], df.iloc[:20]], ignore_index=True)
+    split = run_ssflux_reduce(shuffled, _cfg(), _Logger()).sort_values(ID).reset_index(drop=True)
+    pd.testing.assert_frame_equal(whole, split)
+
+
+def test_nan_rows_survive_for_gap_fill():
+    df = _frame(20)
+    df.loc[df[ID] == 5, [f"L_{p}" for p in PARAM_NAMES]] = np.nan
+    out = run_ssflux_reduce(df, _cfg(), _Logger())
+    assert out.loc[out[ID] == 5, "soil2gw_max"].isna().all()
+    assert out["soil2gw_max"].notna().sum() == 19
+
+
+def test_vpu_scope_normalises_within_each_region():
+    out = run_ssflux_reduce(_frame(40, with_vpu=True), _cfg("vpu"), _Logger())
+    for vpu in ("01", "02"):
+        sub = out[out["vpu"] == vpu]["soil2gw_max"]
+        assert sub.min() == pytest.approx(0.1)
+        assert sub.max() == pytest.approx(0.3)
+
+
+def test_vpu_scope_requires_the_column():
+    with pytest.raises(ValueError, match="vpu"):
+        run_ssflux_reduce(_frame(10), _cfg("vpu"), _Logger())
+
+
+def test_unknown_norm_scope_raises():
+    with pytest.raises(ValueError, match="norm_scope"):
+        run_ssflux_reduce(_frame(10), _cfg("galaxy"), _Logger())
+
+
+def test_missing_L_column_raises():
+    df = _frame(10).drop(columns=["L_gwflow_coef"])
+    with pytest.raises(ValueError, match="L_gwflow_coef"):
+        run_ssflux_reduce(df, _cfg(), _Logger())
+
+
+def test_csv_round_trip_is_lossless(tmp_path):
+    """The map/reduce split writes L_* to CSV and reads them back."""
+    df = _frame(30)
+    p = tmp_path / "batch.csv"
+    df.to_csv(p, index=False)
+    back = pd.read_csv(p)
+    pd.testing.assert_frame_equal(df, back)
+
+
+def test_output_is_not_degenerate():
+    """#175's acceptance criteria, on a realistic log-normal-ish input.
+
+    The pre-fix product had >=89.5% of HRUs within 1% of the range minimum and
+    an IQR spanning 0.1% of the range. Both thresholds here would have failed it.
+    """
+    out = run_ssflux_reduce(_frame(5000), _cfg(), _Logger())
+    for p in FLUX_PARAMS:
+        col = out[p["name"]].to_numpy()
+        rng = p["max"] - p["min"]
+        at_min = np.mean(col <= p["min"] + 0.01 * rng)
+        iqr = np.subtract(*np.percentile(col, [75, 25])) / rng
+        assert at_min <= 0.20, f"{p['name']}: {at_min:.1%} pinned at range minimum"
+        assert iqr >= 0.10, f"{p['name']}: IQR spans only {iqr:.3f} of the range"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+pixi run -e dev pytest tests/test_ssflux.py -v
+```
+
+Expected: `ImportError: cannot import name 'run_ssflux_reduce'`.
+
+- [ ] **Step 3: Rewrite the ssflux map phase**
+
+In `src/gfv2_params/zonal_runners/ssflux.py`, add to the imports:
+
+```python
+from .ssflux_math import (
+    aggregate_k_perm_log,
+    derive_log_params,
+    interpolate_to_range,
+    validate_weight_coverage,
+)
+```
+
+(Do **not** import `PARAM_NAMES` here — the map phase iterates
+`derive_log_params(...)`'s return value and the reducer iterates `flux_params`
+from config, so an unused import would trip ruff's F401.)
+
+Replace lines 66-84 (the source read through `extensive_sorted`) with:
+
+```python
+    source_gdf = gpd.read_file(Path(config["source_shapefile"]))
+    source_gdf["flux_id"] = np.arange(len(source_gdf))
+
+    weights["flux_id"] = weights["flux_id"].astype(str)
+    source_gdf["flux_id"] = source_gdf["flux_id"].astype(str)
+    w = weights.merge(source_gdf[["flux_id", "k_perm"]], on="flux_id")
+
+    # Permeability is INTENSIVE: area-weighted mean, not an area-prorated sum.
+    # k_perm == 0 is Gleeson's no-data flag and is excluded, not floored to
+    # k_perm_min -- see ssflux_math.aggregate_k_perm_log and issue #175.
+    validate_weight_coverage(w, id_feature, logger)
+    agg = aggregate_k_perm_log(w, id_feature)
+    agg[id_feature] = agg[id_feature].astype(int)
+    k_perm_agg = agg.sort_values(by=id_feature).reset_index(drop=True)
+```
+
+The local names `extensive_agg` / `extensive_sorted` are **deleted**, not kept —
+they assert the exact modelling error #175 fixes. Update their single downstream
+use, line 99, from `extensive_sorted.merge(...)` to `k_perm_agg.merge(...)`.
+
+Replace lines 111-142 (the `r_*` derivation through the `df.drop`) with:
+
+```python
+    # Raw values stay in log10 space; normalisation happens in the reduce step
+    # (run_ssflux_reduce) because min/max must be taken over the whole fabric,
+    # not over an arbitrary SLURM batch.
+    log_params = derive_log_params(
+        df["k_perm_log_wtd"].to_numpy(),
+        df["mean_slope_fraction"].to_numpy(),
+        df["hru_area"].to_numpy(),
+    )
+    for name, values in log_params.items():
+        df[f"L_{name}"] = values
+```
+
+Add `vpu` to the batch frame. After the `area_df` block (line 93), add:
+
+```python
+    # Carried so the reducer can honour `norm_scope: vpu`. gfv2 is multi-VPU and
+    # keys this off the per-HRU `vpu` attribute; single-VPU fabrics declare a
+    # `vpu` scalar in their base_config profile instead.
+    if "vpu" in target_gdf.columns:
+        vpu_df = target_gdf[[id_feature, "vpu"]].copy()
+    else:
+        vpu_df = pd.DataFrame(
+            {id_feature: target_gdf[id_feature], "vpu": config.get("vpu", pd.NA)}
+        )
+    vpu_df[id_feature] = vpu_df[id_feature].astype("int64")
+```
+
+and merge it alongside the others (after line 100's `area_df` merge):
+
+```python
+    df = df.merge(vpu_df, on=id_feature, how="left")
+```
+
+- [ ] **Step 4: Add the reducer**
+
+Append to `src/gfv2_params/zonal_runners/ssflux.py`:
+
+```python
+def run_ssflux_reduce(df, config: dict, logger):
+    """Normalise the log-space L_* columns onto each parameter's target range.
+
+    Runs once on the CONCATENATED frame (see run_merge's `reducer` hook), never
+    per batch: TM 6-B9 interpolates over "all HRUs in a GF region", and doing it
+    per SLURM batch made two HRUs with identical geology and slope receive
+    different values depending on how the fabric was chunked (#175 item 3).
+
+    `norm_scope: fabric` (default) takes one min/max over every HRU, which makes
+    the output invariant to batch partitioning by construction. `norm_scope: vpu`
+    reproduces TM 6-B9's per-region wording, at the cost of discontinuities at
+    VPU boundaries.
+    """
+    id_feature = config["id_feature"]
+    flux_params = config["flux_params"]
+    scope = config.get("norm_scope", "fabric")
+    if scope not in ("fabric", "vpu"):
+        raise ValueError(f"Unknown norm_scope '{scope}'; expected 'fabric' or 'vpu'.")
+
+    missing = [f"L_{fp['name']}" for fp in flux_params if f"L_{fp['name']}" not in df.columns]
+    if missing:
+        raise ValueError(
+            f"Merged frame is missing {missing}. The ssflux batch runner must emit "
+            "L_* columns; a frame without them predates the #175 map/reduce split, "
+            "so re-run --mode zonal before merging."
+        )
+
+    if scope == "vpu":
+        if "vpu" not in df.columns or df["vpu"].isna().all():
+            raise ValueError(
+                "norm_scope: vpu needs a populated 'vpu' column in the merged frame. "
+                "Multi-VPU fabrics carry it per HRU; single-VPU fabrics must declare "
+                "a `vpu` scalar in their base_config profile."
+            )
+        groups = list(df.groupby("vpu").groups.items())
+    else:
+        groups = [("__fabric__", df.index)]
+
+    out = df.copy()
+    for fp in flux_params:
+        name, lo, hi = fp["name"], float(fp["min"]), float(fp["max"])
+        col = np.full(len(out), np.nan)
+        for label, idx in groups:
+            pos = out.index.get_indexer(idx)
+            try:
+                col[pos] = interpolate_to_range(out.loc[idx, f"L_{name}"].to_numpy(), lo, hi)
+            except ValueError as exc:
+                raise ValueError(f"{name} (scope={scope}, group={label}): {exc}") from exc
+        out[name] = col
+
+    out = out.drop(columns=[f"L_{fp['name']}" for fp in flux_params])
+    logger.info(
+        "Normalised %d ssflux params over scope=%s (%d group(s))",
+        len(flux_params), scope, len(groups),
+    )
+    return out.sort_values(id_feature).reset_index(drop=True)
+```
+
+- [ ] **Step 5: Register the reducer**
+
+In `src/gfv2_params/zonal_runners/__init__.py`, extend the ssflux import, add `"run_ssflux_reduce"` to `__all__`, and populate the table:
+
+```python
+from .ssflux import run_ssflux_batch, run_ssflux_reduce
+```
+
+```python
+MERGE_REDUCERS = {
+    "ssflux": run_ssflux_reduce,
+}
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+```bash
+pixi run -e dev pytest tests/test_ssflux.py tests/test_ssflux_math.py \
+  tests/test_merge_reducers.py tests/test_zonal_runners_package.py -v
+```
+
+Expected: all pass.
+
+- [ ] **Step 7: Lint and commit**
+
+```bash
+pixi run -e dev pre-commit run --files \
+  src/gfv2_params/zonal_runners/ssflux.py \
+  src/gfv2_params/zonal_runners/__init__.py tests/test_ssflux.py
+git add src/gfv2_params/zonal_runners/ssflux.py \
+        src/gfv2_params/zonal_runners/__init__.py tests/test_ssflux.py
+git commit -m "fix(ssflux): intensive log-space aggregation + reduce-step normalisation (#175)"
+```
+
+---
+
+### Task 4: Config, `prms:` block, and docs
+
+**Files:**
+- Modify: `configs/zonal/zonal_params.yml` (ssflux entry, starts line 451)
+- Modify: `docs/parameter_index.md` (regenerated, do not hand-edit)
+- Modify: `CLAUDE.md`, `docs/ARCHITECTURE.md`
+
+**Interfaces:**
+- Consumes: the `reducer:` tag resolved in Task 2, the columns emitted in Task 3.
+- Produces: no new code interfaces.
+
+- [ ] **Step 1: Update the ssflux config entry**
+
+In `configs/zonal/zonal_params.yml`, in the `- name: ssflux` entry:
+
+Add below `depends_on: build_weights`:
+
+```yaml
+    # Normalisation runs once over the whole merged frame, not per batch --
+    # min/max over an arbitrary SLURM chunk made identical HRUs disagree (#175).
+    reducer: ssflux
+    # `fabric` (one min/max over every HRU) is batch-invariant by construction.
+    # `vpu` reproduces TM 6-B9's per-GF-region wording; it needs the per-HRU
+    # `vpu` attribute and introduces discontinuities at region boundaries.
+    norm_scope: fabric
+```
+
+Change the `dprst_flow_coef` entry in `flux_params` from `max: 0.5` to:
+
+```yaml
+      - name: dprst_flow_coef
+        min: 0.005
+        # 0.1, not 0.5: Driscoll 2020 Table 1 gives the NHM's calibrated range as
+        # 0.0001-0.1 (median 0.048), and pywatershed's default 0.05 sits on that
+        # median. The old 0.5 was 5x the calibrated maximum.
+        max: 0.1
+```
+
+Replace the `provenance:` block with:
+
+```yaml
+      provenance:
+        k_perm_log_wtd:
+          area-weighted mean of log10 permeability (geometric mean, gdptools
+          INTENSIVE form) -- flux-normalisation input, replaces the pre-#175
+          k_perm_wtd which used the EXTENSIVE form and was not an average at all
+        fflux:
+          fraction of HRU area underlain by valid (non-no-data) lithology; -1
+          where there is no overlap at all. Matches the reference
+          implementation's fflux attribute (Viger 2014, doi:10.5066/F7CN71XR).
+          A measured coverage fact, deliberately NOT in fill_columns
+        vpu: per-HRU VPU, carried so the reducer can honour norm_scope: vpu
+        mean_slope_fraction: tan(radians(slope mean)), flux-normalisation input
+        hru_area: fabric geometry.area in m2 -- NOT PRMS hru_area, which is acres
+```
+
+- [ ] **Step 2: Regenerate the parameter index**
+
+```bash
+pixi run --as-is python scripts/build_parameter_index.py
+git diff --stat docs/parameter_index.md
+```
+
+Expected: `docs/parameter_index.md` changes (the `k_perm_wtd` provenance row is replaced by `k_perm_log_wtd`, `fflux`, `vpu`).
+
+- [ ] **Step 3: Verify the config parses and Guard 1 passes**
+
+```bash
+pixi run -e dev pytest tests/test_params_index.py -v
+```
+
+Expected: PASS. (Guard 2, `tests/test_params_index_ondisk.py`, is data-root-gated and SKIPS in CI — record its result by SLURM job id after the rebuild, never infer it from a green badge.)
+
+- [ ] **Step 4: Update the architecture docs**
+
+In `CLAUDE.md`, add to the "Non-obvious conventions & gotchas" list:
+
+```markdown
+- **`k_perm` is INTENSIVE — aggregate it as an area-weighted mean, never an
+  area-prorated sum.** `ssflux.py` originally used gdptools' *extensive* form
+  (`Σ Vᵢ·aᵢ/Aᵢ`, dividing by the SOURCE polygon area, the column gdptools labels
+  "for extensive variables"), which is correct for population or volume but not
+  for a property of the medium. Per-HRU weight sums spanned 3.6e13× instead of
+  1.0, inflating spread from a physical 5.6 to an artifactual 15.4 orders of
+  magnitude and pinning ~90% of HRUs at the range minimum (#175). Use
+  `normalized_area_weight` (gdptools' `wght`) and renormalise by its per-HRU sum
+  — that also corrects the 1,828 coverage-gap and 98 overlapping-source HRUs.
+  Related traps: `k_perm == 0` is a **no-data flag**, not a measurement, and must
+  be excluded rather than floored to `k_perm_min` (-16.48 is simultaneously the
+  genuine least-permeable lithology class, 26,441 polygons); `k_perm` has only
+  **8 distinct values**, so ~5% of HRUs sitting at the range minimum is real
+  geology, not a defect. Normalisation is a **reduce step** — never per batch;
+  and never fix the per-batch scope before fixing the log-space aggregation, or
+  degeneracy goes from ~90% to 97-100%.
+```
+
+In `docs/ARCHITECTURE.md`, document the `reducer:` config key beside the existing `derived_columns:` description: a `(df, config, logger) -> df` callable applied once to the concatenated merged frame, dispatched from `MERGE_REDUCERS`, for params whose values need a whole-population statistic.
+
+- [ ] **Step 5: Full lint under srun, then commit**
+
+```bash
+srun -p cpu -A impd --time=00:20:00 --ntasks=1 --cpus-per-task=4 --mem=64G \
+  pixi run -e dev pre-commit run --all-files
+git add configs/zonal/zonal_params.yml docs/parameter_index.md CLAUDE.md docs/ARCHITECTURE.md
+git commit -m "feat(ssflux): reduce-step config, fflux provenance, cap dprst_flow_coef at 0.1 (#175)"
+```
+
+---
+
+## Validation (after merge, on `gfv2_dev`)
+
+Not part of the plan's tasks — code lands first, CI is the gate. Then:
+
+1. Rebuild ssflux on **`gfv2_dev`**: `--mode build_weights` is unaffected (the weights CSV already carries `normalized_area_weight`), so only `--mode zonal` + `--mode merge` re-run.
+2. Assert the acceptance criteria on the merged CSV — expected, measured from the current inputs:
+
+   | param | % ≤1% of min | IQR/range |
+   |---|---|---|
+   | `soil2gw_max` | 5.0% | 0.383 |
+   | `ssr2gw_rate`, `dprst_seep_rate_open` | 0.0% | 0.261 |
+   | the four `/hru_area` params | 0.0% | 0.139 |
+
+   `598` HRUs are expected to land NaN (no valid lithology) for the KNN gap-fill.
+3. `viz.py` maps of `ssr2gw_rate` and `dprst_seep_rate_open` should show a coherent pattern tracking lithology and slope, not a uniform field.
+4. Optional, settles the cube question empirically: download a region from
+   `GeospatialFabricAttributes-PRMS_Gleeson_{01..21}.zip`
+   ([doi:10.5066/F7CN71XR](https://doi.org/10.5066/F7CN71XR)) and compare
+   **distributionally** — gfv2 has 361,471 HRUs vs the NHM's 109,951, so there is
+   no 1:1 id join.
+5. Promote to `gfv2` only after the gate passes. `oregon` and `tjc` need the same
+   rebuild, no code change.

--- a/docs/superpowers/plans/2026-08-10-ssflux-normalisation.md
+++ b/docs/superpowers/plans/2026-08-10-ssflux-normalisation.md
@@ -254,10 +254,14 @@ K_PERM_NODATA = 0.0
 # reference implementation (Viger 2014, doi:10.5066/F7CN71XR).
 FFLUX_NO_OVERLAP = -1.0
 
-# mean_slope_fraction is tan(slope), so it is unbounded above; 317 CONUS HRUs
-# are exactly 0 and 3 exceed 1 (up to 66.85 deg), where log10(slope) and
-# log10(1 - slope) are undefined. Clamp rather than drop: these are real HRUs
-# that still need a parameter value.
+# mean_slope_fraction is tan(slope), so it is unbounded above; 320 CONUS HRUs
+# are exactly 0 (measured from the slope INPUT, nhm_slope_params.csv,
+# 361,471 rows -- not the stale ssflux output, which undercounts at 317
+# because it has only 361,394 rows; re-measure from nhm_slope_params.csv
+# rather than trusting this number, per CLAUDE.md's re-measure convention)
+# and 3 exceed 1 (up to 66.85 deg), where log10(slope) and log10(1 - slope)
+# are undefined. Clamp rather than drop: these are real HRUs that still need
+# a parameter value.
 SLOPE_FLOOR = 1e-4
 SLOPE_CEIL = 1.0 - 1e-4
 

--- a/docs/superpowers/specs/2026-08-10-ssflux-normalisation-design.md
+++ b/docs/superpowers/specs/2026-08-10-ssflux-normalisation-design.md
@@ -439,9 +439,18 @@ is the genuine least-permeable lithology class.
   per-region reference output for distributional validation.
 - **Viger, R.J., and Leavesley, G.H., 2007** — *The GIS Weasel user's manual*,
   USGS Techniques and Methods 6-B4, 201 p.,
-  [doi:10.3133/tm6B4](https://doi.org/10.3133/tm6B4). The 2014 metadata states
-  the per-attribute methodologies live in this manual's **Appendix**, indexed by
-  PRMS parameter name. Not yet read; the only remaining place a definitive
-  statement of the cube's intended space (log10 vs linear) would live. Not a
-  blocker — D7 makes the cube moot for this design.
+  [doi:10.3133/tm6B4](https://doi.org/10.3133/tm6B4). **Consulted and ruled
+  out** — local copy at `docs/tm6b4.pdf`, notes in
+  `docs/GIS_Weasel_Viger_Leavesley_2007_TM6B4.md`. The 2014 metadata claims the
+  per-attribute methodologies live in this manual's Appendix indexed by PRMS
+  parameter name; **that pointer does not hold for the flux table**. Full-text
+  search returns zero hits for `soil2gw_max`, `ssr2gw_rate`, `slowcoef_lin`,
+  `fastcoef_lin`, `gwflow_coef`, `k_perm`, `Gleeson` or `conductivity` — and
+  cannot, since Gleeson (2011) postdates the manual by four years. Its Appendix
+  documents 37 generic `param_*.aml` zone-summary methods (area, slope,
+  majority, feature counts), none parameter-specific.
+  **Conclusion: no definitive statement of the cube's intended space exists in
+  any reference TM 6-B9 cites.** D7 resolves it from the FGDC attribute
+  definitions instead, and makes the cube moot for this design. Do not re-run
+  this search.
 - Markstrom and others, 2015, table 1–3 — acceptable parameter ranges

--- a/docs/superpowers/specs/2026-08-10-ssflux-normalisation-design.md
+++ b/docs/superpowers/specs/2026-08-10-ssflux-normalisation-design.md
@@ -119,13 +119,86 @@ CONUS-wide linear normalisation is **97.2 – 100%** versus 89.5 – 90.5% per-b
   information. Tests should target the three independent fields.
 - **The cube is a no-op in log space.** `norm(log10(k³)) == norm(log10(k))`
   (`allclose`, max diff 3.05e-16) because ×3 on the exponent is absorbed by the
-  normalisation. Issue item 2 ("missing cube") largely dissolves once the space
-  is right.
+  normalisation. Issue item 2 ("missing cube") dissolves twice over: the
+  reference implementation does not cube those two parameters (D7), and the one
+  cube that remains has no effect on output.
 - **Sign trap.** `k_perm` is negative (−16.48 … −10.87). Substituting it directly
   into TM 6-B9's multiplicative forms inverts the intended response: with `k<0`,
   `k³(1−slope)` *increases* with slope, and `slope>1` flips the sign again.
 - **Source layer is not perfectly continuous.** 1,828 HRUs have coverage gaps
   (Σ`wght` < 0.99) and 98 have overlapping source polygons (Σ up to 2.0).
+
+## Reference implementation (Viger 2014)
+
+The original NHM subsurface-flux values and their FGDC metadata are public:
+**"Geospatial Fabric Attribute Tables for PRMS Subsurface Flux Parameters based
+on Gleeson (Preliminary)"**, [doi:10.5066/F7CN71XR](https://doi.org/10.5066/F7CN71XR)
+(ScienceBase item `537a6a33e4b0efa8af08154d`). It ships per-region attribute
+tables plus `GFAttsNhruPrms_subsurface-Gleeson.xml`. Findings from that record:
+
+**Confirms the intensive reading (root cause #1).** The attribute definitions
+say the parameters derive from *"the feature **average** hydraulic conductivity
+of near surface geology"* — an average, not a prorated sum. The wording appears
+independently in three separate attribute definitions, so it is not a
+copy-paste artifact.
+
+**Confirms linear interpolation.** Every attribute: *"Values for all features
+are then **linearly scaled** to fit within a range."*
+
+**Resolves issue item 2 — against the issue.** The reference cubes
+`soil2gw_max` only:
+
+| attribute | reference wording |
+|---|---|
+| `soil2gw_max` | *"the **cubed power** of the feature average hydraulic conductivity"* |
+| `slowcoef_lin` | *"the hru_slope times the feature average hydraulic conductivity, divided by the hru_area"* — **no cube** |
+| `gwflow_coef` | same as `slowcoef_lin` — **no cube** |
+| `fastcoef_lin` | *"twice the slowcoef_lin value"* |
+
+These are distinct descriptions, not boilerplate. TM 6-B9 (2018) line 790 states
+`k_perm³` for `ssr2gw_rate` and `slowcoef_lin`; the 2014 reference metadata does
+not. **Today's code matches the reference**, so issue item 2 ("missing cube") is
+resolved as *no change required* — and under this design the point is moot
+anyway, since the only cube that survives is the provably-absorbed one.
+
+**Validates the coverage denominator.** The reference publishes `fflux`:
+*"Fraction of the feature area that is underlain by the hydrogeology data layer
+used to derive the groundwater flux-type parameters. Value can range from
+0.0–1.0, with a flag of **−1 for no overlap at all**."* This is exactly the
+renormalisation denominator `den` in this design. **Emit it** as a provenance
+column (see below).
+
+**Caveats — do not over-read this record.** The three `dprst_*` attribute
+*descriptions* are visibly copy-pasted (all read "Depression storage seepage
+rate", including `dprst_flow_coef`, which is an interflow coefficient, and all
+claim to equal `slowcoef_lin` despite carrying different ranges). Treat the
+declared ranges as more reliable than that prose. Also note `ssr2gw_rate` is
+**absent** from this table entirely — it is not a Gleeson-derived flux parameter
+in the reference.
+
+**Declared reference ranges vs ours:**
+
+| param | reference (2014, a priori) | ours | note |
+|---|---|---|---|
+| `soil2gw_max` | 0.1 – 0.3 | 0.1 – 0.3 | match |
+| `fastcoef_lin` | 0.01 – 0.6 | 0.01 – 0.6 | match |
+| `slowcoef_lin` | 0.005 – 0.3 | 0.005 – 0.3 | match |
+| `gwflow_coef` | 0.005 – 0.3 | 0.005 – 0.3 | match |
+| `dprst_seep_rate_open` | 0.3 – 0.7 | 0.005 – 0.2 | differs |
+| `dprst_flow_coef` | 0.01 – 0.6 | 0.005 – 0.5 → **0.1** | differs |
+
+The two `dprst_*` divergences are **not** defects to "fix" back. The reference
+ranges are *a priori* 2014 values; our ranges track Driscoll 2020 Table 1's
+*calibrated* envelope (`dprst_seep_rate_open` 0.00001 – 0.2,
+`dprst_flow_coef` 0.0001 – 0.1). D5 keeps the calibrated target deliberately.
+
+**Available empirical check.** The per-region attribute tables
+(`GeospatialFabricAttributes-PRMS_Gleeson_{01..21}.zip`) contain the reference
+implementation's actual output. Downloading one region and comparing
+distributions would settle the cube reading empirically and satisfies the
+issue's "cross-check against NhmParamDb" criterion. Comparisons must be
+**distributional** — gfv2 has 361,471 HRUs vs the NHM's 109,951, no 1:1 id join.
+Treat this as validation, not a blocker.
 
 ## Decisions
 
@@ -137,6 +210,8 @@ CONUS-wide linear normalisation is **97.2 – 100%** versus 89.5 – 90.5% per-b
 | D4 | Normalisation moves to a **reduce step**; `norm_scope: fabric` (default) or `vpu` | Fixes #4; fabric-wide is batch-invariant by construction, `vpu` retained for NhmParamDb comparison |
 | D5 | Cap `dprst_flow_coef` at **0.1** | Issue item 5; Driscoll 2020 Table 1 calibrated max is 0.1, ours was 5× that |
 | D6 | Plain min–max, **no** percentile anchors | Measured unnecessary — plain linear passes every criterion; keeps maximum fidelity to TM 6-B9 |
+| D7 | Cube `soil2gw_max` **only**; no cube on `ssr2gw_rate`/`slowcoef_lin` | Matches the Viger 2014 reference metadata and today's code; resolves issue item 2 as no-change. Moot under this design — the surviving cube is provably absorbed by the normalisation |
+| D8 | Emit `fflux` (valid-lithology area fraction) as a provenance column, `−1` where an HRU has no overlap | The reference implementation publishes exactly this attribute; it is already computed as the renormalisation denominator, and it makes coverage auditable instead of invisible |
 
 ## Design
 
@@ -165,18 +240,24 @@ Everything stays additive in log10 space, which is what "geometric mean +
 linear interpolation" implies:
 
 ```
-L_soil2gw_max        = 3·k_perm_log_wtd
-L_ssr2gw_rate        = 3·k_perm_log_wtd + log10(1 − slope)
-L_slowcoef_lin       = 3·k_perm_log_wtd + log10(slope) − log10(hru_area)
+L_soil2gw_max        = 3·k_perm_log_wtd                                    # cubed
+L_ssr2gw_rate        =   k_perm_log_wtd + log10(1 − slope)                 # NOT cubed
+L_slowcoef_lin       =   k_perm_log_wtd + log10(slope) − log10(hru_area)   # NOT cubed
 L_fastcoef_lin       = L_slowcoef_lin + log10(2)
 L_gwflow_coef        = L_slowcoef_lin
 L_dprst_seep_rate_open = L_ssr2gw_rate
 L_dprst_flow_coef    = L_fastcoef_lin
 ```
 
-The `×3` is retained for structural fidelity to TM 6-B9 even though it is
-provably absorbed by the normalisation for `soil2gw_max`; it is *not* absorbed
-for the other two, where it re-weights permeability against the slope/area term.
+The cube applies to `soil2gw_max` only — see [Reference implementation](#reference-implementation-viger-2014).
+This matches both the reference implementation and today's code, and minimises
+the diff. It is also self-consistently harmless: for `soil2gw_max` the `×3` is
+*provably absorbed* by the normalisation (`norm(3·k) ≡ norm(k)`), so the cube
+question has no effect on any output under this design.
+
+Both readings were measured and both pass; the cube-on-all variant merely
+redistributes IQR (0.247 vs 0.134 for the slowcoef family) by re-weighting
+permeability against the slope/area term.
 
 ### Map/reduce split
 
@@ -267,6 +348,12 @@ changes the on-disk header, so:
   in CI** — record its result by SLURM job id, never infer it from a green
   badge.
 
+`fflux` is **added** as a new provenance column (D8): the fraction of HRU area
+underlain by valid lithology, i.e. the renormalisation denominator `den`, with
+`−1` where an HRU has no overlap at all. It is `provenance:` in the `prms:`
+block and is **not** added to `fill_columns` — it is a measured coverage fact,
+not something to interpolate.
+
 `fill_columns` is unchanged (the same seven parameters). `fabric_columns`
 `hru_area` handling is unchanged.
 
@@ -287,20 +374,22 @@ New `tests/test_ssflux.py` (none exists today):
 | **batch invariance** | two different batch counts → **identical** merged CSV |
 | CSV round-trip | `L_*` survive write/read bit-exactly |
 | distribution | `% ≤1% of min ≤ 20` and `IQR/range ≥ 0.10` on a fixture |
+| `fflux` | equals the valid-coverage fraction; `−1` for an HRU with no overlap |
+| cube placement | `soil2gw_max` cubed; `ssr2gw_rate`/`slowcoef_lin` not (D7) |
 
 ## Expected outcome (measured on gfv2 inputs)
 
 Fabric-wide linear interpolation, 598 HRUs → NaN for gap-fill:
 
-| param | range | % ≤1% min | IQR/range | |
-|---|---|---|---|---|
-| `soil2gw_max` | 0.1 – 0.3 | 5.0% | 0.383 | PASS |
-| `ssr2gw_rate` | 0.3 – 0.7 | 0.0% | 0.371 | PASS |
-| `fastcoef_lin` | 0.01 – 0.6 | 0.0% | 0.249 | PASS |
-| `slowcoef_lin` | 0.005 – 0.3 | 0.0% | 0.249 | PASS |
-| `gwflow_coef` | 0.005 – 0.3 | 0.0% | 0.249 | PASS |
-| `dprst_seep_rate_open` | 0.005 – 0.2 | 0.0% | 0.371 | PASS |
-| `dprst_flow_coef` | 0.005 – **0.1** | 0.0% | 0.249 | PASS |
+| param | range | % ≤1% min | % ≥1% max | IQR/range | |
+|---|---|---|---|---|---|
+| `soil2gw_max` | 0.1 – 0.3 | 5.0% | 1.6% | 0.383 | PASS |
+| `ssr2gw_rate` | 0.3 – 0.7 | 0.0% | 1.7% | 0.261 | PASS |
+| `fastcoef_lin` | 0.01 – 0.6 | 0.0% | 0.0% | 0.139 | PASS |
+| `slowcoef_lin` | 0.005 – 0.3 | 0.0% | 0.0% | 0.139 | PASS |
+| `gwflow_coef` | 0.005 – 0.3 | 0.0% | 0.0% | 0.139 | PASS |
+| `dprst_seep_rate_open` | 0.005 – 0.2 | 0.0% | 1.7% | 0.261 | PASS |
+| `dprst_flow_coef` | 0.005 – **0.1** | 0.0% | 0.0% | 0.139 | PASS |
 
 Every acceptance criterion in #175 is met. The residual 5.0% on `soil2gw_max`
 is the genuine least-permeable lithology class.
@@ -342,5 +431,17 @@ is the genuine least-permeable lithology class.
 - [gdptools: Extensive vs. intensive variables](https://gdptools.readthedocs.io/en/develop/Examples/PolyToPoly/Extensive_vs_intensive_variables.html)
 - `gdptools/weight_gen_p2p.py:208-230` — `calculate_weights` column semantics
 - Gleeson and others, 2011 — `k_perm` (log10 permeability) source dataset
-- Viger, R.J., 2014; Viger and Leavesley, 2007 — cited by TM 6-B9 for
-  derivation detail (not yet consulted; would settle the cube's intended space)
+- **Viger, R.J., 2014** — *Geospatial Fabric Attribute Tables for PRMS
+  Subsurface Flux Parameters based on Gleeson (Preliminary)*,
+  [doi:10.5066/F7CN71XR](https://doi.org/10.5066/F7CN71XR); FGDC record
+  `GFAttsNhruPrms_subsurface-Gleeson.xml`. **Consulted** — see
+  [Reference implementation](#reference-implementation-viger-2014). Also ships
+  per-region reference output for distributional validation.
+- **Viger, R.J., and Leavesley, G.H., 2007** — *The GIS Weasel user's manual*,
+  USGS Techniques and Methods 6-B4, 201 p.,
+  [doi:10.3133/tm6B4](https://doi.org/10.3133/tm6B4). The 2014 metadata states
+  the per-attribute methodologies live in this manual's **Appendix**, indexed by
+  PRMS parameter name. Not yet read; the only remaining place a definitive
+  statement of the cube's intended space (log10 vs linear) would live. Not a
+  blocker — D7 makes the cube moot for this design.
+- Markstrom and others, 2015, table 1–3 — acceptable parameter ranges

--- a/docs/superpowers/specs/2026-08-10-ssflux-normalisation-design.md
+++ b/docs/superpowers/specs/2026-08-10-ssflux-normalisation-design.md
@@ -307,7 +307,11 @@ Rules for the implementation:
    tolerance there would risk swallowing a genuine measurement — keep exact and
    comment why.
 2. **Guard every `log10` domain.** `slope` is clipped to `[1e-4, 1 − 1e-4]`
-   (317 HRUs at `slope == 0`; 3 at `slope ≥ 1`, up to 66.85°, where `1 − slope`
+   (320 HRUs at `slope == 0`, measured from the slope input
+   `nhm_slope_params.csv` (361,471 rows) — not the stale ssflux output, which
+   undercounts at 317 because it has only 361,394 rows; re-measure from
+   `nhm_slope_params.csv` rather than trusting this number, per CLAUDE.md's
+   re-measure convention; 3 at `slope ≥ 1`, up to 66.85°, where `1 − slope`
    is meaningless). `hru_area` must be `> 0`. A non-positive argument must raise
    or produce an explicit NaN — never a silent `-inf` that then propagates
    through min/max and destroys the whole range.

--- a/docs/superpowers/specs/2026-08-10-ssflux-normalisation-design.md
+++ b/docs/superpowers/specs/2026-08-10-ssflux-normalisation-design.md
@@ -354,6 +354,12 @@ underlain by valid lithology, i.e. the renormalisation denominator `den`, with
 block and is **not** added to `fill_columns` — it is a measured coverage fact,
 not something to interpolate.
 
+`vpu` is **also added** to the on-disk header, unconditionally, on every
+fabric — carried through the map/reduce split so the reducer can honour
+`norm_scope: vpu` (multi-VPU fabrics read it per-HRU off the batch gpkg;
+single-VPU fabrics synthesise it from the `vpu` scalar in their base_config
+profile). Like `fflux`, it is `provenance:` and not in `fill_columns`.
+
 `fill_columns` is unchanged (the same seven parameters). `fabric_columns`
 `hru_area` handling is unchanged.
 

--- a/docs/superpowers/specs/2026-08-10-ssflux-normalisation-design.md
+++ b/docs/superpowers/specs/2026-08-10-ssflux-normalisation-design.md
@@ -1,0 +1,346 @@
+# ssflux normalisation redesign
+
+**Issue:** [#175](https://github.com/rmcd-mscb/gfv2-params/issues/175) — ssflux
+parameter fields are degenerate (~90% pinned at range minimum)
+**Status:** design approved, not yet implemented
+**Date:** 2026-08-10
+
+## Problem
+
+All seven `ssflux` parameters are effectively spatially constant. Measured on
+`gfv2/params/merged/nhm_ssflux_params.csv` (n = 361,394 rows — the gfv2 fabric
+has 361,471 HRUs; the 77-row shortfall is the known gap already documented in
+the `ssflux` config's `fabric_columns` comment):
+
+| param | range | % of HRUs within 1% of range MIN | IQR / range |
+|---|---|---|---|
+| `soil2gw_max` | 0.1 – 0.3 | 99.3% | 0.0000 |
+| `ssr2gw_rate` | 0.3 – 0.7 | 89.5% | 0.0010 |
+| `fastcoef_lin` | 0.01 – 0.6 | 90.5% | 0.0010 |
+| `slowcoef_lin` | 0.005 – 0.3 | 90.5% | 0.0010 |
+| `gwflow_coef` | 0.005 – 0.3 | 90.5% | 0.0010 |
+| `dprst_seep_rate_open` | 0.005 – 0.2 | 89.5% | 0.0010 |
+| `dprst_flow_coef` | 0.005 – 0.5 | 90.5% | 0.0010 |
+
+TM 6-B9 (line 782) states the whole point of these parameters is "to create a
+realistic spatial pattern of variation in values ... **in place of the
+assumption of spatially constant values**". We ship the thing the derivation
+exists to avoid.
+
+This propagates into pywatershed's `PRMSRunoff` via `dprst_seep_rate_open` and
+`dprst_flow_coef`.
+
+## Root causes
+
+Four defects compound. The issue body identified #1 and #4; #2 and #3 were
+found during triage.
+
+### 1. Permeability is aggregated as an EXTENSIVE variable
+
+`zonal_runners/ssflux.py:76`:
+
+```python
+w["k_perm_wtd_sum"] = w["k_perm_actual"] * (w["area_weight"] / w["flux_id_area"])
+```
+
+This is gdptools' documented **extensive** aggregation, `Σ Vᵢ × (aᵢ / Aᵢ)`,
+where `Aᵢ` is the *source* polygon area. `WeightGenP2P.calculate_weights`
+labels that column explicitly:
+
+> `source_id_area`: Total area of the source polygon **(for extensive variables)**.
+
+Permeability is **intensive** — it does not add up when regions combine. The
+correct gdptools form is the area-weighted mean `(Σ vᵢ aᵢ) / (Σ aᵢ)`, available
+directly as the `normalized_area_weight` column (`= wght`, "proportional area
+of the source polygon within the target (0.0–1.0)").
+
+The original intent is explicit in the first commit (`d0a9fbb`, 2025-06-27),
+and the variable names still say it in current code (`extensive_agg`,
+`extensive_sorted`, `ssflux.py:78-99`):
+
+```python
+# For k_perm (m^2), prorate the source's k_perm by the fraction of its area in the target.
+```
+
+The likely trap: permeability is *dimensioned* as an area (m²) but is a
+property of the medium, not an amount of anything.
+
+**Consequence.** Per-HRU weight sums under the extensive construction span
+**3.6e13×** (median 0.0222, max 1116.76) instead of 1.0. The result scales with
+how many lithology polygons an HRU happens to touch and with the HRU-to-polygon
+size ratio — neither related to permeability. This inflates the spread of the
+HRU-level value from a physical **5.6 orders of magnitude** to an artifactual
+**15.4**.
+
+`normalized_area_weight` has **zero consumers** anywhere in `src/`, `scripts/`
+or `configs/`. The correct weight has been in column 6 of every weights CSV the
+whole time.
+
+### 2. Linear min–max normalisation of a log-distributed variable
+
+`ssflux.py:139` maps `[min, max] → [lo, hi]` linearly. Applied to a variable
+spanning 15.4 orders, essentially every HRU lands on the floor. Corroboration:
+`soil2gw_max` is the only parameter that cubes the value (`ssflux.py:111`),
+widening the span to 45 orders, and it is the most degenerate at 99.3%.
+
+### 3. `k_perm == 0` is a no-data flag treated as real data
+
+`ssflux.py:74` maps `0 → k_perm_min = -16.48`. Gleeson `k_perm` is log10
+permeability, so `0` would mean 1 m² — physically impossible; it is a no-data
+flag on **9,409 of 202,108** polygons (4.7%). `-16.48` is simultaneously the
+**genuine least-permeable lithology class** (26,441 polygons, 13%), so the
+current mapping inflates that real class by 36% and asserts "no data == the most
+impermeable rock observed".
+
+### 4. Normalisation is per-batch, not per-region
+
+`ssflux.py:119-121` computes min/max within each SLURM batch. Confirmed: exactly
+**64 HRUs** sit at each configured maximum, one per batch. Two HRUs with
+identical geology and slope get different values depending on how the fabric was
+split, and the product is not reproducible under a change of batch count.
+
+**Sequencing trap.** Fixing #4 alone makes the product strictly *worse* —
+per-batch normalisation is currently *masking* #2. Measured degeneracy under
+CONUS-wide linear normalisation is **97.2 – 100%** versus 89.5 – 90.5% per-batch.
+#4 must never land before #1 and #2.
+
+## Key facts established during triage
+
+- **`k_perm` is categorical, not continuous** — only **8 distinct non-zero
+  values** (−10.87, −11.79, −12.47, −12.50, −12.78, −14.05, −15.05, −16.48),
+  assigned per lithology class. The achievable spatial pattern is 8 classes,
+  area-blended at HRU level and modulated by slope and area. A residual ~5% of
+  HRUs at the range minimum is **genuine geology** (HRUs lying entirely in the
+  least-permeable class), not a defect.
+- **Only 3 of the 7 parameters are independent.** `gwflow_coef` is bit-identical
+  to `slowcoef_lin` on disk; `fastcoef_lin`, `dprst_flow_coef` and
+  `dprst_seep_rate_open` are affine remaps. Min–max normalisation is
+  affine-invariant, so `2 × slowcoef_lin` carries identical normalised
+  information. Tests should target the three independent fields.
+- **The cube is a no-op in log space.** `norm(log10(k³)) == norm(log10(k))`
+  (`allclose`, max diff 3.05e-16) because ×3 on the exponent is absorbed by the
+  normalisation. Issue item 2 ("missing cube") largely dissolves once the space
+  is right.
+- **Sign trap.** `k_perm` is negative (−16.48 … −10.87). Substituting it directly
+  into TM 6-B9's multiplicative forms inverts the intended response: with `k<0`,
+  `k³(1−slope)` *increases* with slope, and `slope>1` flips the sign again.
+- **Source layer is not perfectly continuous.** 1,828 HRUs have coverage gaps
+  (Σ`wght` < 0.99) and 98 have overlapping source polygons (Σ up to 2.0).
+
+## Decisions
+
+| # | Decision | Rationale |
+|---|---|---|
+| D1 | Aggregate `k_perm` with gdptools' **intensive** form, applied in log10 space | Fixes root cause #1 using the library's documented column; an arithmetic mean of log10 k *is* the geometric mean of permeability, the correct average for heterogeneous media |
+| D2 | Derive parameters **additively in log10 space**, then interpolate linearly | Fixes #2 while preserving TM 6-B9's structure and its literal "linearly interpolating" wording |
+| D3 | `k_perm == 0` → NaN; renormalise over valid lithology; HRUs with no valid coverage → NaN for the existing KNN gap-fill | Fixes #3; avoids conflating no-data with the real −16.48 class |
+| D4 | Normalisation moves to a **reduce step**; `norm_scope: fabric` (default) or `vpu` | Fixes #4; fabric-wide is batch-invariant by construction, `vpu` retained for NhmParamDb comparison |
+| D5 | Cap `dprst_flow_coef` at **0.1** | Issue item 5; Driscoll 2020 Table 1 calibrated max is 0.1, ours was 5× that |
+| D6 | Plain min–max, **no** percentile anchors | Measured unnecessary — plain linear passes every criterion; keeps maximum fidelity to TM 6-B9 |
+
+## Design
+
+### Aggregation (replaces `ssflux.py:73-84`)
+
+```python
+# k_perm == 0 is a no-data flag, not a measurement.
+w["k_perm"] = w["k_perm"].replace(0, np.nan)
+
+# gdptools INTENSIVE aggregation, applied to log10 permeability.
+#   (Σ vᵢ aᵢ) / (Σ aᵢ)  ==  Σ(v · wght) / Σ(wght)
+# Renormalising by `den` is load-bearing: it corrects no-data exclusion,
+# the 1,828 coverage-gap HRUs and the 98 overlapping-source HRUs alike.
+valid = w["k_perm"].notna()
+num = (w["k_perm"] * w["normalized_area_weight"])[valid].groupby(w[id_feature]).sum()
+den = w["normalized_area_weight"][valid].groupby(w[id_feature]).sum()
+k_perm_log_wtd = num / den          # geometric mean of permeability, log10 units
+```
+
+`k_perm_log_wtd` replaces `k_perm_wtd` in the output. Range on gfv2:
+−16.48 … −10.87.
+
+### Derivation (replaces `ssflux.py:111-117`)
+
+Everything stays additive in log10 space, which is what "geometric mean +
+linear interpolation" implies:
+
+```
+L_soil2gw_max        = 3·k_perm_log_wtd
+L_ssr2gw_rate        = 3·k_perm_log_wtd + log10(1 − slope)
+L_slowcoef_lin       = 3·k_perm_log_wtd + log10(slope) − log10(hru_area)
+L_fastcoef_lin       = L_slowcoef_lin + log10(2)
+L_gwflow_coef        = L_slowcoef_lin
+L_dprst_seep_rate_open = L_ssr2gw_rate
+L_dprst_flow_coef    = L_fastcoef_lin
+```
+
+The `×3` is retained for structural fidelity to TM 6-B9 even though it is
+provably absorbed by the normalisation for `soil2gw_max`; it is *not* absorbed
+for the other two, where it re-weights permeability against the slope/area term.
+
+### Map/reduce split
+
+Normalisation cannot stay in the per-batch task. The existing chained
+`zonal → merge (afterok)` orchestration already provides the reduce point.
+
+- **Map** (`run_ssflux_batch`, per batch): emit `k_perm_log_wtd`,
+  `mean_slope_fraction`, `hru_area` and the seven `L_*` columns. No
+  normalisation.
+- **Reduce** (new, dispatched from `run_merge`): concatenate, compute
+  `min`/`max` of each `L_*` over the population selected by `norm_scope`,
+  interpolate linearly to each parameter's configured range, drop the `L_*`
+  columns, write the merged CSV.
+
+`run_merge` is currently generic (concat + duplicate check). Add a
+`MERGE_REDUCERS` dispatch table in `zonal_runners/__init__.py` mirroring the
+existing `BATCH_RUNNERS`, keyed off a new optional `reducer:` tag in the param
+config. Params without a `reducer:` keep today's behaviour exactly.
+
+### Config changes (`configs/zonal/zonal_params.yml`, `ssflux` entry)
+
+- `reducer: ssflux`
+- `norm_scope: fabric` (default; `vpu` alternative)
+- `flux_params[dprst_flow_coef].max: 0.5 → 0.1` (D5)
+- `prms:` block updated for `k_perm_wtd → k_perm_log_wtd` and the new `L_*`
+  columns (all `provenance:` — they are inputs to the interpolation, not PRMS
+  parameters). Regenerate `docs/parameter_index.md` via
+  `scripts/build_parameter_index.py`.
+
+`norm_scope: vpu` requires a VPU column in the ssflux flow; source it from the
+fabric profile rather than a naming convention.
+
+## Numerical robustness
+
+Floating point is load-bearing here: one acceptance criterion is a **bit-equality**
+claim ("identical merged output across batch counts"), and the investigation was
+itself derailed once by float dust (normalising `k` to a `[0,1]` index put the
+floor HRUs at ~1e-16 instead of 0, and cubing amplified that into a 45-order
+tail that swamped the real signal).
+
+Rules for the implementation:
+
+1. **No exact `==` on computed floats.** Comparisons against aggregate results
+   (weight sums, degenerate ranges, floor detection) use `math.isclose` /
+   `np.isclose` with a stated tolerance. The one deliberate exception is
+   `k_perm == 0`: that is a *stored* no-data flag, not a computed value, and a
+   tolerance there would risk swallowing a genuine measurement — keep exact and
+   comment why.
+2. **Guard every `log10` domain.** `slope` is clipped to `[1e-4, 1 − 1e-4]`
+   (317 HRUs at `slope == 0`; 3 at `slope ≥ 1`, up to 66.85°, where `1 − slope`
+   is meaningless). `hru_area` must be `> 0`. A non-positive argument must raise
+   or produce an explicit NaN — never a silent `-inf` that then propagates
+   through min/max and destroys the whole range.
+3. **Guard the zero denominator.** `num / den` where `den == 0` (no valid
+   lithology) must yield NaN by explicit mask, not by 0/0 with a
+   `RuntimeWarning`.
+4. **Guard the degenerate range.** The reducer's `hi_in − lo_in` check uses a
+   tolerance, not `== 0`, and raises rather than silently emitting the midpoint
+   for a whole fabric.
+5. **Weight-sum validation.** Log HRUs whose `Σ normalized_area_weight` falls
+   outside `[0.99, 1.01]` and fail if the fraction exceeds a configured
+   threshold. This is the guard that stops the extensive/intensive confusion
+   from silently returning.
+6. **Batch-invariance is achievable bit-exactly, and the test asserts it.**
+   Per-HRU aggregation sums the same weight rows in the same file order
+   regardless of batch partitioning, and `min`/`max` in the reducer are exact
+   and order-independent (no accumulation). So the merged output must be
+   *identical*, not merely close. If a future change introduces an
+   order-dependent accumulation (mean, std, variance), this guarantee breaks and
+   the test is the thing that will catch it.
+7. **CSV round-trip must be lossless.** The map/reduce split writes `L_*` to CSV
+   and reads it back before normalising. `pandas.to_csv` defaults to `repr`,
+   which is round-trippable for float64 — assert this in a test rather than
+   assuming it, since a stray `float_format` would silently quantise every
+   parameter.
+8. **Do not assert bit-equality between algebraically equivalent forms.**
+   `norm(3·k)` and `norm(k)` agree to ~3e-16, not exactly; tests comparing them
+   use a tolerance.
+
+## Output schema change
+
+`k_perm_wtd` (linear, extensive) → `k_perm_log_wtd` (log10, intensive). This
+changes the on-disk header, so:
+
+- update the `prms:` block (`provenance:` bucket) for the ssflux entry;
+- regenerate `docs/parameter_index.md`;
+- Guard 2 (`tests/test_params_index_ondisk.py`) is data-root-gated and **skips
+  in CI** — record its result by SLURM job id, never infer it from a green
+  badge.
+
+`fill_columns` is unchanged (the same seven parameters). `fabric_columns`
+`hru_area` handling is unchanged.
+
+## Test plan
+
+New `tests/test_ssflux.py` (none exists today):
+
+| test | asserts |
+|---|---|
+| intensive weighting | `Σ normalized_area_weight ≈ 1` on a fixture; aggregation equals `(Σ v·a)/(Σ a)` |
+| extensive regression | the old `/ flux_id_area` form is *not* produced (guards the root cause) |
+| no-data handling | `k_perm == 0` excluded; weights renormalised; zero-coverage HRU → NaN |
+| log-additive derivation | `L_*` match the closed forms above |
+| affine no-op | `norm(3·k)` ≈ `norm(k)` within tolerance |
+| affine family | `gwflow_coef` ≡ `slowcoef_lin`; `fastcoef_lin` is the affine remap |
+| slope guards | `slope == 0` and `slope ≥ 1` produce finite output, no `-inf` |
+| degenerate range | reducer raises on a zero-width input range |
+| **batch invariance** | two different batch counts → **identical** merged CSV |
+| CSV round-trip | `L_*` survive write/read bit-exactly |
+| distribution | `% ≤1% of min ≤ 20` and `IQR/range ≥ 0.10` on a fixture |
+
+## Expected outcome (measured on gfv2 inputs)
+
+Fabric-wide linear interpolation, 598 HRUs → NaN for gap-fill:
+
+| param | range | % ≤1% min | IQR/range | |
+|---|---|---|---|---|
+| `soil2gw_max` | 0.1 – 0.3 | 5.0% | 0.383 | PASS |
+| `ssr2gw_rate` | 0.3 – 0.7 | 0.0% | 0.371 | PASS |
+| `fastcoef_lin` | 0.01 – 0.6 | 0.0% | 0.249 | PASS |
+| `slowcoef_lin` | 0.005 – 0.3 | 0.0% | 0.249 | PASS |
+| `gwflow_coef` | 0.005 – 0.3 | 0.0% | 0.249 | PASS |
+| `dprst_seep_rate_open` | 0.005 – 0.2 | 0.0% | 0.371 | PASS |
+| `dprst_flow_coef` | 0.005 – **0.1** | 0.0% | 0.249 | PASS |
+
+Every acceptance criterion in #175 is met. The residual 5.0% on `soil2gw_max`
+is the genuine least-permeable lithology class.
+
+## Rollout
+
+1. Land code + tests; CI is the test gate (not the head node).
+2. Rebuild on **`gfv2_dev`** first, never the canonical `gfv2` product.
+3. Verify: `viz.py` maps of `ssr2gw_rate` and `dprst_seep_rate_open` show a
+   coherent pattern tracking lithology and slope; distributions compared to
+   NhmParamDb **distributionally**, not per-HRU (gfv2 has 361,471 HRUs vs the
+   NHM's 109,951 — no 1:1 id join).
+4. Promote to `gfv2` only after the gate passes.
+5. Blast radius is contained: `ssflux.py` is the only consumer of
+   `lith_weights_*.csv`. `oregon` and `tjc` need the same rebuild but no code
+   change.
+
+## Non-goals / rejected designs
+
+- **Percentile-anchored normalisation** — measured unnecessary; plain linear
+  passes every criterion, and clipping would depart further from TM 6-B9.
+- **Special `hru_area` outlier conditioning** — the apparent `/hru_area`
+  degeneracy was an artifact of an early candidate that normalised `k` to a
+  `[0,1]` index before cubing. Under the log-additive construction it does not
+  arise.
+- **Changing `gwflow_coef`'s method** (issue item 4) — TM 6-B9 derives it from a
+  multiple-linear regression on CONUS GIS data (range 0.004 – 0.055) whereas we
+  set it to `slowcoef_lin`. Recorded, not fixed here; needs its own issue.
+- **Imputing no-data `k_perm` from neighbouring lithology** — considered;
+  defers to the existing KNN gap-fill instead of adding a spatial step to the
+  lithology pipeline.
+
+## References
+
+- `docs/NHM_description_Regan_2018_TM6B9.md` — lines 782, 790 (soil zone
+  parameters, "GF region" interpolation)
+- `docs/Surface_depression_storage_Driscoll_2020.md` — Table 1 (calibrated
+  ranges; `dprst_flow_coef` 0.0001 – 0.1)
+- [gdptools: Extensive vs. intensive variables](https://gdptools.readthedocs.io/en/develop/Examples/PolyToPoly/Extensive_vs_intensive_variables.html)
+- `gdptools/weight_gen_p2p.py:208-230` — `calculate_weights` column semantics
+- Gleeson and others, 2011 — `k_perm` (log10 permeability) source dataset
+- Viger, R.J., 2014; Viger and Leavesley, 2007 — cited by TM 6-B9 for
+  derivation detail (not yet consulted; would settle the cube's intended space)

--- a/docs/tm6b4.pdf
+++ b/docs/tm6b4.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cf9adf814a606f7678b0b19e737ce7edfa7bd1a6448f891888f9158d87dce508
+size 16292502

--- a/pixi.lock
+++ b/pixi.lock
@@ -122,6 +122,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-h5888daf_1005.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ghp-import-2.1.0-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/git-lfs-3.7.1-hd3da7ce_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/glog-0.7.1-hbabe93e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/google-crc32c-1.8.0-py312h03f33d3_1.conda
@@ -905,6 +906,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.14.1-h480dda7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-h5888daf_1005.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/git-lfs-3.7.1-hd3da7ce_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/glog-0.7.1-hbabe93e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/google-crc32c-1.8.0-py312h03f33d3_1.conda
@@ -4750,7 +4752,7 @@ packages:
 - pypi: ./
   name: gfv2-params
   version: 0.1.0
-  sha256: 5a938f478ad3c8dc1e6d6583698ebe6ce1a56d4913b8b98ce2cbdb8d6074cfa9
+  sha256: 7cb37d189663591f0453db4ebfe3df2d10cd7c16ab8a94d5408feedd87a3482c
   requires_dist:
   - gdptools>=0.3.13
   - pandas
@@ -4822,6 +4824,14 @@ packages:
   license: GPL-2.0-or-later and LGPL-2.1-or-later
   size: 11613263
   timestamp: 1763469108409
+- conda: https://conda.anaconda.org/conda-forge/linux-64/git-lfs-3.7.1-hd3da7ce_2.conda
+  sha256: 244db394018bd2ae18e4d833af566ac98ec7e98d967e3c70839765dc1c27a189
+  md5: 2319a87ec34c4d02c2a02711228fba26
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 4957399
+  timestamp: 1781207228441
 - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.86.2-hf516916_0.conda
   sha256: 5517dae367d069de42c16d48f4b7e269acdedc11d43a5d4ec8d077d43ae00f45
   md5: 14ad79cb7501b6a408485b04834a734c

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,12 +175,23 @@ ruff = "*"
 # scripts/render_snarea_figures.py (matplotlib at module import). Runtime figure
 # generation still uses the richer `notebooks` env; dev only needs it to import.
 matplotlib-base = "*"
+# git-lfs manages the reference PDFs in docs/ (see .gitattributes). It lives in
+# `dev` rather than being assumed present on PATH because the HPC nodes have no
+# system git-lfs and no sudo. Anyone cloning this repo needs it to get real PDFs
+# instead of pointer files: `pixi shell -e dev && git lfs install && git lfs pull`.
+git-lfs = "*"
 
 [tool.pixi.feature.docs.dependencies]
 mkdocs = "*"
 mkdocs-material = "*"
 mkdocstrings = "*"
 mkdocstrings-python = "*"
+# poppler provides pdftotext, used to convert the reference PDFs in docs/ into
+# the markdown companions beside them (e.g. tm6b4.pdf ->
+# GIS_Weasel_Viger_Leavesley_2007_TM6B4.md). Prefer `pdftotext -layout` over
+# ghostscript's txtwrite: it preserves table columns, which matters for the
+# parameter tables in TM 6-B9 and Driscoll 2020.
+poppler = "*"
 
 [tool.pixi.feature.docs.pypi-dependencies]
 # include-markdown plugin pulls README.md / RUNME.md / CLAUDE.md into the

--- a/scripts/derive_zonal_params.py
+++ b/scripts/derive_zonal_params.py
@@ -93,8 +93,8 @@ def _build_param_cfg(config: dict, entry: dict) -> dict:
       4. config["fabric"] — active fabric name (from base_config.yml profile via
          `_load_resolved_config`).
       5. base_config.yml fabric profile fields: `expected_max_hru_id` (optional),
-         `id_feature` and `hru_gpkg` (required via `require_config_key`),
-         `hru_layer` (defaults to "nhru").
+         `vpu` (optional; single-VPU fabrics only), `id_feature` and `hru_gpkg`
+         (required via `require_config_key`), `hru_layer` (defaults to "nhru").
 
     Note: `{data_root}`/`{fabric}`/`{vpu}` placeholder expansion happens
     upstream in `_load_resolved_config` (via `_resolve_nested`), so values
@@ -108,6 +108,13 @@ def _build_param_cfg(config: dict, entry: dict) -> dict:
     param_cfg["fabric"] = config["fabric"]
     if "expected_max_hru_id" in config:
         param_cfg["expected_max_hru_id"] = config["expected_max_hru_id"]
+    # vpu is a single-VPU fabric's profile scalar (oregon: "17", tjc: "12"),
+    # read by ssflux's run_ssflux_batch as the norm_scope: vpu fallback when
+    # the batch gpkg carries no per-HRU `vpu` column. Multi-VPU fabrics
+    # (gfv2) omit it from the profile and rely on that per-HRU column
+    # instead, so this stays optional like expected_max_hru_id.
+    if "vpu" in config:
+        param_cfg["vpu"] = config["vpu"]
     # id_feature is a fabric property (base_config.yml profile), not a per-step
     # default — pull it from the resolved base config so it flows through to
     # the merged parameter CSVs.

--- a/scripts/derive_zonal_params.py
+++ b/scripts/derive_zonal_params.py
@@ -29,7 +29,7 @@ from pathlib import Path
 
 from gfv2_params.config import load_config, require_config_key
 from gfv2_params.log import configure_logging
-from gfv2_params.zonal_runners import BATCH_RUNNERS, run_build_weights, run_merge
+from gfv2_params.zonal_runners import BATCH_RUNNERS, MERGE_REDUCERS, run_build_weights, run_merge
 
 
 def _resolve_nested(value, replacements: dict):
@@ -143,7 +143,16 @@ def run_merge_mode(args, logger) -> None:
     entry = _find_param(config, args.param)
     param_cfg = _build_param_cfg(config, entry)
     logger.info("=== merge: param=%s ===", args.param)
-    run_merge(param_cfg, logger)
+    reducer_tag = param_cfg.get("reducer")
+    reducer = None
+    if reducer_tag is not None:
+        if reducer_tag not in MERGE_REDUCERS:
+            raise ValueError(
+                f"Unknown reducer '{reducer_tag}' for param '{args.param}'. "
+                f"Available: {sorted(MERGE_REDUCERS)}"
+            )
+        reducer = MERGE_REDUCERS[reducer_tag]
+    run_merge(param_cfg, logger, reducer=reducer)
 
 
 def run_build_weights_mode(args, logger) -> None:

--- a/slurm_batch/HPC_REFERENCE.md
+++ b/slurm_batch/HPC_REFERENCE.md
@@ -847,6 +847,11 @@ sbatch --export=ALL,BASE_CONFIG=$BASE_CONFIG,FABRIC=$FABRIC \
 # after weights finish, submit ssflux's array + merge as above with P=ssflux
 ```
 
+Since #175, `ssflux` normalises min/max over the whole fabric in the reduce
+step, so a rerun of any one `--mode zonal` batch changes every HRU's seven
+output values, not just the rerun batch's — partial reruns are all-or-nothing;
+always re-run `--mode merge` for the whole fabric afterward.
+
 **Depstor params** — same two-step unit per fraction, then one ratios job after
 all fractions have merged:
 

--- a/slurm_batch/RUNME.md
+++ b/slurm_batch/RUNME.md
@@ -387,6 +387,12 @@ sbatch --export=ALL,BASE_CONFIG=$BASE_CONFIG,FABRIC=$FABRIC slurm_batch/build_zo
 # after weights + slope merge finish, submit ssflux's array + merge with P=ssflux
 ```
 
+Normalisation is now fabric-wide (#175), so re-running any single `ssflux`
+`--mode zonal` batch shifts the global min/max and changes every HRU's seven
+values, not just the rerun batch's. Partial reruns are all-or-nothing: after
+re-running any `ssflux` zonal batch, re-run `--mode merge` for the whole
+fabric before treating the product as current.
+
 **Depstor fractions** — same pair per `F` (any order): `perv_frac`,
 `imperv_frac`, `dprst_frac`, `drains_perv_frac`, `drains_imperv_frac`,
 `onstream_storage_frac`, `drains_to_dprst_frac`, `carea_t8_frac`,

--- a/src/gfv2_params/params_index.py
+++ b/src/gfv2_params/params_index.py
@@ -64,7 +64,7 @@ class DeclaredParam(NamedTuple):
           defects: {}                         # emitted column that does NOT represent
                                               # its PRMS parameter (see below)
           provenance:                         # emitted column that is not a PRMS param
-            k_perm_wtd: litho-weighted permeability, flux-normalisation input
+            k_perm_log_wtd: litho-weighted permeability, flux-normalisation input
 
     `processes` is PER-COLUMN, not per-entry: `ssflux` alone spans PRMSSoilzone,
     PRMSGroundwater and PRMSRunoff across different columns, so an entry-level key

--- a/src/gfv2_params/zonal_runners/__init__.py
+++ b/src/gfv2_params/zonal_runners/__init__.py
@@ -10,7 +10,7 @@ source_raster, batch_dir, target_layer, id_feature, output_dir, merged_file,
 categorical, fabric, the fabric-profile hru_gpkg/hru_layer that
 run_build_weights reads, plus per-script extras like canopy_raster,
 crosswalk_file, keep_raster, source_shapefile, merged_slope_file,
-weight_dir, k_perm_min, flux_params). The orchestrator builds this dict by
+weight_dir, reducer, norm_scope, flux_params). The orchestrator builds this dict by
 flattening the active param entry in ``configs/zonal/zonal_params.yml`` onto
 the top-level ``defaults:`` block (plus the resolved fabric profile).
 

--- a/src/gfv2_params/zonal_runners/__init__.py
+++ b/src/gfv2_params/zonal_runners/__init__.py
@@ -75,7 +75,7 @@ from .lulc import run_lulc_batch
 from .lulc_prederived import run_lulc_prederived_batch
 from .merge import run_merge
 from .soils import run_soils_batch
-from .ssflux import run_ssflux_batch
+from .ssflux import run_ssflux_batch, run_ssflux_reduce
 from .weights import run_build_weights
 from .zonal import run_zonal_batch
 
@@ -88,6 +88,7 @@ __all__ = [
     "run_merge",
     "run_soils_batch",
     "run_ssflux_batch",
+    "run_ssflux_reduce",
     "run_zonal_batch",
 ]
 
@@ -109,4 +110,6 @@ BATCH_RUNNERS = {
 # (df, config, logger) -> df callable applied once to the CONCATENATED merged
 # frame. Mirrors BATCH_RUNNERS above. Params with no `reducer:` tag are
 # unaffected. Used by scripts/derive_zonal_params.py.
-MERGE_REDUCERS = {}
+MERGE_REDUCERS = {
+    "ssflux": run_ssflux_reduce,
+}

--- a/src/gfv2_params/zonal_runners/__init__.py
+++ b/src/gfv2_params/zonal_runners/__init__.py
@@ -81,6 +81,7 @@ from .zonal import run_zonal_batch
 
 __all__ = [
     "BATCH_RUNNERS",
+    "MERGE_REDUCERS",
     "run_build_weights",
     "run_lulc_batch",
     "run_lulc_prederived_batch",
@@ -103,3 +104,9 @@ BATCH_RUNNERS = {
     "lulc_prederived": run_lulc_prederived_batch,
     "ssflux": run_ssflux_batch,
 }
+
+# Dispatch table: `reducer:` tag in configs/zonal/zonal_params.yml -> a
+# (df, config, logger) -> df callable applied once to the CONCATENATED merged
+# frame. Mirrors BATCH_RUNNERS above. Params with no `reducer:` tag are
+# unaffected. Used by scripts/derive_zonal_params.py.
+MERGE_REDUCERS = {}

--- a/src/gfv2_params/zonal_runners/merge.py
+++ b/src/gfv2_params/zonal_runners/merge.py
@@ -50,12 +50,19 @@ def apply_derived_columns(df, derived_columns: dict | None):
     return df
 
 
-def run_merge(config: dict, logger) -> None:
+def run_merge(config: dict, logger, *, reducer=None) -> None:
     """Concat per-batch CSVs for one param into the merged output CSV.
 
     Originally extracted from the now-retired scripts/merge_params.py:process_files()
     (see PR #85). Validates no
     duplicates, warns on gaps (if expected_max_hru_id is set in config).
+
+    ``reducer`` is an optional ``(df, config, logger) -> df`` callable applied
+    once to the CONCATENATED frame, before the file is written. It exists for
+    params whose final values need a statistic over the whole population and so
+    cannot be computed per batch -- ssflux's min/max interpolation. The
+    orchestrator resolves it from the config's ``reducer:`` tag via
+    MERGE_REDUCERS; params without that tag keep today's behaviour exactly.
     """
     source_type = config["source_type"]
     id_feature = config["id_feature"]
@@ -112,6 +119,16 @@ def run_merge(config: dict, logger) -> None:
     if derived:
         merged_df = apply_derived_columns(merged_df, derived)
         logger.info("Applied derived columns: %s", sorted(derived))
+
+    if reducer is not None:
+        merged_df = reducer(merged_df, config, logger)
+        if not isinstance(merged_df, pd.DataFrame):
+            raise TypeError(
+                f"reducer must return a pandas DataFrame, got "
+                f"{type(merged_df).__name__}. It is applied to the concatenated "
+                "frame and its return value is what gets written."
+            )
+        logger.info("Applied merge reducer: %s", config.get("reducer"))
 
     output_path = final_output_dir / merged_file
     merged_df.to_csv(output_path, index=False)

--- a/src/gfv2_params/zonal_runners/merge.py
+++ b/src/gfv2_params/zonal_runners/merge.py
@@ -69,6 +69,19 @@ def run_merge(config: dict, logger, *, reducer=None) -> None:
     merged_file = config["merged_file"]
     fabric = config["fabric"]
     expected_max = config.get("expected_max_hru_id")
+    # pandas infers dtypes PER FILE, not across the whole param. A categorical
+    # column that is all numeric-looking-with-leading-zeros in some batches and
+    # alphanumeric in others (ssflux's `vpu`: "01".."09" vs "03N"/"10L") gets
+    # inferred as int64 in the numeric-only batches and str in the mixed ones --
+    # int64 silently strips the leading zero ("01" -> 1). Measured on a real
+    # gfv2_dev rebuild: 12/20 ssflux batches inferred `vpu` int64, 8/20 str,
+    # producing 28 distinct vpu labels in the merged product where the fabric
+    # has only 21, 8 of which (1,2,4,5,6,7,8,9) don't exist in the fabric at
+    # all -- the same VPU split across two labels depending on which batch an
+    # HRU landed in. `read_dtypes:` lets a param's config pin the dtype for any
+    # such column so every batch is read the same way; it's a property of any
+    # categorical string column emitted per batch, not a vpu special case.
+    read_dtypes = config.get("read_dtypes")
 
     input_dir = Path(config["output_dir"]) / source_type
     final_output_dir = Path(config["output_dir"]) / config.get("merged_subdir", "merged")
@@ -88,7 +101,7 @@ def run_merge(config: dict, logger, *, reducer=None) -> None:
     dfs = []
     for f in files:
         logger.debug("Reading: %s", f)
-        df = pd.read_csv(f)
+        df = pd.read_csv(f, dtype=read_dtypes) if read_dtypes else pd.read_csv(f)
         if id_feature not in df.columns:
             raise ValueError(f"'{id_feature}' column not found in file: {f}")
         dfs.append(df)

--- a/src/gfv2_params/zonal_runners/merge.py
+++ b/src/gfv2_params/zonal_runners/merge.py
@@ -121,6 +121,10 @@ def run_merge(config: dict, logger, *, reducer=None) -> None:
         logger.info("Applied derived columns: %s", sorted(derived))
 
     if reducer is not None:
+        reducer_name = config.get("reducer") or getattr(reducer, "__name__", repr(reducer))
+        pre_n = len(merged_df)
+        pre_ids = set(merged_df[id_feature])
+
         merged_df = reducer(merged_df, config, logger)
         if not isinstance(merged_df, pd.DataFrame):
             raise TypeError(
@@ -128,6 +132,32 @@ def run_merge(config: dict, logger, *, reducer=None) -> None:
                 f"{type(merged_df).__name__}. It is applied to the concatenated "
                 "frame and its return value is what gets written."
             )
+
+        # MERGE_REDUCERS is explicitly designed for extension beyond ssflux
+        # (see zonal_runners/__init__.py), so this invariant protects every
+        # future reducer, not just today's one: pre-reducer validation above
+        # (duplicate check, gap warning) is worthless if the reducer itself is
+        # free to silently drop or relabel rows on the way out.
+        post_n = len(merged_df)
+        if post_n != pre_n:
+            raise ValueError(
+                f"reducer '{reducer_name}' changed the row count from {pre_n} "
+                f"to {post_n}. A reducer must transform columns only -- it may "
+                "not add or drop rows."
+            )
+        if id_feature not in merged_df.columns:
+            raise ValueError(
+                f"reducer '{reducer_name}' dropped the id column '{id_feature}' "
+                "from its output."
+            )
+        post_ids = set(merged_df[id_feature])
+        if post_ids != pre_ids:
+            raise ValueError(
+                f"reducer '{reducer_name}' changed the set of {id_feature} "
+                f"values ({len(pre_ids)} -> {len(post_ids)} distinct ids). A "
+                "reducer must preserve row identity, not just row count."
+            )
+
         logger.info("Applied merge reducer: %s", config.get("reducer"))
 
     output_path = final_output_dir / merged_file

--- a/src/gfv2_params/zonal_runners/ssflux.py
+++ b/src/gfv2_params/zonal_runners/ssflux.py
@@ -98,8 +98,11 @@ def run_ssflux_batch(config: dict, batch_id: int, logger) -> None:
         raise ValueError(f"Non-numeric {id_feature} values in target fabric") from exc
 
     # Carried so the reducer can honour `norm_scope: vpu`. gfv2 is multi-VPU and
-    # keys this off the per-HRU `vpu` attribute; single-VPU fabrics declare a
-    # `vpu` scalar in their base_config profile instead.
+    # keys this off the per-HRU `vpu` attribute on the batch gpkg. Single-VPU
+    # fabrics (oregon, tjc) declare a `vpu` scalar in their base_config
+    # profile instead; scripts/derive_zonal_params.py's `_build_param_cfg`
+    # threads that scalar from the resolved fabric profile into `config["vpu"]`
+    # when present, which is what the fallback below reads.
     if "vpu" in target_gdf.columns:
         vpu_df = target_gdf[[id_feature, "vpu"]].copy()
     else:
@@ -173,6 +176,23 @@ def run_ssflux_reduce(df, config: dict, logger):
                 "Multi-VPU fabrics carry it per HRU; single-VPU fabrics must declare "
                 "a `vpu` scalar in their base_config profile."
             )
+        n_null = int(df["vpu"].isna().sum())
+        if n_null > 0:
+            raise ValueError(
+                f"norm_scope: vpu found {n_null} of {len(df)} HRU(s) with a null "
+                "'vpu' value. A null VPU cannot be normalised per-region -- "
+                "groupby(dropna=True) would silently drop those rows from every "
+                "group, leaving them NaN and indistinguishable from the "
+                "legitimate no-lithology NaN, so they'd be silently KNN gap-filled "
+                "downstream. Fix the source data so every HRU carries a VPU label."
+            )
+        # Per-batch CSVs are read back independently (see run_merge), so
+        # pandas' per-file dtype inference can disagree on the same VPU label
+        # ("01" -> int 1 in one file, str "01" in another); NHDPlus VPU labels
+        # also include non-numeric ones ("10L", "10U"). Cast to string before
+        # grouping so mixed int/str labels can't diverge into separate groups
+        # and groupby(sort=True) doesn't raise TypeError comparing int to str.
+        df = df.assign(vpu=df["vpu"].astype(str))
         groups = list(df.groupby("vpu").groups.items())
     else:
         groups = [("__fabric__", df.index)]

--- a/src/gfv2_params/zonal_runners/ssflux.py
+++ b/src/gfv2_params/zonal_runners/ssflux.py
@@ -28,7 +28,13 @@ from .ssflux_math import (
 # means the function's own default is used -- _coverage_kwargs only forwards
 # keys that are actually present, so an operator touching zero of them gets
 # today's behaviour exactly.
-_COVERAGE_THRESHOLD_KEYS = ("median_tol", "max_bad_fraction", "hard_bad_fraction")
+_COVERAGE_THRESHOLD_KEYS = (
+    "median_tol",
+    "max_bad_fraction",
+    "band_lo",
+    "band_hi",
+    "magnitude_bad_fraction",
+)
 
 
 def _coverage_kwargs(config: dict) -> dict:
@@ -282,8 +288,15 @@ def run_ssflux_reduce(df, config: dict, logger):
         # normalisation groups. Canonicalise numeric-looking labels through
         # int() first so "01" and 1 collapse to the same "1"; non-numeric
         # labels ("10L"/"10U") fall through unchanged.
-        df = df.assign(vpu=df["vpu"].map(_canonical_vpu_label))
-        groups = list(df.groupby("vpu").groups.items())
+        #
+        # This canonicalisation is for GROUPING ONLY -- build a throwaway key
+        # Series and group on that, never assign it back onto df["vpu"]. `vpu`
+        # is declared in the `prms: provenance` block as "per-HRU VPU" and
+        # must record the fabric's label VERBATIM; a fabric whose VPU
+        # attribute is "01" must still read "01" in the merged CSV, not the
+        # canonicalised "1".
+        group_key = df["vpu"].map(_canonical_vpu_label)
+        groups = list(df.groupby(group_key).groups.items())
     else:
         groups = [("__fabric__", df.index)]
 

--- a/src/gfv2_params/zonal_runners/ssflux.py
+++ b/src/gfv2_params/zonal_runners/ssflux.py
@@ -169,6 +169,34 @@ def run_ssflux_reduce(df, config: dict, logger):
             "so re-run --mode zonal before merging."
         )
 
+    # A pre-#175 batch CSV left behind by a failed/unrun array task carries no
+    # L_* columns at all, so pd.concat's column union backfills them with NaN
+    # for every row that file contributed -- the `missing` check above passes
+    # because SOME batch has the columns. The exact invariant this frame must
+    # satisfy is: an L_* column is NaN *iff* k_perm_log_wtd is NaN (slope/area
+    # nulls already raise in the map phase; derive_log_params guards area; so
+    # k_perm_log_wtd is the only legitimate source of NaN in an L_* column).
+    # A row with a non-NaN k_perm_log_wtd but a NaN L_* can therefore only
+    # have come from a stale pre-#175 batch file -- raise rather than let it
+    # merge silently and get KNN gap-filled downstream like real no-data.
+    if "k_perm_log_wtd" in df.columns:
+        has_k = df["k_perm_log_wtd"].notna()
+        stale_mask = pd.Series(False, index=df.index)
+        for fp in flux_params:
+            stale_mask |= has_k & df[f"L_{fp['name']}"].isna()
+        n_stale = int(stale_mask.sum())
+        if n_stale > 0:
+            output_dir = config.get("output_dir", "<output_dir>")
+            raise ValueError(
+                f"{n_stale} row(s) have a populated k_perm_log_wtd but NaN in an "
+                "L_* column. This is the signature of a stale pre-#175 batch CSV "
+                f"left in {output_dir}/ssflux/ by a failed or un-rerun --mode zonal "
+                "array task -- pd.concat backfills its missing L_* columns with "
+                "NaN, which would otherwise merge silently and get KNN gap-filled "
+                "like real no-lithology data. Re-run the failed --mode zonal "
+                "batch(es) and re-run --mode merge."
+            )
+
     if scope == "vpu":
         if "vpu" not in df.columns or df["vpu"].isna().all():
             raise ValueError(

--- a/src/gfv2_params/zonal_runners/ssflux.py
+++ b/src/gfv2_params/zonal_runners/ssflux.py
@@ -16,6 +16,12 @@ import numpy as np
 import pandas as pd
 
 from ..raster_ops import deg_to_fraction
+from .ssflux_math import (
+    aggregate_k_perm_log,
+    derive_log_params,
+    interpolate_to_range,
+    validate_weight_coverage,
+)
 
 
 def run_ssflux_batch(config: dict, batch_id: int, logger) -> None:
@@ -70,18 +76,13 @@ def run_ssflux_batch(config: dict, batch_id: int, logger) -> None:
     source_gdf["flux_id"] = source_gdf["flux_id"].astype(str)
     w = weights.merge(source_gdf[["flux_id", "k_perm"]], on="flux_id")
 
-    k_perm_min = config["k_perm_min"]
-    w["k_perm"] = w["k_perm"].replace(0, k_perm_min)
-    w["k_perm_actual"] = 10 ** w["k_perm"]
-    w["k_perm_wtd_sum"] = w["k_perm_actual"] * (w["area_weight"] / w["flux_id_area"])
-
-    extensive_agg = (
-        w.groupby(id_feature)
-        .agg(k_perm_wtd=("k_perm_wtd_sum", "sum"))
-        .reset_index()
-    )
-    extensive_agg[id_feature] = extensive_agg[id_feature].astype(int)
-    extensive_sorted = extensive_agg.sort_values(by=id_feature).reset_index(drop=True)
+    # Permeability is INTENSIVE: area-weighted mean, not an area-prorated sum.
+    # k_perm == 0 is Gleeson's no-data flag and is excluded, not floored to
+    # k_perm_min -- see ssflux_math.aggregate_k_perm_log and issue #175.
+    validate_weight_coverage(w, id_feature, logger)
+    agg = aggregate_k_perm_log(w, id_feature)
+    agg[id_feature] = agg[id_feature].astype(int)
+    k_perm_agg = agg.sort_values(by=id_feature).reset_index(drop=True)
 
     slope_merge = slope_df[[id_feature, "mean_slope_fraction"]].copy()
     try:
@@ -96,8 +97,20 @@ def run_ssflux_batch(config: dict, batch_id: int, logger) -> None:
     except (ValueError, TypeError) as exc:
         raise ValueError(f"Non-numeric {id_feature} values in target fabric") from exc
 
-    df = extensive_sorted.merge(slope_merge, on=id_feature, how="left").copy()
+    # Carried so the reducer can honour `norm_scope: vpu`. gfv2 is multi-VPU and
+    # keys this off the per-HRU `vpu` attribute; single-VPU fabrics declare a
+    # `vpu` scalar in their base_config profile instead.
+    if "vpu" in target_gdf.columns:
+        vpu_df = target_gdf[[id_feature, "vpu"]].copy()
+    else:
+        vpu_df = pd.DataFrame(
+            {id_feature: target_gdf[id_feature], "vpu": config.get("vpu", pd.NA)}
+        )
+    vpu_df[id_feature] = vpu_df[id_feature].astype("int64")
+
+    df = k_perm_agg.merge(slope_merge, on=id_feature, how="left").copy()
     df = df.merge(area_df, on=id_feature, how="left")
+    df = df.merge(vpu_df, on=id_feature, how="left")
 
     null_slope = df["mean_slope_fraction"].isna().sum()
     null_area = df["hru_area"].isna().sum()
@@ -108,41 +121,77 @@ def run_ssflux_batch(config: dict, batch_id: int, logger) -> None:
             f"use consistent {id_feature} values."
         )
 
-    df["r_soil2gw_max"] = df["k_perm_wtd"] ** 3
-    df["r_ssr2gw_rate"] = df["k_perm_wtd"] * (1 - df["mean_slope_fraction"])
-    df["r_slowcoef_lin"] = (df["k_perm_wtd"] * df["mean_slope_fraction"]) / df["hru_area"]
-    df["r_fastcoef_lin"] = 2 * df["r_slowcoef_lin"]
-    df["r_gwflow_coef"] = df["r_slowcoef_lin"]
-    df["r_dprst_seep_rate_open"] = df["r_ssr2gw_rate"]
-    df["r_dprst_flow_coef"] = df["r_fastcoef_lin"]
-
-    # Normalisation is per-batch (not CONUS-wide), matching prior per-VPU
-    # behaviour. The same raw value may map to slightly different normalised
-    # values across batches because per-batch min/max ranges differ.
-    flux_params = config["flux_params"]
-    param_names = [fp["name"] for fp in flux_params]
-    param_maxes = [fp["max"] for fp in flux_params]
-    param_mins = [fp["min"] for fp in flux_params]
-
-    df_r = df[[f"r_{p}" for p in param_names]].agg(["min", "max"])
-    df_r.loc["range"] = df_r.loc["max"] - df_r.loc["min"]
-
-    for i, p in enumerate(param_names):
-        rcol = f"r_{p}"
-        min_in, rng_in = df_r.at["min", rcol], df_r.at["range", rcol]
-        min_out, max_out = param_mins[i], param_maxes[i]
-        rng_out = max_out - min_out
-        if rng_in == 0:
-            logger.warning("Range is zero for %s; using midpoint of output range", p)
-            df[p] = (min_out + max_out) / 2.0
-        else:
-            norm = (df[rcol] - min_in) / rng_in
-            df[p] = norm * rng_out + min_out
-
-    df.drop(columns=[f"r_{p}" for p in param_names], inplace=True)
+    # Raw values stay in log10 space; normalisation happens in the reduce step
+    # (run_ssflux_reduce) because min/max must be taken over the whole fabric,
+    # not over an arbitrary SLURM batch.
+    log_params = derive_log_params(
+        df["k_perm_log_wtd"].to_numpy(),
+        df["mean_slope_fraction"].to_numpy(),
+        df["hru_area"].to_numpy(),
+    )
+    for name, values in log_params.items():
+        df[f"L_{name}"] = values
 
     ssflux_dir = output_dir / "ssflux"
     ssflux_dir.mkdir(parents=True, exist_ok=True)
     file_prefix = f"base_nhm_ssflux_{fabric}_batch_{batch_id:04d}_param"
     df.to_csv(ssflux_dir / f"{file_prefix}.csv", index=False)
     logger.info("SSFlux parameters saved (batch %d)", batch_id)
+
+
+def run_ssflux_reduce(df, config: dict, logger):
+    """Normalise the log-space L_* columns onto each parameter's target range.
+
+    Runs once on the CONCATENATED frame (see run_merge's `reducer` hook), never
+    per batch: TM 6-B9 interpolates over "all HRUs in a GF region", and doing it
+    per SLURM batch made two HRUs with identical geology and slope receive
+    different values depending on how the fabric was chunked (#175 item 3).
+
+    `norm_scope: fabric` (default) takes one min/max over every HRU, which makes
+    the output invariant to batch partitioning by construction. `norm_scope: vpu`
+    reproduces TM 6-B9's per-region wording, at the cost of discontinuities at
+    VPU boundaries.
+    """
+    id_feature = config["id_feature"]
+    flux_params = config["flux_params"]
+    scope = config.get("norm_scope", "fabric")
+    if scope not in ("fabric", "vpu"):
+        raise ValueError(f"Unknown norm_scope '{scope}'; expected 'fabric' or 'vpu'.")
+
+    missing = [f"L_{fp['name']}" for fp in flux_params if f"L_{fp['name']}" not in df.columns]
+    if missing:
+        raise ValueError(
+            f"Merged frame is missing {missing}. The ssflux batch runner must emit "
+            "L_* columns; a frame without them predates the #175 map/reduce split, "
+            "so re-run --mode zonal before merging."
+        )
+
+    if scope == "vpu":
+        if "vpu" not in df.columns or df["vpu"].isna().all():
+            raise ValueError(
+                "norm_scope: vpu needs a populated 'vpu' column in the merged frame. "
+                "Multi-VPU fabrics carry it per HRU; single-VPU fabrics must declare "
+                "a `vpu` scalar in their base_config profile."
+            )
+        groups = list(df.groupby("vpu").groups.items())
+    else:
+        groups = [("__fabric__", df.index)]
+
+    out = df.copy()
+    for fp in flux_params:
+        name, lo, hi = fp["name"], float(fp["min"]), float(fp["max"])
+        col = np.full(len(out), np.nan)
+        for label, idx in groups:
+            pos = out.index.get_indexer(idx)
+            try:
+                col[pos] = interpolate_to_range(out.loc[idx, f"L_{name}"].to_numpy(), lo, hi)
+            except ValueError as exc:
+                raise ValueError(f"{name} (scope={scope}, group={label}): {exc}") from exc
+        out[name] = col
+
+    out = out.drop(columns=[f"L_{fp['name']}" for fp in flux_params])
+    logger.info(
+        "Normalised %d ssflux params over scope=%s (%d group(s))",
+        len(flux_params), scope, len(groups),
+    )
+    return out.sort_values(id_feature).reset_index(drop=True)

--- a/src/gfv2_params/zonal_runners/ssflux.py
+++ b/src/gfv2_params/zonal_runners/ssflux.py
@@ -23,6 +23,41 @@ from .ssflux_math import (
     validate_weight_coverage,
 )
 
+# validate_weight_coverage's keyword-only thresholds, individually overridable
+# from the ssflux entry in configs/zonal/zonal_params.yml. Absent from config
+# means the function's own default is used -- _coverage_kwargs only forwards
+# keys that are actually present, so an operator touching zero of them gets
+# today's behaviour exactly.
+_COVERAGE_THRESHOLD_KEYS = ("median_tol", "max_bad_fraction", "hard_bad_fraction")
+
+
+def _coverage_kwargs(config: dict) -> dict:
+    """Pull whichever weight-coverage thresholds the config overrides.
+
+    Keeps validate_weight_coverage's own defaults for anything the config
+    doesn't set, rather than re-stating them here and risking the two
+    drifting apart.
+    """
+    return {k: config[k] for k in _COVERAGE_THRESHOLD_KEYS if k in config}
+
+
+def _canonical_vpu_label(value) -> str:
+    """Canonical string form of a VPU label for norm_scope: vpu grouping.
+
+    Independent per-batch-file ``read_csv`` dtype inference can turn the same
+    VPU into "01" (str) in one file and 1 (int) in another; a bare
+    ``astype(str)`` would keep those as the distinct strings "01" and "1" and
+    silently split one VPU's HRUs into two normalisation groups. Numeric-
+    looking labels are canonicalised through ``int()`` so both collapse to
+    "1"; NHDPlus's non-numeric labels ("10L", "10U") pass through unchanged
+    (after stripping whitespace) since ``int()`` rejects them.
+    """
+    s = str(value).strip()
+    try:
+        return str(int(s))
+    except (TypeError, ValueError):
+        return s
+
 
 def run_ssflux_batch(config: dict, batch_id: int, logger) -> None:
     """One HRU batch of subsurface flux parameter derivation.
@@ -79,7 +114,7 @@ def run_ssflux_batch(config: dict, batch_id: int, logger) -> None:
     # Permeability is INTENSIVE: area-weighted mean, not an area-prorated sum.
     # k_perm == 0 is Gleeson's no-data flag and is excluded, not floored to
     # k_perm_min -- see ssflux_math.aggregate_k_perm_log and issue #175.
-    validate_weight_coverage(w, id_feature, logger)
+    validate_weight_coverage(w, id_feature, logger, **_coverage_kwargs(config))
     agg = aggregate_k_perm_log(w, id_feature)
     agg[id_feature] = agg[id_feature].astype(int)
     k_perm_agg = agg.sort_values(by=id_feature).reset_index(drop=True)
@@ -169,32 +204,55 @@ def run_ssflux_reduce(df, config: dict, logger):
             "so re-run --mode zonal before merging."
         )
 
-    # A pre-#175 batch CSV left behind by a failed/unrun array task carries no
-    # L_* columns at all, so pd.concat's column union backfills them with NaN
-    # for every row that file contributed -- the `missing` check above passes
-    # because SOME batch has the columns. The exact invariant this frame must
-    # satisfy is: an L_* column is NaN *iff* k_perm_log_wtd is NaN (slope/area
-    # nulls already raise in the map phase; derive_log_params guards area; so
-    # k_perm_log_wtd is the only legitimate source of NaN in an L_* column).
-    # A row with a non-NaN k_perm_log_wtd but a NaN L_* can therefore only
-    # have come from a stale pre-#175 batch file -- raise rather than let it
-    # merge silently and get KNN gap-filled downstream like real no-data.
-    if "k_perm_log_wtd" in df.columns:
-        has_k = df["k_perm_log_wtd"].notna()
-        stale_mask = pd.Series(False, index=df.index)
-        for fp in flux_params:
-            stale_mask |= has_k & df[f"L_{fp['name']}"].isna()
-        n_stale = int(stale_mask.sum())
-        if n_stale > 0:
-            output_dir = config.get("output_dir", "<output_dir>")
+    # A pre-#175 batch CSV left behind by a failed/unrun array task carries
+    # NEITHER k_perm_log_wtd NOR L_*/fflux -- its real (pre-#175) schema is
+    # <id>, k_perm_wtd, mean_slope_fraction, hru_area, <7 param columns>.
+    # pd.concat's column union backfills every column that file lacks with
+    # NaN for the rows it contributed, which is why a check keyed on
+    # "k_perm_log_wtd populated but L_* NaN" can never fire for a real stale
+    # file: such a row has k_perm_log_wtd == NaN too (it never had that
+    # column at all), so `has_k` is False and the AND short-circuits to
+    # False. That check only ever caught a hand-built test frame that forced
+    # k_perm_log_wtd populated on the "stale" rows -- an impossible state for
+    # an actual pre-#175 CSV.
+    #
+    # Two checks that actually detect a real stale/foreign batch file:
+    output_dir = config.get("output_dir", "<output_dir>")
+
+    # (a) Retired-column check: k_perm_wtd was RENAMED to k_perm_log_wtd by
+    # #175 (root cause #1, extensive -> intensive aggregation). Its presence
+    # in the merged frame at all is conclusive proof some batch predates the
+    # rewrite.
+    if "k_perm_wtd" in df.columns:
+        raise ValueError(
+            "Merged frame contains the retired 'k_perm_wtd' column -- at least "
+            "one batch CSV predates the #175 aggregation rewrite (k_perm_wtd, "
+            "the extensive-form column, was replaced by k_perm_log_wtd, the "
+            f"intensive-form one). Clear stale files from {output_dir}/ssflux/ "
+            "and re-run the affected --mode zonal batch(es), then --mode merge."
+        )
+
+    # (b) Coverage-column check: the map phase (run_ssflux_batch via
+    # aggregate_k_perm_log) always emits a populated `fflux` -- either a real
+    # coverage fraction or the FFLUX_NO_OVERLAP (-1.0) sentinel, NEVER NaN.
+    # This is what separates a stale row from a legitimate no-lithology HRU:
+    # both have NaN k_perm_log_wtd/L_*, but only the legitimate HRU has a
+    # populated fflux. A NaN fflux can therefore only mean the contributing
+    # file didn't produce this column at all -- stale or foreign. (If `fflux`
+    # is missing from EVERY batch, the frame predates #175 entirely and the
+    # `missing` L_* check above already raised -- this check only needs to
+    # catch the mixed case where at least one fresh batch contributed it.)
+    if "fflux" in df.columns:
+        n_nan_fflux = int(df["fflux"].isna().sum())
+        if n_nan_fflux > 0:
             raise ValueError(
-                f"{n_stale} row(s) have a populated k_perm_log_wtd but NaN in an "
-                "L_* column. This is the signature of a stale pre-#175 batch CSV "
-                f"left in {output_dir}/ssflux/ by a failed or un-rerun --mode zonal "
-                "array task -- pd.concat backfills its missing L_* columns with "
-                "NaN, which would otherwise merge silently and get KNN gap-filled "
-                "like real no-lithology data. Re-run the failed --mode zonal "
-                "batch(es) and re-run --mode merge."
+                f"{n_nan_fflux} row(s) have a NaN 'fflux'. The map phase always "
+                "emits fflux as either a real coverage fraction or the "
+                "FFLUX_NO_OVERLAP (-1.0) sentinel -- never NaN -- so these rows "
+                "came from a batch CSV that did not produce this column, i.e. a "
+                f"stale pre-#175 or foreign file. Clear stale files from "
+                f"{output_dir}/ssflux/ and re-run the failed --mode zonal "
+                "batch(es), then --mode merge."
             )
 
     if scope == "vpu":
@@ -216,11 +274,15 @@ def run_ssflux_reduce(df, config: dict, logger):
             )
         # Per-batch CSVs are read back independently (see run_merge), so
         # pandas' per-file dtype inference can disagree on the same VPU label
-        # ("01" -> int 1 in one file, str "01" in another); NHDPlus VPU labels
-        # also include non-numeric ones ("10L", "10U"). Cast to string before
-        # grouping so mixed int/str labels can't diverge into separate groups
-        # and groupby(sort=True) doesn't raise TypeError comparing int to str.
-        df = df.assign(vpu=df["vpu"].astype(str))
+        # ("01" -> int 1 in one file, str "01" in another, both meaning the
+        # same VPU); NHDPlus VPU labels also include non-numeric ones ("10L",
+        # "10U"). A bare astype(str) is not enough -- it turns "01" into the
+        # string "01" and int 1 into the string "1", which are DIFFERENT
+        # groupby keys, silently splitting one VPU's HRUs into two
+        # normalisation groups. Canonicalise numeric-looking labels through
+        # int() first so "01" and 1 collapse to the same "1"; non-numeric
+        # labels ("10L"/"10U") fall through unchanged.
+        df = df.assign(vpu=df["vpu"].map(_canonical_vpu_label))
         groups = list(df.groupby("vpu").groups.items())
     else:
         groups = [("__fabric__", df.index)]

--- a/src/gfv2_params/zonal_runners/ssflux_math.py
+++ b/src/gfv2_params/zonal_runners/ssflux_math.py
@@ -1,0 +1,225 @@
+"""Pure numerical helpers for the ssflux derivation.
+
+Kept separate from ``ssflux.py`` so the maths is unit-testable without geo
+fixtures, a data root, or SLURM. See
+``docs/superpowers/specs/2026-08-10-ssflux-normalisation-design.md``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+# Gleeson k_perm is log10 permeability, so 0 would mean 1 m^2 -- physically
+# impossible. It is the dataset's no-data flag (9,409 of 202,108 CONUS
+# polygons). This is a STORED flag, not a computed value, so exact equality is
+# correct here; a tolerance would risk swallowing a genuine measurement. Note
+# -16.48 is NOT a sentinel -- it is the real least-permeable lithology class
+# (26,441 polygons), which is why no-data must be excluded rather than floored.
+K_PERM_NODATA = 0.0
+
+# fflux value for an HRU with no valid lithology overlap at all, matching the
+# reference implementation (Viger 2014, doi:10.5066/F7CN71XR).
+FFLUX_NO_OVERLAP = -1.0
+
+# mean_slope_fraction is tan(slope), so it is unbounded above; 317 CONUS HRUs
+# are exactly 0 and 3 exceed 1 (up to 66.85 deg), where log10(slope) and
+# log10(1 - slope) are undefined. Clamp rather than drop: these are real HRUs
+# that still need a parameter value.
+SLOPE_FLOOR = 1e-4
+SLOPE_CEIL = 1.0 - 1e-4
+
+# Below this width the input range carries no information and min-max
+# normalisation would divide by ~0.
+RANGE_ATOL = 1e-12
+
+PARAM_NAMES = (
+    "soil2gw_max",
+    "ssr2gw_rate",
+    "fastcoef_lin",
+    "slowcoef_lin",
+    "gwflow_coef",
+    "dprst_seep_rate_open",
+    "dprst_flow_coef",
+)
+
+
+def validate_weight_coverage(
+    weights: pd.DataFrame,
+    id_feature: str,
+    logger,
+    *,
+    weight_col: str = "normalized_area_weight",
+    tol: float = 0.01,
+    max_bad_fraction: float = 0.05,
+) -> None:
+    """Assert the weights behave like gdptools' intensive ``wght``.
+
+    ``wght`` sums to ~1.0 per target for a spatially continuous source layer.
+    Real CONUS data is close but not exact: 1,828 HRUs have coverage gaps and 98
+    have overlapping source polygons, so a handful outside ``[1-tol, 1+tol]`` is
+    expected and only warned about.
+
+    A *wholesale* deviation means the wrong column is being summed -- the
+    extensive construction that caused #175 gave per-HRU sums spanning 3.6e13x
+    with a median of 0.022. That raises. This is the guard that stops the
+    extensive/intensive confusion from silently returning.
+    """
+    if weight_col not in weights.columns:
+        raise ValueError(
+            f"Weight frame is missing '{weight_col}', gdptools' intensive weight. "
+            f"Columns: {sorted(weights.columns)}."
+        )
+    sums = weights.groupby(id_feature)[weight_col].sum()
+    bad = ~np.isclose(sums.to_numpy(), 1.0, rtol=0.0, atol=tol)
+    bad_fraction = float(bad.mean()) if len(sums) else 0.0
+    if bad_fraction > max_bad_fraction:
+        raise ValueError(
+            f"{bad_fraction:.1%} of HRUs have sum({weight_col}) outside "
+            f"1.0 +/- {tol} (median {float(sums.median()):.4f}, "
+            f"min {float(sums.min()):.4g}, max {float(sums.max()):.4g}). "
+            f"'{weight_col}' must be gdptools' `wght`, which sums to ~1 per "
+            "target. A median far from 1 means an EXTENSIVE construction such as "
+            "area_weight / <source>_area is being used -- that is issue #175."
+        )
+    if bad.any():
+        logger.warning(
+            "%d of %d HRUs have sum(%s) outside 1.0 +/- %s (min %.4g, max %.4g) -- "
+            "lithology coverage gaps and overlapping source polygons; the "
+            "aggregation renormalises by the per-HRU sum, so these are handled.",
+            int(bad.sum()), len(sums), weight_col, tol,
+            float(sums.min()), float(sums.max()),
+        )
+
+
+def aggregate_k_perm_log(
+    weights: pd.DataFrame,
+    id_feature: str,
+    *,
+    weight_col: str = "normalized_area_weight",
+    k_col: str = "k_perm",
+) -> pd.DataFrame:
+    """Area-weighted mean of log10 permeability -- gdptools' INTENSIVE form.
+
+    Permeability is intensive: it does not add up when regions combine, so the
+    aggregation is ``(sum v_i a_i) / (sum a_i)``, NOT the extensive
+    ``sum V_i (a_i / A_i)``. gdptools labels the source-polygon area column
+    "for extensive variables"; using it here was the root cause of #175.
+
+    ``weight_col`` is gdptools' ``wght`` (shipped as ``normalized_area_weight``),
+    the proportional area of the source polygon within the target.
+
+    Dividing by ``den`` is load-bearing beyond no-data exclusion: the lithology
+    layer is not perfectly continuous (1,828 CONUS HRUs have coverage gaps, 98
+    have overlapping source polygons).
+
+    Returns one row per HRU with ``k_perm_log_wtd`` (NaN where no valid
+    lithology) and ``fflux`` (valid-coverage fraction, ``FFLUX_NO_OVERLAP``
+    where none).
+    """
+    for col in (id_feature, k_col, weight_col):
+        if col not in weights.columns:
+            raise ValueError(
+                f"Weight frame is missing '{col}'. Columns: {sorted(weights.columns)}. "
+                f"'{weight_col}' is gdptools' intensive weight and is required -- do "
+                f"not substitute area_weight / <source>_area, which is the extensive form."
+            )
+
+    w = weights[[id_feature, k_col, weight_col]].copy()
+    w[k_col] = w[k_col].astype(float)
+    w[weight_col] = w[weight_col].astype(float)
+
+    # Exact comparison is deliberate: a stored no-data flag, not a computed value.
+    valid = w[k_col].notna() & (w[k_col] != K_PERM_NODATA)
+
+    all_ids = pd.Index(w[id_feature].unique(), name=id_feature).sort_values()
+    v = w[valid]
+    num = (v[k_col] * v[weight_col]).groupby(v[id_feature]).sum().reindex(all_ids)
+    den = v[weight_col].groupby(v[id_feature]).sum().reindex(all_ids)
+
+    den_arr = den.to_numpy()
+    covered = np.isfinite(den_arr) & (den_arr > 0.0)
+
+    k_log = np.full(len(all_ids), np.nan)
+    np.divide(num.to_numpy(), den_arr, out=k_log, where=covered)
+
+    fflux = np.where(covered, den_arr, FFLUX_NO_OVERLAP)
+
+    return pd.DataFrame(
+        {id_feature: all_ids.to_numpy(), "k_perm_log_wtd": k_log, "fflux": fflux}
+    )
+
+
+def derive_log_params(
+    k_perm_log_wtd: np.ndarray,
+    slope_fraction: np.ndarray,
+    hru_area: np.ndarray,
+) -> dict[str, np.ndarray]:
+    """TM 6-B9's structure, expressed additively in log10 space.
+
+    Because ``k_perm_log_wtd`` is already log10, a product becomes a sum and the
+    cube becomes a factor of 3 on the exponent::
+
+        L(soil2gw_max)  = 3*k
+        L(ssr2gw_rate)  =   k + log10(1 - slope)
+        L(slowcoef_lin) =   k + log10(slope) - log10(hru_area)
+
+    The cube is on ``soil2gw_max`` only, matching the reference implementation's
+    FGDC attribute definitions (Viger 2014) and today's code -- TM 6-B9 line 790
+    states a cube for the other two, but the 2014 source metadata does not. It
+    makes no difference to output anyway: for ``soil2gw_max`` the x3 is a pure
+    scale on the exponent and is fully absorbed by the later min-max
+    interpolation.
+
+    NaN in ``k_perm_log_wtd`` propagates to NaN, which is the signal for the
+    downstream KNN gap-fill.
+    """
+    k = np.asarray(k_perm_log_wtd, dtype=float)
+    slope = np.asarray(slope_fraction, dtype=float)
+    area = np.asarray(hru_area, dtype=float)
+
+    if np.any(~np.isfinite(area) | (area <= 0.0)):
+        bad = int(np.sum(~np.isfinite(area) | (area <= 0.0)))
+        raise ValueError(
+            f"hru_area must be finite and > 0 for log10; {bad} row(s) violate this. "
+            "A non-positive area means the fabric geometry is degenerate."
+        )
+
+    slope_c = np.clip(slope, SLOPE_FLOOR, SLOPE_CEIL)
+
+    out: dict[str, np.ndarray] = {}
+    out["soil2gw_max"] = 3.0 * k
+    out["ssr2gw_rate"] = k + np.log10(1.0 - slope_c)
+    out["slowcoef_lin"] = k + np.log10(slope_c) - np.log10(area)
+    out["fastcoef_lin"] = out["slowcoef_lin"] + np.log10(2.0)
+    out["gwflow_coef"] = out["slowcoef_lin"]
+    out["dprst_seep_rate_open"] = out["ssr2gw_rate"]
+    out["dprst_flow_coef"] = out["fastcoef_lin"]
+    return out
+
+
+def interpolate_to_range(values: np.ndarray, lo: float, hi: float) -> np.ndarray:
+    """Linearly scale ``values`` onto ``[lo, hi]`` -- TM 6-B9's interpolation.
+
+    NaN is preserved in place (it marks an HRU for the KNN gap-fill) and is
+    excluded from the min/max. ``min``/``max`` are exact and order-independent,
+    which is what makes the merged output invariant to batch partitioning.
+    """
+    v = np.asarray(values, dtype=float)
+    finite = np.isfinite(v)
+    if not finite.any():
+        raise ValueError("No finite values to interpolate; cannot derive a range.")
+
+    lo_in = float(np.min(v[finite]))
+    hi_in = float(np.max(v[finite]))
+    span = hi_in - lo_in
+    if span <= RANGE_ATOL:
+        raise ValueError(
+            f"Input range is degenerate (min={lo_in!r}, max={hi_in!r}, "
+            f"span={span!r} <= {RANGE_ATOL}). Refusing to emit a constant field; "
+            "this means every HRU shares one value, which is the #175 failure mode."
+        )
+
+    out = np.full(v.shape, np.nan)
+    np.divide(v - lo_in, span, out=out, where=finite)
+    return out * (hi - lo) + lo

--- a/src/gfv2_params/zonal_runners/ssflux_math.py
+++ b/src/gfv2_params/zonal_runners/ssflux_math.py
@@ -57,7 +57,9 @@ def validate_weight_coverage(
     tol: float = 0.01,
     max_bad_fraction: float = 0.05,
     median_tol: float = 0.1,
-    hard_bad_fraction: float = 0.35,
+    band_lo: float = 0.5,
+    band_hi: float = 2.0,
+    magnitude_bad_fraction: float = 0.05,
 ) -> None:
     """Assert the weights behave like gdptools' intensive ``wght``.
 
@@ -82,15 +84,38 @@ def validate_weight_coverage(
     MAJORITY of HRUs. A frame with 60% of sums at 1.0 and 40% at 0.05 (the
     exact extensive-form signature on a minority of rows) still has a median
     of 1.0 -- up to just under 50% of HRUs could carry the bug completely
-    undetected by the median alone. So the tail fraction also gets a hard
-    ceiling (``hard_bad_fraction``): the documented legitimate worst case is
-    the clustered-gap batch above at ~32%, so a ceiling picked with real
-    margin above that (default 0.35) is not reachable by legitimate data, and
-    a tail this large is treated as a probable partial extensive-form
-    regression and raised, not merely logged. Between ``max_bad_fraction`` and
-    ``hard_bad_fraction`` the caller only gets a warning -- the median being
-    near 1.0 does not, on its own, prove the extensive form is absent for a
-    large minority of HRUs, so that warning must not claim it does.
+    undetected by the median alone. So a second check covers the minority
+    case, keyed on MAGNITUDE rather than a bare tail count.
+
+    An earlier version of this check used a tail-COUNT ceiling
+    (``hard_bad_fraction``, default 0.35) sitting between the documented ~32%
+    legitimate clustered-gap worst case and an illustrative 40% counterexample
+    -- three points of margin that is not margin, and the 32% figure was not
+    even reproducible from the config (gfv2 ``batch_size`` is 10000, so the
+    1,828 known gap HRUs are ~18% of a batch, not 32%). Measured against the
+    real CONUS weights file (``shared/conus/weights/lith_weights_gfv2.csv``,
+    361,394 HRUs) against the extensive-form construction #175's bug produced::
+
+        per-HRU weight sum      REAL (intensive)   EXTENSIVE (#175 bug)
+        outside [0.5, 2.0]      0.111% (402 HRUs)   85.4%
+        below 0.1               0.071% (255)        63.1%
+        median                  1.0000              0.02215
+
+    So "fraction of HRUs whose weight sum falls outside [``band_lo``,
+    ``band_hi``] = [0.5, 2.0]" separates real data from the bug by ~770x,
+    versus the tail-count rule's ~1.1x margin. Real CONUS data sits at
+    0.111%, so the default ``magnitude_bad_fraction`` of 0.05 (5%) carries
+    ~45x margin over real data -- and, unlike the count rule, it also catches
+    a PARTIAL extensive-form regression affecting as little as ~6% of HRUs;
+    the old count rule needed 35% of HRUs to be affected before it would even
+    consider raising. Raised as a probable partial extensive-form regression,
+    not merely logged.
+
+    Between ``max_bad_fraction`` (the ``[1-tol, 1+tol]`` tail, a soft
+    coverage-gap/overlap signal) and the magnitude band raise, the caller only
+    gets a warning -- the median being near 1.0 does not, on its own, prove
+    the extensive form is absent for a large minority of HRUs, so that warning
+    must not claim it does.
     """
     if weight_col not in weights.columns:
         raise ValueError(
@@ -111,17 +136,31 @@ def validate_weight_coverage(
 
     bad = ~np.isclose(sums.to_numpy(), 1.0, rtol=0.0, atol=tol)
     bad_fraction = float(bad.mean()) if len(sums) else 0.0
-    if bad_fraction > hard_bad_fraction:
+
+    # Magnitude discriminator (replaces the old tail-COUNT hard_bad_fraction
+    # ceiling -- see the docstring for the measured real-vs-extensive table
+    # this threshold rests on). Keyed on how far outside a plausible band the
+    # sum falls, not merely how many HRUs are outside a tight tolerance, so a
+    # cluster of mildly-off legitimate coverage gaps (sums like 0.6-0.95, well
+    # inside [band_lo, band_hi]) cannot trip it no matter how large the
+    # cluster, while a minority of HRUs at extensive-form magnitude
+    # (sums ~0.02-0.05, far outside the band) trips it even at a small
+    # fraction.
+    out_of_band = (sums.to_numpy() < band_lo) | (sums.to_numpy() > band_hi)
+    magnitude_fraction = float(out_of_band.mean()) if len(sums) else 0.0
+    if magnitude_fraction > magnitude_bad_fraction:
         raise ValueError(
-            f"{bad_fraction:.1%} of HRUs have sum({weight_col}) outside 1.0 +/- "
-            f"{tol} (median {median:.4f}), above the hard ceiling of "
-            f"{hard_bad_fraction:.0%}. The documented legitimate worst case is a "
-            "spatially-clustered batch of coverage gaps at ~32% (#175); a tail "
-            "this large -- even with a median near 1.0, which only rules out a "
-            "WHOLESALE extensive-form regression -- is treated as a probable "
-            f"PARTIAL extensive-form regression affecting a minority of HRUs. "
-            f"'{weight_col}' must be gdptools' intensive `wght` -- do not "
-            "substitute area_weight / <source>_area."
+            f"{magnitude_fraction:.1%} of HRUs have sum({weight_col}) outside "
+            f"the plausible band [{band_lo}, {band_hi}] (median {median:.4f}), "
+            f"above the ceiling of {magnitude_bad_fraction:.0%}. Real CONUS "
+            "data measures 0.111% of HRUs outside this band (402 of 361,394), "
+            "vs. 85.4% under the #175 extensive-form bug -- a ~770x "
+            "separation. A fraction this large -- even with a median near "
+            "1.0, which only rules out a WHOLESALE extensive-form regression "
+            "-- is treated as a probable PARTIAL extensive-form regression "
+            f"affecting a minority of HRUs. '{weight_col}' must be gdptools' "
+            "intensive `wght` -- do not substitute area_weight / "
+            "<source>_area."
         )
     if bad_fraction > max_bad_fraction:
         logger.warning(

--- a/src/gfv2_params/zonal_runners/ssflux_math.py
+++ b/src/gfv2_params/zonal_runners/ssflux_math.py
@@ -52,18 +52,28 @@ def validate_weight_coverage(
     weight_col: str = "normalized_area_weight",
     tol: float = 0.01,
     max_bad_fraction: float = 0.05,
+    median_tol: float = 0.1,
 ) -> None:
     """Assert the weights behave like gdptools' intensive ``wght``.
 
     ``wght`` sums to ~1.0 per target for a spatially continuous source layer.
     Real CONUS data is close but not exact: 1,828 HRUs have coverage gaps and 98
     have overlapping source polygons, so a handful outside ``[1-tol, 1+tol]`` is
-    expected and only warned about.
+    only warned about -- and gfv2 batches are spatially contiguous, so those
+    gaps CLUSTER: 1,828 known gap HRUs inside one ~5,650-HRU batch is 32%,
+    comfortably over a tail-fraction threshold like 5%, even though every
+    individual sum is a legitimate renormalised gap, not an extensive-form
+    signature. A tail-COUNT threshold therefore cannot distinguish "the wrong
+    column is being summed" from "this batch happens to contain a coverage-gap
+    cluster" -- see #175 (median 0.022 across the extensive form vs a clustered
+    per-batch tail that is a red herring).
 
-    A *wholesale* deviation means the wrong column is being summed -- the
-    extensive construction that caused #175 gave per-HRU sums spanning 3.6e13x
-    with a median of 0.022. That raises. This is the guard that stops the
-    extensive/intensive confusion from silently returning.
+    The signature that actually distinguishes the extensive form is the
+    **median**: the extensive construction that caused #175 displaced the
+    median itself (0.022 vs 1.0), because it scales with source-polygon size,
+    not target coverage. Raise only when the median strays from 1.0 by more
+    than ``median_tol``; individual out-of-tolerance HRUs (the tail) are only
+    ever warned about, at whatever ``max_bad_fraction`` the caller configures.
     """
     if weight_col not in weights.columns:
         raise ValueError(
@@ -71,18 +81,30 @@ def validate_weight_coverage(
             f"Columns: {sorted(weights.columns)}."
         )
     sums = weights.groupby(id_feature)[weight_col].sum()
+    median = float(sums.median()) if len(sums) else float("nan")
+    if len(sums) and not np.isclose(median, 1.0, rtol=0.0, atol=median_tol):
+        raise ValueError(
+            f"median(sum({weight_col})) = {median:.4f}, more than {median_tol} "
+            "away from 1.0. This is the extensive-form signature: 'wght' sums "
+            "to ~1.0 per target for gdptools' intensive weight, but scales with "
+            f"source-polygon size under the extensive form. '{weight_col}' must "
+            "be gdptools' `wght` -- do not substitute area_weight / "
+            "<source>_area, which is issue #175's root cause."
+        )
+
     bad = ~np.isclose(sums.to_numpy(), 1.0, rtol=0.0, atol=tol)
     bad_fraction = float(bad.mean()) if len(sums) else 0.0
     if bad_fraction > max_bad_fraction:
-        raise ValueError(
-            f"{bad_fraction:.1%} of HRUs have sum({weight_col}) outside "
-            f"1.0 +/- {tol} (median {float(sums.median()):.4f}, "
-            f"min {float(sums.min()):.4g}, max {float(sums.max()):.4g}). "
-            f"'{weight_col}' must be gdptools' `wght`, which sums to ~1 per "
-            "target. A median far from 1 means an EXTENSIVE construction such as "
-            "area_weight / <source>_area is being used -- that is issue #175."
+        logger.warning(
+            "%.1f%% of HRUs have sum(%s) outside 1.0 +/- %s (median %.4f, "
+            "min %.4g, max %.4g) -- median is close to 1.0 so this is not the "
+            "extensive-form signature; likely a clustered batch of legitimate "
+            "lithology coverage gaps/overlaps, which the aggregation "
+            "renormalises by the per-HRU sum.",
+            bad_fraction * 100, weight_col, tol, median,
+            float(sums.min()), float(sums.max()),
         )
-    if bad.any():
+    elif bad.any():
         logger.warning(
             "%d of %d HRUs have sum(%s) outside 1.0 +/- %s (min %.4g, max %.4g) -- "
             "lithology coverage gaps and overlapping source polygons; the "
@@ -205,6 +227,13 @@ def interpolate_to_range(values: np.ndarray, lo: float, hi: float) -> np.ndarray
     excluded from the min/max. ``min``/``max`` are exact and order-independent,
     which is what makes the merged output invariant to batch partitioning.
     """
+    if not hi > lo:
+        raise ValueError(
+            f"Target range is not valid: hi={hi!r} must be strictly greater "
+            f"than lo={lo!r}. A transposed min/max in the flux_params config "
+            "would silently emit an inverted field otherwise."
+        )
+
     v = np.asarray(values, dtype=float)
     finite = np.isfinite(v)
     if not finite.any():

--- a/src/gfv2_params/zonal_runners/ssflux_math.py
+++ b/src/gfv2_params/zonal_runners/ssflux_math.py
@@ -22,10 +22,14 @@ K_PERM_NODATA = 0.0
 # reference implementation (Viger 2014, doi:10.5066/F7CN71XR).
 FFLUX_NO_OVERLAP = -1.0
 
-# mean_slope_fraction is tan(slope), so it is unbounded above; 317 CONUS HRUs
-# are exactly 0 and 3 exceed 1 (up to 66.85 deg), where log10(slope) and
-# log10(1 - slope) are undefined. Clamp rather than drop: these are real HRUs
-# that still need a parameter value.
+# mean_slope_fraction is tan(slope), so it is unbounded above; 320 CONUS HRUs
+# are exactly 0 (measured from the slope INPUT, nhm_slope_params.csv,
+# 361,471 rows -- not the stale ssflux output, which undercounts at 317
+# because it has only 361,394 rows; re-measure from nhm_slope_params.csv
+# rather than trusting this number, per CLAUDE.md's re-measure convention)
+# and 3 exceed 1 (up to 66.85 deg), where log10(slope) and log10(1 - slope)
+# are undefined. Clamp rather than drop: these are real HRUs that still need
+# a parameter value.
 SLOPE_FLOOR = 1e-4
 SLOPE_CEIL = 1.0 - 1e-4
 
@@ -53,6 +57,7 @@ def validate_weight_coverage(
     tol: float = 0.01,
     max_bad_fraction: float = 0.05,
     median_tol: float = 0.1,
+    hard_bad_fraction: float = 0.35,
 ) -> None:
     """Assert the weights behave like gdptools' intensive ``wght``.
 
@@ -68,12 +73,24 @@ def validate_weight_coverage(
     cluster" -- see #175 (median 0.022 across the extensive form vs a clustered
     per-batch tail that is a red herring).
 
-    The signature that actually distinguishes the extensive form is the
-    **median**: the extensive construction that caused #175 displaced the
-    median itself (0.022 vs 1.0), because it scales with source-polygon size,
-    not target coverage. Raise only when the median strays from 1.0 by more
-    than ``median_tol``; individual out-of-tolerance HRUs (the tail) are only
-    ever warned about, at whatever ``max_bad_fraction`` the caller configures.
+    The **median** is the strongest signal: the extensive construction that
+    caused #175 displaced the median itself (0.022 vs 1.0), because it scales
+    with source-polygon size, not target coverage. Raise when the median
+    strays from 1.0 by more than ``median_tol``.
+
+    The median check alone has a blind spot, though: it only reflects the
+    MAJORITY of HRUs. A frame with 60% of sums at 1.0 and 40% at 0.05 (the
+    exact extensive-form signature on a minority of rows) still has a median
+    of 1.0 -- up to just under 50% of HRUs could carry the bug completely
+    undetected by the median alone. So the tail fraction also gets a hard
+    ceiling (``hard_bad_fraction``): the documented legitimate worst case is
+    the clustered-gap batch above at ~32%, so a ceiling picked with real
+    margin above that (default 0.35) is not reachable by legitimate data, and
+    a tail this large is treated as a probable partial extensive-form
+    regression and raised, not merely logged. Between ``max_bad_fraction`` and
+    ``hard_bad_fraction`` the caller only gets a warning -- the median being
+    near 1.0 does not, on its own, prove the extensive form is absent for a
+    large minority of HRUs, so that warning must not claim it does.
     """
     if weight_col not in weights.columns:
         raise ValueError(
@@ -94,13 +111,28 @@ def validate_weight_coverage(
 
     bad = ~np.isclose(sums.to_numpy(), 1.0, rtol=0.0, atol=tol)
     bad_fraction = float(bad.mean()) if len(sums) else 0.0
+    if bad_fraction > hard_bad_fraction:
+        raise ValueError(
+            f"{bad_fraction:.1%} of HRUs have sum({weight_col}) outside 1.0 +/- "
+            f"{tol} (median {median:.4f}), above the hard ceiling of "
+            f"{hard_bad_fraction:.0%}. The documented legitimate worst case is a "
+            "spatially-clustered batch of coverage gaps at ~32% (#175); a tail "
+            "this large -- even with a median near 1.0, which only rules out a "
+            "WHOLESALE extensive-form regression -- is treated as a probable "
+            f"PARTIAL extensive-form regression affecting a minority of HRUs. "
+            f"'{weight_col}' must be gdptools' intensive `wght` -- do not "
+            "substitute area_weight / <source>_area."
+        )
     if bad_fraction > max_bad_fraction:
         logger.warning(
             "%.1f%% of HRUs have sum(%s) outside 1.0 +/- %s (median %.4f, "
-            "min %.4g, max %.4g) -- median is close to 1.0 so this is not the "
-            "extensive-form signature; likely a clustered batch of legitimate "
-            "lithology coverage gaps/overlaps, which the aggregation "
-            "renormalises by the per-HRU sum.",
+            "min %.4g, max %.4g). The median is close to 1.0, which only rules "
+            "out a wholesale extensive-form regression -- it does NOT prove the "
+            "extensive form is absent for this minority. This is consistent "
+            "with EITHER a clustered batch of legitimate lithology coverage "
+            "gaps/overlaps (which the aggregation renormalises by the per-HRU "
+            "sum) OR a partial extensive-form regression affecting a minority "
+            "of HRUs; it warrants checking.",
             bad_fraction * 100, weight_col, tol, median,
             float(sums.min()), float(sums.max()),
         )

--- a/tests/test_merge_reducers.py
+++ b/tests/test_merge_reducers.py
@@ -1,0 +1,64 @@
+"""The optional reduce hook on run_merge."""
+
+import pandas as pd
+import pytest
+
+from gfv2_params.zonal_runners import MERGE_REDUCERS, run_merge
+
+
+class _Logger:
+    def info(self, *a, **k): pass
+    def debug(self, *a, **k): pass
+    def warning(self, *a, **k): pass
+
+
+def _write_batches(tmp_path, n_batches=2):
+    d = tmp_path / "ssflux"
+    d.mkdir(parents=True)
+    rows = [(1, 10.0), (2, 20.0), (3, 30.0), (4, 40.0)]
+    per = len(rows) // n_batches
+    for i in range(n_batches):
+        chunk = rows[i * per:(i + 1) * per]
+        pd.DataFrame(chunk, columns=["nat_hru_id", "L_x"]).to_csv(
+            d / f"base_nhm_ssflux_testfab_batch_{i:04d}_param.csv", index=False
+        )
+    return {
+        "source_type": "ssflux",
+        "id_feature": "nat_hru_id",
+        "merged_file": "out.csv",
+        "fabric": "testfab",
+        "output_dir": str(tmp_path),
+    }
+
+
+def test_merge_without_reducer_is_unchanged(tmp_path):
+    cfg = _write_batches(tmp_path)
+    run_merge(cfg, _Logger())
+    out = pd.read_csv(tmp_path / "merged" / "out.csv")
+    assert list(out.columns) == ["nat_hru_id", "L_x"]
+    assert out["L_x"].tolist() == [10.0, 20.0, 30.0, 40.0]
+
+
+def test_reducer_receives_full_frame_and_its_result_is_written(tmp_path):
+    cfg = _write_batches(tmp_path)
+    seen = {}
+
+    def reducer(df, config, logger):
+        seen["n"] = len(df)
+        return df.assign(scaled=df["L_x"] / df["L_x"].max()).drop(columns=["L_x"])
+
+    run_merge(cfg, _Logger(), reducer=reducer)
+    out = pd.read_csv(tmp_path / "merged" / "out.csv")
+    assert seen["n"] == 4, "reducer must see all batches, not one"
+    assert "L_x" not in out.columns
+    assert out["scaled"].max() == pytest.approx(1.0)
+
+
+def test_reducer_must_return_a_dataframe(tmp_path):
+    cfg = _write_batches(tmp_path)
+    with pytest.raises(TypeError, match="DataFrame"):
+        run_merge(cfg, _Logger(), reducer=lambda df, config, logger: None)
+
+
+def test_merge_reducers_is_a_dict():
+    assert isinstance(MERGE_REDUCERS, dict)

--- a/tests/test_merge_reducers.py
+++ b/tests/test_merge_reducers.py
@@ -62,3 +62,54 @@ def test_reducer_must_return_a_dataframe(tmp_path):
 
 def test_merge_reducers_is_a_dict():
     assert isinstance(MERGE_REDUCERS, dict)
+
+
+def test_reducer_that_drops_a_row_raises(tmp_path):
+    """MERGE_REDUCERS is explicitly designed for extension beyond ssflux, so
+    this protects every future reducer: pre-reducer validation (duplicate
+    check, gap warning) is worthless if the reducer itself can silently drop
+    rows on the way out."""
+    cfg = _write_batches(tmp_path)
+
+    def reducer(df, config, logger):
+        return df.iloc[:-1]
+
+    with pytest.raises(ValueError, match="row count"):
+        run_merge(cfg, _Logger(), reducer=reducer)
+
+
+def test_reducer_that_relabels_an_id_raises(tmp_path):
+    """Same row count, but a different id set -- must also raise; count alone
+    isn't enough to prove row identity survived."""
+    cfg = _write_batches(tmp_path)
+
+    def reducer(df, config, logger):
+        out = df.copy()
+        out.loc[out.index[0], "nat_hru_id"] = 999
+        return out
+
+    with pytest.raises(ValueError, match="nat_hru_id"):
+        run_merge(cfg, _Logger(), reducer=reducer)
+
+
+def test_reducer_that_drops_the_id_column_raises(tmp_path):
+    cfg = _write_batches(tmp_path)
+
+    def reducer(df, config, logger):
+        return df.drop(columns=["nat_hru_id"])
+
+    with pytest.raises(ValueError, match="nat_hru_id"):
+        run_merge(cfg, _Logger(), reducer=reducer)
+
+
+def test_reducer_that_preserves_rows_and_ids_is_unaffected(tmp_path):
+    """The invariant check must not false-positive on a well-behaved reducer."""
+    cfg = _write_batches(tmp_path)
+
+    def reducer(df, config, logger):
+        return df.assign(scaled=df["L_x"] * 2)
+
+    run_merge(cfg, _Logger(), reducer=reducer)
+    out = pd.read_csv(tmp_path / "merged" / "out.csv")
+    assert len(out) == 4
+    assert set(out["nat_hru_id"]) == {1, 2, 3, 4}

--- a/tests/test_merge_reducers.py
+++ b/tests/test_merge_reducers.py
@@ -113,3 +113,63 @@ def test_reducer_that_preserves_rows_and_ids_is_unaffected(tmp_path):
     out = pd.read_csv(tmp_path / "merged" / "out.csv")
     assert len(out) == 4
     assert set(out["nat_hru_id"]) == {1, 2, 3, 4}
+
+
+# ---------------------------------------------------------------------------
+# read_dtypes: per-file dtype inference is not stable across batch files
+# ---------------------------------------------------------------------------
+# This reproduces the real ssflux `vpu` defect: pandas infers a categorical
+# column's dtype PER FILE. If one batch's values are all numeric-looking with
+# leading zeros ("01", "02") and another batch mixes in an alphanumeric label
+# ("03N"), the first batch reads as int64 (silently stripping the leading
+# zero: "01" -> 1) and the second as str -- so the same label ends up split
+# across two representations in the merged frame. Measured on a real gfv2_dev
+# rebuild: 28 distinct vpu labels merged where the fabric has only 21.
+
+
+def _write_mixed_dtype_batches(tmp_path):
+    d = tmp_path / "ssflux"
+    d.mkdir(parents=True)
+    # Batch 0: all-numeric-looking labels -> pandas infers int64, drops the
+    # leading zero ("01" -> 1, "02" -> 2).
+    pd.DataFrame(
+        {"nat_hru_id": [1, 2], "vpu": ["01", "02"]}
+    ).to_csv(d / "base_nhm_ssflux_testfab_batch_0000_param.csv", index=False)
+    # Batch 1: mixed alphanumeric label -> pandas infers str/object.
+    pd.DataFrame(
+        {"nat_hru_id": [3, 4], "vpu": ["01", "03N"]}
+    ).to_csv(d / "base_nhm_ssflux_testfab_batch_0001_param.csv", index=False)
+    return {
+        "source_type": "ssflux",
+        "id_feature": "nat_hru_id",
+        "merged_file": "out.csv",
+        "fabric": "testfab",
+        "output_dir": str(tmp_path),
+    }
+
+
+def test_merge_without_read_dtypes_exhibits_the_vpu_split(tmp_path):
+    """Documents the failure mode: without `read_dtypes`, the same "01" label
+    survives as the string "01" in the mixed batch but as the int 1 in the
+    all-numeric batch."""
+    cfg = _write_mixed_dtype_batches(tmp_path)
+    run_merge(cfg, _Logger())
+    out = pd.read_csv(tmp_path / "merged" / "out.csv", dtype={"nat_hru_id": int})
+    labels = set(out["vpu"].astype(str))
+    # The defect: "01" got silently split into "1" (from the int64 batch) and
+    # "01" (from the str batch) -- two labels in the merged frame for one
+    # fabric VPU.
+    assert labels == {"1", "2", "01", "03N"}
+
+
+def test_merge_with_read_dtypes_preserves_labels_verbatim(tmp_path):
+    """`read_dtypes: {vpu: str}` forces every batch to be read identically,
+    so no leading zero is stripped and no label splits."""
+    cfg = _write_mixed_dtype_batches(tmp_path)
+    cfg["read_dtypes"] = {"vpu": "str"}
+    run_merge(cfg, _Logger())
+    out = pd.read_csv(tmp_path / "merged" / "out.csv", dtype={"vpu": str})
+    assert set(out["vpu"]) == {"01", "02", "03N"}
+    # nat_hru_id 1 and 3 both carry "01" -- confirm it's the same string, not
+    # coincidentally-equal ints and strs.
+    assert out.set_index("nat_hru_id")["vpu"].to_dict() == {1: "01", 2: "02", 3: "01", 4: "03N"}

--- a/tests/test_ssflux.py
+++ b/tests/test_ssflux.py
@@ -1,0 +1,120 @@
+"""Map/reduce behaviour for ssflux (no geo fixtures -- the reducer is pure)."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from gfv2_params.zonal_runners import MERGE_REDUCERS, run_ssflux_reduce
+from gfv2_params.zonal_runners.ssflux_math import PARAM_NAMES
+
+ID = "nat_hru_id"
+
+FLUX_PARAMS = [
+    {"name": "soil2gw_max", "min": 0.1, "max": 0.3},
+    {"name": "ssr2gw_rate", "min": 0.3, "max": 0.7},
+    {"name": "fastcoef_lin", "min": 0.01, "max": 0.6},
+    {"name": "slowcoef_lin", "min": 0.005, "max": 0.3},
+    {"name": "gwflow_coef", "min": 0.005, "max": 0.3},
+    {"name": "dprst_seep_rate_open", "min": 0.005, "max": 0.2},
+    {"name": "dprst_flow_coef", "min": 0.005, "max": 0.1},
+]
+
+
+class _Logger:
+    def info(self, *a, **k): pass
+    def debug(self, *a, **k): pass
+    def warning(self, *a, **k): pass
+
+
+def _frame(n=50, with_vpu=False):
+    rng = np.random.default_rng(0)
+    df = pd.DataFrame({ID: np.arange(1, n + 1)})
+    for p in PARAM_NAMES:
+        df[f"L_{p}"] = rng.normal(-12.0, 2.0, n)
+    if with_vpu:
+        df["vpu"] = np.where(df[ID] <= n // 2, "01", "02")
+    return df
+
+
+def _cfg(scope="fabric"):
+    return {"id_feature": ID, "flux_params": FLUX_PARAMS, "norm_scope": scope}
+
+
+def test_reduce_maps_into_configured_ranges_and_drops_L_columns():
+    out = run_ssflux_reduce(_frame(), _cfg(), _Logger())
+    for p in FLUX_PARAMS:
+        col = out[p["name"]]
+        assert col.min() == pytest.approx(p["min"])
+        assert col.max() == pytest.approx(p["max"])
+    assert not [c for c in out.columns if c.startswith("L_")]
+
+
+def test_reduce_is_registered():
+    assert MERGE_REDUCERS["ssflux"] is run_ssflux_reduce
+
+
+def test_batch_invariance_is_bit_exact():
+    """The issue's acceptance criterion: identical output across batch splits."""
+    df = _frame(40)
+    whole = run_ssflux_reduce(df.copy(), _cfg(), _Logger())
+    # same rows, different partition + arrival order
+    shuffled = pd.concat([df.iloc[20:], df.iloc[:20]], ignore_index=True)
+    split = run_ssflux_reduce(shuffled, _cfg(), _Logger()).sort_values(ID).reset_index(drop=True)
+    pd.testing.assert_frame_equal(whole, split)
+
+
+def test_nan_rows_survive_for_gap_fill():
+    df = _frame(20)
+    df.loc[df[ID] == 5, [f"L_{p}" for p in PARAM_NAMES]] = np.nan
+    out = run_ssflux_reduce(df, _cfg(), _Logger())
+    assert out.loc[out[ID] == 5, "soil2gw_max"].isna().all()
+    assert out["soil2gw_max"].notna().sum() == 19
+
+
+def test_vpu_scope_normalises_within_each_region():
+    out = run_ssflux_reduce(_frame(40, with_vpu=True), _cfg("vpu"), _Logger())
+    for vpu in ("01", "02"):
+        sub = out[out["vpu"] == vpu]["soil2gw_max"]
+        assert sub.min() == pytest.approx(0.1)
+        assert sub.max() == pytest.approx(0.3)
+
+
+def test_vpu_scope_requires_the_column():
+    with pytest.raises(ValueError, match="vpu"):
+        run_ssflux_reduce(_frame(10), _cfg("vpu"), _Logger())
+
+
+def test_unknown_norm_scope_raises():
+    with pytest.raises(ValueError, match="norm_scope"):
+        run_ssflux_reduce(_frame(10), _cfg("galaxy"), _Logger())
+
+
+def test_missing_L_column_raises():
+    df = _frame(10).drop(columns=["L_gwflow_coef"])
+    with pytest.raises(ValueError, match="L_gwflow_coef"):
+        run_ssflux_reduce(df, _cfg(), _Logger())
+
+
+def test_csv_round_trip_is_lossless(tmp_path):
+    """The map/reduce split writes L_* to CSV and reads them back."""
+    df = _frame(30)
+    p = tmp_path / "batch.csv"
+    df.to_csv(p, index=False)
+    back = pd.read_csv(p)
+    pd.testing.assert_frame_equal(df, back)
+
+
+def test_output_is_not_degenerate():
+    """#175's acceptance criteria, on a realistic log-normal-ish input.
+
+    The pre-fix product had >=89.5% of HRUs within 1% of the range minimum and
+    an IQR spanning 0.1% of the range. Both thresholds here would have failed it.
+    """
+    out = run_ssflux_reduce(_frame(5000), _cfg(), _Logger())
+    for p in FLUX_PARAMS:
+        col = out[p["name"]].to_numpy()
+        rng = p["max"] - p["min"]
+        at_min = np.mean(col <= p["min"] + 0.01 * rng)
+        iqr = np.subtract(*np.percentile(col, [75, 25])) / rng
+        assert at_min <= 0.20, f"{p['name']}: {at_min:.1%} pinned at range minimum"
+        assert iqr >= 0.10, f"{p['name']}: IQR spans only {iqr:.3f} of the range"

--- a/tests/test_ssflux.py
+++ b/tests/test_ssflux.py
@@ -131,6 +131,34 @@ def test_missing_L_column_raises():
         run_ssflux_reduce(df, _cfg(), _Logger())
 
 
+def test_stale_pre175_batch_raises_on_populated_k_with_nan_L():
+    """A pre-#175 batch CSV left by a failed array task has no L_* columns.
+
+    pd.concat's column union backfills them with NaN for every row that file
+    contributed, which passes the `missing` check (some OTHER batch has the
+    columns) -- but k_perm_log_wtd is populated for those rows since it's an
+    older-schema column both pre- and post-#175. That combination (non-NaN
+    k_perm_log_wtd, NaN L_*) can only come from a stale batch and must raise,
+    not merge silently into a KNN-fillable NaN.
+    """
+    df = _frame(10)
+    df["k_perm_log_wtd"] = -12.0
+    stale_rows = df[ID].isin([3, 7])
+    df.loc[stale_rows, [f"L_{p}" for p in PARAM_NAMES]] = np.nan
+    with pytest.raises(ValueError, match="stale"):
+        run_ssflux_reduce(df, _cfg(), _Logger())
+
+
+def test_legitimate_nan_k_perm_with_nan_L_does_not_raise():
+    """A genuine no-lithology HRU (NaN k_perm_log_wtd, NaN L_*) is fine."""
+    df = _frame(10)
+    df["k_perm_log_wtd"] = -12.0
+    df.loc[df[ID] == 5, "k_perm_log_wtd"] = np.nan
+    df.loc[df[ID] == 5, [f"L_{p}" for p in PARAM_NAMES]] = np.nan
+    out = run_ssflux_reduce(df, _cfg(), _Logger())
+    assert out.loc[out[ID] == 5, "soil2gw_max"].isna().all()
+
+
 def test_csv_round_trip_is_lossless(tmp_path):
     """The map/reduce split writes L_* to CSV and reads them back."""
     df = _frame(30)

--- a/tests/test_ssflux.py
+++ b/tests/test_ssflux.py
@@ -62,6 +62,18 @@ def test_batch_invariance_is_bit_exact():
     split = run_ssflux_reduce(shuffled, _cfg(), _Logger()).sort_values(ID).reset_index(drop=True)
     pd.testing.assert_frame_equal(whole, split)
 
+    # `shuffled` still has a fresh, monotonic RangeIndex (ignore_index=True),
+    # under which `out.index.get_indexer(idx)` is the identity by
+    # construction -- a broken positional-assignment path would pass
+    # unnoticed. Feed a reversed, non-monotonic index and confirm the result
+    # is unchanged.
+    reindexed = df.copy()
+    reindexed.index = reindexed.index[::-1]
+    reversed_out = (
+        run_ssflux_reduce(reindexed, _cfg(), _Logger()).sort_values(ID).reset_index(drop=True)
+    )
+    pd.testing.assert_frame_equal(whole, reversed_out)
+
 
 def test_nan_rows_survive_for_gap_fill():
     df = _frame(20)
@@ -82,6 +94,30 @@ def test_vpu_scope_normalises_within_each_region():
 def test_vpu_scope_requires_the_column():
     with pytest.raises(ValueError, match="vpu"):
         run_ssflux_reduce(_frame(10), _cfg("vpu"), _Logger())
+
+
+def test_vpu_scope_rejects_partial_null_vpu():
+    """A partially-null vpu column must raise, not silently vanish under
+    groupby(dropna=True) -- that would produce NaN params indistinguishable
+    from the legitimate no-lithology NaN and get silently KNN gap-filled."""
+    df = _frame(40, with_vpu=True)
+    df.loc[df[ID] == 3, "vpu"] = None
+    with pytest.raises(ValueError, match="null"):
+        run_ssflux_reduce(df, _cfg("vpu"), _Logger())
+
+
+def test_vpu_scope_handles_mixed_dtype_and_nonnumeric_labels():
+    """NHDPlus VPU labels include non-numeric ones (10L, 10U); independent
+    per-batch-file read_csv dtype inference can also give int vs str for the
+    same numeric-looking label. Both must group and sort without raising."""
+    df = _frame(30)
+    df["vpu"] = ["10L"] * 10 + ["10U"] * 10 + [1] * 10
+    out = run_ssflux_reduce(df, _cfg("vpu"), _Logger())
+    assert set(out["vpu"]) == {"10L", "10U", "1"}
+    for vpu in ("10L", "10U", "1"):
+        sub = out[out["vpu"] == vpu]["soil2gw_max"]
+        assert sub.min() == pytest.approx(0.1)
+        assert sub.max() == pytest.approx(0.3)
 
 
 def test_unknown_norm_scope_raises():

--- a/tests/test_ssflux.py
+++ b/tests/test_ssflux.py
@@ -5,7 +5,23 @@ import pandas as pd
 import pytest
 
 from gfv2_params.zonal_runners import MERGE_REDUCERS, run_ssflux_reduce
-from gfv2_params.zonal_runners.ssflux_math import PARAM_NAMES
+from gfv2_params.zonal_runners.ssflux import _canonical_vpu_label, _coverage_kwargs
+from gfv2_params.zonal_runners.ssflux_math import (
+    FFLUX_NO_OVERLAP,
+    PARAM_NAMES,
+    aggregate_k_perm_log,
+    derive_log_params,
+    validate_weight_coverage,
+)
+
+# The 8 real discrete Gleeson log10-permeability classes (see the design doc
+# and ssflux_math.py) -- used by test_output_is_not_degenerate so that test
+# exercises the actual achievable spatial pattern, not an arbitrary
+# distribution the production pipeline could never see.
+GLEESON_K_PERM_CLASSES = np.array(
+    [-10.87, -11.79, -12.47, -12.50, -12.78, -14.05, -15.05, -16.48]
+)
+K_PERM_MIN_LEGACY = -16.48  # pre-#175 floor substituted for the no-data flag
 
 ID = "nat_hru_id"
 
@@ -84,8 +100,12 @@ def test_nan_rows_survive_for_gap_fill():
 
 
 def test_vpu_scope_normalises_within_each_region():
+    """Input labels are zero-padded ("01"/"02"); the output column carries
+    the canonical form (leading zero stripped, see
+    test_vpu_scope_normalises_mixed_leading_zero_and_int_labels_into_one_group)
+    so the assertions below read "1"/"2", not the padded input labels."""
     out = run_ssflux_reduce(_frame(40, with_vpu=True), _cfg("vpu"), _Logger())
-    for vpu in ("01", "02"):
+    for vpu in ("1", "2"):
         sub = out[out["vpu"] == vpu]["soil2gw_max"]
         assert sub.min() == pytest.approx(0.1)
         assert sub.max() == pytest.approx(0.3)
@@ -131,32 +151,68 @@ def test_missing_L_column_raises():
         run_ssflux_reduce(df, _cfg(), _Logger())
 
 
-def test_stale_pre175_batch_raises_on_populated_k_with_nan_L():
-    """A pre-#175 batch CSV left by a failed array task has no L_* columns.
+def test_stale_pre175_batch_raises_via_retired_kperm_wtd_column():
+    """Simulates a REAL stale merge, not the impossible frame the old test used.
 
-    pd.concat's column union backfills them with NaN for every row that file
-    contributed, which passes the `missing` check (some OTHER batch has the
-    columns) -- but k_perm_log_wtd is populated for those rows since it's an
-    older-schema column both pre- and post-#175. That combination (non-NaN
-    k_perm_log_wtd, NaN L_*) can only come from a stale batch and must raise,
-    not merge silently into a KNN-fillable NaN.
+    A genuine pre-#175 batch CSV has schema <id>, k_perm_wtd,
+    mean_slope_fraction, hru_area, <7 param columns> -- it has NEITHER
+    k_perm_log_wtd NOR L_*/fflux at all. pd.concat's column union backfills
+    those with NaN for every row the stale file contributed (passing the
+    `missing` check, since the fresh batch has L_*), and k_perm_log_wtd is
+    ALSO NaN for those rows (never populated) -- so the retired guard
+    (`has_k & L_isna`) could never fire on this real shape; it required a
+    hand-built frame that forced k_perm_log_wtd populated on "stale" rows,
+    which is not a state a real stale file produces. The retired 'k_perm_wtd'
+    column itself is what makes this conclusively detectable.
     """
-    df = _frame(10)
-    df["k_perm_log_wtd"] = -12.0
-    stale_rows = df[ID].isin([3, 7])
-    df.loc[stale_rows, [f"L_{p}" for p in PARAM_NAMES]] = np.nan
-    with pytest.raises(ValueError, match="stale"):
-        run_ssflux_reduce(df, _cfg(), _Logger())
+    fresh = _frame(10)
+    fresh["k_perm_log_wtd"] = -12.0
+    fresh["fflux"] = 0.9
+    old_schema = pd.DataFrame(
+        {
+            ID: np.arange(11, 14),
+            "k_perm_wtd": [1.2e-12, 3.4e-13, 5.6e-14],
+            "mean_slope_fraction": [0.1, 0.2, 0.3],
+            "hru_area": [1e5, 2e5, 3e5],
+        }
+    )
+    for p in PARAM_NAMES:
+        old_schema[p] = 0.05
+    merged = pd.concat([fresh, old_schema], ignore_index=True)
+    with pytest.raises(ValueError, match="k_perm_wtd"):
+        run_ssflux_reduce(merged, _cfg(), _Logger())
+
+
+def test_foreign_batch_without_fflux_raises_even_without_retired_column():
+    """A foreign/corrupted file carrying neither the retired k_perm_wtd NOR
+    fflux must still be caught -- by the coverage-column check, which is why
+    both checks are needed and not just the retired-column one."""
+    fresh = _frame(10)
+    fresh["k_perm_log_wtd"] = -12.0
+    fresh["fflux"] = 0.9
+    foreign = pd.DataFrame({ID: np.arange(11, 13)})
+    merged = pd.concat([fresh, foreign], ignore_index=True)
+    with pytest.raises(ValueError, match="fflux"):
+        run_ssflux_reduce(merged, _cfg(), _Logger())
 
 
 def test_legitimate_nan_k_perm_with_nan_L_does_not_raise():
-    """A genuine no-lithology HRU (NaN k_perm_log_wtd, NaN L_*) is fine."""
+    """A genuine no-lithology HRU (NaN k_perm_log_wtd, NaN L_*) must NOT raise.
+
+    This is exactly the case the retired `has_k` check could never actually
+    distinguish from a stale row (see the test above) -- what separates it is
+    that `fflux` is POPULATED here (FFLUX_NO_OVERLAP, -1.0), never NaN, unlike
+    a genuinely stale/foreign row.
+    """
     df = _frame(10)
     df["k_perm_log_wtd"] = -12.0
+    df["fflux"] = 0.9
     df.loc[df[ID] == 5, "k_perm_log_wtd"] = np.nan
+    df.loc[df[ID] == 5, "fflux"] = FFLUX_NO_OVERLAP
     df.loc[df[ID] == 5, [f"L_{p}" for p in PARAM_NAMES]] = np.nan
     out = run_ssflux_reduce(df, _cfg(), _Logger())
     assert out.loc[out[ID] == 5, "soil2gw_max"].isna().all()
+    assert out["soil2gw_max"].notna().sum() == 9
 
 
 def test_csv_round_trip_is_lossless(tmp_path):
@@ -169,16 +225,141 @@ def test_csv_round_trip_is_lossless(tmp_path):
 
 
 def test_output_is_not_degenerate():
-    """#175's acceptance criteria, on a realistic log-normal-ish input.
+    """#175's acceptance criteria, end to end through the real pipeline
+    functions on a realistic Gleeson-class input.
 
-    The pre-fix product had >=89.5% of HRUs within 1% of the range minimum and
-    an IQR spanning 0.1% of the range. Both thresholds here would have failed it.
+    The prior version of this test fed i.i.d. Gaussians straight into
+    run_ssflux_reduce -- it never called aggregate_k_perm_log or
+    derive_log_params, so it would still pass with the entire #175 fix
+    reverted (it tests only that interpolate_to_range maps a normal
+    distribution onto a range, which was never broken). This version instead
+    builds a weight frame from the 8 real discrete Gleeson k_perm classes
+    (plus a no-data slice) and runs it through aggregate_k_perm_log ->
+    derive_log_params -> run_ssflux_reduce -- the actual #175 pipeline.
+
+    It then proves the fix mattered by computing the INVERSE: reconstructing
+    the retired pre-#175 pipeline (extensive aggregation via
+    10**k_perm * area_weight/flux_id_area, then plain linear min-max on the
+    raw, not log10, values -- verbatim from git c5a896d^:ssflux.py) on the
+    IDENTICAL input, and asserting it fails every threshold. If it didn't,
+    this test would not be distinguishing the fix from the bug it replaced.
     """
-    out = run_ssflux_reduce(_frame(5000), _cfg(), _Logger())
+    rng = np.random.default_rng(0)
+    n_hru = 3000
+    ids = np.arange(1, n_hru + 1)
+    # ~5% no-data, echoing Gleeson's measured ~4.7% (see ssflux_math.py).
+    is_nodata = rng.random(n_hru) < 0.05
+    k_perm = np.where(is_nodata, 0.0, rng.choice(GLEESON_K_PERM_CLASSES, size=n_hru))
+    slope_fraction = rng.uniform(0.01, 1.2, n_hru)
+    hru_area = rng.uniform(1e5, 5e7, n_hru)
+
+    # One fully-covering source polygon per HRU (area_weight/flux_id_area ==
+    # normalized_area_weight == 1) -- the common single-dominant-lithology
+    # case, and the simplest input on which the OLD extensive form and the
+    # NEW intensive form are directly comparable: no artificial area-ratio
+    # skew is needed to demonstrate the bug, linear min-max on a
+    # log-distributed variable already fails it on its own (see below).
+    weights = pd.DataFrame(
+        {
+            ID: ids,
+            "k_perm": k_perm,
+            "normalized_area_weight": 1.0,
+            "area_weight": 1.0,
+            "flux_id_area": 1.0,
+        }
+    )
+    meta = pd.DataFrame({ID: ids, "mean_slope_fraction": slope_fraction, "hru_area": hru_area})
+
+    # ---- the actual #175 pipeline: aggregate -> derive -> reduce ----
+    agg = aggregate_k_perm_log(weights, ID)
+    df_new = agg.merge(meta, on=ID)
+    log_params = derive_log_params(
+        df_new["k_perm_log_wtd"].to_numpy(),
+        df_new["mean_slope_fraction"].to_numpy(),
+        df_new["hru_area"].to_numpy(),
+    )
+    for name, values in log_params.items():
+        df_new[f"L_{name}"] = values
+    out_new = run_ssflux_reduce(df_new, _cfg(), _Logger())
+
     for p in FLUX_PARAMS:
-        col = out[p["name"]].to_numpy()
-        rng = p["max"] - p["min"]
-        at_min = np.mean(col <= p["min"] + 0.01 * rng)
-        iqr = np.subtract(*np.percentile(col, [75, 25])) / rng
+        col = out_new[p["name"]].dropna().to_numpy()
+        span = p["max"] - p["min"]
+        at_min = np.mean(col <= p["min"] + 0.01 * span)
+        iqr = np.subtract(*np.percentile(col, [75, 25])) / span
         assert at_min <= 0.20, f"{p['name']}: {at_min:.1%} pinned at range minimum"
         assert iqr >= 0.10, f"{p['name']}: IQR spans only {iqr:.3f} of the range"
+
+    # ---- the inverse: the retired extensive + linear pipeline, by hand ----
+    old = weights.copy()
+    old["k_perm"] = old["k_perm"].replace(0.0, K_PERM_MIN_LEGACY)
+    old["k_perm_actual"] = 10.0 ** old["k_perm"]
+    old["k_perm_wtd_sum"] = old["k_perm_actual"] * (old["area_weight"] / old["flux_id_area"])
+    extensive = old.groupby(ID)["k_perm_wtd_sum"].sum().rename("k_perm_wtd").reset_index()
+    old_df = extensive.merge(meta, on=ID)
+    old_df["r_soil2gw_max"] = old_df["k_perm_wtd"] ** 3
+    old_df["r_ssr2gw_rate"] = old_df["k_perm_wtd"] * (1 - old_df["mean_slope_fraction"])
+    old_df["r_slowcoef_lin"] = (
+        old_df["k_perm_wtd"] * old_df["mean_slope_fraction"]
+    ) / old_df["hru_area"]
+    old_df["r_fastcoef_lin"] = 2 * old_df["r_slowcoef_lin"]
+    old_df["r_gwflow_coef"] = old_df["r_slowcoef_lin"]
+    old_df["r_dprst_seep_rate_open"] = old_df["r_ssr2gw_rate"]
+    old_df["r_dprst_flow_coef"] = old_df["r_fastcoef_lin"]
+
+    for p in FLUX_PARAMS:
+        rcol = f"r_{p['name']}"
+        vv = old_df[rcol].to_numpy()
+        lo_in, hi_in = vv.min(), vv.max()
+        scaled = (vv - lo_in) / (hi_in - lo_in) * (p["max"] - p["min"]) + p["min"]
+        span = p["max"] - p["min"]
+        at_min = np.mean(scaled <= p["min"] + 0.01 * span)
+        iqr = np.subtract(*np.percentile(scaled, [75, 25])) / span
+        assert at_min > 0.20 or iqr < 0.10, (
+            f"{p['name']}: the retired extensive+linear pipeline passed the "
+            "acceptance thresholds on this input -- this test no longer "
+            "distinguishes the #175 fix from the bug it replaced"
+        )
+
+
+def test_vpu_scope_normalises_mixed_leading_zero_and_int_labels_into_one_group():
+    """Per-file read_csv dtype inference can strip leading zeros
+    inconsistently ACROSS batch files -- "01" from one file, int 1 from
+    another, for the SAME VPU -- which a bare astype(str) would leave as two
+    distinct groupby keys ("01" vs "1"), silently splitting one VPU's HRUs
+    into two normalisation groups. Both must land in ONE group."""
+    assert _canonical_vpu_label("01") == "1"
+    assert _canonical_vpu_label(1) == "1"
+    assert _canonical_vpu_label(" 02 ") == "2"
+    assert _canonical_vpu_label("10L") == "10L"
+
+    df = _frame(20)
+    df["vpu"] = ["01"] * 10 + [1] * 10
+    out = run_ssflux_reduce(df, _cfg("vpu"), _Logger())
+    assert set(out["vpu"]) == {"1"}
+    assert out["soil2gw_max"].min() == pytest.approx(0.1)
+    assert out["soil2gw_max"].max() == pytest.approx(0.3)
+
+
+def test_coverage_threshold_config_override_is_honoured():
+    """median_tol/max_bad_fraction/hard_bad_fraction are optional keys on the
+    ssflux entry in configs/zonal/zonal_params.yml; run_ssflux_batch threads
+    whichever ones are present into validate_weight_coverage via
+    _coverage_kwargs. Prove both ends: _coverage_kwargs extracts only the
+    keys actually set (absent keys keep today's behaviour exactly), and
+    threading a real override changes validate_weight_coverage's outcome."""
+    config = {"id_feature": ID, "hard_bad_fraction": 0.9, "unrelated_key": 123}
+    kwargs = _coverage_kwargs(config)
+    assert kwargs == {"hard_bad_fraction": 0.9}
+
+    # 60 HRUs at sum=1.0, 40 at sum=0.05: median stays 1.0 (so the median
+    # check doesn't fire) but the tail is 40% bad, past the default
+    # hard_bad_fraction=0.35 ceiling. Raises by default; must not raise once
+    # the config's looser ceiling is threaded through.
+    rows = [(i, -12.0, 1.0) for i in range(1, 61)] + [
+        (i, -12.0, 0.05) for i in range(61, 101)
+    ]
+    w = pd.DataFrame(rows, columns=[ID, "k_perm", "normalized_area_weight"])
+    with pytest.raises(ValueError, match="ceiling"):
+        validate_weight_coverage(w, ID, _Logger())
+    validate_weight_coverage(w, ID, _Logger(), **kwargs)

--- a/tests/test_ssflux.py
+++ b/tests/test_ssflux.py
@@ -37,9 +37,23 @@ FLUX_PARAMS = [
 
 
 class _Logger:
-    def info(self, *a, **k): pass
+    def __init__(self):
+        self.info_calls = []
+
+    def info(self, msg, *args, **k):
+        self.info_calls.append((msg, args))
+
     def debug(self, *a, **k): pass
     def warning(self, *a, **k): pass
+
+    def n_groups(self):
+        """Pull the group count out of run_ssflux_reduce's own summary log
+        line ("Normalised %d ssflux params over scope=%s (%d group(s))"),
+        without needing the reducer to expose its internal `groups` list."""
+        for msg, args in self.info_calls:
+            if "Normalised" in msg:
+                return args[-1]
+        raise AssertionError("expected a 'Normalised ...' info log call")
 
 
 def _frame(n=50, with_vpu=False):
@@ -100,15 +114,35 @@ def test_nan_rows_survive_for_gap_fill():
 
 
 def test_vpu_scope_normalises_within_each_region():
-    """Input labels are zero-padded ("01"/"02"); the output column carries
-    the canonical form (leading zero stripped, see
-    test_vpu_scope_normalises_mixed_leading_zero_and_int_labels_into_one_group)
-    so the assertions below read "1"/"2", not the padded input labels."""
-    out = run_ssflux_reduce(_frame(40, with_vpu=True), _cfg("vpu"), _Logger())
-    for vpu in ("1", "2"):
+    """Input labels are zero-padded ("01"/"02") and must come back out of the
+    reducer UNCHANGED -- `vpu` is declared in `prms: provenance` as "per-HRU
+    VPU" and must record the fabric's label verbatim, not a canonicalised
+    form (canonicalisation is for grouping only, see
+    test_vpu_scope_normalises_mixed_leading_zero_and_int_labels_into_one_group).
+    The two distinct raw labels must still normalise as two groups."""
+    logger = _Logger()
+    out = run_ssflux_reduce(_frame(40, with_vpu=True), _cfg("vpu"), logger)
+    assert set(out["vpu"]) == {"01", "02"}
+    for vpu in ("01", "02"):
         sub = out[out["vpu"] == vpu]["soil2gw_max"]
         assert sub.min() == pytest.approx(0.1)
         assert sub.max() == pytest.approx(0.3)
+    assert logger.n_groups() == 2
+
+
+def test_vpu_column_is_not_mutated_by_reducer():
+    """Explicit guard on the fidelity requirement: the emitted `vpu` values
+    must be byte-for-byte identical to what was passed in, including dtype --
+    the reducer may build a throwaway canonicalised key for grouping, but
+    must never assign it back onto the returned frame's `vpu` column."""
+    df = _frame(30)
+    df["vpu"] = ["10L"] * 10 + ["10U"] * 10 + [1] * 10
+    out = run_ssflux_reduce(df, _cfg("vpu"), _Logger())
+    merged = df[[ID, "vpu"]].merge(
+        out[[ID, "vpu"]], on=ID, suffixes=("_in", "_out")
+    )
+    assert (merged["vpu_in"] == merged["vpu_out"]).all()
+    assert list(merged["vpu_in"]) == list(merged["vpu_out"])
 
 
 def test_vpu_scope_requires_the_column():
@@ -129,12 +163,14 @@ def test_vpu_scope_rejects_partial_null_vpu():
 def test_vpu_scope_handles_mixed_dtype_and_nonnumeric_labels():
     """NHDPlus VPU labels include non-numeric ones (10L, 10U); independent
     per-batch-file read_csv dtype inference can also give int vs str for the
-    same numeric-looking label. Both must group and sort without raising."""
+    same numeric-looking label. Both must group and sort without raising, and
+    the emitted `vpu` column must still carry the RAW input values verbatim
+    (int 1, not canonicalised str "1")."""
     df = _frame(30)
     df["vpu"] = ["10L"] * 10 + ["10U"] * 10 + [1] * 10
     out = run_ssflux_reduce(df, _cfg("vpu"), _Logger())
-    assert set(out["vpu"]) == {"10L", "10U", "1"}
-    for vpu in ("10L", "10U", "1"):
+    assert set(out["vpu"]) == {"10L", "10U", 1}
+    for vpu in ("10L", "10U", 1):
         sub = out[out["vpu"] == vpu]["soil2gw_max"]
         assert sub.min() == pytest.approx(0.1)
         assert sub.max() == pytest.approx(0.3)
@@ -327,7 +363,10 @@ def test_vpu_scope_normalises_mixed_leading_zero_and_int_labels_into_one_group()
     inconsistently ACROSS batch files -- "01" from one file, int 1 from
     another, for the SAME VPU -- which a bare astype(str) would leave as two
     distinct groupby keys ("01" vs "1"), silently splitting one VPU's HRUs
-    into two normalisation groups. Both must land in ONE group."""
+    into two normalisation groups. Both must land in ONE group -- proven via
+    the reducer's own group-count log line, since the emitted `vpu` column no
+    longer collapses to a single canonical value (it stays verbatim, see
+    test_vpu_column_is_not_mutated_by_reducer)."""
     assert _canonical_vpu_label("01") == "1"
     assert _canonical_vpu_label(1) == "1"
     assert _canonical_vpu_label(" 02 ") == "2"
@@ -335,31 +374,36 @@ def test_vpu_scope_normalises_mixed_leading_zero_and_int_labels_into_one_group()
 
     df = _frame(20)
     df["vpu"] = ["01"] * 10 + [1] * 10
-    out = run_ssflux_reduce(df, _cfg("vpu"), _Logger())
-    assert set(out["vpu"]) == {"1"}
+    logger = _Logger()
+    out = run_ssflux_reduce(df, _cfg("vpu"), logger)
+    # emitted verbatim -- both raw forms still present, NOT collapsed to "1"
+    assert set(out["vpu"]) == {"01", 1}
+    assert logger.n_groups() == 1
     assert out["soil2gw_max"].min() == pytest.approx(0.1)
     assert out["soil2gw_max"].max() == pytest.approx(0.3)
 
 
 def test_coverage_threshold_config_override_is_honoured():
-    """median_tol/max_bad_fraction/hard_bad_fraction are optional keys on the
-    ssflux entry in configs/zonal/zonal_params.yml; run_ssflux_batch threads
-    whichever ones are present into validate_weight_coverage via
-    _coverage_kwargs. Prove both ends: _coverage_kwargs extracts only the
-    keys actually set (absent keys keep today's behaviour exactly), and
-    threading a real override changes validate_weight_coverage's outcome."""
-    config = {"id_feature": ID, "hard_bad_fraction": 0.9, "unrelated_key": 123}
+    """median_tol/max_bad_fraction/band_lo/band_hi/magnitude_bad_fraction are
+    optional keys on the ssflux entry in configs/zonal/zonal_params.yml;
+    run_ssflux_batch threads whichever ones are present into
+    validate_weight_coverage via _coverage_kwargs. Prove both ends:
+    _coverage_kwargs extracts only the keys actually set (absent keys keep
+    today's behaviour exactly), and threading a real override changes
+    validate_weight_coverage's outcome."""
+    config = {"id_feature": ID, "magnitude_bad_fraction": 0.9, "unrelated_key": 123}
     kwargs = _coverage_kwargs(config)
-    assert kwargs == {"hard_bad_fraction": 0.9}
+    assert kwargs == {"magnitude_bad_fraction": 0.9}
 
     # 60 HRUs at sum=1.0, 40 at sum=0.05: median stays 1.0 (so the median
-    # check doesn't fire) but the tail is 40% bad, past the default
-    # hard_bad_fraction=0.35 ceiling. Raises by default; must not raise once
-    # the config's looser ceiling is threaded through.
+    # check doesn't fire) but 40% of sums fall outside the default [0.5, 2.0]
+    # magnitude band, past the default magnitude_bad_fraction=0.05 ceiling.
+    # Raises by default; must not raise once the config's looser ceiling is
+    # threaded through.
     rows = [(i, -12.0, 1.0) for i in range(1, 61)] + [
         (i, -12.0, 0.05) for i in range(61, 101)
     ]
     w = pd.DataFrame(rows, columns=[ID, "k_perm", "normalized_area_weight"])
-    with pytest.raises(ValueError, match="ceiling"):
+    with pytest.raises(ValueError, match="band"):
         validate_weight_coverage(w, ID, _Logger())
     validate_weight_coverage(w, ID, _Logger(), **kwargs)

--- a/tests/test_ssflux_math.py
+++ b/tests/test_ssflux_math.py
@@ -200,7 +200,11 @@ def test_weight_coverage_passes_when_weights_sum_to_one():
 def test_weight_coverage_warns_on_gaps_and_overlaps():
     w = _weights([(1, -10.0, 0.4), (2, -11.0, 2.0), (3, -12.0, 1.0)])
     log = _CapturingLogger()
-    validate_weight_coverage(w, ID, log, max_bad_fraction=0.9)
+    # This tiny 3-HRU fixture is 2/3 "bad" by construction, which is well
+    # past the (CONUS-batch-sized) hard ceiling; raise both max_bad_fraction
+    # and hard_bad_fraction so this stays a test of the tail-count warning
+    # path specifically, not an accidental hit of the ceiling raise.
+    validate_weight_coverage(w, ID, log, max_bad_fraction=0.9, hard_bad_fraction=0.95)
     assert any("outside" in m for m in log.warnings)
 
 
@@ -233,6 +237,36 @@ def test_weight_coverage_clustered_gap_batch_warns_not_raises():
     assert any("outside" in m for m in log.warnings)
 
 
+def test_weight_coverage_raises_on_hard_ceiling_even_with_median_at_one():
+    """The median-only check has a blind spot: up to just under 50% of HRUs
+    can carry the extensive-form bug while the median stays exactly at 1.0,
+    because the median only reflects the majority. 60 HRUs at sum=1.0 plus 40
+    at sum=0.05 (the exact extensive-form signature, on a MINORITY of rows)
+    keeps the median at 1.0 -- but at 40% bad, it is well past the hard
+    ceiling (default 0.35, picked with real margin above the documented 32%
+    legitimate clustered-gap case) and must raise."""
+    rows = [(i, -12.0, 1.0) for i in range(1, 61)]
+    rows += [(i, -12.0, 0.05) for i in range(61, 101)]
+    w = _weights(rows)
+    sums = w.groupby(ID)["normalized_area_weight"].sum()
+    assert sums.median() == pytest.approx(1.0)
+    with pytest.raises(ValueError, match="ceiling"):
+        validate_weight_coverage(w, ID, _CapturingLogger())
+
+
+def test_weight_coverage_hard_ceiling_is_configurable():
+    """hard_bad_fraction is a keyword, not a hardcoded constant."""
+    rows = [(i, -12.0, 1.0) for i in range(1, 61)]
+    rows += [(i, -12.0, 0.05) for i in range(61, 101)]
+    w = _weights(rows)
+    with pytest.raises(ValueError, match="ceiling"):
+        validate_weight_coverage(w, ID, _CapturingLogger(), hard_bad_fraction=0.35)
+    # raising the ceiling above the actual 40% bad fraction: no raise, only warn
+    log = _CapturingLogger()
+    validate_weight_coverage(w, ID, log, hard_bad_fraction=0.9, max_bad_fraction=0.05)
+    assert any("outside" in m for m in log.warnings)
+
+
 def test_weight_coverage_median_tol_is_configurable():
     """The threshold is a keyword, not a hardcoded constant (spec robustness
     rule 5: 'a configured threshold')."""
@@ -240,7 +274,10 @@ def test_weight_coverage_median_tol_is_configurable():
     log = _CapturingLogger()
     # default median_tol=0.1 tolerates 0.85 (within 1.0 +/- 0.1 is false --
     # 0.85 is exactly on the edge at tol 0.15); use an explicit tight/loose
-    # pair to prove the kwarg is actually threaded through.
+    # pair to prove the kwarg is actually threaded through. All 3 HRUs sit at
+    # the same 0.85 (100% "bad" by the tol=0.01 tail test), so also raise
+    # hard_bad_fraction past that once the median check is loosened -- this
+    # test is about median_tol, not the separate hard-ceiling behaviour.
     with pytest.raises(ValueError, match="normalized_area_weight"):
         validate_weight_coverage(w, ID, log, median_tol=0.1)
-    validate_weight_coverage(w, ID, log, median_tol=0.2)
+    validate_weight_coverage(w, ID, log, median_tol=0.2, hard_bad_fraction=1.0)

--- a/tests/test_ssflux_math.py
+++ b/tests/test_ssflux_math.py
@@ -50,6 +50,47 @@ def test_hru_with_no_valid_lithology_is_nan_with_sentinel_fflux():
     assert out.loc[out[ID] == 1, "fflux"].iloc[0] == FFLUX_NO_OVERLAP
 
 
+def test_aggregation_is_batch_partition_invariant():
+    """Per-HRU results must be bit-identical regardless of how the source
+    weight rows are partitioned across SLURM batches (the map stage).
+
+    This is the MAP-side half of the #175 batch-invariance acceptance
+    criterion (test_batch_invariance_is_bit_exact in test_ssflux.py covers the
+    reduce side). It rests on a fact asserted nowhere until now: boolean-mask
+    filtering by id_feature (exactly what run_ssflux_batch does --
+    ``weights[weights[id_feature].isin(batch_ids)]``) preserves each HRU's
+    weight rows in their original file order, so groupby('id').sum() sees the
+    identical operand sequence whether run once over the whole frame or once
+    per disjoint batch. Uses non-trivial floats so a change in summation order
+    would show up at the ULP level rather than being masked by symmetry.
+    """
+    rng = np.random.default_rng(42)
+    ids = np.repeat(np.arange(1, 21), 5)  # 20 HRUs x 5 weight rows each
+    rows = pd.DataFrame(
+        {
+            ID: ids,
+            "k_perm": rng.uniform(-16.0, -10.0, len(ids)),
+            "normalized_area_weight": rng.uniform(0.05, 0.3, len(ids)),
+        }
+    )
+    whole = aggregate_k_perm_log(rows, ID).sort_values(ID).reset_index(drop=True)
+
+    # Partition by HRU id into two disjoint batches via boolean mask -- exactly
+    # what two SLURM array tasks reading the same weights CSV do -- aggregate
+    # each separately, and recombine.
+    part_a = rows[rows[ID] <= 10]
+    part_b = rows[rows[ID] > 10]
+    split = (
+        pd.concat(
+            [aggregate_k_perm_log(part_a, ID), aggregate_k_perm_log(part_b, ID)],
+            ignore_index=True,
+        )
+        .sort_values(ID)
+        .reset_index(drop=True)
+    )
+    pd.testing.assert_frame_equal(whole, split, check_exact=True)
+
+
 def test_aggregation_rejects_missing_weight_column():
     w = _weights([(1, -10.0, 0.5)]).rename(columns={"normalized_area_weight": "wght"})
     with pytest.raises(ValueError, match="normalized_area_weight"):
@@ -114,6 +155,20 @@ def test_interpolate_raises_on_degenerate_range():
         interpolate_to_range(np.array([2.0, 2.0, 2.0]), 0.0, 1.0)
 
 
+def test_interpolate_raises_on_transposed_hi_lo():
+    """A transposed min/max in a flux_params config entry must raise, not
+    silently emit an inverted field."""
+    v = np.array([-3.0, -2.0, -1.0])
+    with pytest.raises(ValueError, match="hi"):
+        interpolate_to_range(v, hi=0.1, lo=0.3)
+
+
+def test_interpolate_raises_on_equal_hi_lo():
+    v = np.array([-3.0, -2.0, -1.0])
+    with pytest.raises(ValueError, match="hi"):
+        interpolate_to_range(v, hi=0.2, lo=0.2)
+
+
 def test_extensive_form_is_not_silently_accepted():
     """A frame carrying ONLY the extensive columns must raise, not guess.
 
@@ -149,8 +204,43 @@ def test_weight_coverage_warns_on_gaps_and_overlaps():
     assert any("outside" in m for m in log.warnings)
 
 
-def test_weight_coverage_raises_when_too_many_are_bad():
-    """A wholesale deviation from 1.0 means the wrong weight column."""
+def test_weight_coverage_raises_when_median_is_displaced():
+    """The extensive-form signature is a displaced MEDIAN (0.022 vs 1.0), not
+    a tail count -- gfv2 batches are spatially contiguous, so legitimate
+    coverage gaps cluster and can blow past a tail-fraction threshold on their
+    own (see the clustered-gap test below). Median is what actually
+    distinguishes "wrong column" from "this batch has a gap cluster"."""
     w = _weights([(1, -10.0, 0.02), (2, -11.0, 0.03), (3, -12.0, 0.01)])
     with pytest.raises(ValueError, match="normalized_area_weight"):
         validate_weight_coverage(w, ID, _CapturingLogger())
+
+
+def test_weight_coverage_clustered_gap_batch_warns_not_raises():
+    """A batch that happens to contain a large cluster of legitimate coverage
+    gaps (~32% of HRUs, matching the measured 1,828-in-~5,650 CONUS batch)
+    must WARN, not raise, as long as the median stays near 1.0 -- the old
+    tail-fraction raise fired here and blamed the extensive form, aborting a
+    CONUS array task over a correct, if clustered, renormalised result."""
+    n_gap = 32
+    n_full = 68
+    rows = [(i, -12.0, 0.5) for i in range(1, n_gap + 1)]
+    rows += [(i, -12.0, 1.0) for i in range(n_gap + 1, n_gap + n_full + 1)]
+    w = _weights(rows)
+    log = _CapturingLogger()
+    sums = w.groupby(ID)["normalized_area_weight"].sum()
+    assert sums.median() == pytest.approx(1.0)
+    validate_weight_coverage(w, ID, log, max_bad_fraction=0.05)
+    assert any("outside" in m for m in log.warnings)
+
+
+def test_weight_coverage_median_tol_is_configurable():
+    """The threshold is a keyword, not a hardcoded constant (spec robustness
+    rule 5: 'a configured threshold')."""
+    w = _weights([(1, -10.0, 0.85), (2, -11.0, 0.85), (3, -12.0, 0.85)])
+    log = _CapturingLogger()
+    # default median_tol=0.1 tolerates 0.85 (within 1.0 +/- 0.1 is false --
+    # 0.85 is exactly on the edge at tol 0.15); use an explicit tight/loose
+    # pair to prove the kwarg is actually threaded through.
+    with pytest.raises(ValueError, match="normalized_area_weight"):
+        validate_weight_coverage(w, ID, log, median_tol=0.1)
+    validate_weight_coverage(w, ID, log, median_tol=0.2)

--- a/tests/test_ssflux_math.py
+++ b/tests/test_ssflux_math.py
@@ -1,0 +1,156 @@
+"""Unit tests for the pure ssflux maths (no geo fixtures, no data root)."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from gfv2_params.zonal_runners.ssflux_math import (
+    FFLUX_NO_OVERLAP,
+    PARAM_NAMES,
+    aggregate_k_perm_log,
+    derive_log_params,
+    interpolate_to_range,
+    validate_weight_coverage,
+)
+
+ID = "nat_hru_id"
+
+
+def _weights(rows):
+    return pd.DataFrame(rows, columns=[ID, "k_perm", "normalized_area_weight"])
+
+
+def test_intensive_aggregation_is_area_weighted_mean():
+    """(sum v*a)/(sum a) -- gdptools INTENSIVE form, not the extensive sum."""
+    w = _weights([(1, -10.0, 0.25), (1, -14.0, 0.75)])
+    out = aggregate_k_perm_log(w, ID)
+    assert out.loc[out[ID] == 1, "k_perm_log_wtd"].iloc[0] == pytest.approx(-13.0)
+
+
+def test_weights_are_renormalised_when_coverage_is_partial():
+    """A gap (weights summing to 0.5) must not halve the mean."""
+    w = _weights([(1, -10.0, 0.25), (1, -14.0, 0.25)])
+    out = aggregate_k_perm_log(w, ID)
+    assert out.loc[out[ID] == 1, "k_perm_log_wtd"].iloc[0] == pytest.approx(-12.0)
+    assert out.loc[out[ID] == 1, "fflux"].iloc[0] == pytest.approx(0.5)
+
+
+def test_nodata_k_perm_is_excluded_not_floored():
+    """k_perm == 0 is a no-data flag; it must not enter the mean."""
+    w = _weights([(1, -10.0, 0.5), (1, 0.0, 0.5)])
+    out = aggregate_k_perm_log(w, ID)
+    assert out.loc[out[ID] == 1, "k_perm_log_wtd"].iloc[0] == pytest.approx(-10.0)
+    assert out.loc[out[ID] == 1, "fflux"].iloc[0] == pytest.approx(0.5)
+
+
+def test_hru_with_no_valid_lithology_is_nan_with_sentinel_fflux():
+    w = _weights([(1, 0.0, 1.0)])
+    out = aggregate_k_perm_log(w, ID)
+    assert np.isnan(out.loc[out[ID] == 1, "k_perm_log_wtd"].iloc[0])
+    assert out.loc[out[ID] == 1, "fflux"].iloc[0] == FFLUX_NO_OVERLAP
+
+
+def test_aggregation_rejects_missing_weight_column():
+    w = _weights([(1, -10.0, 0.5)]).rename(columns={"normalized_area_weight": "wght"})
+    with pytest.raises(ValueError, match="normalized_area_weight"):
+        aggregate_k_perm_log(w, ID)
+
+
+def test_derive_log_params_matches_closed_forms():
+    k = np.array([-12.0])
+    slope = np.array([0.25])
+    area = np.array([100.0])
+    out = derive_log_params(k, slope, area)
+    assert out["soil2gw_max"][0] == pytest.approx(-36.0)              # 3*k
+    assert out["ssr2gw_rate"][0] == pytest.approx(-12.0 + np.log10(0.75))
+    expected_slow = -12.0 + np.log10(0.25) - np.log10(100.0)
+    assert out["slowcoef_lin"][0] == pytest.approx(expected_slow)
+    assert out["fastcoef_lin"][0] == pytest.approx(expected_slow + np.log10(2))
+    assert out["gwflow_coef"][0] == pytest.approx(expected_slow)
+    assert out["dprst_seep_rate_open"][0] == pytest.approx(out["ssr2gw_rate"][0])
+    assert out["dprst_flow_coef"][0] == pytest.approx(out["fastcoef_lin"][0])
+    assert set(out) == set(PARAM_NAMES)
+
+
+def test_slope_guards_produce_finite_output():
+    """slope == 0 and slope >= 1 must not yield -inf or NaN."""
+    k = np.array([-12.0, -12.0, -12.0])
+    slope = np.array([0.0, 1.0, 2.34])
+    area = np.array([100.0, 100.0, 100.0])
+    out = derive_log_params(k, slope, area)
+    for name in PARAM_NAMES:
+        assert np.all(np.isfinite(out[name])), name
+
+
+def test_nan_k_perm_propagates_as_nan_not_an_error():
+    out = derive_log_params(np.array([np.nan]), np.array([0.5]), np.array([100.0]))
+    assert np.isnan(out["soil2gw_max"][0])
+
+
+def test_derive_rejects_non_positive_area():
+    with pytest.raises(ValueError, match="hru_area"):
+        derive_log_params(np.array([-12.0]), np.array([0.5]), np.array([0.0]))
+
+
+def test_interpolate_maps_endpoints_and_is_affine_invariant():
+    v = np.array([-3.0, -2.0, -1.0])
+    out = interpolate_to_range(v, 0.1, 0.3)
+    assert out[0] == pytest.approx(0.1)
+    assert out[-1] == pytest.approx(0.3)
+    # the cube is a scale on the exponent -> absorbed by min-max normalisation
+    assert interpolate_to_range(3 * v, 0.1, 0.3) == pytest.approx(out, abs=1e-12)
+
+
+def test_interpolate_ignores_nan_but_preserves_position():
+    v = np.array([-3.0, np.nan, -1.0])
+    out = interpolate_to_range(v, 0.0, 1.0)
+    assert out[0] == pytest.approx(0.0)
+    assert np.isnan(out[1])
+    assert out[2] == pytest.approx(1.0)
+
+
+def test_interpolate_raises_on_degenerate_range():
+    with pytest.raises(ValueError, match="degenerate"):
+        interpolate_to_range(np.array([2.0, 2.0, 2.0]), 0.0, 1.0)
+
+
+def test_extensive_form_is_not_silently_accepted():
+    """A frame carrying ONLY the extensive columns must raise, not guess.
+
+    Guards the #175 root cause: dividing by the source-polygon area is gdptools'
+    EXTENSIVE form and must never be reachable again by accident.
+    """
+    w = pd.DataFrame(
+        {ID: [1, 1], "k_perm": [-10.0, -14.0],
+         "area_weight": [100.0, 300.0], "flux_id_area": [400.0, 1200.0]}
+    )
+    with pytest.raises(ValueError, match="extensive"):
+        aggregate_k_perm_log(w, ID)
+
+
+class _CapturingLogger:
+    def __init__(self): self.warnings = []
+    def info(self, *a, **k): pass
+    def debug(self, *a, **k): pass
+    def warning(self, msg, *a): self.warnings.append(msg % a if a else msg)
+
+
+def test_weight_coverage_passes_when_weights_sum_to_one():
+    w = _weights([(1, -10.0, 0.5), (1, -12.0, 0.5), (2, -11.0, 1.0)])
+    log = _CapturingLogger()
+    validate_weight_coverage(w, ID, log)
+    assert log.warnings == []
+
+
+def test_weight_coverage_warns_on_gaps_and_overlaps():
+    w = _weights([(1, -10.0, 0.4), (2, -11.0, 2.0), (3, -12.0, 1.0)])
+    log = _CapturingLogger()
+    validate_weight_coverage(w, ID, log, max_bad_fraction=0.9)
+    assert any("outside" in m for m in log.warnings)
+
+
+def test_weight_coverage_raises_when_too_many_are_bad():
+    """A wholesale deviation from 1.0 means the wrong weight column."""
+    w = _weights([(1, -10.0, 0.02), (2, -11.0, 0.03), (3, -12.0, 0.01)])
+    with pytest.raises(ValueError, match="normalized_area_weight"):
+        validate_weight_coverage(w, ID, _CapturingLogger())

--- a/tests/test_ssflux_math.py
+++ b/tests/test_ssflux_math.py
@@ -200,11 +200,12 @@ def test_weight_coverage_passes_when_weights_sum_to_one():
 def test_weight_coverage_warns_on_gaps_and_overlaps():
     w = _weights([(1, -10.0, 0.4), (2, -11.0, 2.0), (3, -12.0, 1.0)])
     log = _CapturingLogger()
-    # This tiny 3-HRU fixture is 2/3 "bad" by construction, which is well
-    # past the (CONUS-batch-sized) hard ceiling; raise both max_bad_fraction
-    # and hard_bad_fraction so this stays a test of the tail-count warning
-    # path specifically, not an accidental hit of the ceiling raise.
-    validate_weight_coverage(w, ID, log, max_bad_fraction=0.9, hard_bad_fraction=0.95)
+    # This tiny 3-HRU fixture is 2/3 "bad" by the tol=0.01 tail test, and one
+    # of the three (sum=0.4) is also outside the [0.5, 2.0] magnitude band;
+    # raise both max_bad_fraction and magnitude_bad_fraction so this stays a
+    # test of the soft tail-count warning path specifically, not an
+    # accidental hit of the magnitude raise.
+    validate_weight_coverage(w, ID, log, max_bad_fraction=0.9, magnitude_bad_fraction=0.95)
     assert any("outside" in m for m in log.warnings)
 
 
@@ -220,50 +221,79 @@ def test_weight_coverage_raises_when_median_is_displaced():
 
 
 def test_weight_coverage_clustered_gap_batch_warns_not_raises():
-    """A batch that happens to contain a large cluster of legitimate coverage
-    gaps (~32% of HRUs, matching the measured 1,828-in-~5,650 CONUS batch)
-    must WARN, not raise, as long as the median stays near 1.0 -- the old
-    tail-fraction raise fired here and blamed the extensive form, aborting a
-    CONUS array task over a correct, if clustered, renormalised result."""
+    """A batch that happens to contain a large cluster of legitimate,
+    MILDLY-off coverage gaps (sums 0.6-0.95, comfortably inside the
+    [band_lo, band_hi]=[0.5, 2.0] magnitude band) at a high fraction (~32% of
+    HRUs, matching the measured 1,828-in-~5,650 CONUS batch) must WARN, not
+    raise, as long as the median stays near 1.0 and the magnitude stays
+    in-band -- proving the new rule keys on MAGNITUDE, not a bare tail count.
+    An old tail-fraction-only raise fired here and blamed the extensive form,
+    aborting a CONUS array task over a correct, if clustered, renormalised
+    result."""
     n_gap = 32
     n_full = 68
-    rows = [(i, -12.0, 0.5) for i in range(1, n_gap + 1)]
+    rng = np.random.default_rng(1)
+    rows = [
+        (i, -12.0, float(v))
+        for i, v in zip(range(1, n_gap + 1), rng.uniform(0.6, 0.95, n_gap))
+    ]
     rows += [(i, -12.0, 1.0) for i in range(n_gap + 1, n_gap + n_full + 1)]
     w = _weights(rows)
     log = _CapturingLogger()
     sums = w.groupby(ID)["normalized_area_weight"].sum()
     assert sums.median() == pytest.approx(1.0)
+    assert ((sums >= 0.5) & (sums <= 2.0)).all(), "fixture must stay inside the magnitude band"
     validate_weight_coverage(w, ID, log, max_bad_fraction=0.05)
     assert any("outside" in m for m in log.warnings)
 
 
-def test_weight_coverage_raises_on_hard_ceiling_even_with_median_at_one():
+def test_weight_coverage_partial_regression_at_low_fraction_raises():
+    """The point of the whole change: a PARTIAL extensive-form regression
+    affecting only ~10% of HRUs (well under the old hard_bad_fraction=0.35
+    ceiling, which would have silently passed this) must now RAISE, because
+    the affected HRUs sit at extensive-form MAGNITUDE (~0.02), far outside
+    the [0.5, 2.0] plausible band."""
+    n_bad = 10
+    n_good = 90
+    rows = [(i, -12.0, 0.02) for i in range(1, n_bad + 1)]
+    rows += [(i, -12.0, 1.0) for i in range(n_bad + 1, n_bad + n_good + 1)]
+    w = _weights(rows)
+    sums = w.groupby(ID)["normalized_area_weight"].sum()
+    assert sums.median() == pytest.approx(1.0)
+    with pytest.raises(ValueError, match="band"):
+        validate_weight_coverage(w, ID, _CapturingLogger())
+
+
+def test_weight_coverage_raises_on_magnitude_ceiling_even_with_median_at_one():
     """The median-only check has a blind spot: up to just under 50% of HRUs
     can carry the extensive-form bug while the median stays exactly at 1.0,
     because the median only reflects the majority. 60 HRUs at sum=1.0 plus 40
     at sum=0.05 (the exact extensive-form signature, on a MINORITY of rows)
-    keeps the median at 1.0 -- but at 40% bad, it is well past the hard
-    ceiling (default 0.35, picked with real margin above the documented 32%
-    legitimate clustered-gap case) and must raise."""
+    keeps the median at 1.0 -- and now raises because 40% of sums fall
+    outside the [0.5, 2.0] plausible band (default magnitude_bad_fraction is
+    0.05), not because of a tuned tail-count ceiling. This is the old
+    hard_bad_fraction=0.35 counterexample; it must still raise under the
+    magnitude discriminator."""
     rows = [(i, -12.0, 1.0) for i in range(1, 61)]
     rows += [(i, -12.0, 0.05) for i in range(61, 101)]
     w = _weights(rows)
     sums = w.groupby(ID)["normalized_area_weight"].sum()
     assert sums.median() == pytest.approx(1.0)
-    with pytest.raises(ValueError, match="ceiling"):
+    with pytest.raises(ValueError, match="band"):
         validate_weight_coverage(w, ID, _CapturingLogger())
 
 
-def test_weight_coverage_hard_ceiling_is_configurable():
-    """hard_bad_fraction is a keyword, not a hardcoded constant."""
+def test_weight_coverage_magnitude_ceiling_is_configurable():
+    """band_lo/band_hi/magnitude_bad_fraction are keywords, not hardcoded
+    constants."""
     rows = [(i, -12.0, 1.0) for i in range(1, 61)]
     rows += [(i, -12.0, 0.05) for i in range(61, 101)]
     w = _weights(rows)
-    with pytest.raises(ValueError, match="ceiling"):
-        validate_weight_coverage(w, ID, _CapturingLogger(), hard_bad_fraction=0.35)
+    with pytest.raises(ValueError, match="band"):
+        validate_weight_coverage(w, ID, _CapturingLogger(), magnitude_bad_fraction=0.05)
     # raising the ceiling above the actual 40% bad fraction: no raise, only warn
     log = _CapturingLogger()
-    validate_weight_coverage(w, ID, log, hard_bad_fraction=0.9, max_bad_fraction=0.05)
+    validate_weight_coverage(w, ID, log, magnitude_bad_fraction=0.9, max_bad_fraction=0.05)
     assert any("outside" in m for m in log.warnings)
 
 
@@ -275,9 +305,9 @@ def test_weight_coverage_median_tol_is_configurable():
     # default median_tol=0.1 tolerates 0.85 (within 1.0 +/- 0.1 is false --
     # 0.85 is exactly on the edge at tol 0.15); use an explicit tight/loose
     # pair to prove the kwarg is actually threaded through. All 3 HRUs sit at
-    # the same 0.85 (100% "bad" by the tol=0.01 tail test), so also raise
-    # hard_bad_fraction past that once the median check is loosened -- this
-    # test is about median_tol, not the separate hard-ceiling behaviour.
+    # the same 0.85, which is inside the default [0.5, 2.0] magnitude band,
+    # so no magnitude override is needed here -- this test is about
+    # median_tol, not the separate magnitude-ceiling behaviour.
     with pytest.raises(ValueError, match="normalized_area_weight"):
         validate_weight_coverage(w, ID, log, median_tol=0.1)
-    validate_weight_coverage(w, ID, log, median_tol=0.2, hard_bad_fraction=1.0)
+    validate_weight_coverage(w, ID, log, median_tol=0.2)

--- a/tests/test_zonal_orchestrator.py
+++ b/tests/test_zonal_orchestrator.py
@@ -147,6 +147,18 @@ def test_ssflux_config_values_are_not_silently_reverted():
         "dprst_flow_coef.max must stay 0.1 (Driscoll 2020 Table 1's calibrated "
         "cap, D5) -- 0.5 was 5x the calibrated maximum"
     )
+    # `vpu` is written verbatim per batch ("01".."09" and alphanumeric labels
+    # like "03N"/"10L"), and pandas infers dtype PER FILE at merge time -- a
+    # numeric-only batch reads it as int64 (dropping the leading zero) while a
+    # mixed-alphanumeric batch reads it as str. Measured on a real gfv2_dev
+    # rebuild: 28 distinct vpu labels merged in where the fabric has only 21.
+    # `read_dtypes: {vpu: str}` pins the read dtype so every batch parses
+    # identically; without it this silently regresses to that split.
+    assert ssflux.get("read_dtypes") == {"vpu": "str"}, (
+        "ssflux must declare `read_dtypes: {vpu: str}` -- without it, "
+        "pandas' per-file dtype inference splits the vpu label across "
+        "int64 and str depending on which batch an HRU landed in"
+    )
 
 
 def test_lulc_entries_use_per_source_names():

--- a/tests/test_zonal_orchestrator.py
+++ b/tests/test_zonal_orchestrator.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
 import yaml
 
 from gfv2_params.zonal_runners import BATCH_RUNNERS
@@ -120,6 +121,31 @@ def test_ssflux_declares_weights_dependency():
     assert "nhm_slope_params.csv" in ssflux["merged_slope_file"], (
         "ssflux merged_slope_file must point at the slope merge output "
         "(nhm_slope_params.csv) so the dispatch chain is correct"
+    )
+
+
+def test_ssflux_config_values_are_not_silently_reverted():
+    """Guards the exact three values #175 changed. An accidental YAML revert
+    (e.g. a bad merge) would resurrect the degenerate pre-#175 output
+    silently -- reducer/norm_scope govern WHERE normalisation happens
+    (per-batch vs. whole-fabric, root cause #4) and dprst_flow_coef.max is
+    the calibrated cap (D5, Driscoll 2020 Table 1)."""
+    config = _load_config_raw()
+    ssflux = next((e for e in config["params"] if e["name"] == "ssflux"), None)
+    assert ssflux is not None, "ssflux entry missing"
+    assert ssflux.get("reducer") == "ssflux", (
+        "ssflux must declare `reducer: ssflux` -- without it, normalisation "
+        "reverts to run_merge's default per-batch-invariant-only behaviour "
+        "and #175's fabric-wide min/max is silently lost"
+    )
+    assert ssflux.get("norm_scope") == "fabric", (
+        "ssflux's default norm_scope must be `fabric` (batch-invariant by "
+        "construction) unless deliberately switched to `vpu`"
+    )
+    flux_params = {fp["name"]: fp for fp in ssflux["flux_params"]}
+    assert flux_params["dprst_flow_coef"]["max"] == pytest.approx(0.1), (
+        "dprst_flow_coef.max must stay 0.1 (Driscoll 2020 Table 1's calibrated "
+        "cap, D5) -- 0.5 was 5x the calibrated maximum"
     )
 
 


### PR DESCRIPTION
## ⚠️ Scope expansion

**6 of 15 commits are unrelated to #175.** They arose from requests during the session, not from the plan, and are already atomic — happy to split them into a separate PR if preferred:

| Commit | What |
|---|---|
| `364b860` | add poppler (docs) + git-lfs (dev) to pixi |
| `751d9bb` | manage `docs/` reference PDFs with git-lfs |
| `e596b3a` | add TM 6-B4 PDF (16 MB, via LFS) + companion doc |
| `7c084e5` | document the git-lfs requirement for cloners |
| `11f26f5` | record that `pre-commit --all-files` needs `srun` + 64G |
| `96adfb0` | gitignore `.superpowers/` SDD scratch |

The remaining 9 commits are the #175 fix and its spec/plan.

---

## What this fixes

Closes #175. The seven `ssflux` PRMS parameters were **effectively spatially constant** — ~90% of 361,394 HRUs within 1% of their configured range *minimum* (`soil2gw_max`: 99.3%), with an interquartile range spanning **0.1%** of the configured range. That defeats the stated purpose of the derivation; TM 6-B9 says these parameters exist to give "a realistic spatial pattern of variation ... **in place of the assumption of spatially constant values**". It also silently degraded two parameters pywatershed's `PRMSRunoff` consumes: `dprst_seep_rate_open` and `dprst_flow_coef`.

## Root causes — four, not the one filed

Triage confirmed the reported degeneracy exactly, then found three further causes. `k_perm_wtd` was reconstructed independently from the weights CSV and lithology DBF, reproducing the on-disk values to **8.1e-16**, so the figures below are measured rather than inferred.

**1. Permeability was aggregated as an EXTENSIVE variable — the dominant cause, not in the issue.**

`ssflux.py:76` divided by `flux_id_area`, the *source-polygon* area. That is gdptools' documented **extensive** form `Σ Vᵢ(aᵢ/Aᵢ)`; `WeightGenP2P.calculate_weights` labels that very column *"for extensive variables"*. Permeability is **intensive** — it does not add up when regions combine. The correct form, `(Σ vᵢaᵢ)/(Σ aᵢ)`, was already available as the unused `normalized_area_weight` column (gdptools' `wght`), which had **zero consumers** repo-wide.

Per-HRU weight sums spanned **3.6e13×** (median 0.022) instead of 1.0, inflating spread from a physical **5.6** to an artifactual **15.4 orders of magnitude**. The original intent is explicit in the first commit's comment — *"prorate the source's k_perm by the fraction of its area in the target"* — and the variable names still said `extensive_agg` / `extensive_sorted`. The likely trap: permeability is *dimensioned* m² but is not an amount of anything.

**2. Linear min–max normalisation of a log-distributed variable** (the filed cause).

**3. `k_perm == 0` is a no-data flag treated as data.** 9,409 of 202,108 polygons, mapped onto −16.48 — which is *simultaneously* the genuine least-permeable lithology class (26,441 polygons), inflating that real class by 36%.

**4. Normalisation ran per SLURM batch** (64 batches confirmed), so identical geology+slope got different values depending on chunking.

### Sequencing trap

Fixing #4 first makes the product **strictly worse** — 89.5–90.5% → **97.2–100%** degenerate. Per-batch normalisation was *masking* the defect.

## The fix

- **Intensive aggregation in log10 space** (`ssflux_math.aggregate_k_perm_log`) — an arithmetic mean of log10 values is the geometric mean of permeability, the correct average for heterogeneous media. Renormalised by the per-HRU sum, which also corrects 1,828 coverage-gap and 98 overlapping-source HRUs.
- **Log-additive derivation** preserving TM 6-B9's structure: `L(soil2gw_max)=3k`, `L(ssr2gw_rate)=k+log10(1−slope)`, `L(slowcoef_lin)=k+log10(slope)−log10(area)`.
- **Normalisation moved to a reduce step** via a new `MERGE_REDUCERS` dispatch mirroring `BATCH_RUNNERS`; `norm_scope: fabric` (default, batch-invariant) or `vpu`.
- **`dprst_flow_coef` capped at 0.1** per Driscoll 2020 Table 1 (calibrated NHM range 0.0001–0.1, median 0.048). The old 0.5 was 5× the calibrated max.
- **`fflux` emitted** — valid-lithology coverage fraction, matching the reference implementation's own attribute.

## Measured outcome

| param | range | % ≤1% of min | IQR/range |
|---|---|---|---|
| `soil2gw_max` | 0.1 – 0.3 | 5.0% | 0.383 |
| `ssr2gw_rate` | 0.3 – 0.7 | 0.0% | 0.261 |
| `fastcoef_lin` | 0.01 – 0.6 | 0.0% | 0.139 |
| `slowcoef_lin` | 0.005 – 0.3 | 0.0% | 0.139 |
| `gwflow_coef` | 0.005 – 0.3 | 0.0% | 0.139 |
| `dprst_seep_rate_open` | 0.005 – 0.2 | 0.0% | 0.261 |
| `dprst_flow_coef` | 0.005 – **0.1** | 0.0% | 0.139 |

Every acceptance criterion in #175 is met. The residual 5.0% on `soil2gw_max` is **genuine geology**, not a defect: `k_perm` is categorical with only **8 distinct values**, so HRUs lying entirely in the least-permeable class legitimately sit at the minimum.

## Resolving issue item 2 (the "missing cube") — against the issue

The reference implementation's FGDC metadata ([doi:10.5066/F7CN71XR](https://doi.org/10.5066/F7CN71XR)) cubes `soil2gw_max` **only**; `slowcoef_lin` and `gwflow_coef` are explicitly not cubed. Today's code already matched. It is moot regardless — under log-space min–max the surviving cube is a pure scale on the exponent and is provably absorbed (verified `allclose`, max diff 3.05e-16).

That metadata also confirms the intensive reading in prose — *"the feature **average** hydraulic conductivity"* — and confirms linear interpolation.

I chased TM 6-B9's cited derivation source (Viger & Leavesley 2007, TM 6-B4) to settle log10-vs-linear definitively. **It does not contain it**: zero hits for `soil2gw_max`, `k_perm`, `Gleeson` or `conductivity` across the full text (confirmed with two independent extractors) — and it cannot, since Gleeson (2011) postdates the 2007 manual by four years. The PDF and that negative finding are recorded in `docs/` so nobody repeats the search.

## Testing

**1065 passed, 4 skipped, 1 failed** (`srun`, full `tests/`; job `2597671`).

The single failure is **expected and cannot be fixed by code**: `test_params_index_ondisk.py::test_guard2_declared_columns_cover_disk[ssflux]` compares the `prms:` declaration against the **on-disk CSV**, which is still the 2026-05-29 pre-#175 product carrying `k_perm_wtd`. The declaration is correct; the data is stale. It clears on rebuild. Guard 2 is data-root-gated and **skips in CI**, so CI is green — which also means CI cannot catch a genuine declaration/header mismatch, hence the job id above.

New: `tests/test_ssflux_math.py`, `tests/test_ssflux.py`, `tests/test_merge_reducers.py` — including bit-exact batch invariance at **both** the map and reduce stages (an explicit #175 acceptance criterion), a stale-batch guard, slope-boundary guards, and a degenerate-range guard.

## Review

Four task reviews plus a whole-branch review (Opus) and one fix wave. Notable catches, all fixed:

- The stale-batch guard checked column *presence*, not *population* — a failed array task's leftover CSV would have passed, its HRUs silently KNN-interpolated into a product that looked complete.
- `validate_weight_coverage` raised on a tail-count rather than the median, so a spatially-contiguous batch of the known clustered coverage gaps would have aborted a CONUS run while blaming the wrong cause.
- `vpu` was never threaded into `param_cfg`, making the `tjc` fallback dead code.
- `groupby("vpu")` defaulted to `dropna=True`, silently dropping partial-null VPUs.

## Rollout — required before this product is used

1. Rebuild ssflux on **`gfv2_dev`**, never canonical `gfv2`. `--mode build_weights` is unaffected (the weights CSV already carries `normalized_area_weight`).
2. Confirm the acceptance table above and re-run Guard 2 (records the SLURM job id).
3. Check `viz.py` maps of `ssr2gw_rate` / `dprst_seep_rate_open` show a coherent pattern tracking lithology and slope.
4. Promote to `gfv2` only after the gate passes. `oregon` and `tjc` need the same rebuild, no code change.

**Operational change:** normalisation is now fabric-wide, so re-running a *single* ssflux batch shifts the global min/max and changes **every** HRU's seven values. Partial reruns are all-or-nothing and require a full `--mode merge`. Documented in RUNME.md and HPC_REFERENCE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
