### PR TITLE
fix(ssflux): give zero-coverage HRUs a row with fflux = -1; stop viz re-corrupting vpu (closes #209)

### DIFF
--- a/src/gfv2_params/viz.py
+++ b/src/gfv2_params/viz.py
@@ -257,7 +257,14 @@ def load_param(params_dir, csv_name, fabric_gdf, id_feature):
     Left join preserves every HRU (missing HRUs in the CSV become NaN). Returns
     a GeoDataFrame indexed like `fabric_gdf`.
     """
-    df = pd.read_csv(Path(params_dir) / csv_name)
+    # `vpu` (when present) mixes zero-padded numeric labels ("01", "02") with
+    # alphanumeric ones ("03N", "10L", "10U"). Per-read dtype inference sees a
+    # column that LOOKS all-numeric and casts it to int, silently stripping
+    # the leading zero ("01" -> 1) -- PR #208 fixed the write side
+    # (`read_dtypes:` in run_merge); this is the read side for ad-hoc
+    # notebook loads. Forcing str is harmless for the many param CSVs that
+    # have no `vpu` column at all: an unmatched key in `dtype=` is a no-op.
+    df = pd.read_csv(Path(params_dir) / csv_name, dtype={"vpu": str})
     gdf = fabric_gdf[[id_feature, "geometry"]].merge(df, on=id_feature, how="left")
     return gdf
 

--- a/src/gfv2_params/zonal_runners/ssflux.py
+++ b/src/gfv2_params/zonal_runners/ssflux.py
@@ -121,7 +121,22 @@ def run_ssflux_batch(config: dict, batch_id: int, logger) -> None:
     # k_perm == 0 is Gleeson's no-data flag and is excluded, not floored to
     # k_perm_min -- see ssflux_math.aggregate_k_perm_log and issue #175.
     validate_weight_coverage(w, id_feature, logger, **_coverage_kwargs(config))
-    agg = aggregate_k_perm_log(w, id_feature)
+
+    # Build the output index from the batch's FULL target HRU list, not just
+    # the weight frame's own unique ids -- an HRU with zero lithology-weight
+    # rows (no overlap at all) must still get a row (NaN k_perm_log_wtd,
+    # fflux == FFLUX_NO_OVERLAP), which is what that sentinel is documented to
+    # mean but was previously unreachable for. See issue #209.
+    target_ids = target_gdf[id_feature]
+    n_zero_coverage = len(set(target_ids) - set(w[id_feature].unique()))
+    if n_zero_coverage:
+        logger.warning(
+            "%d of %d HRUs in batch %d have zero lithology-weight rows (no "
+            "overlap at all); emitted with fflux=FFLUX_NO_OVERLAP and NaN "
+            "k_perm_log_wtd for the downstream KNN gap-fill -- see issue #209.",
+            n_zero_coverage, len(target_ids), batch_id,
+        )
+    agg = aggregate_k_perm_log(w, id_feature, all_ids=target_ids)
     agg[id_feature] = agg[id_feature].astype(int)
     k_perm_agg = agg.sort_values(by=id_feature).reset_index(drop=True)
 

--- a/src/gfv2_params/zonal_runners/ssflux_math.py
+++ b/src/gfv2_params/zonal_runners/ssflux_math.py
@@ -191,6 +191,7 @@ def aggregate_k_perm_log(
     *,
     weight_col: str = "normalized_area_weight",
     k_col: str = "k_perm",
+    all_ids=None,
 ) -> pd.DataFrame:
     """Area-weighted mean of log10 permeability -- gdptools' INTENSIVE form.
 
@@ -205,6 +206,15 @@ def aggregate_k_perm_log(
     Dividing by ``den`` is load-bearing beyond no-data exclusion: the lithology
     layer is not perfectly continuous (1,828 CONUS HRUs have coverage gaps, 98
     have overlapping source polygons).
+
+    ``all_ids`` (optional): the full target HRU id list (e.g. a batch's
+    ``target_gdf[id_feature]``). When supplied, the output index is built from
+    it instead of from the weight frame's own unique ids -- an HRU with ZERO
+    weight rows (no lithology-polygon overlap at all) still gets a row, with
+    NaN ``k_perm_log_wtd`` and ``fflux == FFLUX_NO_OVERLAP`` -- see issue #209.
+    Without it (the default), behaviour is unchanged from before #209: the
+    output index is only the ids that appear in ``weights``, so a
+    zero-coverage HRU is silently absent from the result.
 
     Returns one row per HRU with ``k_perm_log_wtd`` (NaN where no valid
     lithology) and ``fflux`` (valid-coverage fraction, ``FFLUX_NO_OVERLAP``
@@ -225,21 +235,26 @@ def aggregate_k_perm_log(
     # Exact comparison is deliberate: a stored no-data flag, not a computed value.
     valid = w[k_col].notna() & (w[k_col] != K_PERM_NODATA)
 
-    all_ids = pd.Index(w[id_feature].unique(), name=id_feature).sort_values()
+    if all_ids is None:
+        target_ids = pd.Index(w[id_feature].unique(), name=id_feature).sort_values()
+    else:
+        target_ids = pd.Index(
+            pd.unique(pd.Index(all_ids)), name=id_feature
+        ).sort_values()
     v = w[valid]
-    num = (v[k_col] * v[weight_col]).groupby(v[id_feature]).sum().reindex(all_ids)
-    den = v[weight_col].groupby(v[id_feature]).sum().reindex(all_ids)
+    num = (v[k_col] * v[weight_col]).groupby(v[id_feature]).sum().reindex(target_ids)
+    den = v[weight_col].groupby(v[id_feature]).sum().reindex(target_ids)
 
     den_arr = den.to_numpy()
     covered = np.isfinite(den_arr) & (den_arr > 0.0)
 
-    k_log = np.full(len(all_ids), np.nan)
+    k_log = np.full(len(target_ids), np.nan)
     np.divide(num.to_numpy(), den_arr, out=k_log, where=covered)
 
     fflux = np.where(covered, den_arr, FFLUX_NO_OVERLAP)
 
     return pd.DataFrame(
-        {id_feature: all_ids.to_numpy(), "k_perm_log_wtd": k_log, "fflux": fflux}
+        {id_feature: target_ids.to_numpy(), "k_perm_log_wtd": k_log, "fflux": fflux}
     )
 
 

--- a/tests/test_ssflux_math.py
+++ b/tests/test_ssflux_math.py
@@ -91,6 +91,32 @@ def test_aggregation_is_batch_partition_invariant():
     pd.testing.assert_frame_equal(whole, split, check_exact=True)
 
 
+def test_all_ids_gives_zero_coverage_hru_a_row_with_sentinel_fflux():
+    """Issue #209: an HRU with ZERO weight rows (no lithology overlap at all)
+    must still get a row when the caller supplies the full target HRU list --
+    NaN k_perm_log_wtd (feeding the KNN gap-fill) and fflux ==
+    FFLUX_NO_OVERLAP, making that sentinel reachable for the case it's
+    actually named for."""
+    w = _weights([(1, -10.0, 1.0)])  # HRU 2 has NO weight rows at all
+    out = aggregate_k_perm_log(w, ID, all_ids=pd.Index([1, 2], name=ID))
+    assert set(out[ID]) == {1, 2}
+    row2 = out.loc[out[ID] == 2].iloc[0]
+    assert np.isnan(row2["k_perm_log_wtd"])
+    assert row2["fflux"] == FFLUX_NO_OVERLAP
+    # the HRU that DOES have weight rows is unaffected
+    row1 = out.loc[out[ID] == 1].iloc[0]
+    assert row1["k_perm_log_wtd"] == pytest.approx(-10.0)
+    assert row1["fflux"] == pytest.approx(1.0)
+
+
+def test_omitting_all_ids_preserves_current_behavior():
+    """Without all_ids, a zero-coverage HRU stays absent from the output --
+    the pre-#209 behaviour, unchanged for existing callers."""
+    w = _weights([(1, -10.0, 1.0)])
+    out = aggregate_k_perm_log(w, ID)
+    assert set(out[ID]) == {1}
+
+
 def test_aggregation_rejects_missing_weight_column():
     w = _weights([(1, -10.0, 0.5)]).rename(columns={"normalized_area_weight": "wght"})
     with pytest.raises(ValueError, match="normalized_area_weight"):

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -146,6 +146,27 @@ def _synthetic_fabric(id_feature="nat_hru_id"):
     )
 
 
+def test_load_param_preserves_mixed_vpu_labels_verbatim(tmp_path):
+    """The merged ssflux CSV's `vpu` column mixes zero-padded numeric labels
+    ("01", "03") with alphanumeric NHDPlus ones ("03N", "10L", "10U"). Bare
+    `pd.read_csv` per-read dtype inference sees a column that looks numeric
+    and casts it to int, silently stripping "01" to 1 (and emits a
+    DtypeWarning on the mixed-type column). `load_param` must read `vpu` as
+    str so every label round-trips verbatim."""
+    fabric = _synthetic_fabric()
+    df = pd.DataFrame(
+        {"nat_hru_id": [1, 2, 3], "vpu": ["01", "03N", "10L"], "mean": [1.0, 2.0, 3.0]}
+    )
+    csv = tmp_path / "p.csv"
+    df.to_csv(csv, index=False)
+
+    gdf = viz.load_param(tmp_path, "p.csv", fabric, "nat_hru_id")
+    by_id = gdf.set_index("nat_hru_id")["vpu"]
+    assert by_id[1] == "01"
+    assert by_id[2] == "03N"
+    assert by_id[3] == "10L"
+
+
 def test_load_param_left_join_preserves_all_hrus(tmp_path):
     fabric = _synthetic_fabric()
     # CSV covers only HRUs 1 and 2


### PR DESCRIPTION
Closes #209.

## 1. Zero-coverage HRUs now get a row with `fflux = -1` (#209)

`aggregate_k_perm_log` built its output index from the **weight frame**, so an HRU with *zero* rows in the lithology weight matrix never entered the output. The subsequent left merge off `k_perm_agg` could not reintroduce it. `FFLUX_NO_OVERLAP = -1.0` — documented in the `prms: provenance` block as marking "no overlap at all" — was therefore only reachable when an HRU had *some* weight rows but no valid `k_perm`. The genuinely-zero-intersection case, the one the sentinel is named for, produced no row at all.

Measured on gfv2: fabric 361,471 HRUs, 361,394 with ≥1 weight row, merged output 361,394 rows. The 77 dropped HRUs were exactly `fabric − output` (set equality). oregon drops 10, tjc drops some.

`aggregate_k_perm_log` now takes an optional `all_ids`; when supplied the output index comes from the full target list, so every HRU in a batch gets a row — `k_perm_log_wtd = NaN` (feeding the existing KNN gap-fill, as the ~598 no-valid-lithology HRUs already do) and `fflux = -1.0`. Omitting `all_ids` preserves today's behaviour exactly. A per-batch count of zero-coverage HRUs is now logged, so the number is visible rather than inferable by diffing row counts against the fabric.

**Verified, not assumed:** the existing null-check that raises on NaN `mean_slope_fraction`/`hru_area` does *not* fire for the newly-included HRUs. `hru_area` comes from `target_gdf.geometry.area` (no external dependency) and `nhm_slope_params.csv` already carries one row per fabric HRU (361,471). No guard was weakened.

This does not change any of the seven PRMS parameter values — it only makes previously-absent HRUs present and explicitly marked, ahead of the gap-fill that was already synthesising them.

## 2. `viz.py` re-corrupted the `vpu` column on read

`load_param` used a bare `pd.read_csv`, and per-read dtype inference turns the zero-padded `"01"` into int `1` while alphanumeric labels like `03N`/`10L` stay strings — so a consumer saw labels that don't match the fabric, with a visible `DtypeWarning` when plotting ssflux params.

The file on disk is correct; PR #208 fixed the pipeline side via `read_dtypes:` in `run_merge`. This is the consumer side, scoped to the `vpu` column only when present so other param CSVs are unaffected.

## Testing

Full suite: **1083 passed, 4 skipped, 0 failed** (`srun`, `--as-is`).

New coverage: a weight frame omitting an HRU present in the target list still yields a row for it with `fflux == -1.0` and NaN `k_perm_log_wtd`; omitting `all_ids` preserves prior behaviour; a CSV whose `vpu` column mixes `01` and `03N` survives verbatim through `load_param`.

## Rollout

All three fabrics need an ssflux rebuild to pick this up (row counts go to the full fabric size), followed by the gap-fill sweep — the `filled_*` products are currently stale from before #175 anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
