### PR TITLE
fix(snarea): issue #166 minor cleanups + named test gaps

### DIFF
--- a/src/gfv2_params/aggregate/adapter.py
+++ b/src/gfv2_params/aggregate/adapter.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass, field
 
+import pyproj
 import xarray as xr
 
 # gdptools area-weighted reductions we allow (a typo should fail at construction).
@@ -43,6 +44,18 @@ class SourceAdapter:
                 f"SourceAdapter.stat_method={self.stat_method!r} is not a gdptools "
                 f"STATSMETHODS value; expected one of {sorted(_ALLOWED_STAT_METHODS)}"
             )
+        # A typo'd CRS is not caught until gdptools reprojects, deep inside a
+        # multi-hour aggregation — and a *parseable but wrong* one is never
+        # caught at all. Parsing here at least fails the unparseable case at
+        # construction, like stat_method above. Any pyproj-accepted spelling
+        # (EPSG string, integer code, PROJ string, WKT) stays valid.
+        try:
+            pyproj.CRS.from_user_input(self.source_crs)
+        except Exception as exc:  # pyproj raises CRSError, a subclass of RuntimeError
+            raise ValueError(
+                f"SourceAdapter.source_crs={self.source_crs!r} is not a CRS pyproj "
+                f"can parse: {exc}"
+            ) from exc
         if self.grid_variable is None:
             object.__setattr__(self, "grid_variable", self.variables[0])
         elif self.grid_variable not in self.variables:

--- a/src/gfv2_params/aggregate/driver.py
+++ b/src/gfv2_params/aggregate/driver.py
@@ -35,9 +35,11 @@ def compute_or_load_weights(
     fabric_gdf: gpd.GeoDataFrame,
     id_col: str,
     period: tuple[str, str],
-    weight_file: Path,
+    weight_file: Path | str,
 ) -> pd.DataFrame:
     """Return grid→polygon weights, computing and caching them if absent."""
+    # Coerce: callers resolve this out of a config dict, so it may be a str.
+    weight_file = Path(weight_file)
     if weight_file.exists():
         logger.info("Loading cached weights: %s", weight_file)
         return pd.read_csv(weight_file)
@@ -216,6 +218,7 @@ def aggregate_source(
     """
     input_dir = Path(input_dir)
     output_dir = Path(output_dir)
+    weight_file = Path(weight_file)
     output_dir.mkdir(parents=True, exist_ok=True)
 
     files = sorted(input_dir.glob(adapter.files_glob))
@@ -239,20 +242,26 @@ def aggregate_source(
         # materialized as in-memory numpy — neither the hook (if any) nor
         # gdptools touches the full source grid, and gdptools' per-variable
         # .load() reuses in-memory data instead of re-reading chunks.
-        ds = xr.open_dataset(f)
-        ds = subset_to_gdf_bounds(
-            ds, fabric_gdf, adapter.source_crs, adapter.x_coord, adapter.y_coord
-        )
-        if adapter.pre_aggregate_hook is not None:
-            ds = adapter.pre_aggregate_hook(ds)
-        period = _period_bounds(ds, adapter.time_coord)
-        if weights is None:
-            weights = compute_or_load_weights(
-                adapter, ds, fabric_gdf, id_col, period, weight_file
+        # Context-managed: the loop runs once per year (22 for the SNODAS
+        # record), so leaving the handles to the GC held 22 open netCDF files
+        # for the whole run.
+        with xr.open_dataset(f) as raw:
+            ds = subset_to_gdf_bounds(
+                raw, fabric_gdf, adapter.source_crs, adapter.x_coord, adapter.y_coord
             )
-        logger.info("[%d/%d] year %d: aggregating %s ...",
-                    i, len(files), year, list(adapter.variables))
-        hru_ds = aggregate_variables(adapter, ds, fabric_gdf, id_col, weights, period)
+            if adapter.pre_aggregate_hook is not None:
+                ds = adapter.pre_aggregate_hook(ds)
+            period = _period_bounds(ds, adapter.time_coord)
+            if weights is None:
+                weights = compute_or_load_weights(
+                    adapter, ds, fabric_gdf, id_col, period, weight_file
+                )
+            logger.info("[%d/%d] year %d: aggregating %s ...",
+                        i, len(files), year, list(adapter.variables))
+            hru_ds = aggregate_variables(adapter, ds, fabric_gdf, id_col, weights, period)
+            # Inside the `with`: `ds` is a lazy .sel view of `raw`, so the
+            # aggregation must read through before the handle closes.
+            hru_ds.load()
         out = output_dir / f"{output_prefix}_agg_{year}.nc"
         hru_ds.to_netcdf(out)
         written.append(out)

--- a/src/gfv2_params/snarea/build.py
+++ b/src/gfv2_params/snarea/build.py
@@ -14,14 +14,14 @@ import numpy as np
 import pandas as pd
 
 from .representative import median_sdc, select_representative, similarity
-from .season import annual_sdc
+from .season import SDC_LENGTH, annual_sdc
 from .selection import SelectionParams, classify, passes_selection
 from .subgrid import representative_peak_stats
 
 # Placeholder: SCA declines linearly with normalized SWE (1.0 → 0.0).
-DEFAULT_SNAREA_CURVE = np.round(np.linspace(1.0, 0.0, 11), 4)
+DEFAULT_SNAREA_CURVE = np.round(np.linspace(1.0, 0.0, SDC_LENGTH), 4)
 
-_CURVE_COLS = [f"snarea_curve_{i}" for i in range(11)]
+_CURVE_COLS = [f"snarea_curve_{i}" for i in range(SDC_LENGTH)]
 
 
 def validate_default_curve(arr: np.ndarray) -> None:
@@ -34,8 +34,10 @@ def validate_default_curve(arr: np.ndarray) -> None:
     pytest's rootdir-on-sys.path), so a script-to-script import would break when
     run directly via `python scripts/derive_snarea_library.py`.
     """
-    if arr.shape != (11,):
-        raise ValueError(f"default_curve must have shape (11,), got {arr.shape}")
+    if arr.shape != (SDC_LENGTH,):
+        raise ValueError(
+            f"default_curve must have shape ({SDC_LENGTH},), got {arr.shape}"
+        )
     if not np.all((arr >= 0.0) & (arr <= 1.0)):
         raise ValueError(f"default_curve values must all be within [0.0, 1.0], got {arr}")
     if not np.all(np.diff(arr) <= 1e-9):

--- a/src/gfv2_params/snarea/library.py
+++ b/src/gfv2_params/snarea/library.py
@@ -16,18 +16,22 @@ import pandas as pd
 import xarray as xr
 from scipy.stats import norm
 
+from .season import SDC_LENGTH, SWE_LEVELS
+
 _MM_PER_INCH = 25.4
 
-# Descending, matching snarea/season.py SWE_LEVELS.
-SWE_LEVELS = np.round(np.arange(1.0, -1e-4, -0.1), 1)  # 1.0 .. 0.0, 11 values
+# SWE_LEVELS (descending, 1.0 -> 0.0) is imported from .season rather than
+# redefined here: two independent definitions of the same sample grid can drift,
+# and Stage 2's empirical curves are sampled on it while Stage 3 fits analytic
+# curves to those same points.
 
 # Curve column names for snarea_curve_0..10 (descending).
-CURVE_COLS = [f"snarea_curve_{i}" for i in range(11)]
+CURVE_COLS = [f"snarea_curve_{i}" for i in range(SDC_LENGTH)]
 
 # CV search grid: 0.05..3.0 step 0.05 covers the validated range (median ~0.45,
 # up to ~1.2 CONUS) with headroom.
 CV_GRID = np.round(np.arange(0.05, 3.0001, 0.05), 2)
-_INTERIOR = slice(1, 10)  # endpoints (0, 10) are fixed 1.0/0.0 for every cv
+_INTERIOR = slice(1, SDC_LENGTH - 1)  # endpoints are fixed 1.0/0.0 for every cv
 
 
 def sdc_from_cv(cv: float, mu: float = 1.0, n: int = 4000) -> np.ndarray:
@@ -84,8 +88,10 @@ def build_library(
     if cv.size == 0:
         raise ValueError("build_library: no finite CV values to bin")
     default_curve = np.asarray(default_curve, dtype=float)
-    if default_curve.shape != (11,):
-        raise ValueError(f"default_curve must be shape (11,), got {default_curve.shape}")
+    if default_curve.shape != (SDC_LENGTH,):
+        raise ValueError(
+            f"default_curve must be shape ({SDC_LENGTH},), got {default_curve.shape}"
+        )
 
     rows = [
         {

--- a/src/gfv2_params/snarea/season.py
+++ b/src/gfv2_params/snarea/season.py
@@ -10,7 +10,12 @@ from __future__ import annotations
 import numpy as np
 import pandas as pd
 
-SWE_LEVELS = np.round(np.arange(1.0, -0.0001, -0.1), 1)  # 1.0 .. 0.0, 11 values
+# Number of fixed normalized-SWE sample points per depletion curve. PRMS reads
+# snarea_curve as ndeplval = SDC_LENGTH * ndepl, so this is the one place the
+# curve length is defined — every `snarea_curve_0..10` column list, shape check
+# and interior slice in this package derives from it.
+SDC_LENGTH = 11
+SWE_LEVELS = np.round(np.linspace(1.0, 0.0, SDC_LENGTH), 1)  # 1.0 .. 0.0
 
 
 def melt_season(swe: pd.Series, sca: pd.Series):

--- a/tests/test_aggregate_adapter.py
+++ b/tests/test_aggregate_adapter.py
@@ -22,6 +22,28 @@ def test_rejects_empty_variables():
         SourceAdapter(source_key="d", variables=(), files_glob="*.nc")
 
 
+def test_rejects_grid_variable_not_in_variables():
+    # The grid_variable names the variable whose grid WeightGen is built from,
+    # so it must be one the adapter actually aggregates.
+    with pytest.raises(ValueError, match="grid_variable"):
+        SourceAdapter(source_key="d", variables=("swe",), files_glob="*.nc",
+                      grid_variable="scov")
+
+
+def test_rejects_unparseable_source_crs():
+    # A typo'd CRS otherwise surfaces deep inside gdptools (or, worse, silently
+    # mis-projects), so it must fail at construction like stat_method does.
+    with pytest.raises(ValueError, match="source_crs"):
+        SourceAdapter(source_key="d", variables=("swe",), files_glob="*.nc",
+                      source_crs="EPSG:not_a_code")
+
+
+def test_accepts_varied_source_crs_spellings():
+    for crs in ("EPSG:5070", 5070, "+proj=longlat +datum=WGS84 +no_defs"):
+        SourceAdapter(source_key="d", variables=("swe",), files_glob="*.nc",
+                      source_crs=crs)
+
+
 def test_std_variables_defaults_empty_and_validates():
     a = SourceAdapter(source_key="s", variables=("swe", "scov"), files_glob="*.nc")
     assert a.std_variables == ()

--- a/tests/test_aggregate_driver.py
+++ b/tests/test_aggregate_driver.py
@@ -117,6 +117,55 @@ def test_aggregate_source_years_filter_no_match_raises(tmp_path):
         )
 
 
+def test_compute_or_load_weights_accepts_a_str_path(tmp_path):
+    # aggregate_source's caller may pass weight_file as a plain str (it comes
+    # out of a config dict); the cache-hit branch must not depend on it already
+    # being a Path.
+    from gfv2_params.aggregate.driver import compute_or_load_weights
+
+    cached = tmp_path / "w.csv"
+    pd.DataFrame({"hru_id": [1, 2], "i": [0, 0], "j": [0, 1],
+                  "wght": [0.5, 0.5]}).to_csv(cached, index=False)
+    adapter = SourceAdapter(source_key="demo", variables=("swe",), files_glob="*.nc")
+    got = compute_or_load_weights(
+        adapter, xr.Dataset(), _two_polys(), "hru_id", ("2010-01-01", "2010-01-02"),
+        str(cached),
+    )
+    assert list(got["hru_id"]) == [1, 2]
+
+
+def test_compute_or_load_weights_raises_when_no_overlap(tmp_path):
+    # A fabric that does not intersect the grid yields an empty weight table;
+    # that must fail loud rather than aggregating every HRU to NaN.
+    import pytest
+
+    from gfv2_params.aggregate.driver import compute_or_load_weights
+
+    path = _synthetic_grid(tmp_path)
+    ds = xr.open_dataset(path)
+    far = gpd.GeoDataFrame({"hru_id": [1]}, geometry=[box(1e6, 1e6, 1.1e6, 1.1e6)],
+                           crs="EPSG:5070")
+    adapter = SourceAdapter(
+        source_key="demo", variables=("swe",), files_glob="demo_daily_*.nc",
+        source_crs="EPSG:5070", x_coord="x", y_coord="y", time_coord="time",
+    )
+    with pytest.raises((RuntimeError, ValueError)):
+        compute_or_load_weights(
+            adapter, ds, far, "hru_id", ("2010-01-01", "2010-01-02"),
+            tmp_path / "far.csv",
+        )
+
+
+def test_year_of_raises_without_a_four_digit_year():
+    import pytest
+
+    from gfv2_params.aggregate.driver import _year_of
+
+    assert _year_of(Path("snodas_daily_2010.nc")) == 2010
+    with pytest.raises(ValueError, match="4-digit year"):
+        _year_of(Path("snodas_daily_latest.nc"))
+
+
 def test_std_sidecar_emits_var_std(tmp_path):
     import pytest
 

--- a/tests/test_derive_snarea_curve.py
+++ b/tests/test_derive_snarea_curve.py
@@ -11,7 +11,7 @@ import pandas as pd
 import pytest
 import xarray as xr
 
-from scripts.derive_snarea_curve import (  # noqa: E402
+from scripts.derive_snarea_curve import (
     cells_from_weights,
     read_daily_by_hru,
     validate_default_curve,

--- a/tests/test_snarea_build.py
+++ b/tests/test_snarea_build.py
@@ -2,7 +2,11 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from gfv2_params.snarea.build import DEFAULT_SNAREA_CURVE, build_hru_record
+from gfv2_params.snarea.build import (
+    DEFAULT_SNAREA_CURVE,
+    build_hru_record,
+    build_snarea_curve,
+)
 from gfv2_params.snarea.selection import SelectionParams
 
 
@@ -94,3 +98,48 @@ def test_build_hru_record_defaults_subgrid_stats_without_swe_std():
     assert rec["n_peak_years"] == 0
     assert np.isnan(rec["cv_subgrid"])
     assert np.isnan(rec["peak_swe_mm"])
+
+
+# --- build_snarea_curve (the multi-HRU loop) --------------------------------
+
+_EXPECTED_COLUMNS = [
+    "hru_deplcrv", "sdc_status", "sca_class", "similarity", "n_seasons",
+    *[f"snarea_curve_{i}" for i in range(11)],
+    "cv_subgrid", "peak_swe_mm", "n_peak_years",
+]
+
+
+def test_build_snarea_curve_renames_id_and_pins_column_order():
+    # The id column is renamed from the internal "hru_id" to the fabric's
+    # id_feature, and must lead the frame — Stage 3 and the NHM param assembly
+    # both read this CSV positionally-ish, so a silent reorder is a real defect.
+    daily = {1: _daily_two_years(), 2: _daily_two_years()}
+    out = build_snarea_curve(
+        daily, {1: 100, 2: 100}, {1: 0.0, 2: 0.0}, "nat_hru_id",
+        SelectionParams(), DEFAULT_SNAREA_CURVE,
+    )
+    assert list(out.columns) == ["nat_hru_id", *_EXPECTED_COLUMNS]
+    assert "hru_id" not in out.columns
+
+
+def test_build_snarea_curve_defaults_missing_cells_and_water_keys():
+    # cells_by_hru / water_by_hru are read with .get defaults: an HRU absent
+    # from the weight table has 0 contributing cells and must be rejected by
+    # the min_cells criterion, not crash with a KeyError.
+    daily = {1: _daily_two_years(), 2: _daily_two_years()}
+    out = build_snarea_curve(
+        daily, {1: 100}, {}, "hru_id", SelectionParams(), DEFAULT_SNAREA_CURVE,
+    )
+    by_id = out.set_index("hru_id")
+    assert by_id.loc[1, "sdc_status"] == "derived"
+    assert by_id.loc[2, "sdc_status"] == "default_too_few_cells"
+
+
+def test_build_snarea_curve_emits_rows_sorted_by_id():
+    # The loop sorts its items, so an unordered input dict still yields a
+    # deterministic, ascending-id frame.
+    daily = {9: _daily_two_years(), 2: _daily_two_years(), 5: _daily_two_years()}
+    out = build_snarea_curve(
+        daily, {}, {}, "hru_id", SelectionParams(), DEFAULT_SNAREA_CURVE,
+    )
+    assert list(out["hru_id"]) == [2, 5, 9]

--- a/tests/test_snarea_season.py
+++ b/tests/test_snarea_season.py
@@ -14,6 +14,23 @@ def _series(vals):
     return pd.Series(vals, index=idx, dtype="float64")
 
 
+def test_sdc_length_is_the_single_source_of_truth():
+    # Every curve-length-dependent construct in the package derives from
+    # season.SDC_LENGTH, so a change there propagates rather than leaving a
+    # stale `11` behind in one module.
+    from gfv2_params.snarea.build import _CURVE_COLS
+    from gfv2_params.snarea.library import CURVE_COLS
+    from gfv2_params.snarea.library import SWE_LEVELS as LIB_LEVELS
+    from gfv2_params.snarea.season import SDC_LENGTH, SWE_LEVELS
+
+    assert SDC_LENGTH == 11
+    assert len(SWE_LEVELS) == SDC_LENGTH
+    assert len(_CURVE_COLS) == SDC_LENGTH
+    assert len(CURVE_COLS) == SDC_LENGTH
+    # Stage 3 samples the SAME grid as Stage 2 — one definition, not two.
+    assert LIB_LEVELS is SWE_LEVELS
+
+
 def test_swe_levels():
     assert list(SWE_LEVELS) == [1.0, 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1, 0.0]
 

--- a/tests/test_snarea_selection.py
+++ b/tests/test_snarea_selection.py
@@ -42,6 +42,38 @@ def test_classify():
     assert classify(mid) == "mid"
 
 
+def _curve_with_sca_at_half(v):
+    """An 11-point descending curve whose SCA at normalized SWE=0.5 is exactly v."""
+    c = np.linspace(1.0, 0.0, 11)
+    c[5] = v
+    return c
+
+
+def test_classify_boundaries_are_inclusive_to_mid():
+    # The bands are low (<0.45), mid ([0.45, 0.55]), high (>0.55): both edges
+    # belong to `mid`. Flipping either comparison to a strict/non-strict
+    # opposite moves an edge HRU into the wrong band.
+    assert classify(_curve_with_sca_at_half(0.45)) == "mid"
+    assert classify(_curve_with_sca_at_half(0.55)) == "mid"
+    assert classify(_curve_with_sca_at_half(0.45 - 1e-9)) == "low"
+    assert classify(_curve_with_sca_at_half(0.55 + 1e-9)) == "high"
+
+
+def test_passes_selection_boundaries_are_inclusive():
+    # n_cells == min_cells passes (the check is `<`), and each ratio criterion
+    # passes at exactly its threshold.
+    p = SelectionParams(min_cells=25, max_water_frac=0.5, min_seasonal_sca=0.5,
+                        max_constant_frac=0.8, max_similarity=0.15)
+    ok, status = passes_selection(
+        has_snow=True, n_cells=25, water_frac=0.5, seasonal_sca_max=0.5,
+        constant_frac=0.8, similarity_value=0.15, params=p)
+    assert (ok, status) == (True, "derived")
+    ok, status = passes_selection(
+        has_snow=True, n_cells=24, water_frac=0.5, seasonal_sca_max=0.5,
+        constant_frac=0.8, similarity_value=0.15, params=p)
+    assert (ok, status) == (False, "default_too_few_cells")
+
+
 def test_selection_params_recalibrated_defaults():
     # Pin the Oregon-recalibrated defaults so an accidental revert to the
     # paper's 25 / 0.15 is caught (see 2026-07-06 investigation).


### PR DESCRIPTION
Refs #166 (does not close it — this is the "minor code cleanups" and "test gaps" subset).

## What

The mechanical follow-ups from #166, verified still open at HEAD, in four atomic commits.

**Behavior fixes (2)**

- `aggregate_source`'s per-year loop left each `xr.open_dataset` result to the GC, holding one open netCDF handle per year for the whole run (22 across the SNODAS record). Now context-managed. `hru_ds.load()` moves inside the `with` because the aggregated Dataset reads through a lazy `.sel` view of the raw file — without it the handle closes before the data is read.
- `compute_or_load_weights` called `weight_file.exists()` directly, so a caller passing the config-resolved `str` hit `AttributeError` on the cache-hit branch. Coerced with `Path()` in both the helper and `aggregate_source`.
- `SourceAdapter` validated `stat_method` at construction but not `source_crs`, so a typo'd CRS surfaced only once gdptools reprojected — deep inside a multi-hour aggregation. Now parsed with `pyproj.CRS.from_user_input`. Every pyproj-accepted spelling (EPSG string, integer code, PROJ string, WKT) stays valid; this catches unparseable only, not parseable-but-wrong.

**Refactor (1)**

- `SDC_LENGTH` replaces the bare `11` in five code sites across `build.py` / `library.py`. Defined once in `season.py` next to `SWE_LEVELS`, which is now built from it.
- `library.py` also carried its own copy of `SWE_LEVELS` with a comment saying it matched `season.py`'s. Two definitions of the same physical sample grid can drift, and Stage 3 fits analytic curves to exactly the points Stage 2 sampled — so it imports it now. No behavior change: `np.linspace(1.0, 0.0, 11)` rounded to 1 decimal is the same grid `np.arange(1.0, -1e-4, -0.1)` produced (pinned by the existing `test_swe_levels`).

**Tests (the named gaps)**

`grid_variable`-not-in-`variables`; `source_crs` accept/reject; `compute_or_load_weights` cache-hit via str path; empty-weights `RuntimeError`; `_year_of` ValueError; multi-HRU `build_snarea_curve` (id rename, `.get` defaults, id ordering); CSV column order; `classify` at exactly 0.45/0.55; `passes_selection` threshold equality; `SDC_LENGTH` as single source of truth. Dropped a no-op `# noqa: E402`.

## Scope note

Collapsing `library.py`'s duplicate `SWE_LEVELS` is one step beyond the issue's literal "single `SDC_LENGTH` constant" ask. It is the same drift risk in the same two files, so it is folded into that commit rather than left behind.

## Verification

- Full suite under `srun`: **1095 passed, 4 skipped** (job 2603160). The 4 skips are the pre-existing data-root-gated tests.
- Both behavior fixes were written test-first and watched fail: `test_rejects_unparseable_source_crs` and `test_compute_or_load_weights_accepts_a_str_path` failed with `AttributeError: 'str' object has no attribute 'exists'` and a missing-validation pass respectively, before the fixes.
- `pre-commit run --files <11 changed>`: isort, ruff, end-of-files, trailing-whitespace all pass (yaml/shell/prettier/nbstripout no-op — no such files touched).

## Docs check

No live doc references the changed symbols. `docs/ARCHITECTURE.md`'s "11-point areal snow-depletion" stays accurate, `docs/parameter_index.md` is untouched (no emitted column changed, so no `prms:` block edit and no index rebuild). The only other hits are in `docs/superpowers/plans/2026-07-04-snodas-snarea-curve.md`, which is a historical design record and deliberately left as-written.

## Not in this PR

Still open on #166 and needing a decision rather than a keystroke: the criterion-1 coverage check, the `n_years_dropped`/`n_years_total` diagnostic, the weight-cache fabric fingerprint, `read_daily_by_hru` chunking, the `DEFAULT_SNAREA_CURVE` placeholder, and water-fraction wiring. Validation findings for all of these are in https://github.com/rmcd-mscb/gfv2-params/issues/166#issuecomment-5246339050.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
