### PR TITLE
feat(snarea): SNODAS coverage + dropped-season diagnostics (#166)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -314,6 +314,35 @@ These are hard-won; violating them silently corrupts outputs.
   any other fabric use `threshold_mode: percentile` in
   `configs/depstor/depstor_rasters.yml` with `twi_raster` pointing at
   `twi_hydrodem.vrt` and run the `twi_reference` shared-raster step first.
+- **gdptools' `masked_mean` returns `0.0`, NOT NaN, for a polygon whose source
+  cells are all fill** — so "outside the source's domain" is indistinguishable
+  from "genuinely zero" in the aggregated output. For SNODAS this means an HRU
+  off the edge of the domain reports `swe = 0` every day and lands in
+  `default_no_snow` next to Florida: **1,087 CONUS HRUs (0.30%)**, plus **35,315
+  (9.8%)** aggregating over only part of their area. The fix is the `coverage`
+  diagnostic (`gfv2_params.aggregate.coverage`, `derive_aggregate.py --mode
+  coverage`), joined into Stage 2's CSV alongside `n_years_total` /
+  `n_years_dropped`. It is a **diagnostic, never a gate** — a `coverage >= 0.999`
+  selection criterion was measured and rejected because it flips ~13.3k CONUS
+  HRUs off their empirical curve onto the default. A missing coverage table
+  leaves the column NaN ("not measured"), deliberately distinct from a measured
+  `0.0`. Note the source footprint is **not static**: SNODAS's valid domain
+  expands across the record (31 of the 32 CONUS HRUs reading zero-coverage in
+  2004 carry real snow by 2015), so coverage is averaged over one sampled day
+  per year — a single-year probe would call a late-covered HRU permanently
+  absent. Relatedly, an all-fill *year* is silently consumed as a snow-free year
+  and dropped by `annual_sdc`, which is why `n_years_dropped` exists.
+- **A consolidated gdptools weight file mixes per-batch index spaces — its
+  `(i, j)` are NOT global.** Batched aggregation clips the source grid to each
+  batch's own bounds (`driver.subset_to_gdf_bounds`), so every batch's weight
+  `(i, j)` index that batch's subset. `derive_aggregate.py --mode merge`
+  row-concats the per-batch tables into `{source}_weights_{fabric}.csv`, which is
+  therefore safe ONLY for index-agnostic use — `cells_from_weights` does a
+  `groupby().size()`, a count, which is why it has always been fine. Anything
+  positional (the coverage diagnostic, any future per-cell join) must read the
+  per-batch CSVs and pair each with its own `batch_{NNNN}.gpkg`. Mismatched
+  indices do not error on their own — they silently address the wrong cells and
+  return plausible numbers — so `coverage_from_weights` bounds-checks and raises.
 - **`k_perm` is INTENSIVE — aggregate it as an area-weighted mean, never an
   area-prorated sum.** `ssflux.py` originally used gdptools' *extensive* form
   (`Σ Vᵢ·aᵢ/Aᵢ`, dividing by the SOURCE polygon area, the column gdptools labels

--- a/configs/snarea/snarea_curve.yml
+++ b/configs/snarea/snarea_curve.yml
@@ -4,6 +4,13 @@
 # only resolves {data_root}/{fabric} placeholders in top-level string values.
 snodas_agg_dir: "{data_root}/{fabric}/snodas"
 weight_file: "{data_root}/{fabric}/weights_agg/snodas_weights_{fabric}.csv"
+# Per-HRU SNODAS valid-data coverage, written by
+#   pixi run python scripts/derive_aggregate.py --source snodas --fabric <f> --mode coverage
+# Optional: absent -> the `coverage` column is NaN and nothing else changes. It is
+# a DIAGNOSTIC, never a selection gate — gdptools' masked_mean returns 0.0 (not
+# NaN) for an all-fill HRU, so without it an HRU outside the SNODAS domain is
+# indistinguishable from a snow-free one (#166: 1,087 CONUS HRUs, 0.30%).
+coverage_file: "{data_root}/{fabric}/weights_agg/snodas_coverage_{fabric}.csv"
 output_dir: "{data_root}/{fabric}/params/merged/_intermediates"
 merged_file: nhm_snarea_curve_derived.csv
 

--- a/scripts/derive_aggregate.py
+++ b/scripts/derive_aggregate.py
@@ -15,11 +15,18 @@ import pandas as pd
 import pyproj
 
 from gfv2_params.aggregate import aggregate_source
+from gfv2_params.aggregate.coverage import coverage_over_years
+from gfv2_params.aggregate.driver import _year_of
 from gfv2_params.aggregate.snodas import SNODAS_ADAPTER
 from gfv2_params.config import load_config, require_config_key
 from gfv2_params.log import configure_logging
 
 ADAPTERS = {"snodas": SNODAS_ADAPTER}
+
+
+def coverage_file_path(weight_dir: Path, source: str, fabric: str) -> Path:
+    """Canonical per-HRU coverage table (Stage 2 reads this path)."""
+    return Path(weight_dir) / f"{source}_coverage_{fabric}.csv"
 
 
 def _resolve(value, repl: dict):
@@ -44,6 +51,76 @@ def _resolve(value, repl: dict):
     if isinstance(value, dict):
         return {k: _resolve(v, repl) for k, v in value.items()}
     return value
+
+
+def run_coverage(
+    adapter,
+    source_dir: Path,
+    weight_dir: Path,
+    batch_dir: Path,
+    source: str,
+    fabric: str,
+    id_feature: str,
+    hru_layer: str,
+    logger,
+    years: list[int] | None = None,
+) -> Path:
+    """Write the per-HRU source-coverage diagnostic for the whole fabric.
+
+    Reuses the weight tables Stage 1 already cached — no re-aggregation — and
+    reads one day per per-year source file to sample the valid-data footprint
+    (see gfv2_params.aggregate.coverage). Minutes, not hours.
+
+    Runs PER BATCH because each batch's weight ``(i, j)`` index that batch's own
+    bounds-subset of the source grid: the consolidated weight file row-concats
+    64 different index spaces and is unusable for anything positional. Falls
+    back to the whole-fabric weight file when a run was not batched.
+    """
+    files = sorted(Path(source_dir).glob(adapter.files_glob))
+    if years is not None:
+        files = [f for f in files if _year_of(f) in years]
+    if not files:
+        raise FileNotFoundError(f"No files match {source_dir}/{adapter.files_glob}")
+
+    batch_weights = sorted(Path(weight_dir).glob(f"{source}_weights_{fabric}_batch*.csv"))
+    parts: list[pd.DataFrame] = []
+
+    if batch_weights:
+        logger.info("Coverage: %d batches x %d year-file(s)", len(batch_weights), len(files))
+        for n, wf in enumerate(batch_weights, start=1):
+            batch_id = int(wf.stem.split("batch")[-1])
+            gdf = gpd.read_file(Path(batch_dir) / f"batch_{batch_id:04d}.gpkg",
+                                layer=hru_layer)
+            logger.info("[%d/%d] batch %04d: %d HRUs", n, len(batch_weights),
+                        batch_id, len(gdf))
+            parts.append(coverage_over_years(
+                adapter, gdf, id_feature, pd.read_csv(wf), files))
+    else:
+        raise FileNotFoundError(
+            f"No per-batch weight CSVs in {weight_dir} matching "
+            f"{source}_weights_{fabric}_batch*.csv. Coverage is computed per "
+            f"batch because each batch's weight (i, j) index that batch's own "
+            f"bounds-subset; run --mode aggregate --batch_id first."
+        )
+
+    out = pd.concat(parts, ignore_index=True)
+    dupes = int(out[id_feature].duplicated().sum())
+    if dupes:
+        raise ValueError(
+            f"{dupes} duplicate {id_feature} across batch coverage tables — "
+            f"overlapping or re-run per-batch weight files in {weight_dir}."
+        )
+    path = coverage_file_path(weight_dir, source, fabric)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    out.sort_values(id_feature).to_csv(path, index=False)
+    zero = int((out["coverage"] <= 1e-9).sum())
+    logger.info(
+        "Coverage: %d HRUs; %d with ZERO coverage in every sampled year "
+        "(they report source-zero, indistinguishable from a true zero); "
+        "%d partial (<0.999) -> %s",
+        len(out), zero, int((out["coverage"] < 0.999).sum() - zero), path,
+    )
+    return path
 
 
 def run_merge(
@@ -182,7 +259,8 @@ def main() -> None:
     ap.add_argument("--years", nargs="*", type=int, default=None)
     ap.add_argument("--config", default="configs/aggregate/aggregate_sources.yml")
     ap.add_argument("--base_config", default="configs/base_config.yml")
-    ap.add_argument("--mode", choices=["aggregate", "merge"], default="aggregate")
+    ap.add_argument("--mode", choices=["aggregate", "merge", "coverage"],
+                     default="aggregate")
     ap.add_argument("--batch_id", type=int, default=None,
                      help="Spatial batch index (aggregate mode only); omit to run whole-fabric.")
     args = ap.parse_args()
@@ -229,6 +307,15 @@ def main() -> None:
     # snodas_dir may be overridden in the profile; fall back to the source entry.
     snodas_dir = _resolve(cfg.get("snodas_dir", src["snodas_dir"]), repl)
     hru_layer = cfg.get("hru_layer", "nhru")
+
+    if args.mode == "coverage":
+        out = run_coverage(
+            ADAPTERS[args.source], Path(snodas_dir), Path(cfg["weight_dir"]),
+            Path(cfg["batch_dir"]), args.source, args.fabric, id_feature,
+            hru_layer, logger, years=args.years,
+        )
+        logger.info("Wrote per-HRU coverage -> %s", out)
+        return
 
     if args.batch_id is not None:
         batch_gpkg = Path(cfg["batch_dir"]) / f"batch_{args.batch_id:04d}.gpkg"

--- a/scripts/derive_snarea_curve.py
+++ b/scripts/derive_snarea_curve.py
@@ -29,6 +29,7 @@ from gfv2_params.snarea.selection import SelectionParams
 __all__ = [
     "read_daily_by_hru",
     "cells_from_weights",
+    "coverage_from_file",
     "validate_default_curve",
     "main",
 ]
@@ -82,9 +83,24 @@ def read_daily_by_hru(
 
 
 def cells_from_weights(weight_file: Path, id_col: str) -> dict[int, int]:
-    """Per-HRU contributing SNODAS cell count from the gdptools weight table."""
+    """Per-HRU contributing SNODAS cell count from the gdptools weight table.
+
+    Note this is a ``groupby().size()`` — a COUNT of weight rows, which is
+    index-agnostic. That is why the consolidated weight file is safe here even
+    though it row-concats 64 per-batch tables whose ``(i, j)`` index disjoint
+    grid subsets. Anything positional must read the per-batch files instead
+    (see gfv2_params.aggregate.coverage).
+    """
     w = pd.read_csv(weight_file)
     return w.groupby(id_col).size().astype(int).to_dict()
+
+
+def coverage_from_file(coverage_file: Path, id_col: str) -> dict[int, float]:
+    """Per-HRU SNODAS coverage fraction written by ``derive_aggregate.py
+    --mode coverage``. Missing file -> empty dict, so every HRU's `coverage`
+    column is NaN ("not measured") rather than 0.0 ("measured, and empty")."""
+    c = pd.read_csv(coverage_file)
+    return dict(zip(c[id_col], c["coverage"]))
 
 
 def main() -> None:
@@ -120,8 +136,28 @@ def main() -> None:
         water = dict(zip(wdf[id_feature], wdf["water_frac"]))
         logger.info("Loaded water fraction for %d HRUs from %s", len(water), args.water_csv)
 
+    coverage: dict[int, float] = {}
+    cov_file = Path(cfg["coverage_file"]) if "coverage_file" in cfg else None
+    if cov_file is not None and cov_file.exists():
+        coverage = coverage_from_file(cov_file, id_feature)
+        zero = sum(1 for v in coverage.values() if v <= 1e-9)
+        logger.info(
+            "Loaded SNODAS coverage for %d HRUs from %s (%d with zero coverage "
+            "in every sampled year — their swe=0 is a data gap, not snow-free)",
+            len(coverage), cov_file, zero,
+        )
+    else:
+        logger.warning(
+            "No coverage table at %s — the `coverage` column will be NaN. "
+            "Run `derive_aggregate.py --mode coverage` to populate it; without "
+            "it an HRU outside the SNODAS domain is indistinguishable from a "
+            "snow-free one (gdptools masked_mean returns 0.0, not NaN).",
+            cov_file,
+        )
+
     logger.info("Deriving representative snarea_curve for %d HRUs ...", len(daily))
-    table = build_snarea_curve(daily, cells, water, id_feature, sel, default_curve, logger=logger)
+    table = build_snarea_curve(daily, cells, water, id_feature, sel, default_curve,
+                               logger=logger, coverage_by_hru=coverage)
     out = out_dir / cfg["merged_file"]
     table.to_csv(out, index=False)
     logger.info("Wrote %d HRU curves -> %s", len(table), out)

--- a/slurm_batch/RUNME.md
+++ b/slurm_batch/RUNME.md
@@ -542,7 +542,9 @@ one array task per batch, source grid clipped to each batch's extent), then
 into one final `snodas_agg_<year>.nc` per calendar year (area-weighted mean
 SWE + snow-covered-area fraction, now also the per-cell SWE std dev `swe_std`
 sidecar used by Stage 2's sub-grid CV, via the gdptools-backed `aggregate`
-harness); Stage 2 derives per-HRU empirical depletion curves and sub-grid CV
+harness); `derive_snodas_coverage.batch` then computes the per-HRU valid-data
+`coverage` diagnostic (below); Stage 2 derives per-HRU empirical depletion
+curves and sub-grid CV
 from those daily series (Driscoll, Hay & Bock 2017 selection method) and
 writes the intermediate `_intermediates/nhm_snarea_curve_derived.csv` (not yet
 the terminal params); Stage 3 (`derive_snarea_library.py`) builds the
@@ -551,8 +553,25 @@ daily-SWE reload — and writes the terminal `nhm_snarea_curve_library.csv`,
 `nhm_snarea_curve_params.csv`, `nhm_snarea_curve_validation.csv`, and the
 pyWatershed `nhm_snarea_curve.nc`. Fabric-independent — no code change to run
 against `gfv2`, `gfv2_vpu01`, or `oregon`. `submit_snarea_pipeline.sh` submits
-all four jobs (including Stage 2) as an afterok chain; run any stage directly
+all five jobs (including Stage 2) as an afterok chain; run any stage directly
 with `pixi run python ...` / `sbatch` when you want to inspect between stages.
+
+**The `coverage` diagnostic (do not treat it as a gate).** gdptools' `masked_mean`
+returns **0.0, not NaN**, for an HRU whose SNODAS cells are every one of them
+fill — so an HRU outside the SNODAS domain reports `swe = 0` all year and lands
+in `default_no_snow`, indistinguishable from Florida. At CONUS that is **1,087
+HRUs (0.30%)**, plus **35,315 (9.8%)** aggregating over only part of their area.
+The coverage step measures the weight-weighted valid fraction per HRU (reusing
+Stage 1's cached weights and reading one day per year-file — minutes, no
+re-aggregation) and Stage 2 joins it in as a `coverage` column alongside
+`n_years_total`/`n_years_dropped`. It **never** changes `sdc_status` or a curve:
+gating on it was measured and rejected, since a `coverage >= 0.999` gate would
+flip ~13.3k CONUS HRUs off their empirical curve onto the default. If the table
+is missing, Stage 2 logs a warning and leaves `coverage` NaN — "not measured",
+which is deliberately distinct from a measured 0.0. Because SNODAS's valid
+footprint *expands* across the record (31 of the 32 CONUS HRUs reading
+zero-coverage in 2004 carry real snow by 2015), coverage is averaged over one
+sampled day per year rather than probed once.
 
 **Wait for:** the merge job `COMPLETED`, printing one `snodas_agg_<year>.nc`
 per year written; Stage 2 prints the `sdc_status` breakdown and writes the

--- a/slurm_batch/derive_snodas_coverage.batch
+++ b/slurm_batch/derive_snodas_coverage.batch
@@ -1,0 +1,40 @@
+#!/bin/bash
+#SBATCH -p cpu
+#SBATCH -A impd
+#SBATCH --job-name=snodas_cov
+#SBATCH --output=logs/job_%j.out
+#SBATCH --error=logs/job_%j.err
+#SBATCH --time=02:00:00
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=32G
+#
+# Per-HRU SNODAS valid-data coverage (issue #166) — the diagnostic that tells a
+# genuinely snow-free HRU apart from one sitting outside the SNODAS domain.
+# gdptools' masked_mean returns 0.0 (NOT NaN) when every source cell is fill, so
+# without this the two are indistinguishable: at CONUS, 1,087 HRUs (0.30%) land
+# in `default_no_snow` purely because they are off the edge of the data.
+#
+# Cheap: it reuses the gdptools weights Stage 1 already cached and reads ONE day
+# per per-year SNODAS file. No re-aggregation. Runs per batch, because each
+# batch's weight (i, j) index that batch's own bounds-subset of the source grid
+# — the consolidated weight file row-concats those index spaces and is unusable
+# for anything positional.
+#
+# Must run AFTER Stage 1 (needs {fabric}/weights_agg/*_batch*.csv) and BEFORE
+# Stage 2, which joins the result in as the `coverage` column. Stage 2 does not
+# require it: a missing table just leaves `coverage` NaN and logs a warning.
+# submit_snarea_pipeline.sh chains it automatically.
+#
+#   sbatch --export=ALL,FABRIC=gfv2 slurm_batch/derive_snodas_coverage.batch
+
+cd "$SLURM_SUBMIT_DIR"
+BASE_CONFIG=${BASE_CONFIG:-configs/base_config.yml}
+FABRIC=${FABRIC:-oregon}
+
+pixi run --as-is python scripts/derive_aggregate.py \
+    --source snodas \
+    --fabric "$FABRIC" \
+    --config configs/aggregate/aggregate_sources.yml \
+    --base_config "$BASE_CONFIG" \
+    --mode coverage

--- a/slurm_batch/submit_snarea_pipeline.sh
+++ b/slurm_batch/submit_snarea_pipeline.sh
@@ -2,15 +2,18 @@
 # Usage: ./submit_snarea_pipeline.sh <fabric> [base_config] [extra sbatch opts...]
 #
 # One-command recipe for the full 3-stage SNODAS -> snarea_curve pipeline.
-# Submits four SLURM jobs chained --dependency=afterok, so each waits for the
+# Submits five SLURM jobs chained --dependency=afterok, so each waits for the
 # previous to succeed, and prints the job IDs:
 #
 #   1. Stage 1 aggregate  (derive_snodas_aggregate.batch, ARRAY over spatial
 #      batches sized from the fabric manifest: oregon N=2, gfv2 N=64)
 #   2. merge              (merge_snodas_aggregate.batch, --mode merge)
-#   3. Stage 2 derive     (derive_snarea_curve.batch; --mem parameterized —
+#   3. coverage           (derive_snodas_coverage.batch, --mode coverage — the
+#      per-HRU valid-data diagnostic; reuses Stage 1's cached weights, no
+#      re-aggregation. Stage 2 joins it in as the `coverage` column.)
+#   4. Stage 2 derive     (derive_snarea_curve.batch; --mem parameterized —
 #      384G CONUS default, smaller for oregon)
-#   4. Stage 3 library    (derive_snarea_library.batch, CV/lognormal library)
+#   5. Stage 3 library    (derive_snarea_library.batch, CV/lognormal library)
 #
 # Because every job is afterok on the prior one, a failed Stage-1 array task
 # aborts the whole chain (merge/derive/library stay PENDING then cancel) — a
@@ -135,15 +138,19 @@ echo "--- merge ---"
 MID=$(submit --dependency=afterok:"$AID" --export="$EXPORT" -- slurm_batch/merge_snodas_aggregate.batch)
 echo "  merge afterok:$AID -> $MID"
 
+echo "--- coverage diagnostic ---"
+CID=$(submit --dependency=afterok:"$MID" --export="$EXPORT" -- slurm_batch/derive_snodas_coverage.batch)
+echo "  coverage afterok:$MID -> $CID"
+
 echo "--- Stage 2: derive snarea_curve ---"
-S2=$(submit --dependency=afterok:"$MID" --mem="$STAGE2_MEM" "${STAGE2_TIME_ARG[@]}" --export="$EXPORT" \
+S2=$(submit --dependency=afterok:"$CID" --mem="$STAGE2_MEM" "${STAGE2_TIME_ARG[@]}" --export="$EXPORT" \
      -- slurm_batch/derive_snarea_curve.batch)
-echo "  derive afterok:$MID -> $S2"
+echo "  derive afterok:$CID -> $S2"
 
 echo "--- Stage 3: snarea_curve library ---"
 S3=$(submit --dependency=afterok:"$S2" --export="$EXPORT" -- slurm_batch/derive_snarea_library.batch)
 echo "  library afterok:$S2 -> $S3"
 
 echo ""
-echo "Done. Chain: $AID (agg) -> $MID (merge) -> $S2 (derive) -> $S3 (library)"
-echo "Monitor: squeue -u \$USER   |   sacct -j $AID,$MID,$S2,$S3"
+echo "Done. Chain: $AID (agg) -> $MID (merge) -> $CID (coverage) -> $S2 (derive) -> $S3 (library)"
+echo "Monitor: squeue -u \$USER   |   sacct -j $AID,$MID,$CID,$S2,$S3"

--- a/src/gfv2_params/aggregate/coverage.py
+++ b/src/gfv2_params/aggregate/coverage.py
@@ -1,0 +1,144 @@
+"""Per-HRU source-coverage diagnostic.
+
+gdptools' ``masked_mean`` returns **0.0, not NaN**, for a polygon whose source
+cells are every one of them fill. That makes a polygon sitting entirely outside
+the source's valid domain indistinguishable from one that is genuinely
+zero-valued — for SNODAS, an HRU off the edge of the domain reads exactly like
+Florida (issue #166: 1,087 CONUS HRUs, 0.30%, land in ``default_no_snow`` this
+way, and a further 35,315 aggregate over only part of their area).
+
+Coverage is the weight-weighted fraction of a polygon's source cells that carry
+valid data::
+
+    coverage = Σ(wght · valid) / Σ(wght)
+
+It is a **diagnostic**, never a gate: it rides alongside the derived parameter so
+a thin record is visible, and deliberately does not demote any HRU. Gating on it
+was considered and rejected — at a 0.999 threshold it would flip ~13.3k CONUS
+HRUs off their empirical curve onto the default one.
+
+The valid mask comes from the adapter's own ``pre_aggregate_hook`` (which is what
+converts that source's fill sentinel to NaN), so this module has no per-source
+constants; an adapter with no hook falls back to plain NaN.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import geopandas as gpd
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+from .adapter import SourceAdapter
+from .driver import subset_to_gdf_bounds
+
+logger = logging.getLogger(__name__)
+
+
+def coverage_from_weights(
+    adapter: SourceAdapter,
+    source_ds: xr.Dataset,
+    fabric_gdf: gpd.GeoDataFrame,
+    id_col: str,
+    weights: pd.DataFrame,
+    time_index: int = 0,
+) -> dict:
+    """Weight-weighted valid-data fraction per polygon, as ``{id: coverage}``.
+
+    ``weights`` must be the table computed for THIS ``fabric_gdf`` — its
+    ``(i, j)`` index the bounds-subset that :func:`subset_to_gdf_bounds` derives
+    from these polygons, not the full source grid. Batched runs therefore have
+    one index space per batch, and the consolidated weight file (a plain
+    row-concat of them) is **not** usable here: its rows mix 64 different origins.
+    Mismatched indices produce plausible-looking numbers rather than an error, so
+    the bounds check below raises instead of clipping or wrapping.
+
+    ``time_index`` selects the day the valid mask is read from. The mask is a
+    property of the source's domain, not of the weather, so any day in the file
+    works — but the domain can change between files (SNODAS's footprint expands
+    over the record), which is why callers sample one day per year and average.
+    """
+    # Narrow to the single day BEFORE the hook. The hook rewrites every cell of
+    # every variable it touches, so running it on the full year would do ~365x
+    # the work for a mask that is a property of the domain, not of any one day.
+    # The time dim is kept (not squeezed) so a hook written against the
+    # aggregation's Dataset shape still applies unchanged.
+    if adapter.time_coord in source_ds.dims:
+        source_ds = source_ds.isel({adapter.time_coord: [time_index]})
+
+    sub = subset_to_gdf_bounds(
+        source_ds, fabric_gdf, adapter.source_crs, adapter.x_coord, adapter.y_coord
+    )
+    if adapter.pre_aggregate_hook is not None:
+        sub = adapter.pre_aggregate_hook(sub)
+
+    grid = sub[adapter.grid_variable]
+    if adapter.time_coord in grid.dims:
+        grid = grid.isel({adapter.time_coord: 0})
+    valid = grid.notnull().values.astype("float64")
+
+    ny, nx = valid.shape
+    i = weights["i"].to_numpy()
+    j = weights["j"].to_numpy()
+    if i.size and (i.min() < 0 or j.min() < 0 or i.max() >= ny or j.max() >= nx):
+        raise ValueError(
+            f"weight index out of range for this polygon set's bounds-subset "
+            f"(got i in [{i.min()}, {i.max()}], j in [{j.min()}, {j.max()}]; "
+            f"subset is {ny}x{nx}). The weights must be the ones computed for "
+            f"these polygons — a consolidated multi-batch weight file mixes "
+            f"per-batch index spaces and cannot be used here."
+        )
+
+    w = weights["wght"].to_numpy(dtype="float64")
+    frame = pd.DataFrame({id_col: weights[id_col].to_numpy(),
+                          "w": w, "wv": w * valid[i, j]})
+    g = frame.groupby(id_col)[["w", "wv"]].sum()
+    # A polygon whose weights sum to 0 has no source cells at all; report NaN
+    # ("not measurable") rather than a 0/0 warning or a misleading 0.0.
+    cov = np.where(g["w"].to_numpy() > 0,
+                   g["wv"].to_numpy() / np.where(g["w"].to_numpy() > 0, g["w"], 1.0),
+                   np.nan)
+    return dict(zip(g.index.tolist(), cov.tolist()))
+
+
+def coverage_over_years(
+    adapter: SourceAdapter,
+    fabric_gdf: gpd.GeoDataFrame,
+    id_col: str,
+    weights: pd.DataFrame,
+    files: list[Path],
+) -> pd.DataFrame:
+    """Mean per-polygon coverage across one sampled day per per-year file.
+
+    Averaging matters because the source domain is not fixed: SNODAS's valid
+    footprint shifts within a year and expands markedly across the record — 31
+    of the 32 CONUS HRUs that read zero-coverage in 2004 carry real snow by 2015
+    (#166). A single-year probe would therefore call a late-covered HRU
+    permanently absent. The mean gives 0.0 only when the polygon is uncovered in
+    every sampled year, and lands between 0 and 1 for one covered only part of
+    the record — which is exactly the distinction the diagnostic is for.
+
+    Returns a frame of ``[id_col, coverage, n_years_sampled]``.
+    """
+    if not files:
+        raise ValueError("coverage_over_years: no source files given")
+    per_year: list[dict] = []
+    for k, f in enumerate(files, start=1):
+        with xr.open_dataset(f) as ds:
+            per_year.append(
+                coverage_from_weights(adapter, ds, fabric_gdf, id_col, weights)
+            )
+        logger.info("  coverage [%d/%d] %s", k, len(files), Path(f).name)
+
+    ids = sorted({i for d in per_year for i in d})
+    stacked = np.array([[d.get(i, np.nan) for i in ids] for d in per_year])
+    with np.errstate(invalid="ignore"):
+        mean = np.nanmean(stacked, axis=0)
+    return pd.DataFrame({
+        id_col: ids,
+        "coverage": mean,
+        "n_years_sampled": np.sum(~np.isnan(stacked), axis=0),
+    })

--- a/src/gfv2_params/snarea/build.py
+++ b/src/gfv2_params/snarea/build.py
@@ -44,8 +44,17 @@ def validate_default_curve(arr: np.ndarray) -> None:
         raise ValueError(f"default_curve must be non-increasing, got {arr}")
 
 
-def _seasons(daily: pd.DataFrame) -> list[np.ndarray]:
+def _seasons(daily: pd.DataFrame) -> tuple[list[np.ndarray], int]:
     """Up to one annual SDC per WATER YEAR (Oct 1 – Sep 30) in the frame.
+
+    Returns ``(curves, n_years_total)`` — the usable curves, and how many water
+    years were examined to get them. The count is what makes a dropped year
+    visible: an HRU where most years never melt out reports the same
+    ``n_seasons`` as one with that many clean years (see #166), and the
+    difference is the only signal that the record is thin. A year is dropped
+    when SNODAS shows no snow, when the snow never melts out, or when the
+    record is too short — including, at the domain edge, a year that is
+    entirely SNODAS fill and therefore reads as snow-free.
 
     Water-year framing (vs calendar year) keeps each snow season's accumulation
     (Oct–Dec) and melt (Jan–Jul) in one window, so the annual peak is the spring
@@ -58,11 +67,13 @@ def _seasons(daily: pd.DataFrame) -> list[np.ndarray]:
     """
     water_year = daily.index.year + (daily.index.month >= 10).astype(int)
     out = []
+    n_total = 0
     for _wy, grp in daily.groupby(water_year):
+        n_total += 1
         curve = annual_sdc(grp["swe"], grp["sca"])
         if curve is not None:
             out.append(curve)
-    return out
+    return out, n_total
 
 
 def _constant_frac(daily: pd.DataFrame) -> float:
@@ -83,8 +94,9 @@ def build_hru_record(
     water_frac: float,
     params: SelectionParams,
     default_curve: np.ndarray,
+    coverage: float = float("nan"),
 ) -> dict:
-    seasons = _seasons(daily)
+    seasons, n_years_total = _seasons(daily)
     has_snow = daily["swe"].max() > 0
     sim = float("nan")
     rep = default_curve
@@ -119,6 +131,8 @@ def build_hru_record(
         "sca_class": classify(rep),
         "similarity": sim,
         "n_seasons": n_seasons,
+        "n_years_total": n_years_total,
+        "n_years_dropped": n_years_total - n_seasons,
     }
     record.update({c: float(rep[i]) for i, c in enumerate(_CURVE_COLS)})
 
@@ -128,6 +142,12 @@ def build_hru_record(
         else {"cv_subgrid": float("nan"), "peak_swe_mm": float("nan"), "n_peak_years": 0}
     )
     record.update(stats)
+    # Diagnostic only: the fraction of the HRU's SNODAS weight that falls on
+    # valid (non-fill) cells. It never gates selection — see #166, where a
+    # gate would have flipped ~13k CONUS HRUs off their empirical curve — but
+    # without it a zero-coverage HRU is indistinguishable from a snow-free one,
+    # since gdptools' masked_mean returns 0.0 (not NaN) for an all-fill HRU.
+    record["coverage"] = float(coverage)
     return record
 
 
@@ -140,17 +160,22 @@ def build_snarea_curve(
     default_curve: np.ndarray,
     logger: logging.Logger | None = None,
     log_every: int = 25_000,
+    coverage_by_hru: dict | None = None,
 ) -> pd.DataFrame:
     """Per-HRU derivation loop. Pass ``logger`` to emit progress every
     ``log_every`` HRUs — the loop is silent otherwise, which reads as a hang at
     CONUS scale (361k HRUs take minutes)."""
     items = sorted(daily_by_hru.items())
     n = len(items)
+    # NaN, not 0.0: an HRU missing from the coverage table was NOT MEASURED,
+    # which must not be read as "measured, and empty".
+    coverage_by_hru = coverage_by_hru or {}
     rows = []
     for i, (hru_id, daily) in enumerate(items, start=1):
         rows.append(build_hru_record(
             hru_id, daily, cells_by_hru.get(hru_id, 0),
             water_by_hru.get(hru_id, 0.0), params, default_curve,
+            coverage=coverage_by_hru.get(hru_id, float("nan")),
         ))
         if logger is not None and (i % log_every == 0 or i == n):
             logger.info("  derived %d/%d HRUs (%.0f%%)", i, n, 100 * i / n)

--- a/tests/test_aggregate_coverage.py
+++ b/tests/test_aggregate_coverage.py
@@ -1,0 +1,162 @@
+"""Per-HRU source-coverage diagnostic (issue #166).
+
+gdptools' masked_mean returns 0.0 — not NaN — for an HRU whose source cells are
+all fill, so a zero-coverage HRU is indistinguishable from a genuinely zero-valued
+one. These tests pin the weight-weighted valid fraction that makes the difference
+visible.
+"""
+
+import geopandas as gpd
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+from shapely.geometry import box
+
+from gfv2_params.aggregate import SourceAdapter
+from gfv2_params.aggregate.coverage import coverage_from_weights, coverage_over_years
+
+_FILL = -9999.0
+
+
+def _hook(ds: xr.Dataset) -> xr.Dataset:
+    return ds.assign(swe=ds["swe"].where(ds["swe"] > -9990))
+
+
+def _adapter(**over):
+    kw = dict(
+        source_key="demo", variables=("swe",), files_glob="demo_daily_*.nc",
+        source_crs="EPSG:5070", x_coord="x", y_coord="y", time_coord="time",
+        stat_method="masked_mean", pre_aggregate_hook=_hook,
+    )
+    kw.update(over)
+    return SourceAdapter(**kw)
+
+
+def _grid(left_fill: bool, right_fill: bool) -> xr.Dataset:
+    """4x4 1-km grid, EPSG:5070; each half independently all-fill or all-valid."""
+    x = np.array([500.0, 1500.0, 2500.0, 3500.0])
+    y = np.array([3500.0, 2500.0, 1500.0, 500.0])   # descending (north-up)
+    a = np.ones((4, 4), dtype="float32")
+    a[:, :2] = _FILL if left_fill else 1.0
+    a[:, 2:] = _FILL if right_fill else 1.0
+    ds = xr.Dataset(
+        {"swe": (("time", "y", "x"), a[None, ...])},
+        coords={"time": pd.to_datetime(["2010-01-01"]), "y": y, "x": x},
+    )
+    ds["x"].attrs["units"] = "m"
+    ds["y"].attrs["units"] = "m"
+    return ds
+
+
+def _polys() -> gpd.GeoDataFrame:
+    return gpd.GeoDataFrame(
+        {"hru_id": [1, 2]},
+        geometry=[box(0, 0, 2000, 4000), box(2000, 0, 4000, 4000)],
+        crs="EPSG:5070",
+    )
+
+
+def _weights() -> pd.DataFrame:
+    """Equal weight on each of the 8 cells in each half-polygon."""
+    rows = []
+    for hru, js in ((1, (0, 1)), (2, (2, 3))):
+        for i in range(4):
+            for j in js:
+                rows.append({"hru_id": hru, "i": i, "j": j, "wght": 0.125})
+    return pd.DataFrame(rows)
+
+
+def test_all_fill_polygon_reports_zero_coverage():
+    # The load-bearing case: HRU 1 sits entirely on fill, so its masked_mean
+    # is 0.0 and looks snow-free. Coverage must say 0.0, not 1.0.
+    out = coverage_from_weights(
+        _adapter(), _grid(left_fill=True, right_fill=False), _polys(),
+        "hru_id", _weights(),
+    )
+    assert out[1] == pytest.approx(0.0)
+    assert out[2] == pytest.approx(1.0)
+
+
+def test_fully_covered_polygons_report_one():
+    out = coverage_from_weights(
+        _adapter(), _grid(left_fill=False, right_fill=False), _polys(),
+        "hru_id", _weights(),
+    )
+    assert out[1] == pytest.approx(1.0)
+    assert out[2] == pytest.approx(1.0)
+
+
+def test_partial_coverage_is_the_weighted_valid_fraction():
+    # HRU 1 spans both halves: 8 valid cells of 16, equally weighted -> 0.5.
+    gdf = gpd.GeoDataFrame({"hru_id": [1]}, geometry=[box(0, 0, 4000, 4000)],
+                           crs="EPSG:5070")
+    w = pd.DataFrame([
+        {"hru_id": 1, "i": i, "j": j, "wght": 1 / 16}
+        for i in range(4) for j in range(4)
+    ])
+    out = coverage_from_weights(
+        _adapter(), _grid(left_fill=True, right_fill=False), gdf, "hru_id", w)
+    assert out[1] == pytest.approx(0.5)
+
+
+def test_coverage_is_weighted_not_a_plain_cell_count():
+    # Weight the two valid cells far more heavily than the two fill cells; a
+    # naive count would say 0.5, the weighted fraction says 0.9.
+    # This polygon's bounds-subset keeps y = 2500/1500/500 (3 rows, the 2000 m
+    # margin pulls in two extra), so the bottom grid row is index 2, not 3.
+    gdf = gpd.GeoDataFrame({"hru_id": [1]}, geometry=[box(0, 0, 4000, 1000)],
+                           crs="EPSG:5070")
+    w = pd.DataFrame([
+        {"hru_id": 1, "i": 2, "j": 0, "wght": 0.05},   # left half -> fill
+        {"hru_id": 1, "i": 2, "j": 1, "wght": 0.05},   # left half -> fill
+        {"hru_id": 1, "i": 2, "j": 2, "wght": 0.45},   # right half -> valid
+        {"hru_id": 1, "i": 2, "j": 3, "wght": 0.45},   # right half -> valid
+    ])
+    out = coverage_from_weights(
+        _adapter(), _grid(left_fill=True, right_fill=False), gdf, "hru_id", w)
+    assert out[1] == pytest.approx(0.9)
+
+
+def test_raises_when_weight_index_does_not_match_the_subset():
+    # Weight (i, j) index the batch's OWN bounds-subset. Handing in a weight
+    # table from a different batch silently produces plausible-looking garbage
+    # unless this is caught — so it must raise, not guess.
+    bad = pd.DataFrame([{"hru_id": 1, "i": 0, "j": 99, "wght": 1.0}])
+    with pytest.raises(ValueError, match="index"):
+        coverage_from_weights(
+            _adapter(), _grid(left_fill=True, right_fill=False), _polys(),
+            "hru_id", bad)
+
+
+def test_coverage_over_years_averages_a_moving_footprint(tmp_path):
+    # The real SNODAS case: HRU 1 is all-fill in year one and fully valid in
+    # year two. A single-year probe would call it permanently uncovered; the
+    # mean across years reports 0.5, marking it partially covered.
+    y1 = tmp_path / "demo_daily_2004.nc"
+    y2 = tmp_path / "demo_daily_2015.nc"
+    _grid(left_fill=True, right_fill=False).to_netcdf(y1)
+    _grid(left_fill=False, right_fill=False).to_netcdf(y2)
+
+    out = coverage_over_years(
+        _adapter(), _polys(), "hru_id", _weights(), [y1, y2]
+    ).set_index("hru_id")
+    assert out.loc[1, "coverage"] == pytest.approx(0.5)
+    assert out.loc[2, "coverage"] == pytest.approx(1.0)
+    assert out.loc[1, "n_years_sampled"] == 2
+
+
+def test_coverage_over_years_requires_at_least_one_file():
+    with pytest.raises(ValueError, match="no source files"):
+        coverage_over_years(_adapter(), _polys(), "hru_id", _weights(), [])
+
+
+def test_adapter_without_a_hook_treats_nan_as_the_fill_marker():
+    # Coverage is defined by the adapter's own fill convention (its hook), not
+    # by a hard-coded sentinel; an adapter with no hook falls back to NaN.
+    ds = _grid(left_fill=False, right_fill=False)
+    ds["swe"].values[0, :, :2] = np.nan
+    out = coverage_from_weights(
+        _adapter(pre_aggregate_hook=None), ds, _polys(), "hru_id", _weights())
+    assert out[1] == pytest.approx(0.0)
+    assert out[2] == pytest.approx(1.0)

--- a/tests/test_derive_snarea_curve.py
+++ b/tests/test_derive_snarea_curve.py
@@ -13,9 +13,18 @@ import xarray as xr
 
 from scripts.derive_snarea_curve import (
     cells_from_weights,
+    coverage_from_file,
     read_daily_by_hru,
     validate_default_curve,
 )
+
+
+def test_coverage_from_file(tmp_path):
+    p = tmp_path / "cov.csv"
+    pd.DataFrame({"hru_id": [1, 2, 3], "coverage": [1.0, 0.0, 0.42],
+                  "n_years_sampled": [22, 22, 22]}).to_csv(p, index=False)
+    got = coverage_from_file(p, "hru_id")
+    assert got == {1: 1.0, 2: 0.0, 3: 0.42}
 
 
 def test_cells_from_weights(tmp_path):

--- a/tests/test_snarea_build.py
+++ b/tests/test_snarea_build.py
@@ -70,9 +70,12 @@ def test_seasons_uses_water_year_grouping():
     sca[accum] = np.linspace(0.1, 1.0, int(accum.sum()))
     frame = pd.DataFrame({"swe": swe, "sca": sca})
 
-    seasons = _seasons(frame)
+    seasons, n_years_total = _seasons(frame)
     assert len(seasons) == 1          # the real Jan-Mar melt (WY2021), not the Dec spike
     assert seasons[0][0] == 1.0       # normalized SDC starts at 1.0
+    # WY2021 (Jan-Sep) and WY2022 (the Nov-Dec accumulation) were both examined;
+    # only WY2021 yielded a curve.
+    assert n_years_total == 2
 
 
 def test_build_hru_record_has_subgrid_columns():
@@ -100,12 +103,50 @@ def test_build_hru_record_defaults_subgrid_stats_without_swe_std():
     assert np.isnan(rec["peak_swe_mm"])
 
 
+# --- dropped-season diagnostics ---------------------------------------------
+
+
+def _one_good_one_dry_water_year():
+    """WY2010 melts out cleanly; WY2011 has snow that never melts (dropped)."""
+    good = pd.DataFrame(
+        {"swe": [5, 10, 8, 6, 4, 2, 0], "sca": [.5, 1.0, .9, .7, .5, .3, 0.0]},
+        index=pd.date_range("2010-01-31", periods=7, freq="D"),
+    )
+    never_melts = pd.DataFrame(
+        {"swe": [5, 10, 9, 8, 7, 6, 5], "sca": [.5, 1.0, .9, .8, .7, .6, .5]},
+        index=pd.date_range("2011-01-31", periods=7, freq="D"),
+    )
+    return pd.concat([good, never_melts])
+
+
+def test_dropped_water_years_are_visible_in_the_record():
+    # A water year that yields no usable curve is silently omitted from the
+    # season list, so n_seasons alone cannot distinguish "22 clean years" from
+    # "21 unusable + 1". n_years_total / n_years_dropped make that visible.
+    rec = build_hru_record(
+        hru_id=1, daily=_one_good_one_dry_water_year(), n_cells=100,
+        water_frac=0.0, params=SelectionParams(), default_curve=DEFAULT_SNAREA_CURVE)
+    assert rec["n_seasons"] == 1
+    assert rec["n_years_total"] == 2
+    assert rec["n_years_dropped"] == 1
+
+
+def test_no_years_dropped_when_every_season_is_usable():
+    rec = build_hru_record(
+        hru_id=1, daily=_daily_two_years(), n_cells=100, water_frac=0.0,
+        params=SelectionParams(), default_curve=DEFAULT_SNAREA_CURVE)
+    assert rec["n_seasons"] == 2
+    assert rec["n_years_total"] == 2
+    assert rec["n_years_dropped"] == 0
+
+
 # --- build_snarea_curve (the multi-HRU loop) --------------------------------
 
 _EXPECTED_COLUMNS = [
     "hru_deplcrv", "sdc_status", "sca_class", "similarity", "n_seasons",
+    "n_years_total", "n_years_dropped",
     *[f"snarea_curve_{i}" for i in range(11)],
-    "cv_subgrid", "peak_swe_mm", "n_peak_years",
+    "cv_subgrid", "peak_swe_mm", "n_peak_years", "coverage",
 ]
 
 
@@ -133,6 +174,22 @@ def test_build_snarea_curve_defaults_missing_cells_and_water_keys():
     by_id = out.set_index("hru_id")
     assert by_id.loc[1, "sdc_status"] == "derived"
     assert by_id.loc[2, "sdc_status"] == "default_too_few_cells"
+
+
+def test_build_snarea_curve_carries_coverage_through():
+    # coverage is a DIAGNOSTIC: it rides along per HRU but never changes
+    # sdc_status or the curve. An HRU with no coverage entry gets NaN, not 0 —
+    # "not measured" must not read as "no data".
+    daily = {1: _daily_two_years(), 2: _daily_two_years()}
+    out = build_snarea_curve(
+        daily, {1: 100, 2: 100}, {}, "hru_id", SelectionParams(),
+        DEFAULT_SNAREA_CURVE, coverage_by_hru={1: 0.25},
+    )
+    by_id = out.set_index("hru_id")
+    assert by_id.loc[1, "coverage"] == pytest.approx(0.25)
+    assert np.isnan(by_id.loc[2, "coverage"])
+    # low coverage does NOT demote the HRU
+    assert by_id.loc[1, "sdc_status"] == "derived"
 
 
 def test_build_snarea_curve_emits_rows_sorted_by_id():


### PR DESCRIPTION
Refs #166. **Stacked on #212** — base it there, or merge #212 first; the diff against `main` includes #212's four commits.

Implements the two diagnostics from #166 that needed a design decision, both settled as **diagnostic-only, computed at Stage 2 from the already-cached weights** (no Stage 1 re-run).

## The problem, measured

gdptools' `masked_mean` returns **0.0, not NaN**, for a polygon whose source cells are every one of them fill. So "outside the SNODAS domain" and "genuinely snow-free" produce identical output. Measured on the CONUS gfv2 product:

| | HRUs | share |
|---|---|---|
| Zero SNODAS coverage, reported `default_no_snow` | 1,087 | 0.30% |
| Partial coverage (<0.999), currently `derived` | 13,284 | 3.7% |

Two things that were not in the issue and shaped the design:

1. **The SNODAS footprint is not static.** It expands across the record — 31 of the 32 CONUS HRUs reading zero-coverage in 2004 carry real snow by 2015. A single-year probe would call a late-covered HRU permanently absent, so coverage is averaged over one sampled day per year.
2. **The consolidated weight file mixes 64 per-batch `(i, j)` index spaces.** Each batch clips the source to its own bounds, so its weights index that subset. `cells_from_weights` has always been safe because a `groupby().size()` is index-agnostic — but anything positional is silently wrong on it. I walked into this on the first attempt and got plausible-looking garbage (348k "zero-coverage" HRUs, 145k of them simultaneously `derived`), which is why `coverage_from_weights` bounds-checks and raises rather than guessing.

## What

- `gfv2_params/aggregate/coverage.py` — `coverage_from_weights` (weight-weighted valid fraction, `Σ wght·valid / Σ wght`) and `coverage_over_years` (mean across sampled years). The valid mask comes from the adapter's own `pre_aggregate_hook`, so the module carries no per-source fill sentinel.
- `derive_aggregate.py --mode coverage` → `{source}_coverage_{fabric}.csv`, run per batch.
- `slurm_batch/derive_snodas_coverage.batch`, chained into `submit_snarea_pipeline.sh` between merge and Stage 2 (now a five-job chain).
- Stage 2 joins it as a `coverage` column; `build_hru_record` also gains `n_years_total` / `n_years_dropped`, since a year that is entirely fill reads as snow-free and is dropped exactly like a real snow-free year.

## Explicitly not a gate

A `coverage >= 0.999` selection criterion was measured and rejected: it flips ~13.3k CONUS HRUs off their empirical curve onto the default. Nothing here changes a curve, an `sdc_status`, or a selection outcome. A missing coverage table leaves the column **NaN** — "not measured", deliberately distinct from a measured `0.0`.

## Verification

**Ran it, on real data.** Oregon (job 2606241, 22 s for 16,814 HRUs × 21 years):

- 16 HRUs report zero coverage, and they are **exactly** the 16 of Oregon's 20 `default_no_snow` HRUs that are data gaps.
- **None** of those 20 has full coverage — Oregon has essentially no genuinely snow-free HRU.
- 642 `derived` HRUs turn out to be built from partial coverage, 26 from <50%.

That 1:1 correspondence between zero-coverage and `default_no_snow` is what the theory predicts, so it is a real check on the implementation, not just a smoke test.

- Full suite under `srun`: **1107 passed, 4 skipped**. 8 new tests in `tests/test_aggregate_coverage.py`, written test-first.
- `pre-commit run --files <12 changed>` under `srun --mem=64G`: all hooks **Passed**, including yamllint, shellcheck and prettier (YAML and shell both touched this time).

A first Oregon run took >14 min because the adapter hook ran across all 365 days for a mask that is a property of the domain; narrowing to the single day before the hook took it to 22 s.

## Docs

- `RUNME.md` Step 8: new "coverage diagnostic" note with the measured numbers and an explicit not-a-gate statement.
- `CLAUDE.md`: two new gotcha bullets — the `masked_mean` 0.0-vs-NaN trap (with the rejected gate design recorded, so it is not re-proposed) and the per-batch weight index-space trap.
- `parameter_index.md` untouched: these columns live on the Stage 2 `_intermediates` CSV, which has no `prms:` block. No index rebuild needed.

## Follow-ups still open on #166

`read_daily_by_hru` chunking (CONUS ran fine, so perf-only), the weight-cache fabric fingerprint, the `DEFAULT_SNAREA_CURVE` placeholder (blocked on the real NHM curve being staged), and water-fraction wiring.

Note the CONUS `coverage` column stays NaN until `--mode coverage` is run against `gfv2` and Stage 2 is re-run — this PR does not touch the on-disk product.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
